### PR TITLE
New pattern for testing type errors

### DIFF
--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -81,6 +81,8 @@ class FuncDoppler:
     # ==== statements ====
 
     def shift_stmt_Return(self, ret: ast.Return) -> list[ast.Stmt]:
+        color, w_type = self.t.check_expr(ret.value)
+        self.t.typecheck_local(ret.loc, '@return', w_type)
         newvalue = self.shift_expr(ret.value)
         return [ret.replace(value=newvalue)]
 

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -91,6 +91,8 @@ class FuncDoppler:
         sym = self.blue_frame.declare_VarDef(vardef)
         assert sym.is_local
         if sym.color == 'red':
+            valuecolor, w_valuetype = self.t.check_expr(vardef.value)
+            self.t.typecheck_local(vardef.value.loc, vardef.name, w_valuetype)
             newvalue = self.shift_expr(vardef.value)
             newtype = self.shift_expr(vardef.type)
             return [vardef.replace(value=newvalue, type=newtype)]

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -264,63 +264,59 @@ class TestBasic(CompilerTest):
         # it would be nice to report also the location where 'inc' is defined,
         # but we don't carry around this information for now. There is room
         # for improvement
-        ctx = expect_errors(
+        src = """
+        x: i32 = 0
+        def foo() -> void:
+            return x(0)
+        """
+        errors = expect_errors(
             'cannot call objects of type `i32`',
-            ('this is not a function', 'inc'),
-            ('variable defined here', 'inc: i32 = 0'),
+            ('this is not a function', 'x'),
+            ('variable defined here', 'x: i32 = 0'),
         )
-        with ctx:
-            mod = self.compile("""
-            inc: i32 = 0
-            def bar() -> void:
-                return inc(0)
-            """)
-            mod.bar()
+        self.compile_raises(src, "foo", errors)
 
     def test_function_call_missing_args(self):
-        ctx = expect_errors(
+        src = """
+        def inc(x: i32) -> i32:
+            return x+1
+        def foo() -> void:
+            return inc()
+        """
+        errors = expect_errors(
             'this function takes 1 argument but 0 arguments were supplied',
             ('1 argument missing', 'inc'),
             ('function defined here', 'def inc(x: i32) -> i32'),
         )
-        with ctx:
-            mod = self.compile("""
-            def inc(x: i32) -> i32:
-                return x+1
-            def bar() -> void:
-                return inc()
-            """)
-            mod.bar()
+        self.compile_raises(src, "foo", errors)
 
     def test_function_call_extra_args(self):
-        ctx = expect_errors(
+        src = """
+        def inc(x: i32) -> i32:
+            return x+1
+        def foo() -> void:
+            return inc(1, 2, 3)
+        """
+        errors = expect_errors(
             'this function takes 1 argument but 3 arguments were supplied',
             ('2 extra arguments', '2, 3'),
             ('function defined here', 'def inc(x: i32) -> i32'),
         )
-        with ctx:
-            mod = self.compile("""
-            def inc(x: i32) -> i32:
-                return x+1
-            def bar() -> void:
-                return inc(1, 2, 3)
-            """)
-            mod.bar()
+        self.compile_raises(src, 'foo', errors)
 
     def test_function_call_type_mismatch(self):
-        ctx = expect_errors(
+        src = """
+        def inc(x: i32) -> i32:
+            return x+1
+        def foo() -> i32:
+            return inc("hello")
+        """
+        errors = expect_errors(
             'mismatched types',
-            ('expected `i32`, got `str`', 's'),
+            ('expected `i32`, got `str`', '"hello"'),
             ('function defined here', 'def inc(x: i32) -> i32'),
         )
-        with ctx:
-            mod = self.compile("""
-            def inc(x: i32) -> i32:
-                return x+1
-            def bar(s: str) -> i32:
-                return inc(s)
-            """)
-            mod.bar("hello")
+        self.compile_raises(src, "foo", errors)
 
     def test_StmtExpr(self):
         mod = self.compile("""

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -20,17 +20,15 @@ class TestBasic(CompilerTest):
             assert mod.foo.w_func.redshifted
 
     def test_NameError(self):
-        ctx = expect_errors(
+        src = """
+        def foo() -> i32:
+            return x
+        """
+        errors = expect_errors(
             'name `x` is not defined',
             ('not found in this scope', 'x')
         )
-        with ctx:
-            mod = self.compile(
-            """
-            def foo() -> i32:
-                return x
-            """)
-            mod.foo()
+        mod = self.compile_raises(src, 'foo', errors)
 
     def test_resolve_type_errors(self):
         ctx = expect_errors(
@@ -98,7 +96,6 @@ class TestBasic(CompilerTest):
         )
         self.compile_raises(src, "foo", errors)
 
-    #@skip_backends('C', reason='object not supported')
     @pytest.mark.skip('fix me')
     def test_local_upcast_and_downcast(self):
         mod = self.compile("""

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -481,29 +481,33 @@ class TestBasic(CompilerTest):
         self.compile_raises(src, "foo", errors)
 
     def test_getitem_error_1(self):
-        ctx = expect_errors(
+        src = """
+        def bar(a: str, i: bool) -> void:
+            a[i]
+
+        def foo() -> void:
+            bar("hello", True)
+        """
+        errors = expect_errors(
             'mismatched types',
             ('expected `i32`, got `bool`', 'i'),
             ('this is a `str`', 'a'),
             )
-        with ctx:
-            mod = self.compile(f"""
-            def foo(a: str, i: bool) -> void:
-                a[i]
-            """)
-            mod.foo("hello", True)
+        self.compile_raises(src, "foo", errors)
 
     def test_getitem_error_2(self):
-        ctx = expect_errors(
+        src = """
+        def bar(a: bool, i: i32) -> void:
+            a[i]
+
+        def foo() -> void:
+            bar(True, 1)
+        """
+        errors = expect_errors(
             '`bool` does not support `[]`',
             ('this is a `bool`', 'a'),
             )
-        with ctx:
-            mod = self.compile(f"""
-            def foo(a: bool, i: i32) -> void:
-                a[i]
-            """)
-            mod.foo(True, 1)
+        self.compile_raises(src, "foo", errors)
 
     def test_builtin_function(self):
         mod = self.compile("""

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -154,20 +154,18 @@ class TestBasic(CompilerTest):
         assert mod.get_x() == 100
 
     def test_cannot_assign_to_const_globals(self):
-        ctx = expect_errors(
+        src = """
+        x: i32 = 42
+        def set_x() -> void:
+            x = 100
+        """
+        errors = expect_errors(
             'invalid assignment target',
             ('x is const', 'x'),
             ('const declared here', 'x: i32 = 42'),
             ('help: declare it as variable: `var x ...`', 'x: i32 = 42')
         )
-        with ctx:
-            mod = self.compile(
-            """
-            x: i32 = 42
-            def set_x(newval: i32) -> void:
-                x = newval
-            """)
-            mod.set_x(100)
+        self.compile_raises(src, "set_x", errors)
 
     def test_i32_add(self):
         mod = self.compile("""

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -219,34 +219,35 @@ class TestBasic(CompilerTest):
                 mod.implicit_return_i32()
 
     def test_BinOp_error(self):
-        ctx = expect_errors(
+        src = """
+        def bar(a: i32, b: str) -> void:
+            return a + b
+
+        def foo() -> void:
+            bar(1, "hello")
+        """
+        errors = expect_errors(
             'cannot do `i32` + `str`',
             ('this is `i32`', 'a'),
             ('this is `str`', 'b'),
         )
-        with ctx:
-            mod = self.compile("""
-                def bar(a: i32, b: str) -> void:
-                    return a + b
-                """)
-            mod.bar(1, "hello")
+        self.compile_raises(src, "foo", errors)
 
     def test_BinOp_is_dispatched_with_static_types(self):
         # this fails because the static type of 'x' is object, even if its
         # dynamic type is i32
-        ctx = expect_errors(
+        src = """
+        def foo() -> i32:
+            a: object = 1
+            b: i32 = 2
+            return a + b
+        """
+        errors = expect_errors(
             'cannot do `object` + `i32`',
             ('this is `object`', 'a'),
             ('this is `i32`', 'b'),
         )
-        with ctx:
-            mod = self.compile("""
-            def foo() -> i32:
-                a: object = 1
-                b: i32 = 2
-                return a + b
-            """)
-            mod.foo()
+        self.compile_raises(src, "foo", errors)
 
     def test_function_call(self):
         mod = self.compile("""

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -31,15 +31,17 @@ class TestBasic(CompilerTest):
         mod = self.compile_raises(src, 'foo', errors)
 
     def test_resolve_type_errors(self):
-        ctx = expect_errors(
+        # NOTE: this error is always eager because it doesn't happen when
+        # running the function, but when defining it
+        src = """
+        def foo() -> aaa:
+            return 42
+        """
+        errors = expect_errors(
             'name `aaa` is not defined',
             ('not found in this scope', 'aaa')
         )
-        with ctx:
-            mod = self.compile("""
-            def foo() -> aaa:
-                return 42
-            """)
+        self.compile_raises(src, 'foo', errors, error_reporting='eager')
 
     def test_wrong_functype_restype(self):
         ctx = expect_errors(

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -86,19 +86,17 @@ class TestBasic(CompilerTest):
         """)
         assert mod.foo() == 42
 
-    @skip_backends('C', reason='doppler is buggy')
     def test_local_typecheck(self):
-        ctx = expect_errors(
+        src = """
+        def foo() -> i32:
+            x: str = 1
+        """
+        errors = expect_errors(
             'mismatched types',
             ('expected `str`, got `i32`', '1'),
             ('expected `str` because of type declaration', 'str'),
         )
-        with ctx:
-            mod = self.compile("""
-            def foo() -> i32:
-                x: str = 1
-            """)
-            mod.foo()
+        self.compile_raises(src, "foo", errors)
 
     #@skip_backends('C', reason='object not supported')
     @pytest.mark.skip('fix me')

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -65,20 +65,17 @@ class TestBasic(CompilerTest):
                 return 42
             """)
 
-    # XXX the doppler should recognize type errors and act accordingly
-    @skip_backends('C', reason='doppler is buggy')
     def test_wrong_return_type(self):
-        ctx = expect_errors(
+        src = """
+        def foo() -> str:
+            return 42
+        """
+        errors = expect_errors(
             'mismatched types',
             ('expected `str`, got `i32`', "return 42"),
             ('expected `str` because of return type', "str"),
         )
-        with ctx:
-            mod = self.compile("""
-            def foo() -> str:
-                return 42
-            """)
-            mod.foo()
+        self.compile_raises(src, 'foo', errors)
 
     def test_local_variables(self):
         mod = self.compile(
@@ -103,7 +100,8 @@ class TestBasic(CompilerTest):
             """)
             mod.foo()
 
-    @skip_backends('C', reason='object not supported')
+    #@skip_backends('C', reason='object not supported')
+    @pytest.mark.skip('fix me')
     def test_local_upcast_and_downcast(self):
         mod = self.compile("""
         def foo() -> i32:

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -374,17 +374,19 @@ class TestBasic(CompilerTest):
         assert mod.cmp_gte(6, 5) is True
 
     def test_CompareOp_error(self):
-        ctx = expect_errors(
+        src = """
+        def bar(a: i32, b: str) -> bool:
+            return a == b
+
+        def foo() -> void:
+            bar(1, "hello")
+        """
+        errors = expect_errors(
             'cannot do `i32` == `str`',
             ('this is `i32`', 'a'),
             ('this is `str`', 'b'),
         )
-        with ctx:
-            mod = self.compile("""
-            def foo(a: i32, b: str) -> bool:
-                return a == b
-            """)
-            mod.foo(1, 'hello')
+        self.compile_raises(src, 'foo', errors)
 
     def test_if_stmt(self):
         mod = self.compile("""
@@ -449,33 +451,34 @@ class TestBasic(CompilerTest):
         # XXX: eventually, we want to introduce the concept of "truth value"
         # and insert automatic conversions but for now the condition must be a
         # bool
-        ctx = expect_errors(
+        src = """
+        def bar(a: i32) -> i32:
+            if a:
+                return 1
+            return 2
+
+        def foo() -> void:
+            bar(1)
+        """
+        errors = expect_errors(
             'mismatched types',
             ('expected `bool`, got `i32`', 'a'),
             ('implicit conversion to `bool` is not implemented yet', 'a')
         )
-        with ctx:
-            mod = self.compile("""
-            def foo(a: i32) -> i32:
-                if a:
-                    return 1
-                return 2
-            """)
-            mod.foo(1)
+        self.compile_raises(src, "foo", errors)
 
     def test_while_error(self):
-        ctx = expect_errors(
+        src = """
+        def foo() -> void:
+            while 123:
+                pass
+        """
+        errors = expect_errors(
             'mismatched types',
             ('expected `bool`, got `i32`', '123'),
             ('implicit conversion to `bool` is not implemented yet', '123')
         )
-        with ctx:
-            mod = self.compile("""
-            def foo() -> void:
-                while 123:
-                    pass
-            """)
-            mod.foo()
+        self.compile_raises(src, "foo", errors)
 
     def test_getitem_error_1(self):
         ctx = expect_errors(

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -44,26 +44,26 @@ class TestBasic(CompilerTest):
         self.compile_raises(src, 'foo', errors, error_reporting='eager')
 
     def test_wrong_functype_restype(self):
-        ctx = expect_errors(
+        src = """
+        def foo() -> 'hello':
+            return 42
+        """
+        errors = expect_errors(
             'expected `type`, got `str`',
             ('expected `type`', "'hello'")
         )
-        with ctx:
-            self.compile("""
-            def foo() -> 'hello':
-                return 42
-            """)
+        self.compile_raises(src, 'foo', errors, error_reporting='eager')
 
     def test_wrong_functype_argtype(self):
-        ctx = expect_errors(
+        src = """
+        def foo(x: 'hello') -> i32:
+            return 42
+        """
+        errors = expect_errors(
             'expected `type`, got `str`',
             ('expected `type`', "'hello'"),
         )
-        with ctx:
-            self.compile("""
-            def foo(x: 'hello') -> i32:
-                return 42
-            """)
+        self.compile_raises(src, 'foo', errors, error_reporting='eager')
 
     def test_wrong_return_type(self):
         src = """

--- a/spy/tests/support.py
+++ b/spy/tests/support.py
@@ -155,7 +155,8 @@ class CompilerTest:
         else:
             assert False, f'Unknown backend: {self.backend}'
 
-    def compile_raises(self, src: str, funcname: str, ctx: Any) -> None:
+    def compile_raises(self, src: str, funcname: str, ctx: Any,
+                       error_reporting: Optional[str] = None) -> None:
         """
         Compile the given src and run the function with the given funcname.
 
@@ -169,7 +170,10 @@ class CompilerTest:
         `ctx` is a context manager which catches and expects the error, and is
         supposed to be obtained by calling `expect_errors`.
         """
-        if self.error_reporting == 'eager':
+        if error_reporting is None:
+            error_reporting = self.error_reporting
+
+        if error_reporting == 'eager':
             with ctx:
                 mod = self.compile(src)
         else:

--- a/spy/tests/support.py
+++ b/spy/tests/support.py
@@ -117,6 +117,15 @@ class CompilerTest:
         srcfile.write(src)
         return srcfile
 
+    @property
+    def error_reporting(self) -> None:
+        # ideally for 'doppler' and 'C' we would like to be able to choose
+        # either eager or lazy. For now, we hard-code it to eager.
+        if self.backend == 'interp':
+            return 'lazy'
+        else:
+            return 'eager'
+
     def compile(self, src: str) -> Any:
         """
         Compile the W_Module into something which can be accessed and called by
@@ -145,6 +154,30 @@ class CompilerTest:
             return WasmModuleWrapper(self.vm, modname, file_wasm)
         else:
             assert False, f'Unknown backend: {self.backend}'
+
+    def compile_raises(self, src: str, funcname: str, ctx: Any) -> None:
+        """
+        Compile the given src and run the function with the given funcname.
+
+        The code is expected to contains errors, but depending on the
+        `error_reporting` mode, the error is raised at different times:
+
+          - 'eager': the error is expected to be raised at compile-time
+
+          - 'lazy': the error is expected to be raised at run-time
+
+        `ctx` is a context manager which catches and expects the error, and is
+        supposed to be obtained by calling `expect_errors`.
+        """
+        if self.error_reporting == 'eager':
+            with ctx:
+                mod = self.compile(src)
+        else:
+            mod = self.compile(src)
+            with ctx:
+                fn = getattr(mod, funcname)
+                fn()
+
 
 MatchAnnotation = tuple[str, str]
 

--- a/spy/tests/support.py
+++ b/spy/tests/support.py
@@ -156,6 +156,7 @@ class CompilerTest:
             assert False, f'Unknown backend: {self.backend}'
 
     def compile_raises(self, src: str, funcname: str, ctx: Any,
+                       *,
                        error_reporting: Optional[str] = None) -> None:
         """
         Compile the given src and run the function with the given funcname.

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -64,7 +64,9 @@ class ASTFrame:
         self.locals[name] = None
 
     def store_local(self, got_loc: Loc, name: str, w_value: W_Object) -> None:
-        self.t.typecheck_local(got_loc, name, w_value)
+        # XXX: should we do static or dynamic type checking?
+        w_value_type = self.vm.dynamic_type(w_value)
+        self.t.typecheck_local(got_loc, name, w_value_type)
         self.locals[name] = w_value
 
     def load_local(self, name: str) -> W_Object:
@@ -142,7 +144,7 @@ class ASTFrame:
 
     def exec_stmt_Return(self, stmt: ast.Return) -> None:
         fv = self.eval_expr(stmt.value)
-        self.t.typecheck_local(stmt.loc, '@return', fv.w_value)
+        self.t.typecheck_local(stmt.loc, '@return', fv.w_static_type)
         raise Return(fv.w_value)
 
     def exec_stmt_FuncDef(self, funcdef: ast.FuncDef) -> None:

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -42,16 +42,15 @@ class TypeChecker:
             f'variable already declared: {name}'
         self.locals_types_w[name] = w_type
 
-    def typecheck_local(self, got_loc: Loc, name: str, w_got: W_Object) -> None:
+    def typecheck_local(self, got_loc: Loc, name: str, w_got_type: W_Type) -> None:
         assert name in self.locals_types_w
-        w_type = self.locals_types_w[name]
-        loc = self.funcdef.symtable.lookup(name).type_loc
-        if self.vm.is_compatible_type(w_got, w_type):
+        w_exp_type = self.locals_types_w[name]
+        exp_loc = self.funcdef.symtable.lookup(name).type_loc
+        if self.vm.can_assign_from_to(w_got_type, w_exp_type):
             return
         err = SPyTypeError('mismatched types')
-        got = self.vm.dynamic_type(w_got).name
-        exp = w_type.name
-        exp_loc = loc
+        got = w_got_type.name
+        exp = w_exp_type.name
         err.add('error', f'expected `{exp}`, got `{got}`', loc=got_loc)
         if name == '@return':
             because = 'because of return type'


### PR DESCRIPTION
Type errors can be reported lazily (at runtime, e.g. in case of the interp backend) or eagerly  (at compile time, e.g. for doppler and C backends).

This PR introduces a new pattern for being able to test all the desired cases.

Moreover, it fixes doppler to eager typechecks for local variables and return types. This allows to unskip some tests.