### PR TITLE
Introduce the concept of OpImpl

### DIFF
--- a/spy/ast.py
+++ b/spy/ast.py
@@ -463,6 +463,8 @@ class FQNConst(Expr):
     precedence = 100 # the highest
     fqn: FQN
 
+
+# XXX maybe this should be turned into PrimitiveFunc or just use FQNConst?
 @dataclass(eq=False)
 class HelperFunc(Expr):
     """

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -11,7 +11,6 @@ from spy.vm.module import W_Module
 from spy.vm.function import W_ASTFunc, W_BuiltinFunc, W_FuncType
 from spy.vm.vm import SPyVM
 from spy.vm.builtins import B
-from spy.vm import helpers
 from spy.textbuilder import TextBuilder
 from spy.backend.c.context import Context, C_Type, C_Function
 from spy.backend.c import c_ast as C

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -112,3 +112,15 @@ class SPyBackend:
     fmt_expr_Sub = fmt_expr_BinOp
     fmt_expr_Mul = fmt_expr_BinOp
     fmt_expr_Div = fmt_expr_BinOp
+
+    def fmt_expr_Call(self, call: ast.Call) -> str:
+        if isinstance(call.func, ast.HelperFunc):
+            helper2ast = {
+                'i32_add': ast.Add,
+                'i32_mul': ast.Mul,
+            }
+            opclass = helper2ast.get(call.func.funcname)
+            assert len(call.args) == 2
+            binop = opclass(call.loc, call.args[0], call.args[1])
+            return self.fmt_expr_BinOp(binop)
+        raise NotImplementedError('fix me')

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -120,6 +120,7 @@ class SPyBackend:
                 'i32_mul': ast.Mul,
             }
             opclass = helper2ast.get(call.func.funcname)
+            assert opclass is not None
             assert len(call.args) == 2
             binop = opclass(call.loc, call.args[0], call.args[1])
             return self.fmt_expr_BinOp(binop)

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -160,15 +160,11 @@ class FuncDoppler:
     shift_expr_GtE = shift_expr_CompareOp
 
     def shift_expr_GetItem(self, op: ast.GetItem) -> ast.Expr:
-        _, w_vtype = self.t.check_expr(op.value)
-        _, w_itype = self.t.check_expr(op.index)
-        argtypes = (w_vtype, w_itype)
         v = self.shift_expr(op.value)
         i = self.shift_expr(op.index)
-        if argtypes == (B.w_str, B.w_i32):
-            func = ast.HelperFunc(op.loc, 'StrGetItem')
-            return ast.Call(op.loc, func, [v, i])
-        assert False, 'unsupported getitem'
+        opimpl = self.t.expr_opimpl[op]
+        func = ast.HelperFunc(op.loc, opimpl.spy_opname) # XXX
+        return ast.Call(op.loc, func, [v, i])
 
     def shift_expr_Call(self, call: ast.Call) -> ast.Expr:
         # XXX: this assumes that it's a direct call (i.e., call.func is a

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -136,26 +136,11 @@ class FuncDoppler:
         return name
 
     def shift_expr_BinOp(self, binop: ast.BinOp) -> ast.Expr:
-        _, w_ltype = self.t.check_expr(binop.left)
-        _, w_rtype = self.t.check_expr(binop.right)
-        argtypes = (w_ltype, w_rtype)
         l = self.shift_expr(binop.left)
         r = self.shift_expr(binop.right)
-
-        # for int ops, we just use the "generic" ast nodes, for now
-        if argtypes == (B.w_i32, B.w_i32):
-            return binop.replace(left=l, right=r)
-
-        # for string ops, we call helpers
-        if binop.op == '+' and argtypes == (B.w_str, B.w_str):
-            func = ast.HelperFunc(binop.loc, 'StrAdd')
-            return ast.Call(binop.loc, func, [l, r])
-
-        if binop.op == '*' and argtypes == (B.w_str, B.w_i32):
-            func = ast.HelperFunc(binop.loc, 'StrMul')
-            return ast.Call(binop.loc, func, [l, r])
-
-        assert False, "Unsupported binop, bug in the typechecker"
+        opimpl = self.t.expr_opimpl[binop]
+        func = ast.HelperFunc(binop.loc, opimpl.spy_opname) # XXX
+        return ast.Call(binop.loc, func, [l, r])
 
     shift_expr_Add = shift_expr_BinOp
     shift_expr_Sub = shift_expr_BinOp

--- a/spy/libspy/include/spy/str.h
+++ b/spy/libspy/include/spy/str.h
@@ -10,16 +10,16 @@ typedef struct {
 } spy_Str;
 
 spy_Str *
-WASM_EXPORT(spy_StrAlloc)(size_t length);
+WASM_EXPORT(spy_str_alloc)(size_t length);
 
 spy_Str *
-WASM_EXPORT(spy_StrAdd)(spy_Str *a, spy_Str *b);
+WASM_EXPORT(spy_str_add)(spy_Str *a, spy_Str *b);
 
 spy_Str *
-WASM_EXPORT(spy_StrMul)(spy_Str *a, int32_t b);
+WASM_EXPORT(spy_str_mul)(spy_Str *a, int32_t b);
 
 // XXX: should we introduce a separate type Char?
 spy_Str *
-WASM_EXPORT(spy_StrGetItem)(spy_Str *s, int32_t i);
+WASM_EXPORT(spy_str_getitem)(spy_Str *s, int32_t i);
 
 #endif /* SPY_STR_H */

--- a/spy/libspy/src/str.c
+++ b/spy/libspy/src/str.c
@@ -1,7 +1,7 @@
 #include "spy.h"
 
 spy_Str *
-spy_StrAlloc(size_t length) {
+spy_str_alloc(size_t length) {
     size_t size = sizeof(spy_Str) + length;
     spy_Str *res = (spy_Str*)spy_GcAlloc(size).p;
     res->length = length;
@@ -9,9 +9,9 @@ spy_StrAlloc(size_t length) {
 }
 
 spy_Str *
-spy_StrAdd(spy_Str *a, spy_Str *b) {
+spy_str_add(spy_Str *a, spy_Str *b) {
     size_t l = a->length + b->length;
-    spy_Str *res = spy_StrAlloc(l);
+    spy_Str *res = spy_str_alloc(l);
     char *buf = (char*)res->utf8;
     memcpy(buf, a->utf8, a->length);
     memcpy(buf + a->length, b->utf8, b->length);
@@ -19,9 +19,9 @@ spy_StrAdd(spy_Str *a, spy_Str *b) {
 }
 
 spy_Str *
-spy_StrMul(spy_Str *a, int32_t b) {
+spy_str_mul(spy_Str *a, int32_t b) {
     size_t l = a->length * b;
-    spy_Str *res = spy_StrAlloc(l);
+    spy_Str *res = spy_str_alloc(l);
     char *buf = (char*)res->utf8;
     for(int i=0; i<b; i++) {
         memcpy(buf, a->utf8, a->length);
@@ -32,7 +32,7 @@ spy_StrMul(spy_Str *a, int32_t b) {
 
 
 spy_Str *
-spy_StrGetItem(spy_Str *s, int32_t i) {
+spy_str_getitem(spy_Str *s, int32_t i) {
     // XXX this is wrong: it should return a code point
     size_t l = s->length;
     if (i < 0) {
@@ -42,7 +42,7 @@ spy_StrGetItem(spy_Str *s, int32_t i) {
         spy_panic("string index out of bound");
         return NULL;
     }
-    spy_Str *res = spy_StrAlloc(1);
+    spy_Str *res = spy_str_alloc(1);
     char *buf = (char*)res->utf8;
     buf[0] = s->utf8[i];
     return res;

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -503,23 +503,9 @@ class TestBasic(CompilerTest):
             bar("hello", True)
         """
         errors = expect_errors(
-            'mismatched types',
-            ('expected `i32`, got `bool`', 'i'),
-            ('this is a `str`', 'a'),
-            )
-        self.compile_raises(src, "foo", errors)
-
-    def test_getitem_error_2(self):
-        src = """
-        def bar(a: bool, i: i32) -> void:
-            a[i]
-
-        def foo() -> void:
-            bar(True, 1)
-        """
-        errors = expect_errors(
-            '`bool` does not support `[]`',
-            ('this is a `bool`', 'a'),
+            'cannot do `str`[`bool`]',
+            ('this is `str`', 'a'),
+            ('this is `bool`', 'i'),
             )
         self.compile_raises(src, "foo", errors)
 

--- a/spy/tests/test_libspy.py
+++ b/spy/tests/test_libspy.py
@@ -49,7 +49,7 @@ class TestLibSPy(CTest):
         spy_Str H = {6, "hello "};
 
         spy_Str *mk_W(void) {
-            spy_Str *s = spy_StrAlloc(5);
+            spy_Str *s = spy_str_alloc(5);
             memcpy((void*)s->utf8, "world", 5);
             return s;
         }
@@ -62,7 +62,7 @@ class TestLibSPy(CTest):
         ptr_W = ll.call('mk_W')
         assert ll.mem.read(ptr_W, 9) == mk_spy_Str(b'world')
         #
-        ptr_HW = ll.call('spy_StrAdd', ptr_H, ptr_W)
+        ptr_HW = ll.call('spy_str_add', ptr_H, ptr_W)
         assert ll.mem.read(ptr_HW, 15) == mk_spy_Str(b'hello world')
 
     def test_debug_log(self):

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -291,13 +291,8 @@ class ASTFrame:
 
     def eval_expr_GetItem(self, op: ast.GetItem) -> FrameVal:
         color, w_restype = self.t.check_expr_GetItem(op)
+        opimpl = self.t.expr_opimpl[op]
         fv_val = self.eval_expr(op.value)
         fv_index = self.eval_expr(op.index)
-        argtypes = (fv_val.w_static_type, fv_index.w_static_type)
-        if argtypes == (B.w_str, B.w_i32):
-            return self.call_helper(
-                'StrGetItem',
-                [fv_val.w_value, fv_index.w_value],
-                w_restype)
-
-        assert False, 'unsupported getitem, bug in the typechecker'
+        w_res = opimpl(self.vm, fv_val.w_value, fv_index.w_value)
+        return FrameVal(w_restype, w_res)

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -229,8 +229,16 @@ class ASTFrame:
 
     def eval_expr_BinOp(self, binop: ast.BinOp) -> FrameVal:
         color, w_restype = self.t.check_expr_BinOp(binop)
+        opimpl = self.t.expr_opimpl[binop]
+        #
         fv_l = self.eval_expr(binop.left)
         fv_r = self.eval_expr(binop.right)
+        w_res = opimpl(self.vm, fv_l.w_value, fv_r.w_value)
+        return FrameVal(w_restype, w_res)
+
+        assert False, 'Unsupported binop, bug in the typechecker'
+
+        # XXX kill me
         w_ltype = fv_l.w_static_type
         w_rtype = fv_r.w_static_type
         argtypes = (w_ltype, w_rtype)

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -242,15 +242,7 @@ class ASTFrame:
         w_ltype = fv_l.w_static_type
         w_rtype = fv_r.w_static_type
         argtypes = (w_ltype, w_rtype)
-        if argtypes == (B.w_i32, B.w_i32):
-            l = self.vm.unwrap(fv_l.w_value)
-            r = self.vm.unwrap(fv_r.w_value)
-            if binop.op == '+':
-                return FrameVal(B.w_i32, self.vm.wrap(l + r))
-            elif binop.op == '*':
-                return FrameVal(B.w_i32, self.vm.wrap(l * r))
-
-        elif binop.op == '+' and argtypes == (B.w_str, B.w_str):
+        if binop.op == '+' and argtypes == (B.w_str, B.w_str):
             return self.call_helper(
                 'StrAdd',
                 [fv_l.w_value, fv_r.w_value],

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -230,31 +230,11 @@ class ASTFrame:
     def eval_expr_BinOp(self, binop: ast.BinOp) -> FrameVal:
         color, w_restype = self.t.check_expr_BinOp(binop)
         opimpl = self.t.expr_opimpl[binop]
-        #
+        assert opimpl, 'bug in the typechecker'
         fv_l = self.eval_expr(binop.left)
         fv_r = self.eval_expr(binop.right)
         w_res = opimpl(self.vm, fv_l.w_value, fv_r.w_value)
         return FrameVal(w_restype, w_res)
-
-        assert False, 'Unsupported binop, bug in the typechecker'
-
-        # XXX kill me
-        w_ltype = fv_l.w_static_type
-        w_rtype = fv_r.w_static_type
-        argtypes = (w_ltype, w_rtype)
-        if binop.op == '+' and argtypes == (B.w_str, B.w_str):
-            return self.call_helper(
-                'StrAdd',
-                [fv_l.w_value, fv_r.w_value],
-                w_restype)
-
-        elif binop.op == '*' and argtypes == (B.w_str, B.w_i32):
-            return self.call_helper(
-                'StrMul',
-                [fv_l.w_value, fv_r.w_value],
-                w_restype)
-
-        assert False, 'Unsupported binop, bug in the typechecker'
 
     eval_expr_Add = eval_expr_BinOp
     eval_expr_Mul = eval_expr_BinOp

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -11,7 +11,7 @@ from spy.vm.builtins import B
 from spy.vm.object import W_Object, W_Type, W_i32, W_bool
 from spy.vm.str import W_str
 from spy.vm.function import W_Func, W_FuncType, W_ASTFunc, Namespace
-from spy.vm import helpers
+from spy.vm import ops
 from spy.vm.typechecker import TypeChecker
 from spy.vm.typeconverter import TypeConverter
 from spy.util import magic_dispatch
@@ -305,8 +305,8 @@ class ASTFrame:
 
     def call_helper(self, funcname: str, args_w: list[W_Object],
                     w_restype: W_Type) -> FrameVal:
-        helper_func = helpers.get(funcname)
-        w_res = helper_func(self.vm, *args_w)
+        opimpl = ops.get(funcname)
+        w_res = opimpl(self.vm, *args_w)
         return FrameVal(w_restype, w_res)
 
     def eval_expr_GetItem(self, op: ast.GetItem) -> FrameVal:

--- a/spy/vm/ops.py
+++ b/spy/vm/ops.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 from spy.vm.builtins import B
 from spy.vm.str import W_str
 from spy.vm.object import W_Object, W_Type, W_i32
@@ -24,21 +24,21 @@ def signature(sig: str) -> Any:
 
 # XXX explain me
 
-def ADD(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type):
+def ADD(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> Any:
     if w_ltype is w_rtype is B.w_i32:
         return i32_add
     elif w_ltype is w_rtype is B.w_str:
         return str_add
     return None
 
-def MUL(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type):
+def MUL(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> Any:
     if w_ltype is w_rtype is B.w_i32:
         return i32_mul
     if w_ltype is B.w_str and w_rtype is B.w_i32:
         return str_mul
     return None
 
-def GETITEM(vm: 'SPyVM', w_vtype: W_Type, w_itype: W_Type):
+def GETITEM(vm: 'SPyVM', w_vtype: W_Type, w_itype: W_Type) -> Any:
     if w_vtype is B.w_str and w_itype is B.w_i32:
         return str_getitem
     return None
@@ -48,13 +48,13 @@ def GETITEM(vm: 'SPyVM', w_vtype: W_Type, w_itype: W_Type):
 def i32_add(vm: 'SPyVM', w_a: W_i32, w_b: W_i32) -> W_i32:
     a = vm.unwrap(w_a)
     b = vm.unwrap(w_b)
-    return vm.wrap(a + b)
+    return vm.wrap(a + b) # type: ignore
 
 @signature('def(a: i32, b: i32) -> i32')
 def i32_mul(vm: 'SPyVM', w_a: W_i32, w_b: W_i32) -> W_i32:
     a = vm.unwrap(w_a)
     b = vm.unwrap(w_b)
-    return vm.wrap(a * b)
+    return vm.wrap(a * b) # type: ignore
 
 
 # ==================

--- a/spy/vm/ops.py
+++ b/spy/vm/ops.py
@@ -8,31 +8,31 @@ if TYPE_CHECKING:
 def get(funcname: str) -> Any:
     func = globals().get(funcname)
     if func is None:
-        raise KeyError(f'Cannot find {funcname} in helpers.py')
+        raise KeyError(f'Cannot find {funcname} in spy/vm/ops.py')
     return func
 
-def helper(sig: str) -> Any:
+def signature(sig: str) -> Any:
     w_functype = W_FuncType.parse(sig)
     def decorator(fn: Any) -> Any:
         fn.w_functype = w_functype
         return fn
     return decorator
 
-@helper('def(a: str, b: str) -> str')
+@signature('def(a: str, b: str) -> str')
 def StrAdd(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_str:
     assert isinstance(w_a, W_str)
     assert isinstance(w_b, W_str)
     ptr_c = vm.ll.call('spy_StrAdd', w_a.ptr, w_b.ptr)
     return W_str.from_ptr(vm, ptr_c)
 
-@helper('def(s: str, n: i32) -> str')
+@signature('def(s: str, n: i32) -> str')
 def StrMul(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_str:
     assert isinstance(w_a, W_str)
     assert isinstance(w_b, W_i32)
     ptr_c = vm.ll.call('spy_StrMul', w_a.ptr, w_b.value)
     return W_str.from_ptr(vm, ptr_c)
 
-@helper('def(s: str, i: i32) -> str')
+@signature('def(s: str, i: i32) -> str')
 def StrGetItem(vm: 'SPyVM', w_s: W_Object, w_i: W_Object) -> W_str:
     assert isinstance(w_s, W_str)
     assert isinstance(w_i, W_i32)

--- a/spy/vm/ops.py
+++ b/spy/vm/ops.py
@@ -63,19 +63,19 @@ def i32_mul(vm: 'SPyVM', w_a: W_i32, w_b: W_i32) -> W_i32:
 def str_add(vm: 'SPyVM', w_a: W_str, w_b: W_str) -> W_str:
     assert isinstance(w_a, W_str)
     assert isinstance(w_b, W_str)
-    ptr_c = vm.ll.call('spy_StrAdd', w_a.ptr, w_b.ptr)
+    ptr_c = vm.ll.call('spy_str_add', w_a.ptr, w_b.ptr)
     return W_str.from_ptr(vm, ptr_c)
 
 @signature('def(s: str, n: i32) -> str')
 def str_mul(vm: 'SPyVM', w_a: W_str, w_b: W_i32) -> W_str:
     assert isinstance(w_a, W_str)
     assert isinstance(w_b, W_i32)
-    ptr_c = vm.ll.call('spy_StrMul', w_a.ptr, w_b.value)
+    ptr_c = vm.ll.call('spy_str_mul', w_a.ptr, w_b.value)
     return W_str.from_ptr(vm, ptr_c)
 
 @signature('def(s: str, i: i32) -> str')
 def str_getitem(vm: 'SPyVM', w_s: W_str, w_i: W_i32) -> W_str:
     assert isinstance(w_s, W_str)
     assert isinstance(w_i, W_i32)
-    ptr_c = vm.ll.call('spy_StrGetItem', w_s.ptr, w_i.value)
+    ptr_c = vm.ll.call('spy_str_getitem', w_s.ptr, w_i.value)
     return W_str.from_ptr(vm, ptr_c)

--- a/spy/vm/ops.py
+++ b/spy/vm/ops.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Any
+from spy.vm.builtins import B
 from spy.vm.str import W_str
-from spy.vm.object import W_Object, W_i32
+from spy.vm.object import W_Object, W_Type, W_i32
 from spy.vm.function import W_FuncType
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -17,6 +18,26 @@ def signature(sig: str) -> Any:
         fn.w_functype = w_functype
         return fn
     return decorator
+
+# ================
+
+# XXX explain me
+
+def ADD(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type):
+    if w_ltype is w_rtype is B.w_i32:
+        return i32_add
+
+    return None
+
+@signature('def(a: i32, b: i32) -> i32')
+def i32_add(vm: 'SPyVM', w_a: W_i32, w_b: W_i32) -> W_i32:
+    a = vm.unwrap(w_a)
+    b = vm.unwrap(w_b)
+    return vm.wrap(a + b)
+
+
+
+# ==================
 
 @signature('def(a: str, b: str) -> str')
 def StrAdd(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_str:

--- a/spy/vm/ops.py
+++ b/spy/vm/ops.py
@@ -38,6 +38,11 @@ def MUL(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type):
         return str_mul
     return None
 
+def GETITEM(vm: 'SPyVM', w_vtype: W_Type, w_itype: W_Type):
+    if w_vtype is B.w_str and w_itype is B.w_i32:
+        return str_getitem
+    return None
+
 
 @signature('def(a: i32, b: i32) -> i32')
 def i32_add(vm: 'SPyVM', w_a: W_i32, w_b: W_i32) -> W_i32:
@@ -69,7 +74,7 @@ def str_mul(vm: 'SPyVM', w_a: W_str, w_b: W_i32) -> W_str:
     return W_str.from_ptr(vm, ptr_c)
 
 @signature('def(s: str, i: i32) -> str')
-def StrGetItem(vm: 'SPyVM', w_s: W_Object, w_i: W_Object) -> W_str:
+def str_getitem(vm: 'SPyVM', w_s: W_str, w_i: W_i32) -> W_str:
     assert isinstance(w_s, W_str)
     assert isinstance(w_i, W_i32)
     ptr_c = vm.ll.call('spy_StrGetItem', w_s.ptr, w_i.value)

--- a/spy/vm/ops.py
+++ b/spy/vm/ops.py
@@ -26,8 +26,14 @@ def signature(sig: str) -> Any:
 def ADD(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type):
     if w_ltype is w_rtype is B.w_i32:
         return i32_add
-
     return None
+
+def MUL(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type):
+    if w_ltype is w_rtype is B.w_i32:
+        return i32_mul
+    return None
+
+
 
 @signature('def(a: i32, b: i32) -> i32')
 def i32_add(vm: 'SPyVM', w_a: W_i32, w_b: W_i32) -> W_i32:
@@ -35,6 +41,11 @@ def i32_add(vm: 'SPyVM', w_a: W_i32, w_b: W_i32) -> W_i32:
     b = vm.unwrap(w_b)
     return vm.wrap(a + b)
 
+@signature('def(a: i32, b: i32) -> i32')
+def i32_mul(vm: 'SPyVM', w_a: W_i32, w_b: W_i32) -> W_i32:
+    a = vm.unwrap(w_a)
+    b = vm.unwrap(w_b)
+    return vm.wrap(a * b)
 
 
 # ==================

--- a/spy/vm/ops.py
+++ b/spy/vm/ops.py
@@ -26,13 +26,16 @@ def signature(sig: str) -> Any:
 def ADD(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type):
     if w_ltype is w_rtype is B.w_i32:
         return i32_add
+    elif w_ltype is w_rtype is B.w_str:
+        return str_add
     return None
 
 def MUL(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type):
     if w_ltype is w_rtype is B.w_i32:
         return i32_mul
+    if w_ltype is B.w_str and w_rtype is B.w_i32:
+        return str_mul
     return None
-
 
 
 @signature('def(a: i32, b: i32) -> i32')
@@ -51,14 +54,14 @@ def i32_mul(vm: 'SPyVM', w_a: W_i32, w_b: W_i32) -> W_i32:
 # ==================
 
 @signature('def(a: str, b: str) -> str')
-def StrAdd(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_str:
+def str_add(vm: 'SPyVM', w_a: W_str, w_b: W_str) -> W_str:
     assert isinstance(w_a, W_str)
     assert isinstance(w_b, W_str)
     ptr_c = vm.ll.call('spy_StrAdd', w_a.ptr, w_b.ptr)
     return W_str.from_ptr(vm, ptr_c)
 
 @signature('def(s: str, n: i32) -> str')
-def StrMul(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_str:
+def str_mul(vm: 'SPyVM', w_a: W_str, w_b: W_i32) -> W_str:
     assert isinstance(w_a, W_str)
     assert isinstance(w_b, W_i32)
     ptr_c = vm.ll.call('spy_StrMul', w_a.ptr, w_b.value)

--- a/spy/vm/ops.py
+++ b/spy/vm/ops.py
@@ -16,6 +16,7 @@ def signature(sig: str) -> Any:
     w_functype = W_FuncType.parse(sig)
     def decorator(fn: Any) -> Any:
         fn.w_functype = w_functype
+        fn.spy_opname = fn.__name__
         return fn
     return decorator
 

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -13,7 +13,7 @@ def ll_spy_Str_new(ll: LLWasmInstance, s: str) -> int:
     """
     utf8 = s.encode('utf-8')
     length = len(utf8)
-    ptr = ll.call('spy_StrAlloc', length)
+    ptr = ll.call('spy_str_alloc', length)
     ll.mem.write(ptr+4, utf8)
     return ptr
 

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -8,7 +8,7 @@ from spy.location import Loc
 from spy.vm.object import W_Object, W_Type
 from spy.vm.function import W_FuncType, W_ASTFunc
 from spy.vm.builtins import B
-from spy.vm import helpers
+from spy.vm import ops
 from spy.vm.typeconverter import TypeConverter, DynamicCast
 from spy.util import magic_dispatch
 if TYPE_CHECKING:
@@ -294,8 +294,8 @@ class TypeChecker:
 
     def check_expr_HelperFunc(self, node: ast.HelperFunc
                               ) -> tuple[Color, W_Type]:
-        helper = helpers.get(node.funcname)
-        return 'red', helper.w_functype
+        opimpl = ops.get(node.funcname)
+        return 'red', opimpl.w_functype
 
     def check_expr_Call(self, call: ast.Call) -> tuple[Color, W_Type]:
         color, w_functype = self.check_expr(call.func)

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -252,12 +252,6 @@ class TypeChecker:
             w_restype = opimpl.w_functype.w_restype
             return color, w_restype
 
-        # XXX kill this and put this logic into ops.py
-        ## if binop.op == '+' and w_ltype is w_rtype is B.w_str:
-        ##     return color, B.w_str
-        ## if binop.op == '*' and w_ltype is B.w_str and w_rtype is B.w_i32:
-        ##     return color, B.w_str
-        #
         lt = w_ltype.name
         rt = w_rtype.name
         err = SPyTypeError(f'cannot do `{lt}` {binop.op} `{rt}`')

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -287,7 +287,12 @@ class TypeChecker:
         vcolor, w_vtype = self.check_expr(expr.value)
         icolor, w_itype = self.check_expr(expr.index)
         color = maybe_blue(vcolor, icolor)
-        if w_vtype is B.w_str:
+        opimpl = ops.GETITEM(self.vm, w_vtype, w_itype)
+        if opimpl is ops.str_getitem:
+            # XXX for now this is a special case, to check that `i` can be
+            # converted to `i32`. Ideally, we should use the same mechanism
+            # that we have already for calls
+            self.expr_opimpl[expr] = opimpl
             err = self.convert_type_maybe(expr.index, w_itype, B.w_i32)
             if err:
                 err.add('note', f'this is a `str`', expr.value.loc)

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -244,6 +244,8 @@ class TypeChecker:
         opimpl = None
         if binop.op == '+':
             opimpl = ops.ADD(self.vm, w_ltype, w_rtype)
+        elif binop.op == '*':
+            opimpl = ops.MUL(self.vm, w_ltype, w_rtype)
 
         if opimpl is not None:
             self.expr_opimpl[binop] = opimpl
@@ -251,8 +253,6 @@ class TypeChecker:
             return color, w_restype
 
         # XXX kill this and put this logic into ops.py
-        ## if w_ltype is w_rtype is B.w_i32:
-        ##     return color, B.w_i32
         ## if binop.op == '+' and w_ltype is w_rtype is B.w_str:
         ##     return color, B.w_str
         ## if binop.op == '*' and w_ltype is B.w_str and w_rtype is B.w_i32:

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -299,9 +299,11 @@ class TypeChecker:
                 raise err
             return color, B.w_str
         else:
-            got = w_vtype.name
-            err = SPyTypeError(f'`{got}` does not support `[]`')
-            err.add('note', f'this is a `{got}`', expr.value.loc)
+            v = w_vtype.name
+            i = w_itype.name
+            err = SPyTypeError(f'cannot do `{v}`[`{i}`]')
+            err.add('error', f'this is `{v}`', expr.value.loc)
+            err.add('error', f'this is `{i}`', expr.index.loc)
             raise err
 
     def check_expr_HelperFunc(self, node: ast.HelperFunc


### PR DESCRIPTION
This is a big refactoring, and it's a big step towards the final idea of how SPy works.
Until now `+`, `*` and `[]` where handled with ad-hoc code in the typecheker, astframe e C backend, doing different things depending on the types.

Now, we have a generic mechanism for operation dispatching: basically, for each operator we have a builtin `@blue` function which selects the concrete implementation given the input types. In other words:
```
a + b
```

is roughly equivalent to:
```
ops.ADD(type(a), type(b))(a, b)
```

where `ops.ADD` is considered blue and thus redshifted away by the doppler.

In the next PRs, we will make `ops.ADD` & co. "real" SPy primitive functions, and use the same mechanism also for comparison ops.
