### PR TITLE
Refactor type locs

### DIFF
--- a/spy/ast.py
+++ b/spy/ast.py
@@ -341,6 +341,14 @@ class FuncDef(Stmt):
     body: list['Stmt']
     symtable: Any = field(repr=False, default=None)
 
+    @property
+    def prototype_loc(self):
+        """
+        Return the Loc which corresponds to the func prototype, i.e. from the
+        'def' until the return type.
+        """
+        return Loc.combine(self.loc, self.return_type.loc)
+
 @dataclass(eq=False)
 class Pass(Stmt):
     pass

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -342,7 +342,7 @@ class FuncDef(Stmt):
     symtable: Any = field(repr=False, default=None)
 
     @property
-    def prototype_loc(self):
+    def prototype_loc(self) -> Loc:
         """
         Return the Loc which corresponds to the func prototype, i.e. from the
         'def' until the return type.

--- a/spy/irgen/scope.py
+++ b/spy/irgen/scope.py
@@ -136,7 +136,8 @@ class ScopeAnalyzer:
 
     def declare_FuncDef(self, funcdef: ast.FuncDef) -> None:
         # declare the func in the "outer" scope
-        self.add_name(funcdef.name, 'blue', funcdef.loc, funcdef.loc)
+        self.add_name(funcdef.name, 'blue', funcdef.prototype_loc,
+                      funcdef.prototype_loc)
         inner_scope = SymTable(funcdef.name)
         self.push_scope(inner_scope)
         self.funcdef_scopes[funcdef] = inner_scope

--- a/spy/irgen/symtable.py
+++ b/spy/irgen/symtable.py
@@ -14,7 +14,8 @@ class Symbol:
     name: str
     color: Color
     _: KW_ONLY
-    loc: Loc    # where the symbol is defined, in the source code
+    loc: Loc       # where the symbol is defined, in the source code
+    type_loc: Loc  # loc of the TYPE of the symbols
 
     # level indicates in which scope the symbol resides:
     #   0: this Symbol is defined in the scope corresponding to
@@ -55,7 +56,8 @@ class SymTable:
                   col_end=0)
         builtins_mod = vm.modules_w['builtins']
         for fqn, w_obj in builtins_mod.items_w():
-            sym = Symbol(fqn.attr, 'blue', loc=loc, level=0, fqn=fqn)
+            sym = Symbol(fqn.attr, 'blue', loc=loc, type_loc=loc,
+                         level=0, fqn=fqn)
             scope.add(sym)
         return scope
 

--- a/spy/location.py
+++ b/spy/location.py
@@ -1,5 +1,6 @@
 import dataclasses
 from dataclasses import dataclass
+import linecache
 
 @dataclass
 class Loc:
@@ -38,3 +39,13 @@ class Loc:
             return f"<Loc: '{self.filename}'>"
         else:
             return f"<Loc: '{self.filename} {l1}:{c1} {l2}:{c2}'>"
+
+    def pp(self) -> None:
+        """
+        Visualize the piece of code which correspond to this Loc
+        """
+        from spy.errors import ErrorFormatter, Annotation
+        fmt = ErrorFormatter(err=None, use_colors=True) # type: ignore
+        ann = Annotation('note', '', self)
+        fmt.emit_annotation(ann)
+        print(fmt.build())

--- a/spy/location.py
+++ b/spy/location.py
@@ -20,6 +20,18 @@ class Loc:
         """
         return Loc('<fake>', 1, 1, 1, 1)
 
+    @classmethod
+    def combine(cls, start: 'Loc', end: 'Loc') -> 'Loc':
+        """
+        Return a new Loc which spans from 'start' to 'end'
+        """
+        assert start.filename == end.filename
+        l1 = start.line_start
+        c1 = start.col_start
+        l2 = end.line_end
+        c2 = end.col_end
+        return cls(start.filename, l1, l2, c1, c2)
+
     def replace(self, **kwargs: int) -> 'Loc':
         return dataclasses.replace(self, **kwargs)
 

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -250,7 +250,7 @@ class TestBasic(CompilerTest):
         ctx = expect_errors(
             'cannot call objects of type `i32`',
             ('this is not a function', 'inc'),
-            #('variable defined here', 'inc: i32 = 0'),
+            ('variable defined here', 'inc: i32 = 0'),
         )
         with ctx:
             mod = self.compile("""

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -264,7 +264,7 @@ class TestBasic(CompilerTest):
         ctx = expect_errors(
             'this function takes 1 argument but 0 arguments were supplied',
             ('1 argument missing', 'inc'),
-            #('function defined here', 'def inc(x: i32) -> i32'),
+            ('function defined here', 'def inc(x: i32) -> i32'),
         )
         with ctx:
             mod = self.compile("""
@@ -279,7 +279,7 @@ class TestBasic(CompilerTest):
         ctx = expect_errors(
             'this function takes 1 argument but 3 arguments were supplied',
             ('2 extra arguments', '2, 3'),
-            #('function defined here', 'def inc(x: i32) -> i32'),
+            ('function defined here', 'def inc(x: i32) -> i32'),
         )
         with ctx:
             mod = self.compile("""
@@ -294,11 +294,13 @@ class TestBasic(CompilerTest):
         ctx = expect_errors(
             'mismatched types',
             ('expected `i32`, got `str`', 's'),
-            #('function defined here', 'def inc(x: i32) -> i32'),
+            ('function defined here', 'def inc(x: i32) -> i32'),
         )
         with ctx:
             mod = self.compile("""
             def inc(x: i32) -> i32:
+
+
                 return x+1
             def bar(s: str) -> i32:
                 return inc(s)

--- a/spy/tests/test_scope.py
+++ b/spy/tests/test_scope.py
@@ -82,6 +82,7 @@ class TestScopeAnalyzer:
             'x': MatchSymbol('x', 'red'),
             'y': MatchSymbol('y', 'red'),
             'z': MatchSymbol('z', 'red'),
+            '@return': MatchSymbol('@return', 'red'),
             # captured
             'i32': MatchSymbol('i32', 'blue', level=1),
         }
@@ -97,6 +98,7 @@ class TestScopeAnalyzer:
         scope = scopes.by_funcdef(funcdef)
         assert scope._symbols == {
             'x': MatchSymbol('x', 'red'),
+            '@return': MatchSymbol('@return', 'red'),
             'i32': MatchSymbol('i32', 'blue', level=2),
         }
 
@@ -137,6 +139,7 @@ class TestScopeAnalyzer:
         assert foodef.symtable._symbols == {
             'x': MatchSymbol('x', 'red'),
             'bar': MatchSymbol('bar', 'blue'),
+            '@return': MatchSymbol('@return', 'red'),
             'i32': MatchSymbol('i32', 'blue', level=2),
         }
         #
@@ -144,5 +147,6 @@ class TestScopeAnalyzer:
         assert isinstance(bardef, ast.FuncDef)
         assert bardef.symtable._symbols == {
             'y': MatchSymbol('y', 'red'),
+            '@return': MatchSymbol('@return', 'red'),
             'x': MatchSymbol('x', 'red', level=1),
         }

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -45,6 +45,15 @@ class TypeChecker:
         err.add('note', f'expected `{exp}` {because}', loc=exp_loc)
         raise err
 
+    def name2sym_maybe(self, expr: ast.Expr) -> Optional[Symbol]:
+        """
+        If expr is an ast.Name, return the corresponding Symbol.
+        Else, return None.
+        """
+        if isinstance(expr, ast.Name):
+            return self.funcdef.symtable.lookup_maybe(expr.id)
+        return None
+
     def check_expr(self, expr: ast.Expr) -> W_Type:
         """
         Compute the STATIC type of the given expression
@@ -98,8 +107,8 @@ class TypeChecker:
     check_expr_Mul = check_expr_BinOp
 
     def check_expr_Call(self, call: ast.Call) -> W_Type:
-        sym = None # XXX find the loc where the function is defined
         w_functype = self.check_expr(call.func)
+        sym = self.name2sym_maybe(call.func)
         if not isinstance(w_functype, W_FuncType):
             self._call_error_non_callable(call, sym, w_functype)
         #

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -15,24 +15,22 @@ if TYPE_CHECKING:
 class TypeChecker:
     vm: 'SPyVM'
     funcef: ast.FuncDef
-    locals_loc: dict[str, Loc]
     locals_types_w: dict[str, W_Type]
 
     def __init__(self, vm: 'SPyVM', funcdef: ast.FuncDef):
         self.vm = vm
         self.funcdef = funcdef
-        self.locals_loc = {}
         self.locals_types_w = {}
 
-    def declare_local(self, loc: Loc, name: str, w_type: W_Type) -> None:
-        assert name not in self.locals_loc, f'variable already declared: {name}'
-        self.locals_loc[name] = loc
+    def declare_local(self, name: str, w_type: W_Type) -> None:
+        assert name not in self.locals_types_w, \
+            f'variable already declared: {name}'
         self.locals_types_w[name] = w_type
 
     def typecheck_local(self, got_loc: Loc, name: str, w_got: W_Object) -> None:
-        assert name in self.locals_loc
+        assert name in self.locals_types_w
         w_type = self.locals_types_w[name]
-        loc = self.locals_loc[name]
+        loc = self.funcdef.symtable.lookup(name).type_loc
         if self.vm.is_compatible_type(w_got, w_type):
             return
         err = SPyTypeError('mismatched types')


### PR DESCRIPTION
- Kill Typechekr.locals_loc: it's not longer needed since we now have funcdef.symtable
- finally re-enable more precise error messages for function calls: now we include again the Loc where the function was defined