### PR TITLE
Introduce the module registry and create builtins.ops

### DIFF
--- a/spy/ast.py
+++ b/spy/ast.py
@@ -462,17 +462,3 @@ class While(Stmt):
 class FQNConst(Expr):
     precedence = 100 # the highest
     fqn: FQN
-
-
-# XXX maybe this should be turned into PrimitiveFunc or just use FQNConst?
-@dataclass(eq=False)
-class HelperFunc(Expr):
-    """
-    Similar to Name, but refers to helper funcs such as StrAdd, StrMul, etc.
-
-    The difference is that Name can refer only to names which are available in
-    the scope, while HelperFunc represents a sort of "hidden namespace" which
-    is inaccessible to users and special-cased here and there
-    """
-    precedence = 100 # the highest
-    funcname: str

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -333,8 +333,8 @@ class CFuncWriter:
 
         # some calls are special-cased and transformed into a C binop
         binops = {
-            FQN('__ops__::i32_add'): '+',
-            FQN('__ops__::i32_mul'): '*',
+            FQN('builtins.ops::i32_add'): '+',
+            FQN('builtins.ops::i32_mul'): '*',
         }
         op = binops.get(call.func.fqn)
         if op is not None:

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -114,12 +114,12 @@ class SPyBackend:
     fmt_expr_Div = fmt_expr_BinOp
 
     def fmt_expr_Call(self, call: ast.Call) -> str:
-        if isinstance(call.func, ast.HelperFunc):
-            helper2ast = {
-                'i32_add': ast.Add,
-                'i32_mul': ast.Mul,
+        if isinstance(call.func, ast.FQNConst):
+            fqn2ast = {
+                FQN('builtins.ops::i32_add'): ast.Add,
+                FQN('builtins.ops::i32_mul'): ast.Mul,
             }
-            opclass = helper2ast.get(call.func.funcname)
+            opclass = fqn2ast.get(call.func.fqn)
             assert opclass is not None
             assert len(call.args) == 2
             binop = opclass(call.loc, call.args[0], call.args[1])

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -4,7 +4,7 @@ from fixedint import FixedInt
 from spy import ast
 from spy.vm.builtins import B
 from spy.vm.object import W_Object, W_Type
-from spy.vm.function import W_ASTFunc
+from spy.vm.function import W_ASTFunc, W_BuiltinFunc
 from spy.vm.astframe import ASTFrame
 from spy.util import magic_dispatch
 
@@ -138,8 +138,11 @@ class FuncDoppler:
     def shift_expr_BinOp(self, binop: ast.BinOp) -> ast.Expr:
         l = self.shift_expr(binop.left)
         r = self.shift_expr(binop.right)
-        opimpl = self.t.expr_opimpl[binop]
-        func = ast.HelperFunc(binop.loc, opimpl.spy_opname) # XXX
+        w_opimpl = self.t.expr_opimpl[binop]
+        # XXX the following is needed only to get the FQN. Maybe we should
+        # move the fqn attribute up to W_Func?
+        assert isinstance(w_opimpl, W_BuiltinFunc)
+        func = ast.FQNConst(binop.loc, w_opimpl.fqn)
         return ast.Call(binop.loc, func, [l, r])
 
     shift_expr_Add = shift_expr_BinOp

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -165,8 +165,8 @@ class FuncDoppler:
     def shift_expr_GetItem(self, op: ast.GetItem) -> ast.Expr:
         v = self.shift_expr(op.value)
         i = self.shift_expr(op.index)
-        opimpl = self.t.expr_opimpl[op]
-        func = ast.HelperFunc(op.loc, opimpl.spy_opname) # XXX
+        w_opimpl = self.t.expr_opimpl[op]
+        func = ast.FQNConst(op.loc, w_opimpl.fqn)
         return ast.Call(op.loc, func, [v, i])
 
     def shift_expr_Call(self, call: ast.Call) -> ast.Expr:

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -139,9 +139,7 @@ class FuncDoppler:
         l = self.shift_expr(binop.left)
         r = self.shift_expr(binop.right)
         w_opimpl = self.t.expr_opimpl[binop]
-        # XXX the following is needed only to get the FQN. Maybe we should
-        # move the fqn attribute up to W_Func?
-        assert isinstance(w_opimpl, W_BuiltinFunc)
+        assert w_opimpl.fqn is not None
         func = ast.FQNConst(binop.loc, w_opimpl.fqn)
         return ast.Call(binop.loc, func, [l, r])
 
@@ -166,6 +164,7 @@ class FuncDoppler:
         v = self.shift_expr(op.value)
         i = self.shift_expr(op.index)
         w_opimpl = self.t.expr_opimpl[op]
+        assert w_opimpl.fqn is not None
         func = ast.FQNConst(op.loc, w_opimpl.fqn)
         return ast.Call(op.loc, func, [v, i])
 

--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -39,11 +39,11 @@ class ModuleGen:
         self.vm.register_module(self.w_mod)
         #
         # Synthesize and execute the __INIT__ function to populate the module
-        modinit_funcdef = self.make_modinit()
-        fqn = FQN(modname=self.modname, attr='__INIT__')
-        closure = ()
         w_functype = W_FuncType.parse('def() -> void')
-        w_INIT = W_ASTFunc(fqn, closure, w_functype, modinit_funcdef)
+        fqn = FQN(modname=self.modname, attr='__INIT__')
+        modinit_funcdef = self.make_modinit()
+        closure = ()
+        w_INIT = W_ASTFunc(w_functype, fqn, modinit_funcdef, closure)
         frame = ASTFrame(self.vm, w_INIT)
         #
         for decl in self.mod.decls:

--- a/spy/libspy/include/spy.h
+++ b/spy/libspy/include/spy.h
@@ -10,7 +10,6 @@ typedef __SIZE_TYPE__ size_t;
     __attribute__((export_name(#name))) \
     name
 
-
 static inline void *memcpy(void *dest, const void *src, size_t n) {
     return __builtin_memcpy(dest, src, n);
 }

--- a/spy/libspy/include/spy/str.h
+++ b/spy/libspy/include/spy/str.h
@@ -22,4 +22,8 @@ WASM_EXPORT(spy_str_mul)(spy_Str *a, int32_t b);
 spy_Str *
 WASM_EXPORT(spy_str_getitem)(spy_Str *s, int32_t i);
 
+#define spy_builtins_ops__str_add spy_str_add
+#define spy_builtins_ops__str_mul spy_str_mul
+#define spy_builtins_ops__str_getitem spy_str_getitem
+
 #endif /* SPY_STR_H */

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -162,14 +162,14 @@ class TestVM:
 
     def test_call_function(self):
         vm = SPyVM()
-        w_abs = vm.lookup_global(FQN('builtins::abs'))
+        w_abs = B.w_abs
         w_x = vm.wrap(-42)
         w_y = vm.call_function(w_abs, [w_x])
         assert vm.unwrap(w_y) == 42
 
     def test_call_function_TypeError(self):
         vm = SPyVM()
-        w_abs = vm.lookup_global(FQN('builtins::abs'))
+        w_abs = B.w_abs
         w_x = vm.wrap('hello')
         msg = 'Invalid cast. Expected `i32`, got `str`'
         with pytest.raises(SPyTypeError, match=msg):

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -2,7 +2,6 @@ import fixedint
 import pytest
 from spy.vm.vm import SPyVM
 from spy.vm.builtins import B
-from spy.vm.builtins2 import B2
 from spy.fqn import FQN
 from spy.errors import SPyTypeError
 from spy.vm.object import W_Object, W_Type, spytype, W_void, W_i32, W_bool
@@ -163,14 +162,14 @@ class TestVM:
 
     def test_call_function(self):
         vm = SPyVM()
-        w_abs = B2.w_abs
+        w_abs = vm.lookup_global(FQN('builtins::abs'))
         w_x = vm.wrap(-42)
         w_y = vm.call_function(w_abs, [w_x])
         assert vm.unwrap(w_y) == 42
 
     def test_call_function_TypeError(self):
         vm = SPyVM()
-        w_abs = B2.w_abs
+        w_abs = vm.lookup_global(FQN('builtins::abs'))
         w_x = vm.wrap('hello')
         msg = 'Invalid cast. Expected `i32`, got `str`'
         with pytest.raises(SPyTypeError, match=msg):

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -2,6 +2,7 @@ import fixedint
 import pytest
 from spy.vm.vm import SPyVM
 from spy.vm.builtins import B
+from spy.vm.builtins2 import B2
 from spy.fqn import FQN
 from spy.errors import SPyTypeError
 from spy.vm.object import W_Object, W_Type, spytype, W_void, W_i32, W_bool
@@ -162,14 +163,14 @@ class TestVM:
 
     def test_call_function(self):
         vm = SPyVM()
-        w_abs = B.w_abs
+        w_abs = B2.w_abs
         w_x = vm.wrap(-42)
         w_y = vm.call_function(w_abs, [w_x])
         assert vm.unwrap(w_y) == 42
 
     def test_call_function_TypeError(self):
         vm = SPyVM()
-        w_abs = B.w_abs
+        w_abs = B2.w_abs
         w_x = vm.wrap('hello')
         msg = 'Invalid cast. Expected `i32`, got `str`'
         with pytest.raises(SPyTypeError, match=msg):

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -267,26 +267,11 @@ class ASTFrame:
 
     def eval_expr_Call(self, call: ast.Call) -> FrameVal:
         color, w_restype = self.t.check_expr_Call(call)
-        if isinstance(call.func, ast.HelperFunc):
-            # special case CallHelper:
-            args_w = [self.eval_expr_object(arg) for arg in call.args]
-            return self.call_helper(call.func.funcname, args_w, w_restype)
-        #
         fv_func = self.eval_expr(call.func)
         w_func = fv_func.w_value
         assert isinstance(w_func, W_Func)
         args_w = [self.eval_expr_object(arg) for arg in call.args]
         w_res = self.vm.call_function(w_func, args_w)
-        return FrameVal(w_restype, w_res)
-
-    def eval_expr_HelperFunc(self, node: ast.HelperFunc) -> FrameVal:
-        # we should special-case a call to HelperFunc in eval_expr_Call
-        assert False, 'should not be called'
-
-    def call_helper(self, funcname: str, args_w: list[W_Object],
-                    w_restype: W_Type) -> FrameVal:
-        opimpl = ops.get(funcname)
-        w_res = opimpl(self.vm, *args_w)
         return FrameVal(w_restype, w_res)
 
     def eval_expr_GetItem(self, op: ast.GetItem) -> FrameVal:

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -229,11 +229,11 @@ class ASTFrame:
 
     def eval_expr_BinOp(self, binop: ast.BinOp) -> FrameVal:
         color, w_restype = self.t.check_expr_BinOp(binop)
-        opimpl = self.t.expr_opimpl[binop]
-        assert opimpl, 'bug in the typechecker'
+        w_opimpl = self.t.expr_opimpl[binop]
+        assert w_opimpl, 'bug in the typechecker'
         fv_l = self.eval_expr(binop.left)
         fv_r = self.eval_expr(binop.right)
-        w_res = opimpl(self.vm, fv_l.w_value, fv_r.w_value)
+        w_res = self.vm.call_function(w_opimpl, [fv_l.w_value, fv_r.w_value])
         return FrameVal(w_restype, w_res)
 
     eval_expr_Add = eval_expr_BinOp

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -151,7 +151,7 @@ class ASTFrame:
         fqn = FQN(modname='???', attr=funcdef.name)
         # XXX we should capture only the names actually used in the inner func
         closure = self.w_func.closure + (self._locals,)
-        w_func = W_ASTFunc(fqn, closure, w_functype, funcdef)
+        w_func = W_ASTFunc(w_functype, fqn, funcdef, closure)
         self.store_local(funcdef.name, w_func)
 
     def exec_stmt_VarDef(self, vardef: ast.VarDef) -> None:

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -276,8 +276,9 @@ class ASTFrame:
 
     def eval_expr_GetItem(self, op: ast.GetItem) -> FrameVal:
         color, w_restype = self.t.check_expr_GetItem(op)
-        opimpl = self.t.expr_opimpl[op]
+        w_opimpl = self.t.expr_opimpl[op]
         fv_val = self.eval_expr(op.value)
         fv_index = self.eval_expr(op.index)
-        w_res = opimpl(self.vm, fv_val.w_value, fv_index.w_value)
+        w_res = self.vm.call_function(w_opimpl,
+                                      [fv_val.w_value, fv_index.w_value])
         return FrameVal(w_restype, w_res)

--- a/spy/vm/builtins.py
+++ b/spy/vm/builtins.py
@@ -9,7 +9,8 @@ There are additional builtins in builtins2.py -- which is super ugly but it's an
 
 from typing import Optional, TYPE_CHECKING
 from spy.fqn import FQN
-from spy.vm.object import w_DynamicType, W_Object, W_Type, W_void, W_i32, W_bool
+from spy.vm.object import (w_DynamicType, W_Object, W_Type, W_void, W_i32,
+                           W_bool, W_NotImplementedType)
 from spy.vm.str import W_str
 from spy.vm.function import W_FuncType, W_BuiltinFunc
 from spy.vm.registry import ModuleRegistry
@@ -26,3 +27,4 @@ B.add('str', W_str._w)
 B.add('None', W_void._w_singleton)
 B.add('True', W_bool._w_singleton_True)
 B.add('False', W_bool._w_singleton_False)
+B.add('NotImplemented', W_NotImplementedType._w_singleton)

--- a/spy/vm/builtins.py
+++ b/spy/vm/builtins.py
@@ -7,25 +7,22 @@ and constants which are used everywhere).
 There are additional builtins in builtins2.py -- which is super ugly but it's an easy workaround to avoid circular imports
 """
 
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 from spy.fqn import FQN
 from spy.vm.object import w_DynamicType, W_Object, W_Type, W_void, W_i32, W_bool
 from spy.vm.str import W_str
 from spy.vm.function import W_FuncType, W_BuiltinFunc
+from spy.vm.registry import ModuleRegistry
 
-class B:
-    w_object = W_Object._w
-    w_type = W_Type._w
-    w_dynamic = w_DynamicType
-    w_i32 = W_i32._w
-    w_bool = W_bool._w
-    w_void = W_void._w
-    w_str = W_str._w
-    w_None = W_void._w_singleton
-    w_True = W_bool._w_singleton_True
-    w_False = W_bool._w_singleton_False
+B = ModuleRegistry('builtins', '<builtins>')
 
-    @classmethod
-    def lookup(cls, name: str) -> Optional[W_Object]:
-        attr = 'w_' + name
-        return getattr(cls, attr, None)
+B.add('object', W_Object._w)
+B.add('type', W_Type._w)
+B.add('dynamic', w_DynamicType)
+B.add('i32', W_i32._w)
+B.add('bool', W_bool._w)
+B.add('void', W_void._w)
+B.add('str', W_str._w)
+B.add('None', W_void._w_singleton)
+B.add('True', W_bool._w_singleton_True)
+B.add('False', W_bool._w_singleton_False)

--- a/spy/vm/builtins.py
+++ b/spy/vm/builtins.py
@@ -1,3 +1,12 @@
+"""
+Builtins module.
+
+Note that this contains only the "basic" builtins (i.e., all the primitive types
+and constants which are used everywhere).
+
+There are additional builtins in builtins2.py -- which is super ugly but it's an easy workaround to avoid circular imports
+"""
+
 from typing import Optional
 from spy.fqn import FQN
 from spy.vm.object import w_DynamicType, W_Object, W_Type, W_void, W_i32, W_bool
@@ -15,11 +24,6 @@ class B:
     w_None = W_void._w_singleton
     w_True = W_bool._w_singleton_True
     w_False = W_bool._w_singleton_False
-
-    w_abs = W_BuiltinFunc(
-        fqn = FQN('builtins::abs'),
-        w_functype = W_FuncType.make(x=w_i32, w_restype=w_i32),
-    )
 
     @classmethod
     def lookup(cls, name: str) -> Optional[W_Object]:

--- a/spy/vm/builtins2.py
+++ b/spy/vm/builtins2.py
@@ -5,14 +5,16 @@ This is a bit ugly but it has to be separated from builtins.py to avoid
 circular imports
 """
 
-from typing import Optional
-from spy.fqn import FQN
-from spy.vm.function import W_BuiltinFunc
-from spy.vm.registry import register_function
+from typing import TYPE_CHECKING
+from spy.vm.registry import ModuleRegistry
 from spy.vm.object import W_i32
 
+if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
 
-@register_function(FQN('builtins::abs'), 'def(x: i32) -> i32')
+B2 = ModuleRegistry('builtins', '<builtins>')
+
+@B2.primitive('def(x: i32) -> i32')
 def abs(vm: 'SPyVM', w_x: W_i32) -> W_i32:
     x = vm.unwrap_i32(w_x)
     res = vm.ll.call('spy_builtins__abs', x)

--- a/spy/vm/builtins2.py
+++ b/spy/vm/builtins2.py
@@ -8,13 +8,13 @@ circular imports
 from typing import TYPE_CHECKING
 from spy.vm.registry import ModuleRegistry
 from spy.vm.object import W_i32
+from spy.vm.builtins import B
 
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
-B2 = ModuleRegistry('builtins', '<builtins>')
 
-@B2.primitive('def(x: i32) -> i32')
+@B.primitive('def(x: i32) -> i32')
 def abs(vm: 'SPyVM', w_x: W_i32) -> W_i32:
     x = vm.unwrap_i32(w_x)
     res = vm.ll.call('spy_builtins__abs', x)

--- a/spy/vm/builtins2.py
+++ b/spy/vm/builtins2.py
@@ -1,0 +1,14 @@
+"""
+Additional builtins.
+
+This is a bit ugly but it has to be separated from builtins.py to avoid
+circular imports
+"""
+
+from typing import Optional
+from spy.fqn import FQN
+from spy.vm.function import W_BuiltinFunc
+from spy.vm import ops
+
+class B2:
+    w_abs = W_BuiltinFunc(ops.abs.w_functype, FQN('builtins::abs'), ops.abs)

--- a/spy/vm/builtins2.py
+++ b/spy/vm/builtins2.py
@@ -8,7 +8,12 @@ circular imports
 from typing import Optional
 from spy.fqn import FQN
 from spy.vm.function import W_BuiltinFunc
-from spy.vm import ops
+from spy.vm.registry import register_function
+from spy.vm.object import W_i32
 
-class B2:
-    w_abs = W_BuiltinFunc(ops.abs.w_functype, FQN('builtins::abs'), ops.abs)
+
+@register_function(FQN('builtins::abs'), 'def(x: i32) -> i32')
+def abs(vm: 'SPyVM', w_x: W_i32) -> W_i32:
+    x = vm.unwrap_i32(w_x)
+    res = vm.ll.call('spy_builtins__abs', x)
+    return vm.wrap(res) # type: ignore

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -100,24 +100,24 @@ class W_Func(W_Object):
 
 class W_ASTFunc(W_Func):
     fqn: FQN
-    closure: tuple[Namespace, ...]
     funcdef: ast.FuncDef
+    closure: tuple[Namespace, ...]
     # types of local variables: this is non-None IIF the function has been
     # redshifted.
     locals_types_w: Optional[dict[str, W_Type]]
 
     def __init__(self,
-                 fqn: FQN,
-                 closure: tuple[Namespace, ...],
                  w_functype: W_FuncType,
+                 fqn: FQN,
                  funcdef: ast.FuncDef,
+                 closure: tuple[Namespace, ...],
                  *,
                  locals_types_w: Optional[dict[str, W_Type]] = None
                  ) -> None:
-        self.fqn = fqn
-        self.closure = closure
         self.w_functype = w_functype
+        self.fqn = fqn
         self.funcdef = funcdef
+        self.closure = closure
         self.locals_types_w = locals_types_w
 
     @property
@@ -134,9 +134,9 @@ class W_ASTFunc(W_Func):
 class W_BuiltinFunc(W_Func):
     fqn: FQN
 
-    def __init__(self, fqn: FQN, w_functype: W_FuncType) -> None:
-        self.fqn = fqn
+    def __init__(self, w_functype: W_FuncType, fqn: FQN) -> None:
         self.w_functype = w_functype
+        self.fqn = fqn
 
     def __repr__(self) -> str:
         return f"<spy function '{self.fqn}' (builtin)>"

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -148,7 +148,6 @@ class W_BuiltinFunc(W_Func):
     Builtin functions are implemented by calling an interp-level function
     (written in Python).
     """
-
     fqn: FQN
     pyfunc: Callable
 

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -90,6 +90,7 @@ class W_FuncType(W_Type):
 
 class W_Func(W_Object):
     w_functype: W_FuncType
+    fqn: Optional[FQN]
 
     def spy_get_w_type(self, vm: 'SPyVM') -> W_Type:
         return self.w_functype

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -222,3 +222,18 @@ class W_bool(W_Object):
 
 W_bool._w_singleton_True = W_bool._make_singleton(True)
 W_bool._w_singleton_False = W_bool._make_singleton(False)
+
+
+@spytype('NotImplementedType')
+class W_NotImplementedType(W_Object):
+    _w_singleton: ClassVar['W_NotImplementedType']
+
+    def __init__(self) -> None:
+        # this is just a sanity check: we don't want people to be able to
+        # create additional instances
+        raise Exception("You cannot instantiate W_NotImplementedType")
+
+
+W_NotImplementedType._w_singleton = (
+    W_NotImplementedType.__new__(W_NotImplementedType)
+)

--- a/spy/vm/ops.py
+++ b/spy/vm/ops.py
@@ -13,7 +13,7 @@ def get(funcname: str) -> Any:
         raise KeyError(f'Cannot find {funcname} in spy/vm/ops.py')
     return func
 
-OPS = ModuleRegistry('__ops__', '<__ops__>')
+OPS = ModuleRegistry('builtins.ops', '<builtins.ops>')
 
 # ================
 
@@ -30,12 +30,12 @@ def MUL(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Func:
     if w_ltype is w_rtype is B.w_i32:
         return OPS.w_i32_mul
     if w_ltype is B.w_str and w_rtype is B.w_i32:
-        return OPW.w_str_mul
+        return OPS.w_str_mul
     return None
 
 def GETITEM(vm: 'SPyVM', w_vtype: W_Type, w_itype: W_Type) -> W_Func:
     if w_vtype is B.w_str and w_itype is B.w_i32:
-        return OPW.w_str_getitem
+        return OPS.w_str_getitem
     return None
 
 

--- a/spy/vm/ops.py
+++ b/spy/vm/ops.py
@@ -79,13 +79,3 @@ def str_getitem(vm: 'SPyVM', w_s: W_str, w_i: W_i32) -> W_str:
     assert isinstance(w_i, W_i32)
     ptr_c = vm.ll.call('spy_str_getitem', w_s.ptr, w_i.value)
     return W_str.from_ptr(vm, ptr_c)
-
-
-# ===================
-# XXX these should go somewhere else
-
-@signature('def(x: i32) -> i32')
-def abs(vm: 'SPyVM', w_x: W_i32) -> W_i32:
-    x = vm.unwrap_i32(w_x)
-    res = vm.ll.call('spy_builtins__abs', x)
-    return vm.wrap(res) # type: ignore

--- a/spy/vm/ops.py
+++ b/spy/vm/ops.py
@@ -2,7 +2,8 @@ from typing import TYPE_CHECKING, Any, Optional
 from spy.vm.builtins import B
 from spy.vm.str import W_str
 from spy.vm.object import W_Object, W_Type, W_i32
-from spy.vm.function import W_FuncType
+from spy.vm.function import W_FuncType, W_Func
+from spy.vm.registry import ModuleRegistry
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
@@ -12,46 +13,40 @@ def get(funcname: str) -> Any:
         raise KeyError(f'Cannot find {funcname} in spy/vm/ops.py')
     return func
 
-def signature(sig: str) -> Any:
-    w_functype = W_FuncType.parse(sig)
-    def decorator(fn: Any) -> Any:
-        fn.w_functype = w_functype
-        fn.spy_opname = fn.__name__
-        return fn
-    return decorator
+OPS = ModuleRegistry('__ops__', '<__ops__>')
 
 # ================
 
 # XXX explain me
 
-def ADD(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> Any:
+def ADD(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Func:
     if w_ltype is w_rtype is B.w_i32:
-        return i32_add
+        return OPS.w_i32_add
     elif w_ltype is w_rtype is B.w_str:
-        return str_add
+        return OPS.w_str_add
     return None
 
-def MUL(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> Any:
+def MUL(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Func:
     if w_ltype is w_rtype is B.w_i32:
-        return i32_mul
+        return OPS.w_i32_mul
     if w_ltype is B.w_str and w_rtype is B.w_i32:
-        return str_mul
+        return OPW.w_str_mul
     return None
 
-def GETITEM(vm: 'SPyVM', w_vtype: W_Type, w_itype: W_Type) -> Any:
+def GETITEM(vm: 'SPyVM', w_vtype: W_Type, w_itype: W_Type) -> W_Func:
     if w_vtype is B.w_str and w_itype is B.w_i32:
-        return str_getitem
+        return OPW.w_str_getitem
     return None
 
 
-@signature('def(a: i32, b: i32) -> i32')
+@OPS.primitive('def(a: i32, b: i32) -> i32')
 def i32_add(vm: 'SPyVM', w_a: W_i32, w_b: W_i32) -> W_i32:
     a = vm.unwrap(w_a)
     b = vm.unwrap(w_b)
     return vm.wrap(a + b) # type: ignore
 
 
-@signature('def(a: i32, b: i32) -> i32')
+@OPS.primitive('def(a: i32, b: i32) -> i32')
 def i32_mul(vm: 'SPyVM', w_a: W_i32, w_b: W_i32) -> W_i32:
     a = vm.unwrap(w_a)
     b = vm.unwrap(w_b)
@@ -60,21 +55,21 @@ def i32_mul(vm: 'SPyVM', w_a: W_i32, w_b: W_i32) -> W_i32:
 
 # ==================
 
-@signature('def(a: str, b: str) -> str')
+@OPS.primitive('def(a: str, b: str) -> str')
 def str_add(vm: 'SPyVM', w_a: W_str, w_b: W_str) -> W_str:
     assert isinstance(w_a, W_str)
     assert isinstance(w_b, W_str)
     ptr_c = vm.ll.call('spy_str_add', w_a.ptr, w_b.ptr)
     return W_str.from_ptr(vm, ptr_c)
 
-@signature('def(s: str, n: i32) -> str')
+@OPS.primitive('def(s: str, n: i32) -> str')
 def str_mul(vm: 'SPyVM', w_a: W_str, w_b: W_i32) -> W_str:
     assert isinstance(w_a, W_str)
     assert isinstance(w_b, W_i32)
     ptr_c = vm.ll.call('spy_str_mul', w_a.ptr, w_b.value)
     return W_str.from_ptr(vm, ptr_c)
 
-@signature('def(s: str, i: i32) -> str')
+@OPS.primitive('def(s: str, i: i32) -> str')
 def str_getitem(vm: 'SPyVM', w_s: W_str, w_i: W_i32) -> W_str:
     assert isinstance(w_s, W_str)
     assert isinstance(w_i, W_i32)

--- a/spy/vm/ops.py
+++ b/spy/vm/ops.py
@@ -79,3 +79,13 @@ def str_getitem(vm: 'SPyVM', w_s: W_str, w_i: W_i32) -> W_str:
     assert isinstance(w_i, W_i32)
     ptr_c = vm.ll.call('spy_str_getitem', w_s.ptr, w_i.value)
     return W_str.from_ptr(vm, ptr_c)
+
+
+# ===================
+# XXX these should go somewhere else
+
+@signature('def(x: i32) -> i32')
+def abs(vm: 'SPyVM', w_x: W_i32) -> W_i32:
+    x = vm.unwrap_i32(w_x)
+    res = vm.ll.call('spy_builtins__abs', x)
+    return vm.wrap(res) # type: ignore

--- a/spy/vm/ops.py
+++ b/spy/vm/ops.py
@@ -50,6 +50,7 @@ def i32_add(vm: 'SPyVM', w_a: W_i32, w_b: W_i32) -> W_i32:
     b = vm.unwrap(w_b)
     return vm.wrap(a + b) # type: ignore
 
+
 @signature('def(a: i32, b: i32) -> i32')
 def i32_mul(vm: 'SPyVM', w_a: W_i32, w_b: W_i32) -> W_i32:
     a = vm.unwrap(w_a)

--- a/spy/vm/ops.py
+++ b/spy/vm/ops.py
@@ -19,24 +19,24 @@ OPS = ModuleRegistry('builtins.ops', '<builtins.ops>')
 
 # XXX explain me
 
-def ADD(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Func:
+def ADD(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Object:
     if w_ltype is w_rtype is B.w_i32:
         return OPS.w_i32_add
     elif w_ltype is w_rtype is B.w_str:
         return OPS.w_str_add
-    return None
+    return B.w_NotImplemented
 
-def MUL(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Func:
+def MUL(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Object:
     if w_ltype is w_rtype is B.w_i32:
         return OPS.w_i32_mul
     if w_ltype is B.w_str and w_rtype is B.w_i32:
         return OPS.w_str_mul
-    return None
+    return B.w_NotImplemented
 
-def GETITEM(vm: 'SPyVM', w_vtype: W_Type, w_itype: W_Type) -> W_Func:
+def GETITEM(vm: 'SPyVM', w_vtype: W_Type, w_itype: W_Type) -> W_Object:
     if w_vtype is B.w_str and w_itype is B.w_i32:
         return OPS.w_str_getitem
-    return None
+    return B.w_NotImplemented
 
 
 @OPS.primitive('def(a: i32, b: i32) -> i32')

--- a/spy/vm/registry.py
+++ b/spy/vm/registry.py
@@ -1,0 +1,21 @@
+from typing import Callable
+from dataclasses import dataclass
+from spy.fqn import FQN
+from spy.vm.function import W_FuncType, W_BuiltinFunc
+
+@dataclass
+class RegisteredFunction:
+    fqn: FQN
+    w_functype: W_FuncType
+    pyfunc: Callable
+
+FUNCTIONS = []
+
+def register_function(fqn, sig):
+    w_functype = W_FuncType.parse(sig)
+    def decorator(pyfunc):
+        FUNCTIONS.append(
+            RegisteredFunction(fqn, w_functype, pyfunc)
+        )
+        return pyfunc
+    return decorator

--- a/spy/vm/registry.py
+++ b/spy/vm/registry.py
@@ -1,21 +1,33 @@
-from typing import Callable
+from typing import Callable, Optional
 from dataclasses import dataclass
 from spy.fqn import FQN
 from spy.vm.function import W_FuncType, W_BuiltinFunc
+from spy.vm.object import W_Object
 
-@dataclass
-class RegisteredFunction:
-    fqn: FQN
-    w_functype: W_FuncType
-    pyfunc: Callable
+class ModuleRegistry:
+    """
+    Keep track of all the objects which belong to a certain module.
 
-FUNCTIONS = []
+    At startup, the `vm` will create a W_Module out of it.
+    """
+    modname: str
+    filepath: str
+    content: list[tuple[FQN, W_Object]]
 
-def register_function(fqn, sig):
-    w_functype = W_FuncType.parse(sig)
-    def decorator(pyfunc):
-        FUNCTIONS.append(
-            RegisteredFunction(fqn, w_functype, pyfunc)
-        )
-        return pyfunc
-    return decorator
+    def __init__(self, modname: str, filepath: str):
+        self.modname = modname
+        self.filepath = filepath
+        self.content = []
+
+    def primitive(self, sig: str, name: Optional[str] = None) -> Callable:
+        w_functype = W_FuncType.parse(sig)
+
+        def decorator(pyfunc: Callable) -> Callable:
+            attr = name or pyfunc.__name__
+            fqn = FQN(modname=self.modname, attr=attr)
+            w_func = W_BuiltinFunc(w_functype, fqn, pyfunc)
+            setattr(self, f'w_{attr}', w_func)
+            self.content.append((fqn, w_func))
+            return pyfunc
+
+        return decorator

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -247,7 +247,8 @@ class TypeChecker:
         elif binop.op == '*':
             w_opimpl = ops.MUL(self.vm, w_ltype, w_rtype)
 
-        if w_opimpl is not None:
+        if w_opimpl is not B.w_NotImplemented:
+            assert isinstance(w_opimpl, W_Func)
             self.expr_opimpl[binop] = w_opimpl
             w_restype = w_opimpl.w_functype.w_restype
             return color, w_restype
@@ -292,13 +293,13 @@ class TypeChecker:
             # XXX for now this is a special case, to check that `i` can be
             # converted to `i32`. Ideally, we should use the same mechanism
             # that we have already for calls
-            self.expr_opimpl[expr] = w_opimpl
+            self.expr_opimpl[expr] = ops.OPS.w_str_getitem
             err = self.convert_type_maybe(expr.index, w_itype, B.w_i32)
             if err:
                 err.add('note', f'this is a `str`', expr.value.loc)
                 raise err
             return color, B.w_str
-        elif w_opimpl is not None:
+        elif w_opimpl is not B.w_NotImplemented:
             assert False, 'unexpected opimpl?'
         else:
             v = w_vtype.name

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -306,11 +306,6 @@ class TypeChecker:
             err.add('error', f'this is `{i}`', expr.index.loc)
             raise err
 
-    def check_expr_HelperFunc(self, node: ast.HelperFunc
-                              ) -> tuple[Color, W_Type]:
-        opimpl = ops.get(node.funcname)
-        return 'red', opimpl.w_functype
-
     def check_expr_Call(self, call: ast.Call) -> tuple[Color, W_Type]:
         color, w_functype = self.check_expr(call.func)
         sym = self.name2sym_maybe(call.func)

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -6,7 +6,7 @@ from spy.irgen.symtable import Symbol, Color
 from spy.errors import (SPyTypeError, SPyNameError, maybe_plural)
 from spy.location import Loc
 from spy.vm.object import W_Object, W_Type
-from spy.vm.function import W_FuncType, W_ASTFunc
+from spy.vm.function import W_FuncType, W_ASTFunc, W_Func
 from spy.vm.builtins import B
 from spy.vm import ops
 from spy.vm.typeconverter import TypeConverter, DynamicCast
@@ -30,7 +30,7 @@ class TypeChecker:
     funcef: ast.FuncDef
     expr_types: dict[ast.Expr, tuple[Color, W_Type]]
     expr_conv: dict[ast.Expr, TypeConverter]
-    expr_opimpl: dict[ast.Expr, Any] # XXX
+    expr_opimpl: dict[ast.Expr, W_Func]
     locals_types_w: dict[str, W_Type]
 
 

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -287,17 +287,19 @@ class TypeChecker:
         vcolor, w_vtype = self.check_expr(expr.value)
         icolor, w_itype = self.check_expr(expr.index)
         color = maybe_blue(vcolor, icolor)
-        opimpl = ops.GETITEM(self.vm, w_vtype, w_itype)
-        if opimpl is ops.str_getitem:
+        w_opimpl = ops.GETITEM(self.vm, w_vtype, w_itype)
+        if w_opimpl is ops.OPS.w_str_getitem:
             # XXX for now this is a special case, to check that `i` can be
             # converted to `i32`. Ideally, we should use the same mechanism
             # that we have already for calls
-            self.expr_opimpl[expr] = opimpl
+            self.expr_opimpl[expr] = w_opimpl
             err = self.convert_type_maybe(expr.index, w_itype, B.w_i32)
             if err:
                 err.add('note', f'this is a `str`', expr.value.loc)
                 raise err
             return color, B.w_str
+        elif w_opimpl is not None:
+            assert False, 'unexpected opimpl?'
         else:
             v = w_vtype.name
             i = w_itype.name

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -241,15 +241,15 @@ class TypeChecker:
         rcolor, w_rtype = self.check_expr(binop.right)
         color = maybe_blue(lcolor, rcolor)
 
-        opimpl = None
+        w_opimpl = None
         if binop.op == '+':
-            opimpl = ops.ADD(self.vm, w_ltype, w_rtype)
+            w_opimpl = ops.ADD(self.vm, w_ltype, w_rtype)
         elif binop.op == '*':
-            opimpl = ops.MUL(self.vm, w_ltype, w_rtype)
+            w_opimpl = ops.MUL(self.vm, w_ltype, w_rtype)
 
-        if opimpl is not None:
-            self.expr_opimpl[binop] = opimpl
-            w_restype = opimpl.w_functype.w_restype
+        if w_opimpl is not None:
+            self.expr_opimpl[binop] = w_opimpl
+            w_restype = w_opimpl.w_functype.w_restype
             return color, w_restype
 
         lt = w_ltype.name

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -9,6 +9,7 @@ from spy.errors import SPyTypeError
 from spy.vm.object import W_Object, W_Type, W_void, W_i32, W_bool
 from spy.vm.str import W_str
 from spy.vm.builtins import B
+from spy.vm.ops import OPS
 from spy.vm.function import W_FuncType, W_Func, W_ASTFunc, W_BuiltinFunc
 from spy.vm.module import W_Module
 from spy.vm.registry import ModuleRegistry
@@ -34,7 +35,8 @@ class SPyVM:
         self.globals_w = {}
         self.modules_w = {}
         self.path = []
-        self.make_module(B) # builtins
+        self.make_module(B)    # builtins::
+        self.make_module(OPS)  # __ops__::
 
     def import_(self, modname: str) -> W_Module:
         from spy.irgen.irgen import make_w_mod_from_file


### PR DESCRIPTION
`ModuleRegistry` is the new official API to create SPy builtin modules:
- the `builtins` module is now created using this
- the opimpl are now inside the `builtins.ops` module

Thanks to `builtins.ops`, we could remove a lot of ad-hoc support for ops/opimpls: now opimpls are just standard `W_Func` (all of them implemented at interp-level for now, so `W_BuiltinFunc`).

This allows to kill the ugly `ast.HelperFunc` and simplify a lot the code here and there.