### PR TITLE
Introduce the `f64` type and more numeric ops

### DIFF
--- a/spy/backend/c/context.py
+++ b/spy/backend/c/context.py
@@ -56,6 +56,7 @@ class Context:
         self._d = {}
         self._d[B.w_void] = C_Type('void')
         self._d[B.w_i32] = C_Type('int32_t')
+        self._d[B.w_f64] = C_Type('double')
         self._d[B.w_bool] = C_Type('bool')
         self._d[B.w_str] = C_Type('spy_Str *')
 

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -328,6 +328,15 @@ class CFuncWriter:
             FQN('operator::i32_le') : '<=',
             FQN('operator::i32_gt') : '>',
             FQN('operator::i32_ge') : '>=',
+            #
+            FQN('operator::f64_add'): '+',
+            FQN('operator::f64_mul'): '*',
+            FQN('operator::f64_eq') : '==',
+            FQN('operator::f64_ne') : '!=',
+            FQN('operator::f64_lt') : '<',
+            FQN('operator::f64_le') : '<=',
+            FQN('operator::f64_gt') : '>',
+            FQN('operator::f64_ge') : '>=',
         }
         op = binops.get(call.func.fqn)
         if op is not None:

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -194,6 +194,11 @@ class CFuncWriter:
         magic_dispatch(self, 'emit_stmt', stmt)
 
     def fmt_expr(self, expr: ast.Expr) -> C.Expr:
+        # XXX: here we should probably handle typeconv, if present.
+        # However, we cannot yet write a test for it because:
+        #   - we cannot test DynamicCast because we don't support object
+        #   - we cannot test NumericConv because the expressions are
+        #     automatically converted by the C compiler anyway
         return magic_dispatch(self, 'fmt_expr', expr)
 
     # ===== statements =====

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -332,7 +332,9 @@ class CFuncWriter:
             FQN('operator::i32_ge') : '>=',
             #
             FQN('operator::f64_add'): '+',
+            FQN('operator::f64_sub'): '-',
             FQN('operator::f64_mul'): '*',
+            FQN('operator::f64_div'): '/',
             FQN('operator::f64_eq') : '==',
             FQN('operator::f64_ne') : '!=',
             FQN('operator::f64_lt') : '<',

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -250,10 +250,12 @@ class CFuncWriter:
         # unsupported literals are rejected directly by the parser, see
         # Parser.from_py_expr_Constant
         T = type(const.value)
-        assert T in (int, bool, str, NoneType)
+        assert T in (int, float, bool, str, NoneType)
         if T is NoneType:
             return C.Void()
         elif T is int:
+            return C.Literal(str(const.value))
+        elif T is float:
             return C.Literal(str(const.value))
         elif T is bool:
             return C.Literal(str(const.value).lower())

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -321,7 +321,9 @@ class CFuncWriter:
         # some calls are special-cased and transformed into a C binop
         binops = {
             FQN('operator::i32_add'): '+',
+            FQN('operator::i32_sub'): '-',
             FQN('operator::i32_mul'): '*',
+            FQN('operator::i32_div'): '/', # XXX: floor division or int division?
             FQN('operator::i32_eq') : '==',
             FQN('operator::i32_ne') : '!=',
             FQN('operator::i32_lt') : '<',

--- a/spy/backend/c/wrapper.py
+++ b/spy/backend/c/wrapper.py
@@ -68,7 +68,7 @@ class WasmFuncWrapper:
         self.w_functype = w_functype
 
     def py2wasm(self, pyval: Any, w_type: W_Type) -> Any:
-        if w_type is B.w_i32:
+        if w_type in (B.w_i32, B.w_f64):
             return pyval
         elif w_type is B.w_str:
             # XXX: with the GC, we need to think how to keep this alive

--- a/spy/backend/c/wrapper.py
+++ b/spy/backend/c/wrapper.py
@@ -97,6 +97,8 @@ class WasmFuncWrapper:
             return None
         elif w_type is B.w_i32:
             return res
+        elif w_type is B.w_f64:
+            return res
         elif w_type is B.w_bool:
             return bool(res)
         elif w_type is B.w_str:

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -51,7 +51,7 @@ class FuncDoppler:
     def blue_eval(self, expr: ast.Expr) -> ast.Expr:
         w_val = self.blue_frame.eval_expr(expr)
         w_type = self.vm.dynamic_type(w_val)
-        if w_type in (B.w_i32, B.w_bool, B.w_str, B.w_void):
+        if w_type in (B.w_i32, B.w_f64, B.w_bool, B.w_str, B.w_void):
             # this is a primitive, we can just use ast.Constant
             value = self.vm.unwrap(w_val)
             if isinstance(value, FixedInt): # type: ignore

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -304,7 +304,7 @@ class Parser:
         #     None, str, bytes, bool, int, float, complex, Ellipsis
         assert py_node.kind is None  # I don't know what is 'kind' here
         T = type(py_node.value)
-        if T in (int, bool, str, NoneType):
+        if T in (int, float, bool, str, NoneType):
             return spy.ast.Constant(py_node.loc, py_node.value)
         elif T in (bytes, float, complex, Ellipsis):
             self.error(f'unsupported literal: {py_node.value!r}',

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -184,10 +184,17 @@ class TestBasic(CompilerTest):
     def test_i32_BinOp(self):
         mod = self.compile("""
         def add(x: i32, y: i32) -> i32: return x + y
+        def sub(x: i32, y: i32) -> i32: return x - y
         def mul(x: i32, y: i32) -> i32: return x * y
+        def div(x: i32, y: i32) -> i32: return x / y
+
+        # XXX: should i32/i32 return an i32 or a float? For now we just do an
+        # integer division
         """)
         assert mod.add(1, 2) == 3
-        assert mod.mul(3, 4) == 12
+        assert mod.sub(3, 4) == -1
+        assert mod.mul(5, 6) == 30
+        assert mod.div(10, 3) == 3
 
     def test_void_return(self):
         mod = self.compile("""

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -181,18 +181,12 @@ class TestBasic(CompilerTest):
         )
         self.compile_raises(src, "set_x", errors)
 
-    def test_i32_add(self):
+    def test_i32_BinOp(self):
         mod = self.compile("""
-        def add(x: i32, y: i32) -> i32:
-            return x + y
+        def add(x: i32, y: i32) -> i32: return x + y
+        def mul(x: i32, y: i32) -> i32: return x * y
         """)
         assert mod.add(1, 2) == 3
-
-    def test_i32_mul(self):
-        mod = self.compile("""
-        def mul(x: i32, y: i32) -> i32:
-            return x * y
-        """)
         assert mod.mul(3, 4) == 12
 
     def test_void_return(self):

--- a/spy/tests/compiler/test_float.py
+++ b/spy/tests/compiler/test_float.py
@@ -56,3 +56,11 @@ class TestFloat(CompilerTest):
         assert mod.cmp_gte(5.1, 6.2) is False
         assert mod.cmp_gte(5.1, 5.1) is True
         assert mod.cmp_gte(6.2, 5.1) is True
+
+    def test_implicit_conversion(self):
+        mod = self.compile(
+        """
+        def add(x: f64, y: i32) -> f64:
+            return x + y
+        """)
+        assert mod.add(1.5, 2) == 3.5

--- a/spy/tests/compiler/test_float.py
+++ b/spy/tests/compiler/test_float.py
@@ -12,3 +12,43 @@ class TestFloat(CompilerTest):
             return 12.3
         """)
         assert mod.foo() == 12.3
+
+    def test_BinOp(self):
+        mod = self.compile(
+        """
+        def add(x: f64, y: f64) -> f64: return x + y
+        def mul(x: f64, y: f64) -> f64: return x * y
+        """)
+        assert mod.add(1.5, 2.6) == 4.1
+        assert mod.mul(1.5, 0.5) == 0.75
+
+    def test_CompareOp(self):
+        mod = self.compile("""
+        def cmp_eq (x: f64, y: f64) -> bool: return x == y
+        def cmp_neq(x: f64, y: f64) -> bool: return x != y
+        def cmp_lt (x: f64, y: f64) -> bool: return x  < y
+        def cmp_lte(x: f64, y: f64) -> bool: return x <= y
+        def cmp_gt (x: f64, y: f64) -> bool: return x  > y
+        def cmp_gte(x: f64, y: f64) -> bool: return x >= y
+        """)
+        assert mod.cmp_eq(5.1, 5.1) is True
+        assert mod.cmp_eq(5.1, 6.2) is False
+        #
+        assert mod.cmp_neq(5.1, 5.1) is False
+        assert mod.cmp_neq(5.1, 6.2) is True
+        #
+        assert mod.cmp_lt(5.1, 6.2) is True
+        assert mod.cmp_lt(5.1, 5.1) is False
+        assert mod.cmp_lt(6.2, 5.1) is False
+        #
+        assert mod.cmp_lte(5.1, 6.2) is True
+        assert mod.cmp_lte(5.1, 5.1) is True
+        assert mod.cmp_lte(6.2, 5.1) is False
+        #
+        assert mod.cmp_gt(5.1, 6.2) is False
+        assert mod.cmp_gt(5.1, 5.1) is False
+        assert mod.cmp_gt(6.2, 5.1) is True
+        #
+        assert mod.cmp_gte(5.1, 6.2) is False
+        assert mod.cmp_gte(5.1, 5.1) is True
+        assert mod.cmp_gte(6.2, 5.1) is True

--- a/spy/tests/compiler/test_float.py
+++ b/spy/tests/compiler/test_float.py
@@ -1,0 +1,14 @@
+#-*- encoding: utf-8 -*-
+
+import pytest
+from spy.tests.support import CompilerTest, skip_backends, no_backend
+
+class TestFloat(CompilerTest):
+
+    def test_literal(self):
+        mod = self.compile(
+        """
+        def foo() -> f64:
+            return 12.3
+        """)
+        assert mod.foo() == 12.3

--- a/spy/tests/compiler/test_float.py
+++ b/spy/tests/compiler/test_float.py
@@ -60,7 +60,10 @@ class TestFloat(CompilerTest):
     def test_implicit_conversion(self):
         mod = self.compile(
         """
-        def add(x: f64, y: i32) -> f64:
-            return x + y
+        def add(x: f64, y: i32) -> f64: return x + y
+        def sub(x: i32, y: f64) -> f64: return x - y
+        def div(x: f64, y: i32) -> f64: return x / y
         """)
         assert mod.add(1.5, 2) == 3.5
+        assert mod.sub(10, 0.5) == 9.5
+        assert mod.div(1.5, 2) == 0.75

--- a/spy/tests/compiler/test_float.py
+++ b/spy/tests/compiler/test_float.py
@@ -17,10 +17,14 @@ class TestFloat(CompilerTest):
         mod = self.compile(
         """
         def add(x: f64, y: f64) -> f64: return x + y
+        def sub(x: f64, y: f64) -> f64: return x - y
         def mul(x: f64, y: f64) -> f64: return x * y
+        def div(x: f64, y: f64) -> f64: return x / y
         """)
         assert mod.add(1.5, 2.6) == 4.1
+        assert mod.sub(1.5, 0.2) == 1.3
         assert mod.mul(1.5, 0.5) == 0.75
+        assert mod.div(1.5, 2.0)   == 0.75
 
     def test_CompareOp(self):
         mod = self.compile("""

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -180,7 +180,7 @@ class ASTFrame:
         # unsupported literals are rejected directly by the parser, see
         # Parser.from_py_expr_Constant
         T = type(const.value)
-        assert T in (int, bool, str, NoneType)
+        assert T in (int, float, bool, str, NoneType)
         return self.vm.wrap(const.value)
 
     def eval_expr_FQNConst(self, const: ast.FQNConst) -> W_Object:

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -212,7 +212,9 @@ class ASTFrame:
         return w_res
 
     eval_expr_Add = eval_expr_BinOp
+    eval_expr_Sub = eval_expr_BinOp
     eval_expr_Mul = eval_expr_BinOp
+    eval_expr_Div = eval_expr_BinOp
     eval_expr_Eq = eval_expr_BinOp
     eval_expr_NotEq = eval_expr_BinOp
     eval_expr_Lt = eval_expr_BinOp

--- a/spy/vm/b.py
+++ b/spy/vm/b.py
@@ -17,7 +17,7 @@ all over the place and we need to import it very early.
 
 from spy.vm.registry import ModuleRegistry
 from spy.vm.object import (W_Object, W_Type, w_DynamicType, W_Void, W_I32,
-                           W_Bool, W_NotImplementedType)
+                           W_F64, W_Bool, W_NotImplementedType)
 from spy.vm.str import W_Str
 
 
@@ -29,6 +29,7 @@ B.add('type', W_Type._w)
 B.add('void', W_Void._w)
 B.add('dynamic', w_DynamicType)
 B.add('i32', W_I32._w)
+B.add('f64', W_F64._w)
 B.add('bool', W_Bool._w)
 B.add('str', W_Str._w)
 B.add('None', W_Void._w_singleton)

--- a/spy/vm/modules/operator/__init__.py
+++ b/spy/vm/modules/operator/__init__.py
@@ -77,7 +77,9 @@ from . import binop          # side effects
 # fill the _from_token dict
 OP._from_token.update({
     '+': OP.w_ADD,
+    '-': OP.w_SUB,
     '*': OP.w_MUL,
+    '/': OP.w_DIV,
     '==': OP.w_EQ,
     '!=': OP.w_NE,
     '<':  OP.w_LT,

--- a/spy/vm/modules/operator/__init__.py
+++ b/spy/vm/modules/operator/__init__.py
@@ -68,6 +68,7 @@ OP = OPERATOR
 
 # the folloing imports register all the various objects on OP
 from . import opimpl_i32     # side effects
+from . import opimpl_f64     # side effects
 from . import opimpl_str     # side effects
 from . import opimpl_dynamic # side effects
 from . import binop          # side effects

--- a/spy/vm/modules/operator/binop.py
+++ b/spy/vm/modules/operator/binop.py
@@ -32,9 +32,29 @@ MM.register('<=', 'f64', 'f64', OP.w_f64_le)
 MM.register('>' , 'f64', 'f64', OP.w_f64_gt)
 MM.register('>=', 'f64', 'f64', OP.w_f64_ge)
 
-# XXX: ideally, we would like to autogenerate all the possible combinations of
-# numeric ops
+# mixed i32/f64 ops: this is still small enough that we can write it manually,
+# but we should consider the idea of generating this table automatically. This
+# will become especially relevant when we add more integer types.
 MM.register('+',  'f64', 'i32', OP.w_f64_add)
+MM.register('+',  'i32', 'f64', OP.w_f64_add)
+MM.register('-',  'f64', 'i32', OP.w_f64_sub)
+MM.register('-',  'i32', 'f64', OP.w_f64_sub)
+MM.register('*',  'f64', 'i32', OP.w_f64_mul)
+MM.register('*',  'i32', 'f64', OP.w_f64_mul)
+MM.register('/',  'f64', 'i32', OP.w_f64_div)
+MM.register('/',  'i32', 'f64', OP.w_f64_div)
+MM.register('==', 'f64', 'i32', OP.w_f64_eq)
+MM.register('==', 'i32', 'f64', OP.w_f64_eq)
+MM.register('!=', 'f64', 'i32', OP.w_f64_ne)
+MM.register('!=', 'i32', 'f64', OP.w_f64_ne)
+MM.register('<' , 'f64', 'i32', OP.w_f64_lt)
+MM.register('<' , 'i32', 'f64', OP.w_f64_lt)
+MM.register('<=', 'f64', 'i32', OP.w_f64_le)
+MM.register('<=', 'i32', 'f64', OP.w_f64_le)
+MM.register('>' , 'f64', 'i32', OP.w_f64_gt)
+MM.register('>' , 'i32', 'f64', OP.w_f64_gt)
+MM.register('>=', 'f64', 'i32', OP.w_f64_ge)
+MM.register('>=', 'i32', 'f64', OP.w_f64_ge)
 
 # str ops
 MM.register('+',  'str', 'str', OP.w_str_add)

--- a/spy/vm/modules/operator/binop.py
+++ b/spy/vm/modules/operator/binop.py
@@ -22,7 +22,9 @@ MM.register('>=', 'i32', 'i32', OP.w_i32_ge)
 
 # f64 ops
 MM.register('+',  'f64', 'f64', OP.w_f64_add)
+MM.register('-',  'f64', 'f64', OP.w_f64_sub)
 MM.register('*',  'f64', 'f64', OP.w_f64_mul)
+MM.register('/',  'f64', 'f64', OP.w_f64_div)
 MM.register('==', 'f64', 'f64', OP.w_f64_eq)
 MM.register('!=', 'f64', 'f64', OP.w_f64_ne)
 MM.register('<' , 'f64', 'f64', OP.w_f64_lt)

--- a/spy/vm/modules/operator/binop.py
+++ b/spy/vm/modules/operator/binop.py
@@ -32,6 +32,10 @@ MM.register('<=', 'f64', 'f64', OP.w_f64_le)
 MM.register('>' , 'f64', 'f64', OP.w_f64_gt)
 MM.register('>=', 'f64', 'f64', OP.w_f64_ge)
 
+# XXX: ideally, we would like to autogenerate all the possible combinations of
+# numeric ops
+MM.register('+',  'f64', 'i32', OP.w_f64_add)
+
 # str ops
 MM.register('+',  'str', 'str', OP.w_str_add)
 MM.register('*',  'str', 'i32', OP.w_str_mul)

--- a/spy/vm/modules/operator/binop.py
+++ b/spy/vm/modules/operator/binop.py
@@ -18,6 +18,16 @@ MM.register('<=', 'i32', 'i32', OP.w_i32_le)
 MM.register('>' , 'i32', 'i32', OP.w_i32_gt)
 MM.register('>=', 'i32', 'i32', OP.w_i32_ge)
 
+# f64 ops
+MM.register('+',  'f64', 'f64', OP.w_f64_add)
+MM.register('*',  'f64', 'f64', OP.w_f64_mul)
+MM.register('==', 'f64', 'f64', OP.w_f64_eq)
+MM.register('!=', 'f64', 'f64', OP.w_f64_ne)
+MM.register('<' , 'f64', 'f64', OP.w_f64_lt)
+MM.register('<=', 'f64', 'f64', OP.w_f64_le)
+MM.register('>' , 'f64', 'f64', OP.w_f64_gt)
+MM.register('>=', 'f64', 'f64', OP.w_f64_ge)
+
 # str ops
 MM.register('+',  'str', 'str', OP.w_str_add)
 MM.register('*',  'str', 'i32', OP.w_str_mul)

--- a/spy/vm/modules/operator/binop.py
+++ b/spy/vm/modules/operator/binop.py
@@ -10,7 +10,9 @@ MM = MultiMethodTable()
 
 # i32 ops
 MM.register('+',  'i32', 'i32', OP.w_i32_add)
+MM.register('-',  'i32', 'i32', OP.w_i32_sub)
 MM.register('*',  'i32', 'i32', OP.w_i32_mul)
+MM.register('/',  'i32', 'i32', OP.w_i32_div)
 MM.register('==', 'i32', 'i32', OP.w_i32_eq)
 MM.register('!=', 'i32', 'i32', OP.w_i32_ne)
 MM.register('<' , 'i32', 'i32', OP.w_i32_lt)
@@ -50,8 +52,16 @@ def ADD(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Object:
     return MM.lookup('+', w_ltype, w_rtype)
 
 @OP.primitive('def(l: type, r: type) -> dynamic')
+def SUB(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Object:
+    return MM.lookup('-', w_ltype, w_rtype)
+
+@OP.primitive('def(l: type, r: type) -> dynamic')
 def MUL(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Object:
     return MM.lookup('*', w_ltype, w_rtype)
+
+@OP.primitive('def(l: type, r: type) -> dynamic')
+def DIV(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Object:
+    return MM.lookup('/', w_ltype, w_rtype)
 
 @OP.primitive('def(l: type, r: type) -> dynamic')
 def EQ(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Object:

--- a/spy/vm/modules/operator/opimpl_f64.py
+++ b/spy/vm/modules/operator/opimpl_f64.py
@@ -21,8 +21,16 @@ def f64_add(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_F64:
     return _f64_op(vm, w_a, w_b, lambda a, b: a + b)
 
 @OP.primitive('def(a: f64, b: f64) -> f64')
+def f64_sub(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_F64:
+    return _f64_op(vm, w_a, w_b, lambda a, b: a - b)
+
+@OP.primitive('def(a: f64, b: f64) -> f64')
 def f64_mul(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_F64:
     return _f64_op(vm, w_a, w_b, lambda a, b: a * b)
+
+@OP.primitive('def(a: f64, b: f64) -> f64')
+def f64_div(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_F64:
+    return _f64_op(vm, w_a, w_b, lambda a, b: a / b)
 
 @OP.primitive('def(a: f64, b: f64) -> bool')
 def f64_eq(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_Bool:

--- a/spy/vm/modules/operator/opimpl_f64.py
+++ b/spy/vm/modules/operator/opimpl_f64.py
@@ -1,0 +1,49 @@
+from typing import TYPE_CHECKING, Any
+from spy.vm.b import B
+from spy.vm.object import W_Object, W_Type, W_F64, W_Bool
+from . import OP
+if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
+
+# the following style is a bit too verbose. We could greatly reduce code
+# duplication by using some metaprogramming, but it might become too
+# magic. Or, it would be nice to have automatic unwrapping.
+# Let's to the dumb&verbose thing for now
+
+def _f64_op(vm: 'SPyVM', w_a: W_Object, w_b: W_Object, fn: Any) -> Any:
+    a = vm.unwrap_f64(w_a)
+    b = vm.unwrap_f64(w_b)
+    res = fn(a, b)
+    return vm.wrap(res)
+
+@OP.primitive('def(a: f64, b: f64) -> f64')
+def f64_add(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_F64:
+    return _f64_op(vm, w_a, w_b, lambda a, b: a + b)
+
+@OP.primitive('def(a: f64, b: f64) -> f64')
+def f64_mul(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_F64:
+    return _f64_op(vm, w_a, w_b, lambda a, b: a * b)
+
+@OP.primitive('def(a: f64, b: f64) -> bool')
+def f64_eq(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_Bool:
+    return _f64_op(vm, w_a, w_b, lambda a, b: a == b)
+
+@OP.primitive('def(a: f64, b: f64) -> bool')
+def f64_ne(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_Bool:
+    return _f64_op(vm, w_a, w_b, lambda a, b: a != b)
+
+@OP.primitive('def(a: f64, b: f64) -> bool')
+def f64_lt(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_Bool:
+    return _f64_op(vm, w_a, w_b, lambda a, b: a < b)
+
+@OP.primitive('def(a: f64, b: f64) -> bool')
+def f64_le(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_Bool:
+    return _f64_op(vm, w_a, w_b, lambda a, b: a <= b)
+
+@OP.primitive('def(a: f64, b: f64) -> bool')
+def f64_gt(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_Bool:
+    return _f64_op(vm, w_a, w_b, lambda a, b: a > b)
+
+@OP.primitive('def(a: f64, b: f64) -> bool')
+def f64_ge(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_Bool:
+    return _f64_op(vm, w_a, w_b, lambda a, b: a >= b)

--- a/spy/vm/modules/operator/opimpl_i32.py
+++ b/spy/vm/modules/operator/opimpl_i32.py
@@ -21,8 +21,17 @@ def i32_add(vm: 'SPyVM', w_a: W_I32, w_b: W_I32) -> W_I32:
     return _i32_op(vm, w_a, w_b, lambda a, b: a + b)
 
 @OP.primitive('def(a: i32, b: i32) -> i32')
+def i32_sub(vm: 'SPyVM', w_a: W_I32, w_b: W_I32) -> W_I32:
+    return _i32_op(vm, w_a, w_b, lambda a, b: a - b)
+
+@OP.primitive('def(a: i32, b: i32) -> i32')
 def i32_mul(vm: 'SPyVM', w_a: W_I32, w_b: W_I32) -> W_I32:
     return _i32_op(vm, w_a, w_b, lambda a, b: a * b)
+
+# XXX: should we do floor division or float division?
+@OP.primitive('def(a: i32, b: i32) -> i32')
+def i32_div(vm: 'SPyVM', w_a: W_I32, w_b: W_I32) -> W_I32:
+    return _i32_op(vm, w_a, w_b, lambda a, b: a // b)
 
 @OP.primitive('def(a: i32, b: i32) -> bool')
 def i32_eq(vm: 'SPyVM', w_a: W_I32, w_b: W_I32) -> W_Bool:

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -196,6 +196,21 @@ class W_I32(W_Object):
         return self.value
 
 
+@spytype('f64')
+class W_F64(W_Object):
+    value: float
+
+    def __init__(self, value: float) -> None:
+        assert type(value) is float
+        self.value = value
+
+    def __repr__(self) -> str:
+        return f'W_F64({self.value})'
+
+    def spy_unwrap(self, vm: 'SPyVM') -> float:
+        return self.value
+
+
 @spytype('bool')
 class W_Bool(W_Object):
     value: bool

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -9,7 +9,7 @@ from spy.vm.object import W_Object, W_Type
 from spy.vm.function import W_FuncType, W_ASTFunc, W_Func
 from spy.vm.b import B
 from spy.vm.modules.operator import OP
-from spy.vm.typeconverter import TypeConverter, DynamicCast
+from spy.vm.typeconverter import TypeConverter, DynamicCast, NumericConv
 from spy.util import magic_dispatch
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -104,6 +104,10 @@ class TypeChecker:
         elif self.vm.issubclass(w_exp, w_got):
             # implicit upcast
             self.expr_conv[expr] = DynamicCast(w_exp)
+            return None
+        elif w_got is B.w_i32 and w_exp is B.w_f64:
+            # numeric conversion
+            self.expr_conv[expr] = NumericConv(w_type=w_exp, w_fromtype=w_got)
             return None
         # mismatched types
         err = SPyTypeError('mismatched types')
@@ -255,6 +259,7 @@ class TypeChecker:
             raise err
 
         assert isinstance(w_opimpl, W_Func)
+        self.opimpl_check_args(w_opimpl, binop, [binop.left, binop.right])
         self.expr_opimpl[binop] = w_opimpl
         w_restype = w_opimpl.w_functype.w_restype
         return color, w_restype
@@ -269,6 +274,30 @@ class TypeChecker:
     check_expr_LtE = check_expr_BinOp
     check_expr_Gt = check_expr_BinOp
     check_expr_GtE = check_expr_BinOp
+
+    def opimpl_check_args(self, w_opimpl: W_Func, op: ast.Expr,
+                          args: list[ast.Expr]) -> None:
+        """
+        Check that arg types that we are passing to the opimpl, and insert
+        appropriate type conversions if needed.
+
+        Note: this is very similar to check_call & co: the difference is
+        that if here we find mistake in the signature (e.g. wrong argcount
+        or type mismatch) we treat it as an internal error instead of an
+        user error.
+
+        Maybe we could reduce a bit the code duplication in the future.
+        """
+        w_functype = w_opimpl.w_functype
+        argtypes_w = [self.check_expr(arg)[1] for arg in args]
+        got_nargs = len(argtypes_w)
+        exp_nargs = len(w_functype.params)
+        assert got_nargs == exp_nargs, 'wrong opimpl?'
+
+        for i, (param, w_arg_type) in enumerate(zip(w_functype.params,
+                                                    argtypes_w)):
+            err = self.convert_type_maybe(args[i], w_arg_type, param.w_type)
+            assert not err, 'wrong opimpl?'
 
     def check_expr_GetItem(self, expr: ast.GetItem) -> tuple[Color, W_Type]:
         vcolor, w_vtype = self.check_expr(expr.value)

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -218,9 +218,11 @@ class TypeChecker:
 
     def check_expr_Constant(self, const: ast.Constant) -> tuple[Color, W_Type]:
         T = type(const.value)
-        assert T in (int, bool, str, NoneType)
+        assert T in (int, float, bool, str, NoneType)
         if T is int:
             return 'blue', B.w_i32
+        elif T is float:
+            return 'blue', B.w_f64
         elif T is bool:
             return 'blue', B.w_bool
         elif T is str:

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -260,7 +260,9 @@ class TypeChecker:
         return color, w_restype
 
     check_expr_Add = check_expr_BinOp
+    check_expr_Sub = check_expr_BinOp
     check_expr_Mul = check_expr_BinOp
+    check_expr_Div = check_expr_BinOp
     check_expr_Eq = check_expr_BinOp
     check_expr_NotEq = check_expr_BinOp
     check_expr_Lt = check_expr_BinOp

--- a/spy/vm/typeconverter.py
+++ b/spy/vm/typeconverter.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 from dataclasses import dataclass
 from spy.vm.object import W_Object, W_Type
+from spy.vm.b import B
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
@@ -30,3 +31,19 @@ class DynamicCast(TypeConverter):
     def convert(self, vm: 'SPyVM', w_obj: W_Object) -> W_Object:
         vm.typecheck(w_obj, self.w_type)
         return w_obj
+
+@dataclass
+class NumericConv(TypeConverter):
+    """
+    Convert between numeric types.
+
+    At the moment, the only supported conversion is i32->f64, and it's
+    hard-coded
+    """
+    w_fromtype: W_Type
+
+    def convert(self, vm: 'SPyVM', w_obj: W_Object) -> W_Object:
+        assert self.w_type is B.w_f64
+        assert self.w_fromtype is B.w_i32
+        val = vm.unwrap_i32(w_obj)
+        return vm.wrap(float(val))

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -218,6 +218,11 @@ class SPyVM:
             raise Exception('Type mismatch')
         return w_value.value
 
+    def unwrap_f64(self, w_value: W_Object) -> Any:
+        if not isinstance(w_value, W_F64):
+            raise Exception('Type mismatch')
+        return w_value.value
+
     def call_function(self, w_func: W_Func, args_w: list[W_Object]) -> W_Object:
         w_functype = w_func.w_functype
         assert w_functype.arity == len(args_w)

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -7,7 +7,7 @@ from spy.fqn import FQN
 from spy import libspy
 from spy.doppler import redshift
 from spy.errors import SPyTypeError
-from spy.vm.object import W_Object, W_Type, W_I32
+from spy.vm.object import W_Object, W_Type, W_I32, W_F64
 from spy.vm.str import W_Str
 from spy.vm.b import B
 from spy.vm.function import W_FuncType, W_Func, W_ASTFunc, W_BuiltinFunc
@@ -190,6 +190,8 @@ class SPyVM:
             return B.w_None
         elif T in (int, fixedint.Int32):
             return W_I32(value)
+        elif T is float:
+            return W_F64(value)
         elif T is bool:
             if value:
                 return B.w_True


### PR DESCRIPTION
This PR adds a lot of long-needed features regarding numeric operations:

- introduce the f64 type, and add support for it a bit everywhere

- implement - and / for both i32 and f64

- introduce support for implicit conversions from i32 to f64