### PR TITLE
Keep track of static types in AST frames

### DIFF
--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -78,14 +78,14 @@ class ModuleGen:
     def gen_FuncDef(self, frame: ASTFrame, funcdef: ast.FuncDef) -> None:
         fqn = FQN(modname=self.modname, attr=funcdef.name)
         frame.exec_stmt_FuncDef(funcdef)
-        w_func = frame.load_local(funcdef.name)
-        self.vm.add_global(fqn, None, w_func)
+        fv = frame.load_local(funcdef.name)
+        self.vm.add_global(fqn, None, fv.w_val)
 
     def gen_GlobalVarDef(self, frame: ASTFrame, vardef: ast.VarDef) -> None:
         assert vardef.value is not None, 'WIP?'
         fqn = FQN(modname=self.modname, attr=vardef.name)
         w_type = frame.eval_expr_type(vardef.type)
-        w_value = frame.eval_expr(vardef.value)
+        w_value = frame.eval_expr_object(vardef.value)
         self.vm.add_global(fqn, w_type, w_value)
 
     # ===== legacy stuff, to kill eventually =====

--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -78,7 +78,7 @@ class ModuleGen:
     def gen_FuncDef(self, frame: ASTFrame, funcdef: ast.FuncDef) -> None:
         fqn = FQN(modname=self.modname, attr=funcdef.name)
         frame.exec_stmt_FuncDef(funcdef)
-        w_func = frame.locals.get(funcdef.name)
+        w_func = frame.load_local(funcdef.name)
         self.vm.add_global(fqn, None, w_func)
 
     def gen_GlobalVarDef(self, frame: ASTFrame, vardef: ast.VarDef) -> None:

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -96,6 +96,16 @@ class TestBasic(CompilerTest):
             """)
             mod.foo()
 
+    def test_local_upcast_and_downcast(self):
+        mod = self.compile("""
+        def foo() -> i32:
+            x: i32 = 1
+            # this works, but will insert a downcast in the compiled code
+            y: object = x
+            return y
+        """)
+        assert mod.foo() == 1
+
     def test_function_arguments(self):
         mod = self.compile(
         """
@@ -204,6 +214,23 @@ class TestBasic(CompilerTest):
                     return a + b
                 """)
             mod.bar(1, "hello")
+
+    def test_BinOp_is_dispatched_with_static_types(self):
+        # this fails because the static type of 'x' is object, even if its
+        # dynamic type is i32
+        ctx = expect_errors(
+            'cannot do `object` + `i32`',
+            ('this is `object`', 'a'),
+            ('this is `i32`', 'b'),
+        )
+        with ctx:
+            mod = self.compile("""
+            def foo() -> i32:
+                a: object = 1
+                b: i32 = 2
+                return a + b
+            """)
+            mod.foo()
 
     def test_function_call(self, legacy):
         mod = self.compile("""

--- a/spy/vm/varstorage.py
+++ b/spy/vm/varstorage.py
@@ -1,3 +1,5 @@
+# XXX kill me with the rest of legacy stuff
+
 from typing import Optional, TYPE_CHECKING
 from spy.location import Loc
 from spy.errors import SPyRuntimeError, SPyTypeError


### PR DESCRIPTION
The ASTFrame is a dynamic interpreter, but the semantics of SPy requires that some operations are dispatched using their static types.

This PR introduces FrameVal, which is a small wrapper arund W_Object to keep track of the static types.