### PR TITLE
More precise expect_errors

### DIFF
--- a/spy/__main__.py
+++ b/spy/__main__.py
@@ -2,7 +2,7 @@ from typing import Annotated, Any, no_type_check
 from pathlib import Path
 import typer
 import py.path
-from spy.errors import SPyCompileError
+from spy.errors import SPyError
 from spy.parser import Parser
 from spy.compiler import Compiler
 from spy.vm.vm import SPyVM
@@ -30,7 +30,7 @@ def main(filename: Path,
          ) -> None:
     try:
         do_main(filename, pyparse, parse, dis, cwrite, g)
-    except SPyCompileError as e:
+    except SPyError as e:
         print(e.format(use_colors=True))
 
 def do_main(filename: Path, pyparse: bool, parse: bool, dis: bool,

--- a/spy/errors.py
+++ b/spy/errors.py
@@ -21,6 +21,19 @@ class Annotation:
     message: str
     loc: Loc
 
+    def get_src(self) -> str:
+        """
+        Return the piece of source code pointed by the annotation.
+        """
+        loc = self.loc
+        filename = loc.filename
+        assert loc.line_start == loc.line_end, 'multi-line not supported'
+        line = loc.line_start
+        a = loc.col_start
+        b = loc.col_end
+        srcline = linecache.getline(filename, line)
+        return srcline[a:b]
+
 
 class ErrorFormatter:
     err: 'SPyError'

--- a/spy/errors.py
+++ b/spy/errors.py
@@ -23,10 +23,10 @@ class Annotation:
 
 
 class ErrorFormatter:
-    err: 'SPyCompileError'
+    err: 'SPyError'
     lines: list[str]
 
-    def __init__(self, err: 'SPyCompileError', use_colors: bool) -> None:
+    def __init__(self, err: 'SPyError', use_colors: bool) -> None:
         self.err = err
         self.color = ColorFormatter(use_colors)
         # add "custom colors" to ColorFormatter, so that we can do
@@ -66,7 +66,7 @@ class ErrorFormatter:
         return line + ' ' + message
 
 
-class SPyCompileError(Exception):
+class SPyError(Exception):
     message: str
     annotations: list[Annotation]
 
@@ -76,7 +76,7 @@ class SPyCompileError(Exception):
         super().__init__(message)
 
     @classmethod
-    def simple(cls, primary: str, secondary: str, loc: Loc) -> 'SPyCompileError':
+    def simple(cls, primary: str, secondary: str, loc: Loc) -> 'SPyError':
         err = cls(primary)
         err.add('error', secondary, loc)
         return err
@@ -95,19 +95,19 @@ class SPyCompileError(Exception):
         return fmt.build()
 
 
-class SPyParseError(SPyCompileError):
+class SPyParseError(SPyError):
     pass
 
 
-class SPyTypeError(SPyCompileError):
+class SPyTypeError(SPyError):
     pass
 
 
-class SPyImportError(SPyCompileError):
+class SPyImportError(SPyError):
     pass
 
 
-class SPyScopeError(SPyCompileError):
+class SPyScopeError(SPyError):
     """
     Raised if a variable declaration redeclares or shadows a name, see
     symtable.py

--- a/spy/irgen/legacy_codegen.py
+++ b/spy/irgen/legacy_codegen.py
@@ -4,7 +4,7 @@ from spy.location import Loc
 from spy.irgen.typechecker import TypeChecker
 from spy.irgen.symtable import SymTable
 from spy.irgen import multiop
-from spy.errors import SPyCompileError
+from spy.errors import SPyError
 from spy.vm.vm import SPyVM, Builtins as B
 from spy.vm.object import W_Object
 from spy.vm.codeobject import W_CodeObject, OpCode
@@ -360,7 +360,7 @@ class LegacyCodeGen:
             # XXX there is no test for this at the moment because we don't
             # have higher order functions, so it's impossible to reach this
             # branch
-            err = SPyCompileError('indirect calls not supported')
+            err = SPyError('indirect calls not supported')
             raise err
         for expr in call.args:
             self.eval_expr(expr)

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -5,7 +5,7 @@ import ast as py_ast
 import spy.ast
 from spy.fqn import FQN
 from spy.location import Loc
-from spy.errors import SPyCompileError, SPyParseError
+from spy.errors import SPyError, SPyParseError
 from spy.util import magic_dispatch
 
 class Parser:

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -52,7 +52,7 @@ class Parser:
         if reason is None:
             reason = node.__class__.__name__
         self.error(f'not implemented yet: {reason}',
-                   'this is not yet supported by SPy', node.loc)
+                   'this is not supported', node.loc)
 
     def from_py_Module(self, py_mod: py_ast.Module) -> spy.ast.Module:
         mod = spy.ast.Module(filename=self.filename, decls=[])

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -27,36 +27,38 @@ class TestBasic(CompilerTest):
             ])
 
     def test_wrong_functype_restype(self):
-        self.expect_errors(
-            """
+        ctx = expect_errors(
+            'expected `type`, got `str`',
+            ('expected `type`', "'hello'")
+        )
+        with ctx:
+            self.compile("""
             def foo() -> 'hello':
                 return 42
-            """,
-            errors = [
-                'expected `type`, got `str`',
-                'expected `type`',
-            ])
+            """)
 
     def test_wrong_functype_argtype(self):
-        self.expect_errors(
-            """
-            def foo(x: "hello") -> i32:
+        ctx = expect_errors(
+            'expected `type`, got `str`',
+            ('expected `type`', "'hello'"),
+        )
+        with ctx:
+            self.compile("""
+            def foo(x: 'hello') -> i32:
                 return 42
-            """,
-            errors = [
-                'expected `type`, got `str`',
-                'expected `type`',
-            ])
+            """)
 
     def test_wrong_return_type(self):
-        mod = self.compile("""
-        def foo() -> str:
-            return 42
-        """)
-        with expect_errors([
-                'mismatched types',
-                'expected `str`, got `i32`',
-                'expected `str` because of return type']) as exc:
+        ctx = expect_errors(
+            'mismatched types',
+            ('expected `str`, got `i32`', "return 42"),
+            ('expected `str` because of return type', "str"),
+        )
+        with ctx:
+            mod = self.compile("""
+            def foo() -> str:
+                return 42
+            """)
             mod.foo()
 
     def test_local_variables(self, legacy):

--- a/spy/tests/support.py
+++ b/spy/tests/support.py
@@ -8,7 +8,7 @@ from spy.compiler import Compiler
 from spy.backend.interp import InterpModuleWrapper
 from spy.backend.c.wrapper import WasmModuleWrapper
 from spy.cbuild import ZigToolchain
-from spy.errors import SPyCompileError
+from spy.errors import SPyError
 from spy.fqn import FQN
 from spy.vm.vm import SPyVM
 from spy.vm.module import W_Module
@@ -154,11 +154,11 @@ def expect_errors(errors: list[str]) -> Any:
     """
     Similar to pytest.raises but:
 
-      - expect a SPyCompileError
+      - expect a SPyError
       - check that the given messages are present in the error, either as
         the main message or in the annotations.
     """
-    with pytest.raises(SPyCompileError) as exc:
+    with pytest.raises(SPyError) as exc:
         yield exc
 
     err = exc.value

--- a/spy/tests/support.py
+++ b/spy/tests/support.py
@@ -15,7 +15,6 @@ from spy.vm.module import W_Module
 from spy.vm.codeobject import OpCode, W_CodeObject
 from spy.vm.function import W_UserFunc, W_FuncType
 
-
 Backend = Literal['interp', 'C']
 ALL_BACKENDS = Backend.__args__  # type: ignore
 
@@ -84,6 +83,7 @@ class CompilerTest:
 
     @pytest.fixture
     def legacy(self):
+        pytest.skip("legacy")
         self._legacy = True
 
     @pytest.fixture(params=params_with_marks(ALL_BACKENDS))  # type: ignore
@@ -136,17 +136,6 @@ class CompilerTest:
             return WasmModuleWrapper(self.vm, modname, file_wasm)
         else:
             assert False, f'Unknown backend: {self.backend}'
-
-    def expect_errors(self, src: str, *, errors: list[str]):
-        """
-        Expect that compilation fails, and check that the expected errors are
-        reported
-        """
-        modname = 'test'
-        srcfile = self.write_file(f'{modname}.spy', src)
-        with expect_errors(errors):
-            self.vm.import_(modname, legacy=self._legacy)
-
 
 MatchAnnotation = tuple[str, str]
 

--- a/spy/tests/support.py
+++ b/spy/tests/support.py
@@ -148,15 +148,20 @@ class CompilerTest:
             self.vm.import_(modname, legacy=self._legacy)
 
 
+MatchAnnotation = tuple[str, str]
 
 @contextmanager
-def expect_errors(errors: list[str]) -> Any:
+def expect_errors(main: str, *anns_to_match: MatchAnnotation) -> Any:
     """
     Similar to pytest.raises but:
 
       - expect a SPyError
-      - check that the given messages are present in the error, either as
-        the main message or in the annotations.
+
+      - check that the main error message matches
+
+      - check that the given additional annotations match. For each
+        annotation, you need to provide the message and the extract of source
+        code which the annotation points to
     """
     with pytest.raises(SPyError) as exc:
         yield exc
@@ -164,16 +169,31 @@ def expect_errors(errors: list[str]) -> Any:
     err = exc.value
     formatted_error = err.format(use_colors=True)
     formatted_error = textwrap.indent(formatted_error, '    ')
-    all_messages = [err.message] + [ann.message for ann in err.annotations]
-    for expected in errors:
-        if expected not in all_messages:
-            print('Error match failed!')
-            print('The following error message was expected but not found:')
-            print(f'  - {expected}')
-            print()
-            print('Captured error')
-            print(formatted_error)
-            pytest.fail(f'Error message not found: {expected}')
+
+    def fail(msg: str, src: str):
+        print('Error match failed!')
+        print('The following message was expected but not found:')
+        print(f'  - {msg}')
+        if src:
+            print(f'  - {src}')
+        print()
+        print('Captured error')
+        print(formatted_error)
+        pytest.fail(f'Error message not found: {msg}')
+
+    def match_one_annotation(expected_msg: str, expected_src: str) -> bool:
+        for ann in err.annotations:
+            got_src = ann.get_src()
+            if ann.message == expected_msg and expected_src == got_src:
+                return True
+        return False
+
+    if err.message != main:
+        fail(main, '')
+
+    for msg, src in anns_to_match:
+        if not match_one_annotation(msg, src):
+            fail(msg, src)
 
     print()
     print("The following error was expected (everything is good):")

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -240,15 +240,15 @@ class TestParser:
     def test_unsupported_literal(self):
         # Eventually this test should be killed, when we support all the
         # literals
+        src = """
+        def foo() -> i32:
+            return 42j
+        """
         self.expect_errors(
-            """
-            def foo() -> i32:
-                return 42j
-            """,
-            errors = [
-                'unsupported literal: 42j',
-                'this is not supported yet',
-            ])
+            src,
+            'unsupported literal: 42j',
+            ('this is not supported yet', "42j"),
+        )
 
     def test_GetItem(self):
         mod = self.parse("""
@@ -429,12 +429,14 @@ class TestParser:
         self.assert_dump(stmt, expected)
 
     def test_CompareOp_chained(self):
+        src = """
+        def foo() -> i32:
+            return 1 == 2 == 3
+        """
         self.expect_errors(
-            """
-            def foo() -> i32:
-                return 1 == 2 == 3
-            """,
-            errors = ["not implemented yet: chained comparisons"],
+            src,
+            "not implemented yet: chained comparisons",
+            ("this is not supported", "3"),
         )
 
     def test_Assign(self):
@@ -451,20 +453,26 @@ class TestParser:
         """
         self.assert_dump(stmt, expected)
 
-    def test_Assign_unsupported(self):
+    def test_Assign_unsupported_1(self):
+        src = """
+        def foo() -> void:
+            a = b = 1
+        """
         self.expect_errors(
-            """
-            def foo() -> void:
-                a = b = 1
-            """,
-            errors = ["not implemented yet: assign to multiple targets"]
+            src,
+            "not implemented yet: assign to multiple targets",
+            ("this is not supported", "a = b = 1"),
         )
+
+    def test_Assign_unsupported_2(self):
+        src = """
+        def foo() -> void:
+            a, b = 1, 2
+        """
         self.expect_errors(
-            """
-            def foo() -> void:
-                a, b = 1, 2
-            """,
-            errors = ["not implemented yet: assign to complex expressions"]
+            src,
+            "not implemented yet: assign to complex expressions",
+            ("this is not supported", "a, b"),
         )
 
     def test_Call(self):
@@ -488,12 +496,14 @@ class TestParser:
         self.assert_dump(stmt, expected)
 
     def test_Call_errors(self):
+        src = """
+        def foo() -> i32:
+            return Bar(1, 2, x=3)
+        """
         self.expect_errors(
-            """
-            def foo() -> i32:
-                return Bar(1, 2, x=3)
-            """,
-            errors = ["not implemented yet: keyword arguments"],
+            src,
+            "not implemented yet: keyword arguments",
+            ("this is not supported", "x=3"),
         )
 
     def test_If(self):


### PR DESCRIPTION
This augments expect_errors with the ability of checking also the precise piece of source code which is pointed by each annotation.