### PR TITLE
Re-introduce the typechecker

### DIFF
--- a/spy/irgen/irgen.py
+++ b/spy/irgen/irgen.py
@@ -2,14 +2,13 @@ from typing import Any
 import py.path
 import spy.ast
 from spy.parser import Parser
-from spy.irgen.typechecker import TypeChecker
 from spy.irgen.scope import ScopeAnalyzer
 from spy.irgen.modgen import ModuleGen
 from spy.vm.vm import SPyVM
 from spy.vm.module import W_Module
 
 
-def make_w_mod_from_file(vm: SPyVM, f: py.path.local, legacy: bool) -> W_Module:
+def make_w_mod_from_file(vm: SPyVM, f: py.path.local) -> W_Module:
     """
     Glue together all the various pieces which are necessary to convert SPy
     source code into an W_Module.
@@ -17,15 +16,7 @@ def make_w_mod_from_file(vm: SPyVM, f: py.path.local, legacy: bool) -> W_Module:
     parser = Parser.from_filename(str(f))
     mod = parser.parse()
     modname = f.purebasename
-    t: Any      # just to silence mypy
-    scopes: Any # just to silence mypy
-    if legacy:
-        t = TypeChecker(vm, mod)
-        t.check_everything()
-        scopes = None
-    else:
-        t = None
-        scopes = ScopeAnalyzer(vm, modname, mod)
-        scopes.analyze()
-    modgen = ModuleGen(vm, scopes, t, modname, mod, f, legacy)
+    scopes = ScopeAnalyzer(vm, modname, mod)
+    scopes.analyze()
+    modgen = ModuleGen(vm, scopes, modname, mod, f, legacy)
     return modgen.make_w_mod()

--- a/spy/irgen/irgen.py
+++ b/spy/irgen/irgen.py
@@ -18,5 +18,5 @@ def make_w_mod_from_file(vm: SPyVM, f: py.path.local) -> W_Module:
     modname = f.purebasename
     scopes = ScopeAnalyzer(vm, modname, mod)
     scopes.analyze()
-    modgen = ModuleGen(vm, scopes, modname, mod, f, legacy)
+    modgen = ModuleGen(vm, scopes, modname, mod, f)
     return modgen.make_w_mod()

--- a/spy/irgen/legacy_codegen.py
+++ b/spy/irgen/legacy_codegen.py
@@ -1,5 +1,7 @@
 # mypy: ignore-errors
 
+assert False, 'no longer used, kill me'
+
 import spy.ast
 from spy.fqn import FQN
 from spy.location import Loc

--- a/spy/irgen/legacy_typechecker.py
+++ b/spy/irgen/legacy_typechecker.py
@@ -1,5 +1,7 @@
 # mypy: ignore-errors
 
+assert False, 'no longer used, kill me eventually'
+
 from typing import NoReturn, Optional
 from types import NoneType
 import spy.ast

--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -66,8 +66,8 @@ class ModuleGen:
     def gen_FuncDef(self, frame: ASTFrame, funcdef: ast.FuncDef) -> None:
         fqn = FQN(modname=self.modname, attr=funcdef.name)
         frame.exec_stmt_FuncDef(funcdef)
-        fv = frame.load_local(funcdef.name)
-        self.vm.add_global(fqn, None, fv.w_val)
+        w_func = frame.load_local(funcdef.name)
+        self.vm.add_global(fqn, None, w_func)
 
     def gen_GlobalVarDef(self, frame: ASTFrame, vardef: ast.VarDef) -> None:
         assert vardef.value is not None, 'WIP?'

--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -3,7 +3,6 @@ from spy import ast
 from spy.location import Loc
 from spy.fqn import FQN
 from spy.irgen.scope import ScopeAnalyzer
-from spy.irgen.typechecker import TypeChecker
 from spy.irgen.legacy_codegen import LegacyCodeGen
 from spy.vm.vm import SPyVM
 from spy.vm.builtins import B
@@ -21,17 +20,13 @@ class ModuleGen:
     modname: str
     mod: ast.Module
     scopes: ScopeAnalyzer
-    t: TypeChecker
-    legacy: bool # XXX kill me
 
     def __init__(self,
                  vm: SPyVM,
                  scopes: ScopeAnalyzer,
-                 t: TypeChecker,
                  modname: str,
                  mod: ast.Module,
                  file_spy: py.path.local,
-                 legacy: bool,
                  ) -> None:
         self.vm = vm
         self.scopes = scopes
@@ -39,15 +34,10 @@ class ModuleGen:
         self.modname = modname
         self.mod = mod
         self.file_spy = file_spy
-        self.legacy = legacy # XXX kill me
 
     def make_w_mod(self) -> W_Module:
         self.w_mod = W_Module(self.vm, self.modname, str(self.file_spy))
         self.vm.register_module(self.w_mod)
-        if self.legacy:
-            # XXX kill me
-            self.make_w_mod_legacy()
-            return self.w_mod
         #
         # Synthesize and execute the __INIT__ function to populate the module
         modinit_funcdef = self.make_modinit()

--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -3,7 +3,6 @@ from spy import ast
 from spy.location import Loc
 from spy.fqn import FQN
 from spy.irgen.scope import ScopeAnalyzer
-from spy.irgen.legacy_codegen import LegacyCodeGen
 from spy.vm.vm import SPyVM
 from spy.vm.builtins import B
 from spy.vm.module import W_Module
@@ -30,7 +29,6 @@ class ModuleGen:
                  ) -> None:
         self.vm = vm
         self.scopes = scopes
-        self.t = t
         self.modname = modname
         self.mod = mod
         self.file_spy = file_spy
@@ -77,33 +75,3 @@ class ModuleGen:
         w_type = frame.eval_expr_type(vardef.type)
         w_value = frame.eval_expr_object(vardef.value)
         self.vm.add_global(fqn, w_type, w_value)
-
-    # ===== legacy stuff, to kill eventually =====
-
-    def make_w_mod_legacy(self) -> None:
-        for decl in self.mod.decls:
-            if isinstance(decl, ast.GlobalFuncDef):
-                name = decl.funcdef.name
-                fqn = FQN(modname=self.modname, attr=name)
-                w_type = self.t.global_scope.lookup_type(name)
-                assert w_type is not None
-                w_func = self.make_w_func_legacy(decl.funcdef)
-                self.vm.add_global(fqn, w_type, w_func)
-            elif isinstance(decl, ast.GlobalVarDef):
-                assert isinstance(decl.vardef.value, ast.Constant)
-                fqn = FQN(modname=self.modname, attr=decl.vardef.name)
-                w_type = self.t.global_scope.lookup_type(decl.vardef.name)
-                assert w_type is not None
-                w_const = self.t.get_w_const(decl.vardef.value)
-                self.vm.add_global(fqn, w_type, w_const)
-
-    def make_w_func_legacy(self, funcdef: ast.FuncDef) -> W_UserFunc:
-        assert self.legacy
-        assert funcdef.color == 'red'
-        w_functype = self.t.funcdef_types[funcdef]
-        fqn = FQN(modname=self.modname, attr=funcdef.name)
-        w_functype, scope = self.t.get_funcdef_info(funcdef)
-        codegen = LegacyCodeGen(self.vm, self.t, self.modname, funcdef)
-        w_code = codegen.make_w_code()
-        w_func = W_UserFunc(fqn, w_functype, w_code)
-        return w_func

--- a/spy/irgen/symtable.py
+++ b/spy/irgen/symtable.py
@@ -5,18 +5,6 @@ from spy.fqn import FQN
 from spy.location import Loc
 from spy.errors import SPyScopeError
 from spy.vm.vm import SPyVM
-from spy.vm.builtins import B
-from spy.vm.object import W_Type, W_Object
-
-Qualifier = Literal['var', 'const']
-
-class SymbolAlreadyDeclaredError(Exception):
-    """
-    A symbol is being redeclared
-
-    XXX kill me
-    """
-
 
 @dataclass
 class Symbol:
@@ -26,11 +14,6 @@ class Symbol:
     loc: Loc           # where the symbol is defined, in the source code
     scope: 'SymTable'  # the scope where the symbol lives in
     fqn: Optional[FQN] = None
-    #
-    # only for legacy, will be killed soon
-    qualifier: Optional[Qualifier] = None
-    w_type: Optional[W_Type] = None
-
 
 
 class SymTable:
@@ -51,13 +34,9 @@ class SymTable:
                   line_end=0,
                   col_start=0,
                   col_end=0)
-        #
         builtins_mod = vm.modules_w['builtins']
         for fqn, w_obj in builtins_mod.items_w():
-            w_type = vm.dynamic_type(w_obj)
-            # XXX kill declare_legacy and use declare
-            res.declare_legacy(fqn.attr, 'const', w_type, loc, fqn=fqn,
-                               color='blue')
+            res.declare(fqn.attr, 'blue', loc, fqn=fqn)
         return res
 
     def __repr__(self) -> str:
@@ -92,20 +71,6 @@ class SymTable:
                                         fqn = fqn)
         return s
 
-    def declare_legacy(self, name: str, qualifier: Qualifier, w_type: W_Type,
-                       loc: Loc, fqn: Optional[FQN] = None,
-                       color: Color = 'red') -> Symbol:
-        if name in self.symbols:
-            raise SymbolAlreadyDeclaredError(name)
-        self.symbols[name] = s = Symbol(name = name,
-                                        color = color,
-                                        qualifier = qualifier,
-                                        loc = loc,
-                                        scope = self,
-                                        fqn = fqn,
-                                        w_type = w_type)
-        return s
-
     def lookup(self, name: str) -> Optional[Symbol]:
         if name in self.symbols:
             # found in the local scope
@@ -114,9 +79,3 @@ class SymTable:
             return self.parent.lookup(name)
         else:
             return None # not found
-
-    def lookup_type(self, name: str) -> Optional[W_Type]:
-        sym = self.lookup(name)
-        if sym:
-            return sym.w_type
-        return None

--- a/spy/tests/compiler/test_debug.py
+++ b/spy/tests/compiler/test_debug.py
@@ -6,9 +6,7 @@ from spy.tests.support import CompilerTest, skip_backends, no_backend
 
 class TestDebug(CompilerTest):
 
-    def test_debug_info(self):
-        self._legacy = True
-
+    def test_debug_info(self, legacy):
         mod = self.compile(
         """
         def foo(a: i32, b: i32) -> i32:   # line 2

--- a/spy/tests/compiler/test_modules.py
+++ b/spy/tests/compiler/test_modules.py
@@ -1,3 +1,6 @@
+# mypy: ignore-errors
+# ^^^ remove this line when we re-enable these tests
+
 import pytest
 from spy.tests.support import CompilerTest, skip_backends, no_backend
 
@@ -33,7 +36,6 @@ class TestBasic(CompilerTest):
             ]
         )
 
-    @skip_backends("C")
     def test_two_modules(self, legacy):
         self.write_file(
             "delta.spy",

--- a/spy/tests/support.py
+++ b/spy/tests/support.py
@@ -79,12 +79,9 @@ class CompilerTest:
     vm: SPyVM
 
     # <hack hack hack>
-    _legacy = False
-
     @pytest.fixture
     def legacy(self):
         pytest.skip("legacy")
-        self._legacy = True
 
     def expect_errors(self, src: str, errors: list[str]):
         raise NotImplementedError("KILL ME")
@@ -125,17 +122,14 @@ class CompilerTest:
         """
         modname = 'test'
         self.write_file(f'{modname}.spy', src)
-        self.w_mod = self.vm.import_(modname, legacy=self._legacy)
+        self.w_mod = self.vm.import_(modname)
         if self.backend == '':
             pytest.fail('Cannot call self.compile() on @no_backend tests')
         elif self.backend == 'interp':
             interp_mod = InterpModuleWrapper(self.vm, self.w_mod)
             return interp_mod
         elif self.backend == 'C':
-
-            if not self._legacy:
-                pytest.skip("C backend only works with legacy")
-
+            pytest.skip("C backend is skipped for now")
             compiler = Compiler(self.vm, modname, self.builddir)
             file_wasm = compiler.cbuild()
             return WasmModuleWrapper(self.vm, modname, file_wasm)

--- a/spy/tests/test_typechecker.py
+++ b/spy/tests/test_typechecker.py
@@ -4,7 +4,7 @@ import textwrap
 import pytest
 
 from spy.parser import Parser
-from spy.irgen.typechecker import TypeChecker
+#from spy.irgen.typechecker import TypeChecker
 from spy.irgen.symtable import Symbol
 from spy.vm.vm import SPyVM
 from spy.vm.builtins import B

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -198,8 +198,10 @@ class ASTFrame:
                 fqn = FQN(modname='builtins', attr=name.id)
             else:
                 fqn = FQN(modname=self.w_func.modname, attr=name.id)
-            w_value = self.vm.lookup_global(fqn)
-            return FrameVal(w_type, w_value)
+            w_value2 = self.vm.lookup_global(fqn)
+            assert w_value2 is not None, \
+                f'{fqn} not found. Bug in the ScopeAnalyzer?'
+            return FrameVal(w_type, w_value2)
         else:
             assert False, f'Invalid scope {name.scope}. Bug in the TypeChecker?'
 

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -105,6 +105,12 @@ class ASTFrame:
         return magic_dispatch(self, 'exec_stmt', stmt)
 
     def eval_expr(self, expr: ast.Expr) -> FrameVal:
+        """
+        Typecheck and eval the given expr.
+
+        Every concrete implementation of this MUST call the corresponding
+        self.t.check_*
+        """
         return magic_dispatch(self, 'eval_expr', expr)
 
     def eval_expr_object(self, expr: ast.Expr) -> W_Object:
@@ -198,6 +204,7 @@ class ASTFrame:
             assert False, f'Invalid scope {name.scope}. Bug in the TypeChecker?'
 
     def eval_expr_BinOp(self, binop: ast.BinOp) -> FrameVal:
+        self.t.check_expr_BinOp(binop)
         fv_l = self.eval_expr(binop.left)
         fv_r = self.eval_expr(binop.right)
         w_ltype = fv_l.w_static_type
@@ -210,12 +217,7 @@ class ASTFrame:
             elif binop.op == '*':
                 return FrameVal(B.w_i32, self.vm.wrap(l * r))
         #
-        lt = w_ltype.name
-        rt = w_rtype.name
-        err = SPyTypeError(f'cannot do `{lt}` {binop.op} `{rt}`')
-        err.add('error', f'this is `{lt}`', binop.left.loc)
-        err.add('error', f'this is `{rt}`', binop.right.loc)
-        raise err
+        assert False, 'Unsupported binop, bug in the typechecker'
 
     eval_expr_Add = eval_expr_BinOp
     eval_expr_Mul = eval_expr_BinOp

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -211,12 +211,10 @@ class ASTFrame:
 
     def eval_expr_BinOp(self, binop: ast.BinOp) -> FrameVal:
         from spy.vm.builtins import B
+        w_ltype = self.t.check_expr(binop.left)
+        w_rtype = self.t.check_expr(binop.right)
         fv_l = self.eval_expr(binop.left)
         fv_r = self.eval_expr(binop.right)
-        # NOTE: we do the dispatch based on the STATIC types of the operands,
-        # not the dynamic ones.
-        w_ltype = fv_l.w_static_type
-        w_rtype = fv_r.w_static_type
         if w_ltype is B.w_i32 and w_rtype is B.w_i32:
             l = self.vm.unwrap(fv_l.w_val)
             r = self.vm.unwrap(fv_r.w_val)

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -31,7 +31,7 @@ class FrameVal:
     The naming convention is to call them fv_*.
     """
     w_static_type: W_Type
-    w_val: W_Object
+    w_value: W_Object
 
 
 class ASTFrame:
@@ -46,7 +46,7 @@ class ASTFrame:
         self.w_func = w_func
         self.funcdef = w_func.funcdef
         self.locals = {}
-        self.t = TypeChecker(vm)
+        self.t = TypeChecker(vm, self.w_func.modname)
 
     def __repr__(self) -> str:
         return f'<ASTFrame for {self.w_func.fqn}>'
@@ -56,17 +56,16 @@ class ASTFrame:
         self.t.declare_local(loc, name, w_type)
         self.locals[name] = None
 
-    def store_local(self, loc: Loc, name: str, w_val: W_Object) -> None:
-        self.t.typecheck_local(loc, name, w_val)
-        self.locals[name] = w_val
+    def store_local(self, loc: Loc, name: str, w_value: W_Object) -> None:
+        self.t.typecheck_local(loc, name, w_value)
+        self.locals[name] = w_value
 
-    def load_local(self, name: str) -> FrameVal:
+    def load_local(self, name: str) -> W_Object:
         assert name in self.locals
         w_obj = self.locals[name]
         if w_obj is None:
             raise SPyRuntimeError('read from uninitialized local')
-        w_type = self.t.locals_types_w[name] # XXX
-        return FrameVal(w_type, w_obj)
+        return w_obj
 
     def run(self, args_w: list[W_Object]) -> W_Object:
         self.init_arguments(args_w)
@@ -110,13 +109,14 @@ class ASTFrame:
 
     def eval_expr_object(self, expr: ast.Expr) -> W_Object:
         fv = self.eval_expr(expr)
-        return fv.w_val
+        return fv.w_value
 
     def eval_expr_type(self, expr: ast.Expr) -> W_Type:
         fv = self.eval_expr(expr)
-        if isinstance(fv.w_val, W_Type):
-            return fv.w_val
-        w_valtype = self.vm.dynamic_type(fv.w_val)
+        if isinstance(fv.w_value, W_Type):
+            assert fv.w_static_type is B.w_type
+            return fv.w_value
+        w_valtype = self.vm.dynamic_type(fv.w_value)
         msg = f'expected `type`, got `{w_valtype.name}`'
         raise SPyTypeError.simple(msg, "expected `type`", expr.loc)
 
@@ -124,8 +124,8 @@ class ASTFrame:
 
     def exec_stmt_Return(self, stmt: ast.Return) -> None:
         fv = self.eval_expr(stmt.value)
-        self.t.typecheck_local(stmt.loc, '@return', fv.w_val)
-        raise Return(fv.w_val)
+        self.t.typecheck_local(stmt.loc, '@return', fv.w_value)
+        raise Return(fv.w_value)
 
     def exec_stmt_FuncDef(self, funcdef: ast.FuncDef) -> None:
         # evaluate the functype
@@ -159,22 +159,17 @@ class ASTFrame:
         # which scope we want to assign to. For now we just assume that if
         # it's not local, it's module.
         name = assign.target
-        w_value = self.eval_expr_object(assign.value)
+        fv = self.eval_expr(assign.value)
         if name in self.funcdef.locals:
-            # NOTE: we are consciously forgetting the STATIC type here. In the
-            # interpreter, what we care about is that the dynamic type is
-            # correct. It is the job of the doppler transformer to insert a
-            # downcast if necessary.
             if name not in self.locals:
                 # first assignment, implicit declaration
-                w_type = self.vm.dynamic_type(w_value)
-                self.declare_local(assign.loc, name, w_type)
-            self.store_local(assign.value.loc, assign.target, w_value)
+                self.declare_local(assign.loc, name, fv.w_static_type)
+            self.store_local(assign.value.loc, assign.target, fv.w_value)
         else:
             # we assume it's module-level.
             # XXX we should check that this global is red/non-constant
             fqn = FQN(modname=self.w_func.modname, attr=name)
-            self.vm.store_global(fqn, w_value)
+            self.vm.store_global(fqn, fv.w_value)
 
     # ==== expressions ====
 
@@ -183,41 +178,33 @@ class ASTFrame:
         # Parser.from_py_expr_Constant
         T = type(const.value)
         assert T in (int, bool, str, NoneType)
-        w_val = self.vm.wrap(const.value)
-        w_type = self.vm.dynamic_type(w_val)
-        return FrameVal(w_type, w_val)
+        w_type = self.t.check_expr_Constant(const)
+        w_value = self.vm.wrap(const.value)
+        return FrameVal(w_type, w_value)
 
     def eval_expr_Name(self, name: ast.Name) -> FrameVal:
+        w_type = self.t.check_expr_Name(name)
         if name.scope == 'local':
-            return self.load_local(name.id)
+            w_value = self.load_local(name.id)
+            return FrameVal(w_type, w_value)
         elif name.scope in ('module', 'builtins'):
             if name.scope == 'builtins':
                 fqn = FQN(modname='builtins', attr=name.id)
             else:
                 fqn = FQN(modname=self.w_func.modname, attr=name.id)
             w_value = self.vm.lookup_global(fqn)
-            assert w_value is not None
-            # XXX this is wrong: we should keep track of the static type of
-            # FQNs :(
-            w_type = self.vm.dynamic_type(w_value)
             return FrameVal(w_type, w_value)
-        elif name.scope == 'non-declared':
-            msg = f"name `{name.id}` is not defined"
-            raise SPyNameError.simple(msg, "not found in this scope", name.loc)
-        elif name.scope == "unknown":
-            assert False, "bug in the ScopeAnalyzer?"
         else:
-            assert False, f"Invalid value for scope: {name.scope}"
+            assert False, f'Invalid scope {name.scope}. Bug in the TypeChecker?'
 
     def eval_expr_BinOp(self, binop: ast.BinOp) -> FrameVal:
-        from spy.vm.builtins import B
-        w_ltype = self.t.check_expr(binop.left)
-        w_rtype = self.t.check_expr(binop.right)
         fv_l = self.eval_expr(binop.left)
         fv_r = self.eval_expr(binop.right)
+        w_ltype = fv_l.w_static_type
+        w_rtype = fv_r.w_static_type
         if w_ltype is B.w_i32 and w_rtype is B.w_i32:
-            l = self.vm.unwrap(fv_l.w_val)
-            r = self.vm.unwrap(fv_r.w_val)
+            l = self.vm.unwrap(fv_l.w_value)
+            r = self.vm.unwrap(fv_r.w_value)
             if binop.op == '+':
                 return FrameVal(B.w_i32, self.vm.wrap(l + r))
             elif binop.op == '*':

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -1,0 +1,46 @@
+from typing import TYPE_CHECKING
+from spy import ast
+from spy.errors import (SPyRuntimeAbort, SPyTypeError, SPyNameError,
+                        SPyRuntimeError)
+from spy.location import Loc
+from spy.vm.object import W_Object, W_Type
+if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
+
+class TypeChecker:
+    locals_loc: dict[str, Loc]
+    locals_types_w: dict[str, W_Type]
+
+    def __init__(self, vm: 'SPyVM'):
+        self.vm = vm
+        self.locals_loc = {}
+        self.locals_types_w = {}
+
+    def declare_local(self, loc: Loc, name: str, w_type: W_Type) -> None:
+        assert name not in self.locals_loc, f'variable already declared: {name}'
+        self.locals_loc[name] = loc
+        self.locals_types_w[name] = w_type
+
+    def typecheck_local(self, got_loc: Loc, name: str, w_got: W_Object) -> None:
+        assert name in self.locals_loc
+        w_type = self.locals_types_w[name]
+        loc = self.locals_loc[name]
+        if self.vm.is_compatible_type(w_got, w_type):
+            return
+        err = SPyTypeError('mismatched types')
+        got = self.vm.dynamic_type(w_got).name
+        exp = w_type.name
+        exp_loc = loc
+        err.add('error', f'expected `{exp}`, got `{got}`', loc=got_loc)
+        if name == '@return':
+            because = 'because of return type'
+        else:
+            because = 'because of type declaration'
+        err.add('note', f'expected `{exp}` {because}', loc=exp_loc)
+        raise err
+
+    ## def check_expr(self, expr: ast.Expr) -> W_Type:
+    ##     """
+    ##     Compute the STATIC type of the given expression
+    ##     """
+    ##     magic_dispatch(...)

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -89,3 +89,16 @@ class TypeChecker:
         elif T is NoneType:
             return B.w_void
         assert False
+
+    def check_expr_BinOp(self, binop: ast.BinOp) -> W_Type:
+        w_ltype = self.check_expr(binop.left)
+        w_rtype = self.check_expr(binop.right)
+        if w_ltype is B.w_i32 and w_rtype is B.w_i32:
+            return B.w_i32
+        #
+        lt = w_ltype.name
+        rt = w_rtype.name
+        err = SPyTypeError(f'cannot do `{lt}` {binop.op} `{rt}`')
+        err.add('error', f'this is `{lt}`', binop.left.loc)
+        err.add('error', f'this is `{rt}`', binop.right.loc)
+        raise err

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -38,8 +38,7 @@ class SPyVM:
         self.path = []
         self.make_builtins_module()
 
-    def import_(self, modname: str, *, legacy: bool = False) -> W_Module:
-        # XXX eventually we should kill "legacy"
+    def import_(self, modname: str) -> W_Module:
         from spy.irgen.irgen import make_w_mod_from_file
         if modname in self.modules_w:
             return self.modules_w[modname]
@@ -48,7 +47,7 @@ class SPyVM:
         # mechanism and support for packages
         assert self.path, 'vm.path not set'
         file_spy = py.path.local(self.path[0]).join(f'{modname}.spy')
-        w_mod = make_w_mod_from_file(self, file_spy, legacy=legacy)
+        w_mod = make_w_mod_from_file(self, file_spy)
         self.modules_w[modname] = w_mod
         return w_mod
 


### PR DESCRIPTION
The ASTFrame was becoming messy, because it contained logic to evaluate the expressions (thus propagating their dynamic types) AND to do typechecking (which must use the static types).

This PR clearly split the logic into two:
- the job of the ASTFrame is to evaluate expressions
- the job of the typechecker is to compute and keep track of the static types

The main difference w.r.t. the legacy typecheker is that the new one operates on a per-function basis, instead of the whole module. This is needed because with blue/generic functions, type annotations are not known until runtime/doppler time.

The other advantage is that when we will implement the doppler, we should be able to reuse the typechecker