### PR TITLE
Add print() and spy --run

### DIFF
--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -556,3 +556,22 @@ class TestBasic(CompilerTest):
             return make_adder(3)(6)
         """)
         mod.foo()
+
+    @skip_backends("C", reason="implement me")
+    def test_print(self, capsys):
+        mod = self.compile("""
+        def foo() -> void:
+            print("hello world")
+            print(42)
+            print(12.3)
+            print(True)
+            print(None)
+        """)
+        mod.foo()
+        out, err = capsys.readouterr()
+        assert out == '\n'.join(["hello world",
+                                 "42",
+                                 "12.3",
+                                 "True",
+                                 "None",
+                                 ""])

--- a/spy/tests/test___main__.py
+++ b/spy/tests/test___main__.py
@@ -55,6 +55,14 @@ class TestMain:
         res, stdout = self.run('--parse', self.foo_spy)
         assert stdout.startswith('Module(')
 
+    def test_run(self):
+        self.foo_spy.write(textwrap.dedent("""
+        def main() -> void:
+            print("hello world")
+        """))
+        res, stdout = self.run("--run", self.foo_spy)
+        assert stdout == "hello world\n"
+
     def test_redshift(self):
         res, stdout = self.run('--redshift', self.foo_spy)
         assert stdout.startswith('def add(x: i32, y: i32) -> i32:')

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -4,14 +4,31 @@ Second half of the `builtins` module.
 The first half is in vm/b.py. See its docstring for more details.
 """
 
-from typing import TYPE_CHECKING
-from spy.vm.object import W_I32
-from spy.vm.b import BUILTINS
+from typing import TYPE_CHECKING, Any
+from spy.vm.object import W_I32, W_F64, W_Bool, W_Object, W_Void
+from spy.vm.str import W_Str
+from spy.vm.b import BUILTINS, B
+
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
+
+PY_PRINT = print  # type: ignore
 
 @BUILTINS.primitive('def(x: i32) -> i32')
 def abs(vm: 'SPyVM', w_x: W_I32) -> W_I32:
     x = vm.unwrap_i32(w_x)
     res = vm.ll.call('spy_builtins__abs', x)
     return vm.wrap(res) # type: ignore
+
+@BUILTINS.primitive('def(x: dynamic) -> void')
+def print(vm: 'SPyVM', w_x: W_Object) -> W_Void:
+    """
+    Super minimal implementation of print().
+
+    It takes just one argument.
+    """
+    if isinstance(w_x, (W_I32, W_F64, W_Bool, W_Str, W_Void)):
+        PY_PRINT(vm.unwrap(w_x))
+    else:
+        PY_PRINT(w_x)
+    return B.w_None

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -168,7 +168,7 @@ class SPyVM:
         Like vm.isinstance(), but raise SPyTypeError if the check fails.
         """
         w_t1 = self.dynamic_type(w_obj)
-        if not self.issubclass(w_t1, w_type):
+        if w_t1 != w_type and not self.issubclass(w_t1, w_type):
             exp = w_type.name
             got = w_t1.name
             msg = f"Invalid cast. Expected `{exp}`, got `{got}`"


### PR DESCRIPTION
This PR adds:

  - a minimal implementation of print()

  - the possibility of running spy --run foo.spy to run a script from the command line
