### PR TITLE
Refactor vardef

### DIFF
--- a/spy/ast.py
+++ b/spy/ast.py
@@ -149,6 +149,7 @@ class GlobalFuncDef(Decl):
 @dataclass(eq=False)
 class GlobalVarDef(Decl):
     vardef: 'VarDef'
+    assign: 'Assign'
 
     @property
     def loc(self) -> Loc:
@@ -420,7 +421,6 @@ class VarDef(Stmt):
     kind: VarKind
     name: str
     type: Expr
-    value: Optional[Expr]
 
 @dataclass(eq=False)
 class StmtExpr(Stmt):

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -207,11 +207,8 @@ class CFuncWriter:
             self.out.wl(f'return {v};')
 
     def emit_stmt_VarDef(self, vardef: ast.VarDef) -> None:
-        assert vardef.value is not None, 'XXX'
-        # we don't need to eval vardef.type, because all local vars have
-        # already been declared
-        v = self.fmt_expr(vardef.value)
-        self.out.wl(f'{vardef.name} = {v};')
+        # all local vars have already been declared, nothing to do
+        pass
 
     def emit_stmt_Assign(self, assign: ast.Assign) -> None:
         v = self.fmt_expr(assign.value)

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -85,10 +85,8 @@ class SPyBackend:
         self.wl(f'{assign.target} = {v}')
 
     def emit_stmt_VarDef(self, vardef: ast.VarDef) -> None:
-        assert vardef.value is not None, 'XXX'
         t = self.fmt_expr(vardef.type)
-        v = self.fmt_expr(vardef.value)
-        self.wl(f'{vardef.name}: {t} = {v}')
+        self.wl(f'{vardef.name}: {t}')
 
     # expressions
 

--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -50,7 +50,7 @@ class ModuleGen:
             if isinstance(decl, ast.GlobalFuncDef):
                 self.gen_FuncDef(frame, decl.funcdef)
             elif isinstance(decl, ast.GlobalVarDef):
-                self.gen_GlobalVarDef(frame, decl.vardef)
+                self.gen_GlobalVarDef(frame, decl)
         #
         return self.w_mod
 
@@ -72,9 +72,10 @@ class ModuleGen:
         w_func = frame.load_local(funcdef.name)
         self.vm.add_global(fqn, None, w_func)
 
-    def gen_GlobalVarDef(self, frame: ASTFrame, vardef: ast.VarDef) -> None:
-        assert vardef.value is not None, 'WIP?'
+    def gen_GlobalVarDef(self, frame: ASTFrame, decl: ast.GlobalVarDef) -> None:
+        vardef = decl.vardef
+        assign = decl.assign
         fqn = FQN(modname=self.modname, attr=vardef.name)
         w_type = frame.eval_expr_type(vardef.type)
-        w_value = frame.eval_expr_object(vardef.value)
+        w_value = frame.eval_expr_object(assign.value)
         self.vm.add_global(fqn, w_type, w_value)

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -64,6 +64,7 @@ class Parser:
                 mod.decls.append(globfunc)
             elif isinstance(py_stmt, py_ast.AnnAssign):
                 vardef, assign = self.from_py_AnnAssign(py_stmt, is_global=True)
+                assert assign is not None
                 globvar = spy.ast.GlobalVarDef(vardef, assign)
                 mod.decls.append(globvar)
             elif isinstance(py_stmt, py_ast.ImportFrom):
@@ -175,13 +176,14 @@ class Parser:
     # ====== spy.ast.Stmt ======
 
     def from_py_body(self, py_body: list[py_ast.stmt]) -> list[spy.ast.Stmt]:
-        body = []
+        body: list[spy.ast.Stmt] = []
         for py_stmt in py_body:
             if isinstance(py_stmt, py_ast.AnnAssign):
                 # special case, as it's the stmt wich generates two
                 vardef, assign = self.from_py_AnnAssign(py_stmt)
                 body.append(vardef)
-                body.append(assign)
+                if assign:
+                    body.append(assign)
             else:
                 stmt = self.from_py_stmt(py_stmt)
                 body.append(stmt)

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -63,8 +63,8 @@ class Parser:
                 globfunc = spy.ast.GlobalFuncDef(funcdef.loc, funcdef)
                 mod.decls.append(globfunc)
             elif isinstance(py_stmt, py_ast.AnnAssign):
-                vardef = self.from_py_stmt_AnnAssign(py_stmt, is_global=True)
-                globvar = spy.ast.GlobalVarDef(vardef)
+                vardef, assign = self.from_py_AnnAssign(py_stmt, is_global=True)
+                globvar = spy.ast.GlobalVarDef(vardef, assign)
                 mod.decls.append(globvar)
             elif isinstance(py_stmt, py_ast.ImportFrom):
                 importdecls = self.from_py_ImportFrom(py_stmt)
@@ -175,7 +175,17 @@ class Parser:
     # ====== spy.ast.Stmt ======
 
     def from_py_body(self, py_body: list[py_ast.stmt]) -> list[spy.ast.Stmt]:
-        return [self.from_py_stmt(py_stmt) for py_stmt in py_body]
+        body = []
+        for py_stmt in py_body:
+            if isinstance(py_stmt, py_ast.AnnAssign):
+                # special case, as it's the stmt wich generates two
+                vardef, assign = self.from_py_AnnAssign(py_stmt)
+                body.append(vardef)
+                body.append(assign)
+            else:
+                stmt = self.from_py_stmt(py_stmt)
+                body.append(stmt)
+        return body
 
     def from_py_stmt(self, py_node: py_ast.stmt) -> spy.ast.Stmt:
         return magic_dispatch(self, 'from_py_stmt', py_node)
@@ -202,10 +212,10 @@ class Parser:
             value = self.from_py_expr(py_node.value)
         return spy.ast.Return(py_node.loc, value)
 
-    def from_py_stmt_AnnAssign(self,
-                               py_node: py_ast.AnnAssign,
-                               is_global: bool = False
-                               ) -> spy.ast.VarDef:
+    def from_py_AnnAssign(self,
+                          py_node: py_ast.AnnAssign,
+                          is_global: bool = False
+                          ) -> tuple[spy.ast.VarDef, Optional[spy.ast.Assign]]:
         if not py_node.simple:
             self.error(f"not supported: assignments targets with parentheses",
                        "this is not supported", py_node.target.loc)
@@ -222,13 +232,25 @@ class Parser:
             kind = 'var'
         else:
             kind = 'const'
-        return spy.ast.VarDef(
+
+        vardef = spy.ast.VarDef(
             loc = py_node.loc,
             kind = kind,
             name = py_node.target.id,
             type = self.from_py_expr(py_node.annotation),
-            value = self.from_py_expr(py_node.value)
         )
+
+        if py_node.value is None:
+            assign = None
+        else:
+            assign = spy.ast.Assign(
+                loc = py_node.loc,
+                target_loc = py_node.target.loc,
+                target = py_node.target.id,
+                value = self.from_py_expr(py_node.value)
+            )
+
+        return vardef, assign
 
     def from_py_stmt_Assign(self, py_node: py_ast.Assign) -> spy.ast.Stmt:
         # Assign can be pretty complex: it can have multiple targets, and a

--- a/spy/tests/test_backend_spy.py
+++ b/spy/tests/test_backend_spy.py
@@ -52,9 +52,12 @@ class TestSPyBackend(CompilerTest):
         """)
 
     def test_vardef(self):
-        src = """
+        mod = self.compile("""
         def foo() -> void:
             x: i32 = 1
-        """
-        mod = self.compile(src)
-        self.assert_dump(mod.foo.w_func, src)
+        """)
+        self.assert_dump(mod.foo.w_func, """
+        def foo() -> void:
+            x: i32
+            x = 1
+        """)

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -52,7 +52,13 @@ class TestDoppler:
             return x
         """
         w_func = self.redshift(src, 'foo')
-        self.assert_dump(w_func, src)
+        expected = """
+        def foo() -> i32:
+            x: i32
+            x = 1
+            return x
+        """
+        self.assert_dump(w_func, expected)
 
     def test_funcargs(self):
         src = """
@@ -70,7 +76,8 @@ class TestDoppler:
         w_func = self.redshift(src, 'foo')
         expected = """
         def foo(x: `builtins::i32`) -> `builtins::void`:
-            y: `builtins::str` = 'hello'
+            y: `builtins::str`
+            y = 'hello'
         """
         self.assert_dump(w_func, expected, fqn_format='full')
 

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -272,18 +272,24 @@ class TestParser:
         def foo() -> void:
             x: i32 = 42
         """)
-        stmt = mod.get_funcdef('foo').body[0]
-        expected = """
+        vardef, assign = mod.get_funcdef('foo').body[:2]
+        vardef_expected = """
         VarDef(
             kind='var',
             name='x',
             type=Name(id='i32'),
+        )
+        """
+        assign_expected = """
+        Assign(
+            target='x',
             value=Constant(value=42),
         )
         """
-        self.assert_dump(stmt, expected)
+        self.assert_dump(vardef, vardef_expected)
+        self.assert_dump(assign, assign_expected)
 
-    def test_global_VarDef(self):
+    def test_global_VarDef_const(self):
         mod = self.parse("""
         x: i32 = 42
         """)
@@ -296,6 +302,9 @@ class TestParser:
                         kind='const',
                         name='x',
                         type=Name(id='i32'),
+                    ),
+                    assign=Assign(
+                        target='x',
                         value=Constant(value=42),
                     ),
                 ),
@@ -317,6 +326,9 @@ class TestParser:
                         kind='var',
                         name='x',
                         type=Name(id='i32'),
+                    ),
+                    assign=Assign(
+                        target='x',
                         value=Constant(value=42),
                     ),
                 ),

--- a/spy/tests/test_scope.py
+++ b/spy/tests/test_scope.py
@@ -151,7 +151,7 @@ class TestScopeAnalyzer:
             'i32': MatchSymbol('i32', 'blue', level=2),
         }
         #
-        bardef = foodef.body[1]
+        bardef = foodef.body[2]
         assert isinstance(bardef, ast.FuncDef)
         assert bardef.symtable._symbols == {
             'y': MatchSymbol('y', 'red'),

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -167,18 +167,10 @@ class ASTFrame:
         self.declare_local(funcdef.name, w_func.w_functype)
         self.store_local(funcdef.loc, funcdef.name, w_func)
 
-    def declare_VarDef(self, vardef: ast.VarDef) -> Symbol:
-        sym = self.funcdef.symtable.lookup(vardef.name)
-        assert sym.is_local
+    def exec_stmt_VarDef(self, vardef: ast.VarDef) -> None:
+        self.t.check_expr(vardef.type)
         w_type = self.eval_expr_type(vardef.type)
         self.declare_local(vardef.name, w_type)
-        return sym
-
-    def exec_stmt_VarDef(self, vardef: ast.VarDef) -> None:
-        self.declare_VarDef(vardef)
-        assert vardef.value is not None, 'WIP?'
-        w_value = self.eval_expr_object(vardef.value)
-        self.store_local(vardef.value.loc, vardef.name, w_value)
 
     def exec_stmt_Assign(self, assign: ast.Assign) -> None:
         self.t.check_stmt_Assign(assign)


### PR DESCRIPTION
`ast.VarDef` now represents only the variable declaration. The initialization is rendered as a separate `ast.Assign` node.

This should hopefully make astframe, typechecker and doppler easier and less tangled (more PRs to come)