### PR TITLE
Use symbolic labels instead of numeric

### DIFF
--- a/spy/backend/c/context.py
+++ b/spy/backend/c/context.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from spy.vm.vm import SPyVM, Builtins as B
 from spy.vm.object import W_Type
-from spy.vm.function import W_FunctionType
+from spy.vm.function import W_FuncType
 
 @dataclass
 class C_Type:
@@ -63,7 +63,7 @@ class Context:
             return self._d[w_type]
         raise NotImplementedError(f'Cannot translate type {w_type} to C')
 
-    def c_function(self, name: str, w_functype: W_FunctionType) -> C_Function:
+    def c_function(self, name: str, w_functype: W_FuncType) -> C_Function:
         c_restype = self.w2c(w_functype.w_restype)
         c_params = [
             C_FuncParam(name=p.name, c_type=self.w2c(p.w_type))

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -5,7 +5,7 @@ from spy.fqn import FQN
 from spy.vm.object import W_Type, W_Object, W_i32
 from spy.vm.str import W_str
 from spy.vm.module import W_Module
-from spy.vm.function import W_UserFunction, W_BuiltinFunction, W_FuncType
+from spy.vm.function import W_UserFunc, W_BuiltinFunc, W_FuncType
 from spy.vm.codeobject import OpCode
 from spy.vm.vm import SPyVM, Builtins as B
 from spy.vm import helpers
@@ -70,13 +70,13 @@ class CModuleWriter:
         for fqn, w_obj in self.w_mod.items_w():
             assert w_obj is not None, 'uninitialized global?'
             # XXX we should mangle the name somehow
-            if isinstance(w_obj, W_UserFunction):
+            if isinstance(w_obj, W_UserFunc):
                 self.emit_function(fqn, w_obj)
             else:
                 self.emit_variable(fqn, w_obj)
         return self.out.build()
 
-    def emit_function(self, fqn: FQN, w_func: W_UserFunction) -> None:
+    def emit_function(self, fqn: FQN, w_func: W_UserFunc) -> None:
         fw = CFuncWriter(self.ctx, self, fqn, w_func)
         fw.emit()
 
@@ -95,7 +95,7 @@ class CFuncWriter:
     cmod: CModuleWriter
     out: TextBuilder
     fqn: FQN
-    w_func: W_UserFunction
+    w_func: W_UserFunc
     tmp_vars: dict[str, C_Type]
     stack: list[c_expr.Expr]
     labels: dict[str, int]
@@ -104,7 +104,7 @@ class CFuncWriter:
                  ctx: Context,
                  cmod: CModuleWriter,
                  fqn: FQN,
-                 w_func: W_UserFunction) -> None:
+                 w_func: W_UserFunc) -> None:
         self.ctx = ctx
         self.cmod = cmod
         self.out = cmod.out

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -98,6 +98,7 @@ class CFuncWriter:
     w_func: W_UserFunction
     tmp_vars: dict[str, C_Type]
     stack: list[c_expr.Expr]
+    labels: dict[str, int]
 
     def __init__(self,
                  ctx: Context,

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -5,7 +5,7 @@ from spy.fqn import FQN
 from spy.vm.object import W_Type, W_Object, W_i32
 from spy.vm.str import W_str
 from spy.vm.module import W_Module
-from spy.vm.function import W_UserFunction, W_BuiltinFunction, W_FunctionType
+from spy.vm.function import W_UserFunction, W_BuiltinFunction, W_FuncType
 from spy.vm.codeobject import OpCode
 from spy.vm.vm import SPyVM, Builtins as B
 from spy.vm import helpers
@@ -336,12 +336,12 @@ class CFuncWriter:
 
     def emit_op_call_global(self, fqn: FQN, argcount: int) -> None:
         w_functype = self.ctx.vm.lookup_global_type(fqn)
-        assert isinstance(w_functype, W_FunctionType)
+        assert isinstance(w_functype, W_FuncType)
         self._emit_op_call(fqn.c_name, argcount, w_functype)
 
-    def _emit_op_call(self, llname: str, argcount: int, w_functype: W_FunctionType) -> None:
+    def _emit_op_call(self, llname: str, argcount: int, w_functype: W_FuncType) -> None:
         arglist = self._pop_args(argcount)
-        assert isinstance(w_functype, W_FunctionType)
+        assert isinstance(w_functype, W_FuncType)
         w_restype = w_functype.w_restype
         c_restype = self.ctx.w2c(w_restype)
         #

--- a/spy/backend/c/wrapper.py
+++ b/spy/backend/c/wrapper.py
@@ -8,7 +8,7 @@ from spy.libspy import LLSPyInstance
 from spy.vm.object import W_Type
 from spy.vm.str import ll_spy_Str_new
 from spy.vm.module import W_Module
-from spy.vm.function import W_Function, W_FuncType
+from spy.vm.function import W_Func, W_FuncType
 from spy.vm.vm import SPyVM, Builtins as B
 
 
@@ -38,7 +38,7 @@ class WasmModuleWrapper:
 
     def read_function(self, fqn: FQN) -> 'WasmFuncWrapper':
         w_func = self.vm.lookup_global(fqn)
-        assert isinstance(w_func, W_Function)
+        assert isinstance(w_func, W_Func)
         return WasmFuncWrapper(self.vm, self.ll,
                                fqn.c_name, w_func.w_functype)
 

--- a/spy/backend/c/wrapper.py
+++ b/spy/backend/c/wrapper.py
@@ -8,7 +8,7 @@ from spy.libspy import LLSPyInstance
 from spy.vm.object import W_Type
 from spy.vm.str import ll_spy_Str_new
 from spy.vm.module import W_Module
-from spy.vm.function import W_Function, W_FunctionType
+from spy.vm.function import W_Function, W_FuncType
 from spy.vm.vm import SPyVM, Builtins as B
 
 
@@ -57,10 +57,10 @@ class WasmFuncWrapper:
     vm: SPyVM
     ll: LLSPyInstance
     c_name: str
-    w_functype: W_FunctionType
+    w_functype: W_FuncType
 
     def __init__(self, vm: SPyVM, ll: LLSPyInstance, c_name: str,
-                 w_functype: W_FunctionType) -> None:
+                 w_functype: W_FuncType) -> None:
         self.vm = vm
         self.ll = ll
         self.c_name = c_name

--- a/spy/backend/interp.py
+++ b/spy/backend/interp.py
@@ -12,7 +12,7 @@ vice-versa, by using vm.wrap and vm.unwrap.
 from typing import Any
 from spy.vm.vm import SPyVM
 from spy.vm.module import W_Module
-from spy.vm.function import W_Function, W_UserFunction, W_FunctionType
+from spy.vm.function import W_Function, W_UserFunction, W_FuncType
 
 
 class InterpModuleWrapper:
@@ -42,7 +42,7 @@ class InterpFuncWrapper:
     """
     vm: SPyVM
     w_func: W_Function
-    w_functype: W_FunctionType
+    w_functype: W_FuncType
 
     def __init__(self, vm: SPyVM, w_func: W_Function):
         self.vm = vm

--- a/spy/backend/interp.py
+++ b/spy/backend/interp.py
@@ -12,7 +12,7 @@ vice-versa, by using vm.wrap and vm.unwrap.
 from typing import Any
 from spy.vm.vm import SPyVM
 from spy.vm.module import W_Module
-from spy.vm.function import W_Function, W_UserFunction, W_FuncType
+from spy.vm.function import W_Func, W_UserFunc, W_FuncType
 
 
 class InterpModuleWrapper:
@@ -31,26 +31,26 @@ class InterpModuleWrapper:
 
     def __getattr__(self, attr: str) -> Any:
         w_obj = self.w_mod.getattr(attr)
-        if isinstance(w_obj, W_Function):
+        if isinstance(w_obj, W_Func):
             return InterpFuncWrapper(self.vm, w_obj)
         return self.vm.unwrap(w_obj)
 
 
 class InterpFuncWrapper:
     """
-    Wrap a W_Function.
+    Wrap a W_Func.
     """
     vm: SPyVM
-    w_func: W_Function
+    w_func: W_Func
     w_functype: W_FuncType
 
-    def __init__(self, vm: SPyVM, w_func: W_Function):
+    def __init__(self, vm: SPyVM, w_func: W_Func):
         self.vm = vm
         self.w_func = w_func
         self.w_functype = w_func.w_functype
 
     def dis(self) -> None:
-        assert isinstance(self.w_func, W_UserFunction)
+        assert isinstance(self.w_func, W_UserFunc)
         self.w_func.w_code.pp()
 
     def __call__(self, *args: Any) -> Any:

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -3,7 +3,7 @@ from spy.fqn import FQN
 from spy.vm.vm import SPyVM
 from spy.vm.object import W_Type, W_Object
 from spy.vm.codeobject import W_CodeObject, OpCode
-from spy.vm.function import W_UserFunction
+from spy.vm.function import W_UserFunc
 
 class DopplerInterpreter:
     """
@@ -17,7 +17,7 @@ class DopplerInterpreter:
     """
     typestack_w: list[W_Type]
 
-    def __init__(self, vm: SPyVM, w_func: W_UserFunction):
+    def __init__(self, vm: SPyVM, w_func: W_UserFunc):
         self.vm = vm
         self.w_func = w_func
         self.code = w_func.w_code
@@ -47,12 +47,12 @@ class DopplerInterpreter:
         # XXX implement me
         pass
 
-    def run(self) -> W_UserFunction:
+    def run(self) -> W_UserFunc:
         """
         Do abstract interpretation of the whole code
         """
         self.run_range(0, len(self.code.body))
-        return W_UserFunction(self.code_out)
+        return W_UserFunc(self.code_out)
 
     def run_range(self, pc_start: int, pc_end: int) -> None:
         """

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -5,9 +5,13 @@ from spy.vm.object import W_Type, W_Object
 from spy.vm.codeobject import W_CodeObject, OpCode
 from spy.vm.function import W_UserFunction
 
-class RainbowInterpreter:
+class DopplerInterpreter:
     """
     Perform typecheck and partial evaluation on the given function object.
+
+    The input bytecode contains blue and red operations. The output bytecode
+    contains only red operations, thus it performs a "red shift"... hence the
+    name :)
 
     Return a new function object where all blue ops have been evaluated.
     """
@@ -18,7 +22,7 @@ class RainbowInterpreter:
         self.w_func = w_func
         self.code = w_func.w_code
         self.code_out = W_CodeObject(
-            FQN('rainbow::test'),
+            FQN('doppler::test'),
             w_functype = w_func.w_functype,
             filename = w_func.w_code.filename,
             lineno = w_func.w_code.lineno)

--- a/spy/irgen/__init__.py
+++ b/spy/irgen/__init__.py
@@ -1,5 +1,5 @@
 """
 IR code generator.
 
-Turn the AST into IR-compiled live objects, such as W_Module, W_Function, etc.
+Turn the AST into IR-compiled live objects, such as W_Module, W_Func, etc.
 """

--- a/spy/irgen/codegen.py
+++ b/spy/irgen/codegen.py
@@ -52,7 +52,7 @@ class CodeGen:
                 continue
             self.w_code.declare_local(sym.name, sym.w_type)
 
-    def new_label(self, stem):
+    def new_label(self, stem: str) -> str:
         """
         Create a new unique label name
         """
@@ -60,7 +60,7 @@ class CodeGen:
         self.label_counter += 1
         return f'{stem}_{n}'
 
-    def new_labels(self, *stems):
+    def new_labels(self, *stems: str) -> list[str]:
         """
         Create multiple unique label names
         """

--- a/spy/irgen/codegen.py
+++ b/spy/irgen/codegen.py
@@ -8,7 +8,7 @@ from spy.errors import SPyCompileError
 from spy.vm.vm import SPyVM, Builtins as B
 from spy.vm.object import W_Object
 from spy.vm.codeobject import W_CodeObject, OpCode
-from spy.vm.function import W_FunctionType
+from spy.vm.function import W_FuncType
 from spy.util import magic_dispatch
 
 class CodeGen:

--- a/spy/irgen/codegen.py
+++ b/spy/irgen/codegen.py
@@ -184,25 +184,25 @@ class CodeGen:
              mark_if_then IF
              <eval cond>
         IF:
-             br_if THEN ENDIF ENDIF
+            br_if THEN ENDIF ENDIF
         THEN:
-             <then body>
+            <then body>
         ENDIF:
-             <rest of the program>
+            <rest of the program>
 
         if-then-else case
         ------------------
              mark_if_then_else IF
              <eval cond>
         IF:
-             br_if THEN ELSE ENDIF
+            br_if THEN ELSE ENDIF
         THEN:
-             <then body>
-             br ENDIF
+            <then body>
+            br ENDIF
         ELSE:
-             <else body>
+            <else body>
         ENDIF:
-             <rest of the program>
+            <rest of the program>
         """
         IF, THEN, ELSE, ENDIF = self.new_labels('if', 'then', 'else', 'endif')
         has_else  = len(if_node.else_body) > 0
@@ -230,25 +230,29 @@ class CodeGen:
 
     def do_exec_While(self, while_node: spy.ast.While) -> None:
         """
-               mark_while IF, LOOP
-        START: <eval cond>
-        IF:    br_if_not END
-               <body>
-        LOOP:  br START
-        END:   <rest of the program>
+            mark_while WHILE IF END
+        WHILE:
+            <eval cond>
+        IF:
+            br_while_not END
+            <body>
+            br WHILE
+        END:
+            <rest of the program>
         """
-        _, op_mark = self.emit(while_node.loc, 'mark_while', ...)
-        START = self.get_label()
+        WHILE, IF, END = self.new_labels('while', 'while_if', 'while_end')
+        self.emit(while_node.loc, 'mark_while', WHILE, IF, END)
+        # WHILE:
+        self.emit_label(WHILE)
         self.eval_expr(while_node.test)
-        #
-        IF, br_if_not = self.emit(while_node.test.loc, 'br_if_not', ...)
+        # IF:
+        self.emit_label(IF)
+        self.emit(while_node.test.loc, 'br_while_not', END)
         for stmt in while_node.body:
             self.exec_stmt(stmt)
-        #
-        LOOP, _ = self.emit(while_node.loc, 'br', START)
-        END = self.get_label()
-        br_if_not.set_args(END)
-        op_mark.set_args(IF, LOOP)
+        self.emit(while_node.loc, 'br', WHILE)
+        # END:
+        self.emit_label(END)
 
     # ====== expressions ======
 

--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -5,7 +5,7 @@ from spy.irgen.codegen import CodeGen
 from spy.vm.vm import SPyVM
 from spy.vm.module import W_Module
 from spy.vm.object import W_Type
-from spy.vm.function import W_FunctionType, W_UserFunction
+from spy.vm.function import W_FuncType, W_UserFunction
 
 
 class ModuleGen:

--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -5,7 +5,7 @@ from spy.irgen.codegen import CodeGen
 from spy.vm.vm import SPyVM
 from spy.vm.module import W_Module
 from spy.vm.object import W_Type
-from spy.vm.function import W_FuncType, W_UserFunction
+from spy.vm.function import W_FuncType, W_UserFunc
 
 
 class ModuleGen:
@@ -47,9 +47,9 @@ class ModuleGen:
                 self.vm.add_global(fqn, w_type, w_const)
         return self.w_mod
 
-    def make_w_func(self, funcdef: spy.ast.FuncDef) -> W_UserFunction:
+    def make_w_func(self, funcdef: spy.ast.FuncDef) -> W_UserFunc:
         w_functype, scope = self.t.get_funcdef_info(funcdef)
         codegen = CodeGen(self.vm, self.t, self.modname, funcdef)
         w_code = codegen.make_w_code()
-        w_func = W_UserFunction(w_code)
+        w_func = W_UserFunc(w_code)
         return w_func

--- a/spy/irgen/typechecker.py
+++ b/spy/irgen/typechecker.py
@@ -7,7 +7,7 @@ from spy.irgen.symtable import SymTable, Symbol
 from spy.irgen import multiop
 from spy.vm.vm import SPyVM, Builtins as B
 from spy.vm.object import W_Type, W_Object
-from spy.vm.function import W_FunctionType, FuncParam
+from spy.vm.function import W_FuncType, FuncParam
 from spy.util import magic_dispatch
 
 def can_assign_to(w_type_from: W_Type, w_type_to: W_Type) -> bool:
@@ -18,7 +18,7 @@ def can_assign_to(w_type_from: W_Type, w_type_to: W_Type) -> bool:
 class TypeChecker:
     vm: SPyVM
     mod: spy.ast.Module
-    funcdef_types: dict[spy.ast.FuncDef, W_FunctionType]
+    funcdef_types: dict[spy.ast.FuncDef, W_FuncType]
     funcdef_scopes: dict[spy.ast.FuncDef, SymTable]
     expr_types: dict[spy.ast.Expr, W_Type]
     consts_w: dict[spy.ast.Constant, W_Object]
@@ -52,7 +52,7 @@ class TypeChecker:
 
     def get_funcdef_info(self,
                          funcdef: spy.ast.FuncDef
-                         ) -> tuple[W_FunctionType, SymTable]:
+                         ) -> tuple[W_FuncType, SymTable]:
         w_type = self.funcdef_types[funcdef]
         scope = self.funcdef_scopes[funcdef]
         return w_type, scope
@@ -173,7 +173,7 @@ class TypeChecker:
             for arg in funcdef.args
         ]
         w_return_type = self.resolve_type(funcdef.return_type, scope)
-        w_functype = W_FunctionType(params, w_return_type)
+        w_functype = W_FuncType(params, w_return_type)
         scope.declare(funcdef.name, 'const', w_functype, funcdef.loc)
         self.funcdef_types[funcdef] = w_functype
 
@@ -417,7 +417,7 @@ class TypeChecker:
     def check_expr_Call(self, call: spy.ast.Call, scope: SymTable) -> W_Type:
         sym = self.lookup_Name_maybe(call.func, scope) # for error reporting
         w_functype = self.check_expr(call.func, scope)
-        if not isinstance(w_functype, W_FunctionType):
+        if not isinstance(w_functype, W_FuncType):
             self._call_error_non_callable(call, sym, w_functype)
         #
         argtypes_w = [self.check_expr(arg, scope) for arg in call.args]

--- a/spy/rainbow.py
+++ b/spy/rainbow.py
@@ -1,7 +1,8 @@
+from typing import Any, Optional
 from spy.fqn import FQN
 from spy.vm.vm import SPyVM
-from spy.vm.object import W_Type
-from spy.vm.codeobject import W_CodeObject
+from spy.vm.object import W_Type, W_Object
+from spy.vm.codeobject import W_CodeObject, OpCode
 from spy.vm.function import W_UserFunction
 
 class RainbowInterpreter:
@@ -15,7 +16,7 @@ class RainbowInterpreter:
     def __init__(self, vm: SPyVM, w_func: W_UserFunction):
         self.vm = vm
         self.w_func = w_func
-        self.code= w_func.w_code
+        self.code = w_func.w_code
         self.code_out = W_CodeObject(
             FQN('rainbow::test'),
             w_functype = w_func.w_functype,
@@ -33,23 +34,23 @@ class RainbowInterpreter:
     def poptype(self) -> W_Type:
         return self.typestack_w.pop()
 
-    def emit(self, op):
+    def emit(self, op: OpCode) -> None:
         ## if self.label_maps:
         ##     op = op.relabel(self.label_maps[-1])
         self.code_out.body.append(op)
 
-    def flush(self):
+    def flush(self) -> None:
         # XXX implement me
         pass
 
-    def run(self):
+    def run(self) -> W_UserFunction:
         """
         Do abstract interpretation of the whole code
         """
         self.run_range(0, len(self.code.body))
         return W_UserFunction(self.code_out)
 
-    def run_range(self, pc_start, pc_end):
+    def run_range(self, pc_start: int, pc_end: int) -> None:
         """
         Do abstract interpretation of the given code range
         """
@@ -58,7 +59,7 @@ class RainbowInterpreter:
             pc = self.run_single_op(pc)
         self.flush()
 
-    def run_single_op(self, pc):
+    def run_single_op(self, pc: int) -> int:
         """
         Do abstract interpretation of the op at the given PC.
 
@@ -73,19 +74,20 @@ class RainbowInterpreter:
             assert type(pc_next) is int
             return pc_next
 
-    def op_default(self, pc, op, *args):
+    def op_default(self, pc: int, op: OpCode, *args: Any) -> Optional[int]:
         raise NotImplementedError(f'op_{op.name}')
         ## if self.is_blue(op):
         ##     return self.op_blue(pc, op, *args)
         ## else:
         ##     return self.op_red(pc, op, *args)
 
-    def op_load_const(self, pc, op, w_value):
+    def op_load_const(self, pc: int, op: OpCode,
+                      w_value: W_Object) -> Any:
         w_type = self.vm.dynamic_type(w_value)
         self.pushtype(w_type)
         self.emit(op)
 
-    def op_return(self, pc, op):
+    def op_return(self, pc: int, op: OpCode) -> Any:
         w_type = self.poptype()
         # XXX this should be turned into a proper error
         # XXX 2: we should use is_compatible_type

--- a/spy/rainbow.py
+++ b/spy/rainbow.py
@@ -1,0 +1,93 @@
+from spy.fqn import FQN
+from spy.vm.vm import SPyVM
+from spy.vm.object import W_Type
+from spy.vm.codeobject import W_CodeObject
+from spy.vm.function import W_UserFunction
+
+class RainbowInterpreter:
+    """
+    Perform typecheck and partial evaluation on the given function object.
+
+    Return a new function object where all blue ops have been evaluated.
+    """
+    typestack_w: list[W_Type]
+
+    def __init__(self, vm: SPyVM, w_func: W_UserFunction):
+        self.vm = vm
+        self.w_func = w_func
+        self.code= w_func.w_code
+        self.code_out = W_CodeObject(
+            FQN('rainbow::test'),
+            w_functype = w_func.w_functype,
+            filename = w_func.w_code.filename,
+            lineno = w_func.w_code.lineno)
+
+        self.typestack_w = []
+        ## self.blueframe = Frame(w_func)
+        ## self.label_maps = []
+        ## self.unique_id = 0
+
+    def pushtype(self, w_type: W_Type) -> None:
+        self.typestack_w.append(w_type)
+
+    def poptype(self) -> W_Type:
+        return self.typestack_w.pop()
+
+    def emit(self, op):
+        ## if self.label_maps:
+        ##     op = op.relabel(self.label_maps[-1])
+        self.code_out.body.append(op)
+
+    def flush(self):
+        # XXX implement me
+        pass
+
+    def run(self):
+        """
+        Do abstract interpretation of the whole code
+        """
+        self.run_range(0, len(self.code.body))
+        return W_UserFunction(self.code_out)
+
+    def run_range(self, pc_start, pc_end):
+        """
+        Do abstract interpretation of the given code range
+        """
+        pc = pc_start
+        while pc < pc_end:
+            pc = self.run_single_op(pc)
+        self.flush()
+
+    def run_single_op(self, pc):
+        """
+        Do abstract interpretation of the op at the given PC.
+
+        Return the PC of the operation to execute next.
+        """
+        op = self.code.body[pc].copy()
+        meth = getattr(self, f'op_{op.name}', self.op_default)
+        pc_next = meth(pc, op, *op.args)
+        if pc_next is None:
+            return pc + 1
+        else:
+            assert type(pc_next) is int
+            return pc_next
+
+    def op_default(self, pc, op, *args):
+        raise NotImplementedError(f'op_{op.name}')
+        ## if self.is_blue(op):
+        ##     return self.op_blue(pc, op, *args)
+        ## else:
+        ##     return self.op_red(pc, op, *args)
+
+    def op_load_const(self, pc, op, w_value):
+        w_type = self.vm.dynamic_type(w_value)
+        self.pushtype(w_type)
+        self.emit(op)
+
+    def op_return(self, pc, op):
+        w_type = self.poptype()
+        # XXX this should be turned into a proper error
+        # XXX 2: we should use is_compatible_type
+        assert w_type == self.w_func.w_functype.w_restype
+        self.emit(op)

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -3,7 +3,7 @@ from spy.fqn import FQN
 from spy.errors import SPyRuntimeAbort
 from spy.irgen.symtable import Symbol
 from spy.vm.vm import Builtins as B
-from spy.vm.function import W_FunctionType
+from spy.vm.function import W_FuncType
 from spy.util import ANYTHING
 from spy.tests.support import CompilerTest, skip_backends, no_backend
 
@@ -16,7 +16,7 @@ class TestBasic(CompilerTest):
             return 42
         """)
         vm = self.vm
-        w_expected_functype = W_FunctionType([], B.w_i32)
+        w_expected_functype = W_FuncType([], B.w_i32)
         #
         # typechecker tests
         t = self.compiler.t
@@ -27,7 +27,7 @@ class TestBasic(CompilerTest):
         }
         #
         funcdef = self.get_funcdef('foo')
-        w_expected_functype = W_FunctionType([], B.w_i32)
+        w_expected_functype = W_FuncType([], B.w_i32)
         w_functype, scope = t.get_funcdef_info(funcdef)
         assert w_functype == w_expected_functype
         assert scope.symbols == {
@@ -145,7 +145,7 @@ class TestBasic(CompilerTest):
         vm = self.vm
         # typechecker tests
         funcdef = self.get_funcdef('inc')
-        w_expected_functype = W_FunctionType.make(x=B.w_i32, w_restype=B.w_i32)
+        w_expected_functype = W_FuncType.make(x=B.w_i32, w_restype=B.w_i32)
         w_functype, scope = self.compiler.t.get_funcdef_info(funcdef)
         assert w_functype == w_expected_functype
         assert scope.symbols == {
@@ -453,7 +453,6 @@ class TestBasic(CompilerTest):
         assert mod.a == 0
         assert mod.b == 200
         assert mod.c == 300
-        mod.if_then.w_func.w_code.pp()
 
     def test_while(self):
         mod = self.compile("""

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -453,6 +453,7 @@ class TestBasic(CompilerTest):
         assert mod.a == 0
         assert mod.b == 200
         assert mod.c == 300
+        mod.if_then.w_func.w_code.pp()
 
     def test_while(self):
         mod = self.compile("""

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -409,7 +409,7 @@ class TestBasic(CompilerTest):
             ]
         )
 
-    def test_if(self):
+    def test_if_stmt(self):
         mod = self.compile("""
         a: i32 = 0
         b: i32 = 0

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -3,14 +3,14 @@ from spy.fqn import FQN
 from spy.vm.vm import SPyVM, Builtins as B
 from spy.vm.codeobject import OpCode, W_CodeObject
 from spy.vm.function import W_FunctionType, W_UserFunction
-from spy.rainbow import RainbowInterpreter
+from spy.doppler import DopplerInterpreter
 
-class TestRainbow:
+class TestDoppler:
 
-    def rainbow_peval(self, vm: SPyVM,
+    def doppler(self, vm: SPyVM,
                       w_func: W_UserFunction) -> W_UserFunction:
-        self.rainbow = RainbowInterpreter(vm, w_func)
-        return self.rainbow.run()
+        self.interp = DopplerInterpreter(vm, w_func)
+        return self.interp.run()
 
     def test_simple(self):
         vm = SPyVM()
@@ -22,7 +22,7 @@ class TestRainbow:
             OpCode('return'),
         ]
         w_func = W_UserFunction(code)
-        w_func2 = self.rainbow_peval(vm, w_func)
+        w_func2 = self.doppler(vm, w_func)
         assert vm.call_function(w_func2, []) == w_42
         assert w_func2.w_code.equals("""
         0 load_const W_i32(42)

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -2,13 +2,13 @@ import pytest
 from spy.fqn import FQN
 from spy.vm.vm import SPyVM, Builtins as B
 from spy.vm.codeobject import OpCode, W_CodeObject
-from spy.vm.function import W_FuncType, W_UserFunction
+from spy.vm.function import W_FuncType, W_UserFunc
 from spy.doppler import DopplerInterpreter
 
 class TestDoppler:
 
     def doppler(self, vm: SPyVM,
-                      w_func: W_UserFunction) -> W_UserFunction:
+                      w_func: W_UserFunc) -> W_UserFunc:
         self.interp = DopplerInterpreter(vm, w_func)
         return self.interp.run()
 
@@ -21,7 +21,7 @@ class TestDoppler:
             OpCode('load_const', w_42),
             OpCode('return'),
         ]
-        w_func = W_UserFunction(code)
+        w_func = W_UserFunc(code)
         w_func2 = self.doppler(vm, w_func)
         assert vm.call_function(w_func2, []) == w_42
         assert w_func2.w_code.equals("""

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -25,6 +25,6 @@ class TestDoppler:
         w_func2 = self.doppler(vm, w_func)
         assert vm.call_function(w_func2, []) == w_42
         assert w_func2.w_code.equals("""
-        0 load_const W_i32(42)
-        1 return
+        load_const W_i32(42)
+        return
         """)

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -2,28 +2,39 @@ import pytest
 from spy.fqn import FQN
 from spy.vm.vm import SPyVM, Builtins as B
 from spy.vm.codeobject import OpCode, W_CodeObject
+from spy.vm.object import W_i32
 from spy.vm.function import W_FuncType, W_UserFunc
 from spy.doppler import DopplerInterpreter
 
+@pytest.mark.usefixtures('init')
 class TestDoppler:
 
-    def doppler(self, vm: SPyVM,
-                      w_func: W_UserFunc) -> W_UserFunc:
-        self.interp = DopplerInterpreter(vm, w_func)
+    @pytest.fixture
+    def init(self):
+        self.vm = SPyVM()
+
+    def make_func(self, ft: str, body: list[OpCode]):
+        w_functype = W_FuncType.parse(ft)
+        code = W_CodeObject(FQN('test::fn'), w_functype=w_functype)
+        code.body = body
+        w_func = W_UserFunc(code)
+        return w_func
+
+    def doppler(self, w_func: W_UserFunc) -> W_UserFunc:
+        self.interp = DopplerInterpreter(self.vm, w_func)
         return self.interp.run()
 
     def test_simple(self):
-        vm = SPyVM()
-        w_42 = vm.wrap(42)
-        w_functype = W_FuncType.make(w_restype=B.w_i32)
-        code = W_CodeObject(FQN('test::fn'), w_functype=w_functype)
-        code.body = [
-            OpCode('load_const', w_42),
-            OpCode('return'),
-        ]
-        w_func = W_UserFunc(code)
-        w_func2 = self.doppler(vm, w_func)
-        assert vm.call_function(w_func2, []) == w_42
+        w_func = self.make_func(
+            'def() -> i32',
+            body=[
+                OpCode('load_const', W_i32(42)),
+                OpCode('return'),
+            ]
+        )
+        w_func2 = self.doppler(w_func)
+        w_res = self.vm.call_function(w_func2, [])
+        assert self.vm.unwrap(w_res) == 42
         assert w_func2.w_code.equals("""
         load_const W_i32(42)
         return

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -2,7 +2,7 @@ import pytest
 from spy.fqn import FQN
 from spy.vm.vm import SPyVM, Builtins as B
 from spy.vm.codeobject import OpCode, W_CodeObject
-from spy.vm.function import W_FunctionType, W_UserFunction
+from spy.vm.function import W_FuncType, W_UserFunction
 from spy.doppler import DopplerInterpreter
 
 class TestDoppler:
@@ -15,7 +15,7 @@ class TestDoppler:
     def test_simple(self):
         vm = SPyVM()
         w_42 = vm.wrap(42)
-        w_functype = W_FunctionType.make(w_restype=B.w_i32)
+        w_functype = W_FuncType.make(w_restype=B.w_i32)
         code = W_CodeObject(FQN('test::fn'), w_functype=w_functype)
         code.body = [
             OpCode('load_const', w_42),

--- a/spy/tests/test_rainbow.py
+++ b/spy/tests/test_rainbow.py
@@ -1,0 +1,29 @@
+import pytest
+from spy.fqn import FQN
+from spy.vm.vm import SPyVM, Builtins as B
+from spy.vm.codeobject import OpCode, W_CodeObject
+from spy.vm.function import W_FunctionType, W_UserFunction
+from spy.rainbow import RainbowInterpreter
+
+class TestRainbow:
+
+    def rainbow_peval(self, vm, w_func):
+        self.rainbow = RainbowInterpreter(vm, w_func)
+        return self.rainbow.run()
+
+    def test_simple(self):
+        vm = SPyVM()
+        w_42 = vm.wrap(42)
+        w_functype = W_FunctionType.make(w_restype=B.w_i32)
+        code = W_CodeObject(FQN('test::fn'), w_functype=w_functype)
+        code.body = [
+            OpCode('load_const', w_42),
+            OpCode('return'),
+        ]
+        w_func = W_UserFunction(code)
+        w_func2 = self.rainbow_peval(vm, w_func)
+        assert vm.call_function(w_func2, []) == w_42
+        assert w_func2.w_code.equals("""
+        0 load_const W_i32(42)
+        1 return
+        """)

--- a/spy/tests/test_rainbow.py
+++ b/spy/tests/test_rainbow.py
@@ -7,7 +7,8 @@ from spy.rainbow import RainbowInterpreter
 
 class TestRainbow:
 
-    def rainbow_peval(self, vm, w_func):
+    def rainbow_peval(self, vm: SPyVM,
+                      w_func: W_UserFunction) -> W_UserFunction:
         self.rainbow = RainbowInterpreter(vm, w_func)
         return self.rainbow.run()
 

--- a/spy/tests/vm/test_codeobject.py
+++ b/spy/tests/vm/test_codeobject.py
@@ -13,13 +13,6 @@ class TestOpCode:
         with pytest.raises(ValueError, match='Invalid opcode: xxx'):
             op = OpCode('xxx')
 
-    def test_set_args(self):
-        op = OpCode('br_if_not', ...)
-        op.set_args(42)
-        assert op.args == (42,)
-        with pytest.raises(ValueError, match='Cannot set args on a fully constructed op'):
-            op.set_args(43)
-
     def test_match(self):
         op = OpCode('load_local', 'a')
         assert op.match('load_local', 'a')

--- a/spy/tests/vm/test_frame.py
+++ b/spy/tests/vm/test_frame.py
@@ -135,18 +135,22 @@ class TestFrame:
         result = vm.unwrap(w_result)
         assert result == 42
 
-    def test_br_if_not(self):
+    def test_br_if(self):
         vm = SPyVM()
         w_functype = W_FunctionType.make(a=B.w_bool, w_restype=B.w_i32)
         code = W_CodeObject(FQN('test::fn'), w_functype=w_functype)
         code.declare_local('a', B.w_bool)
         code.body = [
-            OpCode('load_local', 'a'),           # 0
-            OpCode('br_if_not', 4),              # 1
-            OpCode('load_const', vm.wrap(100)),  # 2
-            OpCode('return'),                    # 3
-            OpCode('load_const', vm.wrap(200)),  # 4
-            OpCode('return'),                    # 5
+            OpCode('load_local', 'a'),
+            OpCode('br_if', 'then_0', 'else_0', 'endif_0'),
+            OpCode('label', 'then_0'),
+            OpCode('load_const', vm.wrap(100)),
+            OpCode('return'),
+            OpCode('label', 'else_0'),
+            OpCode('load_const', vm.wrap(200)),
+            OpCode('return'),
+            OpCode('label', 'endif_0'),
+            OpCode('abort', 'unreachable'),
         ]
         frame1 = Frame(vm, code)
         w_result = frame1.run([B.w_True])

--- a/spy/tests/vm/test_frame.py
+++ b/spy/tests/vm/test_frame.py
@@ -6,7 +6,7 @@ from spy.vm.vm import SPyVM, Builtins as B
 from spy.vm.object import W_Object
 from spy.vm.frame import Frame
 from spy.vm.codeobject import OpCode, W_CodeObject
-from spy.vm.function import W_FunctionType
+from spy.vm.function import W_FuncType
 from spy.vm.module import W_Module
 
 class TestFrame:
@@ -14,7 +14,7 @@ class TestFrame:
     def test_simple_eval(self):
         vm = SPyVM()
         w_42 = vm.wrap(42)
-        w_functype = W_FunctionType.make(w_restype=B.w_i32)
+        w_functype = W_FuncType.make(w_restype=B.w_i32)
         code = W_CodeObject(FQN('test::fn'), w_functype=w_functype)
         code.body = [
             OpCode('load_const', w_42),
@@ -28,7 +28,7 @@ class TestFrame:
         vm = SPyVM()
         w_100 = vm.wrap(100)
         w_1 = vm.wrap(1)
-        w_functype = W_FunctionType.make(w_restype=B.w_i32)
+        w_functype = W_FuncType.make(w_restype=B.w_i32)
         code = W_CodeObject(FQN('test::fn'), w_functype=w_functype)
         code.body = [
             OpCode('load_const', w_100),
@@ -45,7 +45,7 @@ class TestFrame:
         vm = SPyVM()
         w_50 = vm.wrap(50)
         w_8 = vm.wrap(8)
-        w_functype = W_FunctionType.make(w_restype=B.w_i32)
+        w_functype = W_FuncType.make(w_restype=B.w_i32)
         code = W_CodeObject(FQN('test::fn'), w_functype=w_functype)
         code.body = [
             OpCode('load_const', w_50),
@@ -60,7 +60,7 @@ class TestFrame:
 
     def test_uninitialized_locals(self):
         vm = SPyVM()
-        w_functype = W_FunctionType.make(w_restype=B.w_i32)
+        w_functype = W_FuncType.make(w_restype=B.w_i32)
         code = W_CodeObject(FQN('test::fn'), w_functype=w_functype)
         code.declare_local('a', B.w_i32)
         code.body = [
@@ -75,7 +75,7 @@ class TestFrame:
     def test_locals(self):
         vm = SPyVM()
         w_100 = vm.wrap(100)
-        w_functype = W_FunctionType.make(w_restype=B.w_i32)
+        w_functype = W_FuncType.make(w_restype=B.w_i32)
         code = W_CodeObject(FQN('test::fn'), w_functype=w_functype)
         code.declare_local('a', B.w_i32)
         code.body = [
@@ -92,7 +92,7 @@ class TestFrame:
         vm = SPyVM()
         w_mod = W_Module(vm, 'mymod')
         vm.register_module(w_mod)
-        w_functype = W_FunctionType.make(w_restype=B.w_i32)
+        w_functype = W_FuncType.make(w_restype=B.w_i32)
         code = W_CodeObject(FQN('test::fn'), w_functype=w_functype)
 
         mymod_a = FQN('mymod::a')
@@ -117,7 +117,7 @@ class TestFrame:
 
     def test_params(self):
         vm = SPyVM()
-        w_functype = W_FunctionType.make(a=B.w_i32, b=B.w_i32, w_restype=B.w_i32)
+        w_functype = W_FuncType.make(a=B.w_i32, b=B.w_i32, w_restype=B.w_i32)
         code = W_CodeObject(FQN('test::fn'), w_functype=w_functype)
         code.declare_local('a', B.w_i32)
         code.declare_local('b', B.w_i32)
@@ -137,7 +137,7 @@ class TestFrame:
 
     def test_br_if(self):
         vm = SPyVM()
-        w_functype = W_FunctionType.make(a=B.w_bool, w_restype=B.w_i32)
+        w_functype = W_FuncType.make(a=B.w_bool, w_restype=B.w_i32)
         code = W_CodeObject(FQN('test::fn'), w_functype=w_functype)
         code.declare_local('a', B.w_bool)
         code.body = [

--- a/spy/tests/vm/test_function.py
+++ b/spy/tests/vm/test_function.py
@@ -10,15 +10,25 @@ from spy.vm.module import W_Module
 class TestFunction:
 
     def test_FunctionType_repr(self):
-        vm = SPyVM()
         w_functype = W_FunctionType.make(x=B.w_i32, y=B.w_i32, w_restype=B.w_i32)
         assert w_functype.name == 'def(x: i32, y: i32) -> i32'
         assert repr(w_functype) == "<spy type 'def(x: i32, y: i32) -> i32'>"
 
+    def test_FunctionType_parse(self):
+        w_ft = W_FunctionType.parse('def() -> i32')
+        assert w_ft == W_FunctionType.make(w_restype=B.w_i32)
+        #
+        w_ft = W_FunctionType.parse('def(x: str) -> i32')
+        assert w_ft == W_FunctionType.make(x=B.w_str, w_restype=B.w_i32)
+        #
+        w_ft = W_FunctionType.parse('def(x: str, y: i32,) -> i32')
+        assert w_ft == W_FunctionType.make(x=B.w_str,
+                                           y=B.w_i32,
+                                           w_restype=B.w_i32)
+
     def test_simple_function(self):
         vm = SPyVM()
-        w_functype = W_FunctionType([], B.w_i32)
-        #
+        w_functype = W_FunctionType.parse('def() -> i32')
         w_code = W_CodeObject(FQN('test::fn'), w_functype=w_functype)
         w_code.body = [
             OpCode('load_const', vm.wrap(42)),
@@ -39,7 +49,7 @@ class TestFunction:
                       B.w_i32,
                       vm.wrap(10))
         #
-        w_functype = W_FunctionType([], B.w_i32)
+        w_functype = W_FunctionType.parse('def() -> i32')
         w_code = W_CodeObject(FQN('test::fn'), w_functype=w_functype)
         w_code.body = [
             OpCode('load_global', FQN('mymod::a')),
@@ -53,10 +63,7 @@ class TestFunction:
     def test_call_function_with_arguments(self):
         vm = SPyVM()
         w_mod = W_Module(vm, 'mymod')
-        w_functype = W_FunctionType.make(
-            a=B.w_i32,
-            b=B.w_i32,
-            w_restype=B.w_i32)
+        w_functype = W_FunctionType.parse('def(a: i32, b: i32) -> i32')
         w_code = W_CodeObject(FQN('test::fn'), w_functype=w_functype)
         w_code.declare_local('a', B.w_i32)
         w_code.declare_local('b', B.w_i32)

--- a/spy/tests/vm/test_function.py
+++ b/spy/tests/vm/test_function.py
@@ -2,7 +2,7 @@ import pytest
 from spy.fqn import FQN
 from spy.vm.vm import SPyVM, Builtins as B
 from spy.vm.codeobject import W_CodeObject, OpCode
-from spy.vm.function import W_FuncType, W_UserFunction, FuncParam
+from spy.vm.function import W_FuncType, W_UserFunc, FuncParam
 from spy.vm.varstorage import VarStorage
 from spy.vm.module import W_Module
 
@@ -35,7 +35,7 @@ class TestFunction:
             OpCode('return'),
         ]
         #
-        w_func = W_UserFunction(w_code)
+        w_func = W_UserFunc(w_code)
         assert repr(w_func) == "<spy function 'test::fn'>"
         #
         w_t = vm.dynamic_type(w_func)
@@ -56,7 +56,7 @@ class TestFunction:
             OpCode('return'),
         ]
         #
-        w_fn = W_UserFunction(w_code)
+        w_fn = W_UserFunc(w_code)
         w_result = vm.call_function(w_fn, [])
         assert vm.unwrap(w_result) == 10
 
@@ -74,6 +74,6 @@ class TestFunction:
             OpCode('return'),
         ]
         #
-        w_fn = W_UserFunction(w_code)
+        w_fn = W_UserFunc(w_code)
         w_result = vm.call_function(w_fn, [vm.wrap(100), vm.wrap(80)])
         assert vm.unwrap(w_result) == 20

--- a/spy/tests/vm/test_function.py
+++ b/spy/tests/vm/test_function.py
@@ -2,7 +2,7 @@ import pytest
 from spy.fqn import FQN
 from spy.vm.vm import SPyVM, Builtins as B
 from spy.vm.codeobject import W_CodeObject, OpCode
-from spy.vm.function import W_FunctionType, W_UserFunction, FuncParam
+from spy.vm.function import W_FuncType, W_UserFunction, FuncParam
 from spy.vm.varstorage import VarStorage
 from spy.vm.module import W_Module
 
@@ -10,25 +10,25 @@ from spy.vm.module import W_Module
 class TestFunction:
 
     def test_FunctionType_repr(self):
-        w_functype = W_FunctionType.make(x=B.w_i32, y=B.w_i32, w_restype=B.w_i32)
+        w_functype = W_FuncType.make(x=B.w_i32, y=B.w_i32, w_restype=B.w_i32)
         assert w_functype.name == 'def(x: i32, y: i32) -> i32'
         assert repr(w_functype) == "<spy type 'def(x: i32, y: i32) -> i32'>"
 
     def test_FunctionType_parse(self):
-        w_ft = W_FunctionType.parse('def() -> i32')
-        assert w_ft == W_FunctionType.make(w_restype=B.w_i32)
+        w_ft = W_FuncType.parse('def() -> i32')
+        assert w_ft == W_FuncType.make(w_restype=B.w_i32)
         #
-        w_ft = W_FunctionType.parse('def(x: str) -> i32')
-        assert w_ft == W_FunctionType.make(x=B.w_str, w_restype=B.w_i32)
+        w_ft = W_FuncType.parse('def(x: str) -> i32')
+        assert w_ft == W_FuncType.make(x=B.w_str, w_restype=B.w_i32)
         #
-        w_ft = W_FunctionType.parse('def(x: str, y: i32,) -> i32')
-        assert w_ft == W_FunctionType.make(x=B.w_str,
+        w_ft = W_FuncType.parse('def(x: str, y: i32,) -> i32')
+        assert w_ft == W_FuncType.make(x=B.w_str,
                                            y=B.w_i32,
                                            w_restype=B.w_i32)
 
     def test_simple_function(self):
         vm = SPyVM()
-        w_functype = W_FunctionType.parse('def() -> i32')
+        w_functype = W_FuncType.parse('def() -> i32')
         w_code = W_CodeObject(FQN('test::fn'), w_functype=w_functype)
         w_code.body = [
             OpCode('load_const', vm.wrap(42)),
@@ -49,7 +49,7 @@ class TestFunction:
                       B.w_i32,
                       vm.wrap(10))
         #
-        w_functype = W_FunctionType.parse('def() -> i32')
+        w_functype = W_FuncType.parse('def() -> i32')
         w_code = W_CodeObject(FQN('test::fn'), w_functype=w_functype)
         w_code.body = [
             OpCode('load_global', FQN('mymod::a')),
@@ -63,7 +63,7 @@ class TestFunction:
     def test_call_function_with_arguments(self):
         vm = SPyVM()
         w_mod = W_Module(vm, 'mymod')
-        w_functype = W_FunctionType.parse('def(a: i32, b: i32) -> i32')
+        w_functype = W_FuncType.parse('def(a: i32, b: i32) -> i32')
         w_code = W_CodeObject(FQN('test::fn'), w_functype=w_functype)
         w_code.declare_local('a', B.w_i32)
         w_code.declare_local('b', B.w_i32)

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -3,7 +3,7 @@ import pytest
 from spy.vm.vm import SPyVM, Builtins as B, FQN
 from spy.vm.object import W_Object, W_Type, spytype, W_void, W_i32, W_bool
 from spy.vm.str import W_str
-from spy.vm.function import W_BuiltinFunction
+from spy.vm.function import W_BuiltinFunc
 
 class TestVM:
 

--- a/spy/util.py
+++ b/spy/util.py
@@ -1,6 +1,8 @@
 #-*- encoding: utf-8 -*-
 import typing
 from typing import Optional
+import difflib
+from spy.textbuilder import Color
 
 class AnythingClass:
     """
@@ -74,6 +76,21 @@ def print_class_hierarchy(cls):
             print_class(subclasses[-1], prefix, indent=SPACE, marker=CORNER)
 
     print_class(cls, prefix='', indent='', marker='')
+
+
+def print_diff(a: str, b: str, fromfile: str, tofile: str) -> None:
+    a = a.splitlines()
+    b = b.splitlines()
+    diff = difflib.unified_diff(a, b, fromfile, tofile, lineterm="")
+    print()
+    for line in diff:
+        if line.startswith('+'):
+            line = Color.set('yellow', line)
+        elif line.startswith('-'):
+            line = Color.set('red', line)
+        elif line.startswith('@@'):
+            line = Color.set('fuchsia', line)
+        print(line)
 
 
 def shortrepr(s: str, n: int) -> str:

--- a/spy/util.py
+++ b/spy/util.py
@@ -79,9 +79,9 @@ def print_class_hierarchy(cls):
 
 
 def print_diff(a: str, b: str, fromfile: str, tofile: str) -> None:
-    a = a.splitlines()
-    b = b.splitlines()
-    diff = difflib.unified_diff(a, b, fromfile, tofile, lineterm="")
+    la = a.splitlines()
+    lb = b.splitlines()
+    diff = difflib.unified_diff(la, lb, fromfile, tofile, lineterm="")
     print()
     for line in diff:
         if line.startswith('+'):

--- a/spy/vm/codeobject.py
+++ b/spy/vm/codeobject.py
@@ -47,6 +47,7 @@ ALL_OPCODES = [
     'pop_and_discard',
     'br',
     'br_if',
+    'br_while_not',
     'label',
 ]
 
@@ -61,10 +62,6 @@ class OpCode:
 
         Each opcode expects a specific number of args, it's up to the caller
         to ensure it's correct.
-
-        A special case is passing ... (the ellipsis object) as the only arg:
-        in this case, it means that the OpCode is not fully constructed, and
-        can be amended later by calling set_args().
         """
         if name not in ALL_OPCODES:
             raise ValueError(f'Invalid opcode: {name}')
@@ -87,11 +84,6 @@ class OpCode:
         else:
             # match also the args
             return self.name == name and self.args == args
-
-    def set_args(self, *args: int) -> None:
-        if self.args != (...,):
-            raise ValueError('Cannot set args on a fully constructed op')
-        self.args = args
 
     def copy(self) -> 'OpCode':
         return OpCode(self.name, *self.args)

--- a/spy/vm/codeobject.py
+++ b/spy/vm/codeobject.py
@@ -146,19 +146,21 @@ class W_CodeObject(W_Object):
         #
         lines = []
         for i, op in enumerate(self.body):
-            line = [color.set('blue', op.name)]
             args = ', '.join([str(arg) for arg in op.args])
-            if op.name in ('load_local', 'store_local', 'load_global', 'store_global'):
+            if op.name == 'label':
+                label_name, = op.args
+                lines.append(color.set('yellow', f'{label_name}:'))
+                continue
+            #
+            if op.name in ('load_local', 'store_local',
+                           'load_global', 'store_global'):
                 args = color.set('green', args)
-            elif op.is_br():
-                args = color.set('red', args)
+            elif op.is_br() or op.name.startswith('mark_'):
+                args = color.set('yellow', args)
             elif op.name == 'abort':
                 args = repr(args)
             #
-            label = format(i, '>5')
-            if i in all_br_targets:
-                label = color.set('red', label)
-            lines.append((f'    {label} {op.name:<15} {args}'))
+            lines.append((f'    {op.name:<15} {args}'))
         return '\n'.join(lines)
 
 

--- a/spy/vm/codeobject.py
+++ b/spy/vm/codeobject.py
@@ -9,7 +9,7 @@ from spy.textbuilder import ColorFormatter
 from spy.util import print_diff
 
 if typing.TYPE_CHECKING:
-    from spy.vm.function import W_FunctionType
+    from spy.vm.function import W_FuncType
 
 
 RE_WHITESPACE = re.compile(r" +")
@@ -92,13 +92,13 @@ class OpCode:
 @spytype('CodeObject')
 class W_CodeObject(W_Object):
     fqn: FQN
-    w_functype: 'W_FunctionType'
+    w_functype: 'W_FuncType'
     filename: str
     lineno: int
     body: list[OpCode]
     locals_w_types: dict[str, W_Type]
 
-    def __init__(self, fqn: FQN, *, w_functype: 'W_FunctionType',
+    def __init__(self, fqn: FQN, *, w_functype: 'W_FuncType',
                  filename: str = '', lineno: int = -1) -> None:
         # XXX this might be wrong? The fqn should be attached to the function,
         # not to the code object. With closures/generic, we could have the

--- a/spy/vm/codeobject.py
+++ b/spy/vm/codeobject.py
@@ -134,7 +134,7 @@ class W_CodeObject(W_Object):
         body = self.dump(color)
         print(body)
 
-    def dump(self, color: Optional[ColorFormatter] = None) -> None:
+    def dump(self, color: Optional[ColorFormatter] = None) -> str:
         if color is None:
             color = ColorFormatter(use_colors=False)
 

--- a/spy/vm/codeobject.py
+++ b/spy/vm/codeobject.py
@@ -46,7 +46,8 @@ ALL_OPCODES = [
     'i32_gte',
     'pop_and_discard',
     'br',
-    'br_if_not',
+    'br_if',
+    'label',
 ]
 
 @dataclass

--- a/spy/vm/frame.py
+++ b/spy/vm/frame.py
@@ -55,8 +55,8 @@ class Frame:
                 assert l not in self.labels, f'duplicate label: {l}'
                 self.labels[l] = pc
 
-    def jump(self, label: str):
-        self.pc = self.labels[label]
+    def jump(self, LABEL: str):
+        self.pc = self.labels[LABEL]
 
     def push(self, w_value: W_Object) -> None:
         assert isinstance(w_value, W_Object)
@@ -107,9 +107,11 @@ class Frame:
         assert self.w_code.body[pc_if + 1].match('br_if', ...)
     op_mark_if_then_else = op_mark_if_then
 
-    def op_mark_while(self, IF: int, LOOP: int) -> None:
-        assert self.w_code.body[IF].match('br_if_not', ...)
-        assert self.w_code.body[LOOP].match('br', ...)
+    def op_mark_while(self, WHILE: str, IF: str, END: str) -> None:
+        pc_if = self.labels[IF]
+        pc_end = self.labels[END]
+        assert self.w_code.body[pc_if + 1].match('br_while_not', ...)
+        assert self.w_code.body[pc_end - 1].match('br', WHILE)
 
     def op_pop_and_discard(self) -> None:
         self.pop()
@@ -195,13 +197,19 @@ class Frame:
         w_res = helper_func(self.vm, *args_w)
         self.push(w_res)
 
-    def op_br(self, target: str) -> None:
-        self.jump(target)
+    def op_br(self, TARGET: str) -> None:
+        self.jump(TARGET)
 
-    def op_br_if(self, then: str, else_: str, endif: str) -> None:
+    def op_br_if(self, THEN: str, ELSE: str, ENDIF: str) -> None:
         w_cond = self.pop()
         assert isinstance(w_cond, W_bool)
         if self.vm.is_True(w_cond):
-            self.jump(then)
+            self.jump(THEN)
         else:
-            self.jump(else_)
+            self.jump(ELSE)
+
+    def op_br_while_not(self, END: str) -> None:
+        w_cond = self.pop()
+        assert isinstance(w_cond, W_bool)
+        if self.vm.is_False(w_cond):
+            self.jump(END)

--- a/spy/vm/frame.py
+++ b/spy/vm/frame.py
@@ -23,7 +23,7 @@ from spy.vm.object import W_Object, W_Type, W_i32, W_bool
 from spy.vm.str import W_str
 from spy.vm.codeobject import W_CodeObject
 from spy.vm.varstorage import VarStorage
-from spy.vm.function import W_Function
+from spy.vm.function import W_Func
 from spy.vm import helpers
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -183,10 +183,10 @@ class Frame:
 
     def op_call_global(self, fqn: FQN, argcount: int) -> None:
         w_func = self.vm.lookup_global(fqn)
-        assert isinstance(w_func, W_Function)
+        assert isinstance(w_func, W_Func)
         return self._op_call(w_func, argcount)
 
-    def _op_call(self, w_func: W_Function, argcount: int) -> None:
+    def _op_call(self, w_func: W_Func, argcount: int) -> None:
         args_w = self._pop_args(argcount)
         w_res = self.vm.call_function(w_func, args_w)
         self.push(w_res)

--- a/spy/vm/frame.py
+++ b/spy/vm/frame.py
@@ -55,7 +55,7 @@ class Frame:
                 assert l not in self.labels, f'duplicate label: {l}'
                 self.labels[l] = pc
 
-    def jump(self, LABEL: str):
+    def jump(self, LABEL: str) -> None:
         self.pc = self.labels[LABEL]
 
     def push(self, w_value: W_Object) -> None:

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -15,7 +15,7 @@ class FuncParam:
 
 
 @dataclass(repr=False)
-class W_FunctionType(W_Type):
+class W_FuncType(W_Type):
     params: list[FuncParam]
     w_restype: W_Type
 
@@ -29,16 +29,16 @@ class W_FunctionType(W_Type):
         super().__init__(f'def{sig}', W_Function)
 
     @classmethod
-    def make(cls, *, w_restype: W_Type, **kwargs: W_Type) -> 'W_FunctionType':
+    def make(cls, *, w_restype: W_Type, **kwargs: W_Type) -> 'W_FuncType':
         """
-        Small helper to make it easier to build W_FunctionType, especially in
+        Small helper to make it easier to build W_FuncType, especially in
         tests
         """
         params = [FuncParam(key, w_type) for key, w_type in kwargs.items()]
         return cls(params, w_restype)
 
     @classmethod
-    def parse(cls, s: str) -> 'W_FunctionType':
+    def parse(cls, s: str) -> 'W_FuncType':
         """
         Quick & dirty function to parse function types.
 
@@ -75,7 +75,7 @@ class W_FunctionType(W_Type):
 class W_Function(W_Object):
 
     @property
-    def w_functype(self) -> W_FunctionType:
+    def w_functype(self) -> W_FuncType:
         raise NotImplementedError
 
     def spy_get_w_type(self, vm: 'SPyVM') -> W_Type:
@@ -95,15 +95,15 @@ class W_UserFunction(W_Function):
         return f"<spy function '{self.w_code.fqn}'>"
 
     @property
-    def w_functype(self) -> W_FunctionType:
+    def w_functype(self) -> W_FuncType:
         return self.w_code.w_functype
 
 
 class W_BuiltinFunction(W_Function):
     fqn: FQN
-    _w_functype: W_FunctionType
+    _w_functype: W_FuncType
 
-    def __init__(self, fqn: FQN, w_functype: W_FunctionType) -> None:
+    def __init__(self, fqn: FQN, w_functype: W_FuncType) -> None:
         self.fqn = fqn
         self._w_functype = w_functype
 
@@ -111,7 +111,7 @@ class W_BuiltinFunction(W_Function):
         return f"<spy function '{self.fqn}' (builtin)>"
 
     @property
-    def w_functype(self) -> W_FunctionType:
+    def w_functype(self) -> W_FuncType:
         return self._w_functype
 
     def spy_call(self, vm: 'SPyVM', args_w: list[W_Object]) -> W_Object:

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -26,7 +26,7 @@ class W_FuncType(W_Type):
         self.params = params
         self.w_restype = w_restype
         sig = self._str_sig()
-        super().__init__(f'def{sig}', W_Function)
+        super().__init__(f'def{sig}', W_Func)
 
     @classmethod
     def make(cls, *, w_restype: W_Type, **kwargs: W_Type) -> 'W_FuncType':
@@ -72,7 +72,7 @@ class W_FuncType(W_Type):
 
 
 
-class W_Function(W_Object):
+class W_Func(W_Object):
 
     @property
     def w_functype(self) -> W_FuncType:
@@ -85,7 +85,7 @@ class W_Function(W_Object):
         raise NotImplementedError
 
 
-class W_UserFunction(W_Function):
+class W_UserFunc(W_Func):
     w_code: W_CodeObject
 
     def __init__(self, w_code: W_CodeObject) -> None:
@@ -99,7 +99,7 @@ class W_UserFunction(W_Function):
         return self.w_code.w_functype
 
 
-class W_BuiltinFunction(W_Function):
+class W_BuiltinFunc(W_Func):
     fqn: FQN
     _w_functype: W_FuncType
 

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -4,7 +4,7 @@ from spy.vm.object import W_Object, spytype, W_Type
 from spy.vm.varstorage import VarStorage
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
-    from spy.vm.function import W_UserFunction
+    from spy.vm.function import W_UserFunc
 
 
 @spytype('module')
@@ -29,10 +29,10 @@ class W_Module(W_Object):
         assert w_obj is not None
         return w_obj
 
-    def getattr_userfunc(self, attr: str) -> 'W_UserFunction':
-        from spy.vm.function import W_UserFunction
+    def getattr_userfunc(self, attr: str) -> 'W_UserFunc':
+        from spy.vm.function import W_UserFunc
         w_obj = self.getattr(attr)
-        assert isinstance(w_obj, W_UserFunction)
+        assert isinstance(w_obj, W_UserFunc)
         return w_obj
 
     def keys(self) -> Iterable[FQN]:
@@ -49,12 +49,12 @@ class W_Module(W_Object):
         """
         Pretty print
         """
-        from spy.vm.function import W_UserFunction
+        from spy.vm.function import W_UserFunc
         print(f'Module {self.name}:')
         for attr, w_obj in self.items_w():
             print(f'    {attr}: {w_obj}')
 
         print()
         for attr, w_obj in self.items_w():
-            if isinstance(w_obj, W_UserFunction):
+            if isinstance(w_obj, W_UserFunc):
                 w_obj.w_code.pp()

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -5,7 +5,7 @@ from spy.fqn import FQN
 from spy import libspy
 from spy.vm.object import W_Object, W_Type, W_void, W_i32, W_bool
 from spy.vm.str import W_str
-from spy.vm.function import (W_FunctionType, W_Function, W_UserFunction,
+from spy.vm.function import (W_FuncType, W_Function, W_UserFunction,
                              W_BuiltinFunction)
 from spy.vm.module import W_Module
 from spy.vm.codeobject import W_CodeObject
@@ -25,7 +25,7 @@ class Builtins:
 
     w_abs = W_BuiltinFunction(
         fqn = FQN('builtins::abs'),
-        w_functype = W_FunctionType.make(x=w_i32, w_restype=w_i32),
+        w_functype = W_FuncType.make(x=w_i32, w_restype=w_i32),
     )
 
     @classmethod

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -5,8 +5,8 @@ from spy.fqn import FQN
 from spy import libspy
 from spy.vm.object import W_Object, W_Type, W_void, W_i32, W_bool
 from spy.vm.str import W_str
-from spy.vm.function import (W_FuncType, W_Function, W_UserFunction,
-                             W_BuiltinFunction)
+from spy.vm.function import (W_FuncType, W_Func, W_UserFunc,
+                             W_BuiltinFunc)
 from spy.vm.module import W_Module
 from spy.vm.codeobject import W_CodeObject
 from spy.vm.frame import Frame
@@ -23,7 +23,7 @@ class Builtins:
     w_True = W_bool._w_singleton_True
     w_False = W_bool._w_singleton_False
 
-    w_abs = W_BuiltinFunction(
+    w_abs = W_BuiltinFunc(
         fqn = FQN('builtins::abs'),
         w_functype = W_FuncType.make(x=w_i32, w_restype=w_i32),
     )
@@ -161,16 +161,16 @@ class SPyVM:
         # be "compatible", but we don't have this notion yet
         return self.dynamic_type(w_arg) is w_type
 
-    def call_function(self, w_func: W_Function, args_w: list[W_Object]) -> W_Object:
+    def call_function(self, w_func: W_Func, args_w: list[W_Object]) -> W_Object:
         w_functype = w_func.w_functype
         assert len(w_functype.params) == len(args_w)
         for param, w_arg in zip(w_functype.params, args_w):
             assert self.is_compatible_type(w_arg, param.w_type)
         #
-        if isinstance(w_func, W_UserFunction):
+        if isinstance(w_func, W_UserFunc):
             frame = Frame(self, w_func.w_code)
             return frame.run(args_w)
-        elif isinstance(w_func, W_BuiltinFunction):
+        elif isinstance(w_func, W_BuiltinFunc):
             return w_func.spy_call(self, args_w)
         else:
             assert False


### PR DESCRIPTION
This PR changes the IR to use an explicit `label` opcode and use symbolic names for jumps.
It will make the job of the doppler interpreter much easier.