### PR TITLE
Add support for `var` globals

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ wasmtime==8.0.1
 fixedint==0.2.0
 mypy==1.3.0
 typer==0.9.0
+untokenize==0.1.1
 ziglang==0.10.1.post1

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Optional, Iterator, Any
+from typing import Optional, Iterator, Any, Literal
 import pprint
 import ast as py_ast
 import dataclasses
@@ -10,6 +10,7 @@ from spy.irgen.symtable import SymTable, Color
 from spy.util import extend
 
 AnyNode = typing.Union[py_ast.AST, 'Node']
+VarKind = typing.Literal['const', 'var']
 
 @extend(py_ast.AST)
 class AST:
@@ -425,6 +426,7 @@ class Return(Stmt):
 
 @dataclass(eq=False)
 class VarDef(Stmt):
+    kind: VarKind
     name: str
     type: Expr
     value: Optional[Expr]

--- a/spy/ast_dump.py
+++ b/spy/ast_dump.py
@@ -57,6 +57,8 @@ class Dumper(TextBuilder):
         name = 'py:' + node.__class__.__name__
         fields = list(node.__class__._fields)
         fields = [f for f in fields if f not in self.fields_to_ignore]
+        if isinstance(node, py_ast.Name):
+            fields.append('is_var')
         self._dump_node(node, name, fields, color='turquoise')
 
     def _dump_node(self, node: Any, name: str, fields: list[str], color: str) -> None:

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -205,7 +205,7 @@ class CFuncWriter:
     def fmt_expr_BinOp(self, binop: ast.BinOp) -> C.Expr:
         l = self.fmt_expr(binop.left)
         r = self.fmt_expr(binop.right)
-        return C.BinOp(op, l, r)
+        return C.BinOp(binop.op, l, r)
 
     fmt_expr_Add = fmt_expr_BinOp
     fmt_expr_Sub = fmt_expr_BinOp

--- a/spy/irgen/scope.py
+++ b/spy/irgen/scope.py
@@ -153,9 +153,14 @@ class ScopeAnalyzer:
         raise err
 
     def declare_GlobalVarDef(self, decl: ast.GlobalVarDef) -> None:
-        self.add_name(decl.vardef.name, 'blue', decl.loc, decl.vardef.type.loc)
+        if decl.vardef.kind == 'var':
+            color = 'red'
+        else:
+            color = 'blue'
+        self.add_name(decl.vardef.name, color, decl.loc, decl.vardef.type.loc)
 
     def declare_VarDef(self, vardef: ast.VarDef) -> None:
+        assert vardef.kind == 'var'
         self.add_name(vardef.name, 'red', vardef.loc, vardef.type.loc)
 
     def declare_FuncDef(self, funcdef: ast.FuncDef) -> None:

--- a/spy/magic_py_parse.py
+++ b/spy/magic_py_parse.py
@@ -1,0 +1,108 @@
+"""
+This is a hack.
+
+The goal is be able to parse lines such as:
+    var x: i32 = 0
+
+We want to reuse the Python parser, but the line above is not valid syntax.
+
+The idea is the following:
+
+1. tokenize the source
+
+2. search for pairs of NAMEs starting with 'var' (from the point of view of
+   the tokenizer, 'var' is a plain NAME
+
+3. remove the 'var' token, and keep track of the location in which it was seen
+
+4. turn back the (modified) tokens into source code
+
+5. parse the generated source code into an AST
+
+6. add a new field "is_var: bool" to all ast.Name nodes, using the infos
+   gathered at point (3)
+
+It is important to make sure that whitespace is preserved as much as possible,
+because we want the AST to contain location info which match the actual file
+on disk. For this, we use the `untokenize` module (available on PyPI) which
+does exactly that.
+"""
+
+from dataclasses import dataclass
+import ast as py_ast
+from tokenize import tokenize, NUMBER, STRING, NAME, OP, TokenInfo
+from io import BytesIO
+import untokenize
+import spy.ast_dump
+
+@dataclass(frozen=True)
+class LocInfo:
+    lineno: int
+    end_lineno: int
+    col_offset: int
+    end_col_offset: int
+
+def magic_py_parse(src: str):
+    """
+    Like ast.parse, but supports the new "var" syntax. See the module
+    docstring for more info.
+    """
+    src2, var_locs = preprocess(src)
+    py_mod = py_ast.parse(src2)
+
+    for node in py_ast.walk(py_mod):
+        if isinstance(node, py_ast.Name):
+            loc = LocInfo(node.lineno, node.end_lineno,
+                          node.col_offset, node.end_col_offset)
+            node.is_var = loc in var_locs
+
+    return py_mod
+
+def get_tokens(src: str) -> list[TokenInfo]:
+    readline = BytesIO(src.encode('utf-8')).readline
+    return list(tokenize(readline))
+
+def preprocess(src: str) -> tuple[str, set[LocInfo]]:
+    tokens = get_tokens(src)
+    newtokens = []
+    i = 0
+    N = len(tokens)
+    var_locs = set()
+
+    while i < N-1:
+        tok0 = tokens[i]
+        tok1 = tokens[i+1]
+        if tok0.type == NAME and tok0.string == 'var' and tok1.type == NAME:
+            # tok0 is 'var'
+            # tok1 is the name
+            # basically, we want to turn:
+            #     var x: i32 = 100
+            # into:
+            #     x    : i32 = 100
+            #
+            # so that the Locs in the final AST maps to the correct places in
+            # the original source code.
+            var_l0, var_c0 = tok0.start
+            var_l1, var_c1 = tok0.end
+            name_l0, name_c0 = tok1.start
+            name_l1, name_c1 = tok1.end
+            assert var_l0 == var_l1 == name_l0 == name_l1, \
+                'multiline var not supported'
+            spaces = ' ' * (name_c0 - var_c0)
+            newtok = TokenInfo(NAME, tok1.string + spaces,
+                               tok0.start, tok1.end, tok1.line)
+            newtokens.append(newtok)
+            # compute the location info of the future ast.Name
+            loc = LocInfo(
+                lineno = var_l0,
+                end_lineno = var_l0,
+                col_offset = var_c0,
+                end_col_offset = var_c0 + len(tok1.string)
+            )
+            var_locs.add(loc)
+            i += 1
+        else:
+            newtokens.append(tok0)
+        i += 1
+    src2 = untokenize.untokenize(newtokens)
+    return src2, var_locs

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -3,6 +3,7 @@ from types import NoneType
 import textwrap
 import ast as py_ast
 import spy.ast
+from spy.magic_py_parse import magic_py_parse
 from spy.fqn import FQN
 from spy.location import Loc
 from spy.errors import SPyError, SPyParseError
@@ -36,7 +37,7 @@ class Parser:
         return Parser(src, filename)
 
     def parse(self) -> spy.ast.Module:
-        py_mod = py_ast.parse(self.src)
+        py_mod = magic_py_parse(self.src)
         assert isinstance(py_mod, py_ast.Module)
         py_mod.compute_all_locs(self.filename)
         return self.from_py_Module(py_mod)

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -142,11 +142,10 @@ class TestBasic(CompilerTest):
             """)
         assert mod.foo() == 42
 
-    @skip_backends('doppler', 'C', reason='red globals not implemented')
     def test_global_variables(self):
         mod = self.compile(
         """
-        x: i32 = 42
+        var x: i32 = 42
         def get_x() -> i32:
             return x
         def set_x(newval: i32) -> void:

--- a/spy/tests/test_backend_c.py
+++ b/spy/tests/test_backend_c.py
@@ -5,7 +5,7 @@ This is just a small part of the tests: the majority of the functionality is
 tested by tests/compiler/*.py.
 """
 
-from spy.backend.c.expr import make_table, Literal, BinOp, UnaryOp
+from spy.backend.c.c_ast import make_table, Literal, BinOp, UnaryOp
 
 class TestExpr:
 
@@ -31,7 +31,7 @@ class TestExpr:
             ),
             right = Literal('3')
         )
-        assert expr.str() == '(1 + 2) * 3'
+        assert str(expr) == '(1 + 2) * 3'
 
     def test_BinOp2(self):
         expr = BinOp('*',
@@ -44,7 +44,7 @@ class TestExpr:
                 )
             )
         )
-        assert expr.str() == '1 * (2 + 3 * 4)'
+        assert str(expr) == '1 * (2 + 3 * 4)'
 
     def test_UnaryOp(self):
         expr = UnaryOp('-',
@@ -53,11 +53,11 @@ class TestExpr:
                 right = Literal('2'),
             )
         )
-        assert expr.str() == '-(1 * 2)'
+        assert str(expr) == '-(1 * 2)'
 
     def test_Literal_from_bytes(self):
         def cstr(b: bytes) -> str:
-            return Literal.from_bytes(b).str()
+            return str(Literal.from_bytes(b))
         #
         assert cstr(b'--hello--') == '"--hello--"'
         assert cstr(b'--"hello"--') == r'"--\"hello\"--"'

--- a/spy/tests/test_magic_py_parse.py
+++ b/spy/tests/test_magic_py_parse.py
@@ -1,0 +1,51 @@
+import textwrap
+from spy.magic_py_parse import magic_py_parse, preprocess
+from spy.ast_dump import dump
+
+def test_preprocess_plain():
+    src1 = textwrap.dedent("""
+    x: i32 = 100
+    """)
+    src2, var_locs = preprocess(src1)
+    assert src1 == src2
+
+def test_preprocess_var():
+    src1 = textwrap.dedent("""
+    var x: i32 = 100
+    var    y     : i32 = 200
+    """)
+    src2, var_locs = preprocess(src1)
+    expected = textwrap.dedent("""
+    x    : i32 = 100
+    y            : i32 = 200
+    """)
+    assert src2 == expected
+    assert len(var_locs) == 2
+
+def test_magic_py_parse():
+    src = textwrap.dedent("""
+    var x: i32 = 100
+    y: i32 = 200
+    """)
+    py_mod = magic_py_parse(src)
+    dumped = dump(py_mod, use_colors=False)
+    expected = textwrap.dedent("""
+    py:Module(
+        body=[
+            py:AnnAssign(
+                target=py:Name(id='x', ctx=py:Store(), is_var=True),
+                annotation=py:Name(id='i32', ctx=py:Load(), is_var=False),
+                value=py:Constant(value=100, kind=None),
+                simple=1,
+            ),
+            py:AnnAssign(
+                target=py:Name(id='y', ctx=py:Store(), is_var=False),
+                annotation=py:Name(id='i32', ctx=py:Load(), is_var=False),
+                value=py:Constant(value=200, kind=None),
+                simple=1,
+            ),
+        ],
+        type_ignores=[],
+    )
+    """)
+    assert dumped.strip() == expected.strip()

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -275,6 +275,7 @@ class TestParser:
         stmt = mod.get_funcdef('foo').body[0]
         expected = """
         VarDef(
+            kind='var',
             name='x',
             type=Name(id='i32'),
             value=Constant(value=42),
@@ -292,6 +293,28 @@ class TestParser:
             decls=[
                 GlobalVarDef(
                     vardef=VarDef(
+                        kind='const',
+                        name='x',
+                        type=Name(id='i32'),
+                        value=Constant(value=42),
+                    ),
+                ),
+            ],
+        )
+        """
+        self.assert_dump(mod, expected)
+
+    def test_global_VarDef_var(self):
+        mod = self.parse("""
+        var x: i32 = 42
+        """)
+        expected = f"""
+        Module(
+            filename='{self.tmpdir}/test.spy',
+            decls=[
+                GlobalVarDef(
+                    vardef=VarDef(
+                        kind='var',
                         name='x',
                         type=Name(id='i32'),
                         value=Constant(value=42),

--- a/spy/tests/test_scope.py
+++ b/spy/tests/test_scope.py
@@ -58,6 +58,7 @@ class TestScopeAnalyzer:
     def test_global(self):
         scopes = self.analyze("""
         x: i32 = 0
+        var y: i32 = 0
 
         def foo() -> void:
             pass
@@ -68,6 +69,7 @@ class TestScopeAnalyzer:
         scope = scopes.by_module()
         assert scope._symbols == {
             'x': MatchSymbol('x', 'blue'),
+            'y': MatchSymbol('y', 'red'),
             'foo': MatchSymbol('foo', 'blue'),
             'bar': MatchSymbol('bar', 'blue'),
             # captured

--- a/stubs/_ast.pyi
+++ b/stubs/_ast.pyi
@@ -422,6 +422,9 @@ class Name(expr):
         __match_args__ = ("id", "ctx")
     id: _Identifier
     ctx: expr_context
+    # <spy>
+    is_var: bool
+    # </spy>
 
 class List(expr):
     if sys.version_info >= (3, 10):


### PR DESCRIPTION
global variables are by default const and blue, but this PR makes it possible to declare them `var`, and thus they become red.

The hard part was to add support to it to the parser, see the long docstring inside `magic_py_parser.py`.