### PR TITLE
Introduce type converters

### DIFF
--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -98,16 +98,31 @@ class TestBasic(CompilerTest):
         )
         self.compile_raises(src, "foo", errors)
 
-    @pytest.mark.skip('fix me')
-    def test_local_upcast_and_downcast(self):
+    @skip_backends('C', reason='type <object> not supported')
+    def test_upcast_and_downcast(self):
         mod = self.compile("""
         def foo() -> i32:
             x: i32 = 1
-            # this works, but will insert a downcast in the compiled code
+            # this works, but it will check the type at runtime
             y: object = x
             return y
         """)
         assert mod.foo() == 1
+
+    @skip_backends('C', reason='type <object> not supported')
+    def test_downcast_error(self):
+        # NOTE: we don't check this with expect_errors because this is ALWAYS
+        # a runtime error. The compilation always succeed.
+        mod = self.compile("""
+        def foo() -> str:
+            x: i32 = 1
+            y: object = x
+            return y
+        """)
+        msg = "Invalid cast. Expected `str`, got `i32`"
+        with pytest.raises(SPyTypeError, match=msg):
+            mod.foo()
+
 
     def test_function_arguments(self):
         mod = self.compile(

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -72,7 +72,7 @@ class TestBasic(CompilerTest):
         """
         errors = expect_errors(
             'mismatched types',
-            ('expected `str`, got `i32`', "return 42"),
+            ('expected `str`, got `i32`', "42"),
             ('expected `str` because of return type', "str"),
         )
         self.compile_raises(src, 'foo', errors)

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -3,6 +3,7 @@ import pytest
 from spy.vm.vm import SPyVM
 from spy.vm.builtins import B
 from spy.fqn import FQN
+from spy.errors import SPyTypeError
 from spy.vm.object import W_Object, W_Type, spytype, W_void, W_i32, W_bool
 from spy.vm.str import W_str
 from spy.vm.function import W_BuiltinFunc
@@ -147,3 +148,18 @@ class TestVM:
         assert vm.dynamic_type(w_hello) is B.w_str
         assert vm.unwrap(w_hello) == 'hello'
         assert repr(w_hello) == "W_str('hello')"
+
+    def test_call_function(self):
+        vm = SPyVM()
+        w_abs = B.w_abs
+        w_x = vm.wrap(-42)
+        w_y = vm.call_function(w_abs, [w_x])
+        assert vm.unwrap(w_y) == 42
+
+    def test_call_function_TypeError(self):
+        vm = SPyVM()
+        w_abs = B.w_abs
+        w_x = vm.wrap('hello')
+        msg = 'Invalid cast. Expected `i32`, got `str`'
+        with pytest.raises(SPyTypeError, match=msg):
+            vm.call_function(w_abs, [w_x])

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -113,10 +113,11 @@ class ASTFrame:
         if typeconv is None:
             return fv
         else:
+            # apply the type converter, if present. Note that the static type
+            # of the expression is the one given by the converter, not the
+            # original one in fv.w_static_type
             w_newvalue = typeconv.convert(self.vm, fv.w_value)
-            # XXX: I THINK this should use typeconv.w_type, but I would like
-            # to write a test to be sure
-            return FrameVal(fv.w_static_type, w_newvalue)
+            return FrameVal(typeconv.w_type, w_newvalue)
 
     def eval_expr_object(self, expr: ast.Expr) -> W_Object:
         fv = self.eval_expr(expr)

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -93,13 +93,10 @@ class ASTFrame:
         params = self.w_func.w_functype.params
         arglocs = [arg.loc for arg in self.funcdef.args]
         for loc, param, w_arg in zip(arglocs, params, args_w, strict=True):
-            # XXX: we should do a proper typecheck and raise a nice error
-            # here. We don't have any test for it
-            w_got_type = self.vm.dynamic_type(w_arg)
-            assert self.vm.can_assign_from_to(
-                w_got_type,
-                self.t.locals_types_w[param.name]
-            )
+            # we assume that the arguments' types are correct. It's not the
+            # job of astframe to raise SPyTypeError if there is a type
+            # mismatch here, it is the job of vm.call_function
+            assert self.vm.isinstance(w_arg, param.w_type)
             self.store_local(param.name, w_arg)
 
     def exec_stmt(self, stmt: ast.Stmt) -> None:

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -281,14 +281,9 @@ class TypeChecker:
         icolor, w_itype = self.check_expr(expr.index)
         color = maybe_blue(vcolor, icolor)
         if w_vtype is B.w_str:
-            if w_itype is B.w_i32:
-                return color, B.w_str
-            else:
-                err = SPyTypeError('mismatched types')
-                got = w_itype.name
-                err.add('error', f'expected `i32`, got `{got}`', expr.index.loc)
-                err.add('note', f'this is a `str`', expr.value.loc)
-                raise err
+            err = self.convert_type_maybe(expr.index, w_itype, B.w_i32)
+            err.add('note', f'this is a `str`', expr.value.loc)
+            raise err
         else:
             got = w_vtype.name
             err = SPyTypeError(f'`{got}` does not support `[]`')

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -282,8 +282,10 @@ class TypeChecker:
         color = maybe_blue(vcolor, icolor)
         if w_vtype is B.w_str:
             err = self.convert_type_maybe(expr.index, w_itype, B.w_i32)
-            err.add('note', f'this is a `str`', expr.value.loc)
-            raise err
+            if err:
+                err.add('note', f'this is a `str`', expr.value.loc)
+                raise err
+            return color, B.w_str
         else:
             got = w_vtype.name
             err = SPyTypeError(f'`{got}` does not support `[]`')

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -309,11 +309,11 @@ class TypeChecker:
         #
         for i, (param, w_arg_type) in enumerate(zip(w_functype.params,
                                                     argtypes_w)):
-            # TODO: kill this!
-            if not self.vm.can_assign_from_to(w_arg_type, param.w_type):
-                self._call_error_type_mismatch(call, sym, i,
-                                               w_exp_type = param.w_type,
-                                               w_got_type = w_arg_type)
+            err = self.convert_type_maybe(call.args[i], w_arg_type, param.w_type)
+            if err:
+                if sym:
+                    err.add('note', 'function defined here', sym.loc)
+                raise err
         #
         color = 'red' # XXX fix me
         return color, w_functype.w_restype
@@ -352,21 +352,6 @@ class TypeChecker:
             )
             err.add('error', f'{diff} extra {arguments}', loc)
         #
-        if sym:
-            err.add('note', 'function defined here', sym.loc)
-        raise err
-
-    def _call_error_type_mismatch(self,
-                                  call: ast.Call,
-                                  sym: Optional[Symbol],
-                                  i: int,
-                                  w_exp_type: W_Type,
-                                  w_got_type: W_Type
-                                  ) -> NoReturn:
-        err = SPyTypeError('mismatched types')
-        exp = w_exp_type.name
-        got = w_got_type.name
-        err.add('error', f'expected `{exp}`, got `{got}`', call.args[i].loc)
         if sym:
             err.add('note', 'function defined here', sym.loc)
         raise err

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -75,6 +75,14 @@ class TypeChecker:
         err.add('note', f'expected `{exp}` {because}', loc=exp_loc)
         raise err
 
+    def typecheck_bool(self, expr: ast.Expr) -> None:
+        color, w_type = self.check_expr(expr)
+        err = self.convert_type_maybe(expr, w_type, B.w_bool)
+        if err:
+            msg = 'implicit conversion to `bool` is not implemented yet'
+            err.add('note', msg, expr.loc)
+            raise err
+
     def convert_type_maybe(self, expr: ast.Expr, w_got: W_Type,
                            w_exp: W_Type) -> Optional[SPyTypeError]:
         """
@@ -110,15 +118,6 @@ class TypeChecker:
         if isinstance(expr, ast.Name):
             return self.funcdef.symtable.lookup_maybe(expr.id)
         return None
-
-    def assert_bool(self, w_type: W_Type, loc: Loc) -> None:
-        if w_type is not B.w_bool:
-            err = SPyTypeError('mismatched types')
-            err.add('error', f'expected `bool`, got `{w_type.name}`', loc)
-            err.add('note',
-                    f'implicit conversion to `bool` is not implemented yet',
-                    loc)
-            raise err
 
     def check_stmt(self, stmt: ast.Stmt) -> None:
         magic_dispatch(self, 'check_stmt', stmt)
@@ -167,12 +166,10 @@ class TypeChecker:
         pass
 
     def check_stmt_If(self, if_node: ast.If) -> None:
-        color, w_cond_type = self.check_expr(if_node.test)
-        self.assert_bool(w_cond_type, if_node.test.loc)
+        self.typecheck_bool(if_node.test)
 
     def check_stmt_While(self, while_node: ast.While) -> None:
-        color, w_cond_type = self.check_expr(while_node.test)
-        self.assert_bool(w_cond_type, while_node.test.loc)
+        self.typecheck_bool(while_node.test)
 
     def check_stmt_Assign(self, assign: ast.Assign) -> None:
         name = assign.target

--- a/spy/vm/typeconverter.py
+++ b/spy/vm/typeconverter.py
@@ -1,0 +1,32 @@
+from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from spy.vm.object import W_Object, W_Type
+if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
+
+@dataclass
+class TypeConverter:
+    """
+    Base class to represent a type conversion step.
+    """
+    w_type: W_Type # the desired type after the conversion
+
+    def convert(self, vm: 'SPyVM', w_obj: W_Object) -> W_Object:
+        """
+        Convert w_obj to the desired type.
+
+        The invariant is that the result of convert() must pass a
+        vm.typecheck(..., self.w_type) check.
+        """
+        raise NotImplementedError
+
+
+class DynamicCast(TypeConverter):
+    """
+    This doesn't actually perform any active "conversion", it just checks at
+    runtime that the given object is an instance of the desired type.
+    """
+
+    def convert(self, vm: 'SPyVM', w_obj: W_Object) -> W_Object:
+        vm.typecheck(w_obj, self.w_type)
+        return w_obj

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -184,8 +184,7 @@ class SPyVM:
         w_functype = w_func.w_functype
         assert w_functype.arity == len(args_w)
         for param, w_arg in zip(w_functype.params, args_w):
-            # XXX in theory we should raise a nice SPyTypeError here
-            assert self.isinstance(w_arg, param.w_type)
+            self.typecheck(w_arg, param.w_type)
         #
         if isinstance(w_func, W_ASTFunc):
             frame2 = ASTFrame(self, w_func)

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -5,6 +5,7 @@ import fixedint
 from spy.fqn import FQN
 from spy import libspy
 from spy.doppler import redshift
+from spy.errors import SPyTypeError
 from spy.vm.object import W_Object, W_Type, W_void, W_i32, W_bool
 from spy.vm.str import W_str
 from spy.vm.builtins import B
@@ -121,6 +122,21 @@ class SPyVM:
                 return True
             w_class = w_class.w_base  # type:ignore
         return False
+
+    def isinstance(self, w_obj: W_Object, w_type: W_Type) -> bool:
+        w_t1 = self.dynamic_type(w_obj)
+        return self.issubclass(w_t1, w_type)
+
+    def typecheck(self, w_obj: W_Object, w_type: W_Type) -> None:
+        """
+        Like vm.isinstance(), but raise SPyTypeError if the check fails.
+        """
+        w_t1 = self.dynamic_type(w_obj)
+        if not self.issubclass(w_t1, w_type):
+            exp = w_type.name
+            got = w_t1.name
+            msg = f"Invalid cast. Expected `{exp}`, got `{got}`"
+            raise SPyTypeError(msg)
 
     def is_True(self, w_obj: W_bool) -> bool:
         return w_obj is B.w_True

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -86,7 +86,7 @@ class SPyVM:
         if w_type is None:
             w_type = self.dynamic_type(w_value)
         else:
-            assert self.is_compatible_type(w_value, w_type)
+            assert self.isinstance(w_value, w_type)
         self.globals_types[name] = w_type
         self.globals_w[name] = w_value
 
@@ -106,7 +106,7 @@ class SPyVM:
 
     def store_global(self, fqn: FQN, w_value: W_Object) -> None:
         w_type = self.globals_types[fqn]
-        assert self.is_compatible_type(w_value, w_type)
+        assert self.isinstance(w_value, w_type)
         self.globals_w[fqn] = w_value
 
     def dynamic_type(self, w_obj: W_Object) -> W_Type:
@@ -180,21 +180,12 @@ class SPyVM:
             raise Exception('Type mismatch')
         return w_value.value
 
-    def is_compatible_type(self, w_arg: W_Object, w_type: W_Type) -> bool:
-        # XXX kill this
-        return w_type is B.w_object or self.dynamic_type(w_arg) is w_type
-
-    def can_assign_from_to(self, w_from: W_Type, w_to: W_Type) -> bool:
-        # XXX: this check is wrong: e.g., it should be possible to convert
-        # between floats and integers even if one is not a subclass of the
-        # other
-        return self.issubclass(w_from, w_to)
-
     def call_function(self, w_func: W_Func, args_w: list[W_Object]) -> W_Object:
         w_functype = w_func.w_functype
         assert w_functype.arity == len(args_w)
         for param, w_arg in zip(w_functype.params, args_w):
-            assert self.is_compatible_type(w_arg, param.w_type)
+            # XXX in theory we should raise a nice SPyTypeError here
+            assert self.isinstance(w_arg, param.w_type)
         #
         if isinstance(w_func, W_ASTFunc):
             frame2 = ASTFrame(self, w_func)


### PR DESCRIPTION
This simplifies a lot of things in the dance between the typechecker, the astframe and (later) the doppler:

- whenever the typechecker expects an exception of a certain type, it calls convert_type_maybe
- convert_type_maybe can "attach" a TypeConverter to the expression, in case it's needed
- if the type conversion cannot be done, we raise a SPyTypeError. This simplifies a lot of the old code and reduce code duplication
- the astframe no longer needs to deal with implicit conversions which were assumed to exist by the typechecker: it can assume that the types of objects are always correct

We can use the new mechanism to implement conversions to and from `object`: everything can be converted to `object` and it always succeed. `object` can be converted to anything, but it will introduce a runtime check. Note that the C backend does not support `object` yet.

Another consequence is that now we can finally kill the super-ugly vm.is_compatible_type and vm.can_assign_from_to.
