### PR TITLE
Support complex expressions as initializers of global vars and consts

### DIFF
--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -78,6 +78,12 @@ class ModuleGen:
         assign = decl.assign
         fqn = self.vm.get_unique_FQN(modname=self.modname, attr=vardef.name,
                                      is_global=True)
-        w_type = frame.eval_expr_type(vardef.type)
-        w_val = frame.eval_expr(assign.value)
-        self.vm.add_global(fqn, w_type, w_val)
+        if vardef.type is None:
+            # type inference
+            w_val = frame.eval_expr(assign.value)
+            self.vm.add_global(fqn, None, w_val)
+        else:
+            # eval the type and use it in the globals declaration
+            w_type = frame.eval_expr_type(vardef.type)
+            w_val = frame.eval_expr(assign.value)
+            self.vm.add_global(fqn, w_type, w_val)

--- a/spy/irgen/scope.py
+++ b/spy/irgen/scope.py
@@ -158,7 +158,12 @@ class ScopeAnalyzer:
             color = 'red'
         else:
             color = 'blue'
-        self.add_name(decl.vardef.name, color, decl.loc, decl.vardef.type.loc)
+
+        if decl.vardef.type is None:
+            typeloc = decl.assign.value.loc
+        else:
+            typeloc = decl.vardef.type.loc
+        self.add_name(decl.vardef.name, color, decl.loc, typeloc)
 
     def declare_VarDef(self, vardef: ast.VarDef) -> None:
         assert vardef.kind == 'var'

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -67,6 +67,10 @@ class Parser:
                 assert assign is not None
                 globvar = spy.ast.GlobalVarDef(vardef, assign)
                 mod.decls.append(globvar)
+            elif isinstance(py_stmt, py_ast.Assign):
+                vardef, assign = self.from_py_global_Assign(py_stmt)
+                globvar = spy.ast.GlobalVarDef(vardef, assign)
+                mod.decls.append(globvar)
             elif isinstance(py_stmt, py_ast.ImportFrom):
                 importdecls = self.from_py_ImportFrom(py_stmt)
                 mod.decls += importdecls
@@ -213,6 +217,17 @@ class Parser:
         else:
             value = self.from_py_expr(py_node.value)
         return spy.ast.Return(py_node.loc, value)
+
+
+    def from_py_global_Assign(self, py_node: py_ast.Assign
+                              ) -> tuple[spy.ast.VarDef, spy.ast.Assign]:
+        assign = self.from_py_stmt_Assign(py_node)
+        kind = 'const'
+        if py_node.targets[0].is_var:
+            kind = 'var'
+        vardef = spy.ast.VarDef(loc=py_node.loc, kind=kind,
+                                name=assign.target, type=None)
+        return vardef, assign
 
     def from_py_AnnAssign(self,
                           py_node: py_ast.AnnAssign,

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -2,6 +2,7 @@ import pytest
 from spy.fqn import FQN
 from spy.errors import SPyTypeError
 from spy.vm.b import B
+from spy.fqn import FQN
 from spy.tests.support import (CompilerTest, skip_backends, no_backend,
                                expect_errors, only_interp)
 
@@ -575,3 +576,17 @@ class TestBasic(CompilerTest):
                                  "True",
                                  "None",
                                  ""])
+
+    def test_global_const_type_inference(self):
+        mod = self.compile(
+        """
+        @blue
+        def INIT_X():
+            return 1 + 2 * 3
+
+        x = INIT_X()
+        """)
+        vm = self.vm
+        assert mod.x == 7
+        w_xtype = self.vm.globals_types[FQN("test::x")]
+        assert w_xtype is B.w_i32


### PR DESCRIPTION
This adds type inference support for global vars and consts.

It is also possible to init them by calling a `@blue` function.
