### PR TITLE
Support for `dynamic` calls

### DIFF
--- a/spy/__main__.py
+++ b/spy/__main__.py
@@ -63,7 +63,7 @@ def do_main(filename: Path, pyparse: bool, parse: bool, redshift: bool,
     vm.path.append(str(builddir))
     w_mod = vm.import_(modname)
 
-    vm.redshift(modname)
+    vm.redshift()
     if redshift:
         dump_spy_mod(vm, modname)
         return

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -73,7 +73,8 @@ class CModuleWriter:
             assert w_obj is not None, 'uninitialized global?'
             # XXX we should mangle the name somehow
             if isinstance(w_obj, W_ASTFunc):
-                self.emit_function(fqn, w_obj)
+                if w_obj.color != 'blue':
+                    self.emit_function(fqn, w_obj)
             else:
                 self.emit_variable(fqn, w_obj)
         return self.out.build()

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -114,14 +114,22 @@ class SPyBackend:
     fmt_expr_Div = fmt_expr_BinOp
 
     def fmt_expr_Call(self, call: ast.Call) -> str:
-        if isinstance(call.func, ast.FQNConst):
-            fqn2ast = {
-                FQN('operator::i32_add'): ast.Add,
-                FQN('operator::i32_mul'): ast.Mul,
-            }
-            opclass = fqn2ast.get(call.func.fqn)
-            assert opclass is not None
+        if not isinstance(call.func, ast.FQNConst):
+            raise NotImplementedError('fix me')
+
+        # let's see whether it's a special case
+        fqn2ast = {
+            FQN('operator::i32_add'): ast.Add,
+            FQN('operator::i32_mul'): ast.Mul,
+        }
+        opclass = fqn2ast.get(call.func.fqn)
+        if opclass is not None:
             assert len(call.args) == 2
             binop = opclass(call.loc, call.args[0], call.args[1])
             return self.fmt_expr_BinOp(binop)
-        raise NotImplementedError('fix me')
+
+        # standard case
+        name = self.fmt_expr(call.func)
+        arglist = [self.fmt_expr(arg) for arg in call.args]
+        args = ', '.join(arglist)
+        return f'{name}({args})'

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -48,8 +48,9 @@ class FuncDoppler:
             locals_types_w = self.t.locals_types_w.copy())
         return w_newfunc
 
-    def blue_eval(self, expr: ast.Expr, w_type: W_Type) -> ast.Expr:
+    def blue_eval(self, expr: ast.Expr) -> ast.Expr:
         w_val = self.blue_frame.eval_expr(expr)
+        w_type = self.vm.dynamic_type(w_val)
         if w_type in (B.w_i32, B.w_bool, B.w_str, B.w_void):
             # this is a primitive, we can just use ast.Constant
             value = self.vm.unwrap(w_val)
@@ -81,7 +82,7 @@ class FuncDoppler:
     def shift_expr(self, expr: ast.Expr) -> ast.Expr:
         color, w_type = self.t.check_expr(expr)
         if color == 'blue':
-            return self.blue_eval(expr, w_type)
+            return self.blue_eval(expr)
         return magic_dispatch(self, 'shift_expr', expr)
 
     # ==== statements ====

--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -69,6 +69,7 @@ class ModuleGen:
     def gen_FuncDef(self, frame: ASTFrame, funcdef: ast.FuncDef) -> None:
         frame.exec_stmt_FuncDef(funcdef)
         w_func = frame.load_local(funcdef.name)
+        assert isinstance(w_func, W_ASTFunc)
         fqn = w_func.fqn
         self.vm.add_global(fqn, None, w_func)
 

--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -67,15 +67,16 @@ class ModuleGen:
         )
 
     def gen_FuncDef(self, frame: ASTFrame, funcdef: ast.FuncDef) -> None:
-        fqn = FQN(modname=self.modname, attr=funcdef.name)
         frame.exec_stmt_FuncDef(funcdef)
         w_func = frame.load_local(funcdef.name)
+        fqn = w_func.fqn
         self.vm.add_global(fqn, None, w_func)
 
     def gen_GlobalVarDef(self, frame: ASTFrame, decl: ast.GlobalVarDef) -> None:
         vardef = decl.vardef
         assign = decl.assign
-        fqn = FQN(modname=self.modname, attr=vardef.name)
+        fqn = self.vm.get_unique_FQN(modname=self.modname, attr=vardef.name,
+                                     is_global=True)
         w_type = frame.eval_expr_type(vardef.type)
         w_val = frame.eval_expr(assign.value)
         self.vm.add_global(fqn, w_type, w_val)

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -543,7 +543,6 @@ class TestBasic(CompilerTest):
         """)
         assert mod.foo() == 7
 
-    @skip_backends('doppler', 'C', reason='fixme')
     def test_call_blue_closure(self):
         mod = self.compile("""
         @blue

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -530,6 +530,19 @@ class TestBasic(CompilerTest):
         assert w_functype.name == 'def(x: i32) -> i32'
         assert mod.foo(1) == 2
 
+    def test_redshift_nonglobal_function(self):
+        mod = self.compile("""
+        @blue
+        def make_inc() -> dynamic:
+            def inc(x: i32) -> i32:
+                return x + 1
+            return inc
+
+        def foo() -> i32:
+            return make_inc()(6)
+        """)
+        assert mod.foo() == 7
+
     @skip_backends('doppler', 'C', reason='fixme')
     def test_call_blue_closure(self):
         mod = self.compile("""

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -529,3 +529,17 @@ class TestBasic(CompilerTest):
         w_functype = mod.foo.w_functype
         assert w_functype.name == 'def(x: i32) -> i32'
         assert mod.foo(1) == 2
+
+    @skip_backends('doppler', 'C', reason='fixme')
+    def test_call_blue_closure(self):
+        mod = self.compile("""
+        @blue
+        def make_adder(x: i32) -> dynamic:
+            def adder(y: i32) -> i32:
+                return x + y
+            return adder
+
+        def foo() -> i32:
+            return make_adder(3)(6)
+        """)
+        mod.foo()

--- a/spy/tests/compiler/test_dynamic.py
+++ b/spy/tests/compiler/test_dynamic.py
@@ -111,12 +111,18 @@ class TestDynamic(CompilerTest):
         """)
         assert mod.foo() == 8
 
-    @pytest.mark.xfail(reason="fixme")
     def test_wrong_call(self):
+        if self.backend == 'doppler':
+            pytest.skip('fixme')
+
         mod = self.compile("""
+        @blue
+        def get_inc() -> dynamic:
+            return 'hello'
+
         def foo() -> i32:
-            fn: dynamic = 'hello';
-            return fn(7)
+            return get_inc()(7)
         """)
-        # we would like this to raise an error at runtime
-        mod.foo()
+        msg = 'cannot call objects of type `str`'
+        with pytest.raises(SPyTypeError, match=msg):
+            mod.foo()

--- a/spy/tests/compiler/test_dynamic.py
+++ b/spy/tests/compiler/test_dynamic.py
@@ -94,6 +94,7 @@ class TestDynamic(CompilerTest):
         assert mod.gte(5, 5) is True
         assert mod.gte(6, 5) is True
 
+    @pytest.mark.xfail(reason="fixme")
     def test_call(self):
         mod = self.compile("""
         def inc(x: i32) -> i32:
@@ -105,7 +106,7 @@ class TestDynamic(CompilerTest):
         """)
         assert mod.foo() == 8
 
-    @pytest.mark.xfail("fixme")
+    @pytest.mark.xfail(reason="fixme")
     def test_wrong_call(self):
         mod = self.compile("""
         def foo() -> i32:

--- a/spy/tests/compiler/test_dynamic.py
+++ b/spy/tests/compiler/test_dynamic.py
@@ -109,9 +109,6 @@ class TestDynamic(CompilerTest):
         assert mod.foo() == 8
 
     def test_wrong_call(self):
-        if self.backend == 'doppler':
-            pytest.skip('fixme')
-
         mod = self.compile("""
         @blue
         def get_inc() -> dynamic:

--- a/spy/tests/compiler/test_dynamic.py
+++ b/spy/tests/compiler/test_dynamic.py
@@ -93,3 +93,24 @@ class TestDynamic(CompilerTest):
         assert mod.gte(5, 6) is False
         assert mod.gte(5, 5) is True
         assert mod.gte(6, 5) is True
+
+    def test_call(self):
+        mod = self.compile("""
+        def inc(x: i32) -> i32:
+            return x + 1
+
+        def foo() -> i32:
+            fn: dynamic = inc;
+            return fn(7)
+        """)
+        assert mod.foo() == 8
+
+    @pytest.mark.xfail("fixme")
+    def test_wrong_call(self):
+        mod = self.compile("""
+        def foo() -> i32:
+            fn: dynamic = 'hello';
+            return fn(7)
+        """)
+        # we would like this to raise an error at runtime
+        mod.foo()

--- a/spy/tests/compiler/test_dynamic.py
+++ b/spy/tests/compiler/test_dynamic.py
@@ -95,9 +95,6 @@ class TestDynamic(CompilerTest):
         assert mod.gte(6, 5) is True
 
     def test_call(self):
-        if self.backend == 'doppler':
-            pytest.skip('fixme')
-
         mod = self.compile("""
         def inc(x: i32) -> i32:
             return x + 1

--- a/spy/tests/compiler/test_dynamic.py
+++ b/spy/tests/compiler/test_dynamic.py
@@ -94,15 +94,20 @@ class TestDynamic(CompilerTest):
         assert mod.gte(5, 5) is True
         assert mod.gte(6, 5) is True
 
-    @pytest.mark.xfail(reason="fixme")
     def test_call(self):
+        if self.backend == 'doppler':
+            pytest.skip('fixme')
+
         mod = self.compile("""
         def inc(x: i32) -> i32:
             return x + 1
 
+        @blue
+        def get_inc() -> dynamic:
+            return inc
+
         def foo() -> i32:
-            fn: dynamic = inc;
-            return fn(7)
+            return get_inc()(7)
         """)
         assert mod.foo() == 8
 

--- a/spy/tests/support.py
+++ b/spy/tests/support.py
@@ -133,11 +133,11 @@ class CompilerTest:
             interp_mod = InterpModuleWrapper(self.vm, self.w_mod)
             return interp_mod
         elif self.backend == 'doppler':
-            self.vm.redshift(modname)
+            self.vm.redshift()
             interp_mod = InterpModuleWrapper(self.vm, self.w_mod)
             return interp_mod
         elif self.backend == 'C':
-            self.vm.redshift(modname)
+            self.vm.redshift()
             compiler = Compiler(self.vm, modname, self.builddir)
             file_wasm = compiler.cbuild()
             return WasmModuleWrapper(self.vm, modname, file_wasm)

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -88,3 +88,19 @@ class TestDoppler:
         """
         w_func = self.redshift(src, 'foo')
         self.assert_dump(w_func, src)
+
+    def test_dont_redshift_function_calls(self):
+        src = """
+        def inc(x: i32) -> i32:
+            return x + 1
+
+        def foo() -> i32:
+            return inc(5)
+        """
+        w_func = self.redshift(src, 'foo')
+        expected = """
+        def foo() -> i32:
+            return `test::inc`(5)
+        """
+        w_func = self.redshift(src, 'foo')
+        self.assert_dump(w_func, expected)

--- a/spy/tests/test_fqn.py
+++ b/spy/tests/test_fqn.py
@@ -41,3 +41,11 @@ def test_hash_eq():
 def test_c_name():
     a = FQN("a.b.c::xxx")
     assert a.c_name == "spy_a_b_c__xxx"
+
+def test_uniq_suffix():
+    a = FQN("aaa::bbb", uniq_suffix='0')
+    assert str(a) == "aaa::bbb#0"
+    assert a.c_name == "spy_aaa__bbb__0"
+    b = FQN(modname="aaa", attr="bbb", uniq_suffix='i32')
+    assert str(b) == "aaa::bbb#i32"
+    assert b.c_name == "spy_aaa__bbb__i32"

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -7,6 +7,7 @@ from spy.errors import SPyTypeError
 from spy.vm.object import W_Object, W_Type, spytype, W_void, W_i32, W_bool
 from spy.vm.str import W_str
 from spy.vm.function import W_BuiltinFunc
+from spy.vm.module import W_Module
 
 class TestVM:
 
@@ -174,3 +175,21 @@ class TestVM:
         msg = 'Invalid cast. Expected `i32`, got `str`'
         with pytest.raises(SPyTypeError, match=msg):
             vm.call_function(w_abs, [w_x])
+
+    def test_get_unique_FQN(self):
+        vm = SPyVM()
+        w_mod = W_Module(vm, "test", "...")
+        vm.register_module(w_mod)
+        #
+        a = vm.get_unique_FQN(modname="test", attr="a", is_global=True)
+        assert a == FQN("test::a")
+        #
+        with pytest.raises(AssertionError):
+            vm.get_unique_FQN(modname="test", attr="a", is_global=True)
+        #
+        b0 = vm.get_unique_FQN(modname="test", attr="b", is_global=False)
+        assert b0 == FQN("test::b", uniq_suffix="0")
+        assert str(b0) == "test::b#0"
+        b1 = vm.get_unique_FQN(modname="test", attr="b", is_global=False)
+        assert b1 == FQN("test::b", uniq_suffix='1')
+        assert str(b1) == "test::b#1"

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -216,6 +216,8 @@ class ASTFrame:
     eval_expr_GtE = eval_expr_BinOp
 
     def eval_expr_Call(self, call: ast.Call) -> W_Object:
+        color, w_functype = self.t.check_expr(call.func)
+        assert color == 'blue', 'indirect calls not supported'
         w_func = self.eval_expr(call.func)
         assert isinstance(w_func, W_Func)
         args_w = [self.eval_expr(arg) for arg in call.args]

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -219,7 +219,18 @@ class ASTFrame:
         color, w_functype = self.t.check_expr(call.func)
         assert color == 'blue', 'indirect calls not supported'
         w_func = self.eval_expr(call.func)
+
+        if w_functype is B.w_dynamic:
+            # if the static type is `dynamic` and thing is not a function,
+            # it's a TypeError
+            if not isinstance(w_func, W_Func):
+                t = self.vm.dynamic_type(w_func)
+                raise SPyTypeError(f'cannot call objects of type `{t.name}`')
+
+        # if the static type is not `dynamic` and the thing is not a function,
+        # it's a bug in the typechecker
         assert isinstance(w_func, W_Func)
+
         args_w = [self.eval_expr(arg) for arg in call.args]
         w_res = self.vm.call_function(w_func, args_w)
         return w_res

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -124,7 +124,13 @@ class ASTFrame:
         self.t.lazy_check_FuncDef(funcdef, w_functype)
         #
         # create the w_func
-        fqn = FQN(modname='???', attr=funcdef.name)
+
+        # if the current func is __INIT__, then we are creating a module-level
+        # global. Else, it's a closure
+        is_global = self.w_func.fqn.attr == '__INIT__'
+        modname = self.w_func.fqn.modname # the module of the "outer" function
+        fqn = self.vm.get_unique_FQN(modname=modname, attr=funcdef.name,
+                                     is_global=is_global)
         # XXX we should capture only the names actually used in the inner func
         closure = self.w_func.closure + (self._locals,)
         w_func = W_ASTFunc(w_functype, fqn, funcdef, closure)

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -132,6 +132,13 @@ class W_ASTFunc(W_Func):
     def redshifted(self) -> bool:
         return self.locals_types_w is not None
 
+    @property
+    def color(self):
+        """
+        Just a shortcut
+        """
+        return self.w_functype.color
+
     def __repr__(self) -> str:
         if self.redshifted:
             return f"<spy function '{self.fqn}' (redshifted)>"

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -133,7 +133,7 @@ class W_ASTFunc(W_Func):
         return self.locals_types_w is not None
 
     @property
-    def color(self):
+    def color(self) -> Color:
         """
         Just a shortcut
         """

--- a/spy/vm/modules/operator/multimethod.py
+++ b/spy/vm/modules/operator/multimethod.py
@@ -47,7 +47,7 @@ class MultiMethodTable:
         assert key not in self.impls
         self.impls[key] = w_impl
 
-    def register_partial(self, op: str, atype: str, w_impl: W_Object):
+    def register_partial(self, op: str, atype: str, w_impl: W_Object) -> None:
         self.register(op, atype, None, w_impl)
         self.register(op, None, atype, w_impl)
 

--- a/spy/vm/modules/operator/opimpl_dynamic.py
+++ b/spy/vm/modules/operator/opimpl_dynamic.py
@@ -18,6 +18,7 @@ def _dynamic_op(vm: 'SPyVM', w_op: W_Func,
         l = w_ltype.name
         r = w_rtype.name
         raise SPyTypeError(f'cannot do `{l}` {token} `{r}`')
+    assert isinstance(w_opimpl, W_Func)
     return vm.call_function(w_opimpl, [w_a, w_b])
 
 

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -294,6 +294,10 @@ class TypeChecker:
     def check_expr_Call(self, call: ast.Call) -> tuple[Color, W_Type]:
         color, w_functype = self.check_expr(call.func)
         sym = self.name2sym_maybe(call.func)
+
+        if w_functype is B.w_dynamic:
+            return color, B.w_dynamic
+
         if not isinstance(w_functype, W_FuncType):
             self._call_error_non_callable(call, sym, w_functype)
         #

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -210,11 +210,11 @@ class TypeChecker:
         elif sym.is_local:
             return sym.color, self.locals_types_w[name.id]
         else:
-            #assert sym.color == 'blue' # XXX this fails?
+            # closed-over variables are always blue
             namespace = self.w_func.closure[sym.level]
             w_value = namespace[sym.name]
             assert w_value is not None
-            return sym.color, self.vm.dynamic_type(w_value)
+            return 'blue', self.vm.dynamic_type(w_value)
 
     def check_expr_Constant(self, const: ast.Constant) -> tuple[Color, W_Type]:
         T = type(const.value)

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -315,8 +315,10 @@ class TypeChecker:
                     err.add('note', 'function defined here', sym.loc)
                 raise err
         #
-        color = 'red' # XXX fix me
-        return color, w_functype.w_restype
+        # the color of the result depends on the color of the function: if we
+        # call a @blue function, we get a blue result
+        rescolor = w_functype.color
+        return rescolor, w_functype.w_restype
 
     def _call_error_non_callable(self, call: ast.Call,
                                  sym: Optional[Symbol],

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -296,7 +296,18 @@ class TypeChecker:
         sym = self.name2sym_maybe(call.func)
 
         if w_functype is B.w_dynamic:
-            return color, B.w_dynamic
+            # XXX: how are we supposed to know the color of the result if we
+            # are calling a dynamic expr?
+            # E.g.:
+            #
+            # @blue
+            # def foo(): ...
+            #
+            # @blue
+            # def bar(): ...
+            #     x: dynamic = foo
+            #     x()   # color???
+            return 'red', B.w_dynamic # ???
 
         if not isinstance(w_functype, W_FuncType):
             self._call_error_non_callable(call, sym, w_functype)

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -73,14 +73,13 @@ class SPyVM:
                 break
             self._redshift_some(funcs)
 
-    def _redshift_some(self, funcs) -> None:
+    def _redshift_some(self, funcs: list[tuple[FQN, W_ASTFunc]]) -> None:
         for fqn, w_func in funcs:
-            if isinstance(w_func, W_ASTFunc):
-                assert w_func.color != 'blue'
-                assert not w_func.redshifted
-                w_newfunc = redshift(self, w_func)
-                assert w_newfunc.redshifted
-                self.globals_w[fqn] = w_newfunc
+            assert w_func.color != 'blue'
+            assert not w_func.redshifted
+            w_newfunc = redshift(self, w_func)
+            assert w_newfunc.redshifted
+            self.globals_w[fqn] = w_newfunc
 
     def register_module(self, w_mod: W_Module) -> None:
         assert w_mod.name not in self.modules_w

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -57,6 +57,10 @@ class SPyVM:
         """
         for fqn, w_func in self.globals_w.items():
             if fqn.modname == modname and isinstance(w_func, W_ASTFunc):
+                # we don't want to redshift @blue functions
+                if w_func.w_functype.color == 'blue':
+                    continue
+
                 assert not w_func.redshifted, 'redshift already called'
                 w_newfunc = redshift(self, w_func)
                 assert w_newfunc.redshifted


### PR DESCRIPTION
   This PR does two things:
    
    1. add support for calling expressions whose type is `dynamic`
    
    2. add support for redshifting/compiling closures which are generated
       inside @blue functions