### PR TITLE
Add support for __INIT__ and basic support for setattr

### DIFF
--- a/spy/ast.py
+++ b/spy/ast.py
@@ -446,7 +446,7 @@ class Assign(Stmt):
     value: Expr
 
 @dataclass(eq=False)
-class SetAttr(Expr):
+class SetAttr(Stmt):
     target_loc: Loc = field(repr=False)
     target: Expr
     attr: str

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -446,6 +446,13 @@ class Assign(Stmt):
     value: Expr
 
 @dataclass(eq=False)
+class SetAttr(Expr):
+    target_loc: Loc = field(repr=False)
+    target: Expr
+    attr: str
+    value: Expr
+
+@dataclass(eq=False)
 class If(Stmt):
     test: Expr
     then_body: list[Stmt]

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -110,6 +110,11 @@ class SPyBackend:
         v = self.fmt_expr(assign.value)
         self.wl(f'{assign.target} = {v}')
 
+    def emit_stmt_SetAttr(self, node: ast.GetAttr) -> str:
+        t = self.fmt_expr(node.target)
+        v = self.fmt_expr(node.value)
+        self.wl(f'{t}.{node.attr} = {v}')
+
     def emit_stmt_VarDef(self, vardef: ast.VarDef) -> None:
         t = self.fmt_expr(vardef.type)
         self.wl(f'{vardef.name}: {t}')

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -110,7 +110,7 @@ class SPyBackend:
         v = self.fmt_expr(assign.value)
         self.wl(f'{assign.target} = {v}')
 
-    def emit_stmt_SetAttr(self, node: ast.GetAttr) -> str:
+    def emit_stmt_SetAttr(self, node: ast.SetAttr) -> None:
         t = self.fmt_expr(node.target)
         v = self.fmt_expr(node.value)
         self.wl(f'{t}.{node.attr} = {v}')

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -146,7 +146,7 @@ class FuncDoppler:
     def shift_expr_BinOp(self, binop: ast.BinOp) -> ast.Expr:
         l = self.shift_expr(binop.left)
         r = self.shift_expr(binop.right)
-        w_opimpl = self.t.expr_opimpl[binop]
+        w_opimpl = self.t.opimpl[binop]
         assert w_opimpl.fqn is not None
         func = ast.FQNConst(binop.loc, w_opimpl.fqn)
         return ast.Call(binop.loc, func, [l, r])
@@ -165,7 +165,7 @@ class FuncDoppler:
     def shift_expr_GetItem(self, op: ast.GetItem) -> ast.Expr:
         v = self.shift_expr(op.value)
         i = self.shift_expr(op.index)
-        w_opimpl = self.t.expr_opimpl[op]
+        w_opimpl = self.t.opimpl[op]
         assert w_opimpl.fqn is not None
         func = ast.FQNConst(op.loc, w_opimpl.fqn)
         return ast.Call(op.loc, func, [v, i])

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -24,7 +24,7 @@ class FQN:
     fn_i32 = make_fn(i32)  # fqn is 'test::foo#1'
     fn_f64 = make_fn(f64)  # fqn is 'test::foo#2'
 
-    See also SPy.get_unique_FQN().
+    See also SPyVM.get_unique_FQN().
     """
     modname: str
     attr: str

--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -40,7 +40,7 @@ class ModuleGen:
         #
         # Synthesize and execute the __INIT__ function to populate the module
         w_functype = W_FuncType.parse('def() -> void')
-        fqn = FQN(modname=self.modname, attr='__INIT__')
+        fqn = FQN(modname=self.modname, attr='__INIT0__')
         modinit_funcdef = self.make_modinit()
         closure = ()
         w_INIT = W_ASTFunc(w_functype, fqn, modinit_funcdef, closure)
@@ -52,6 +52,12 @@ class ModuleGen:
             elif isinstance(decl, ast.GlobalVarDef):
                 self.gen_GlobalVarDef(frame, decl)
         #
+
+        w_init = self.w_mod.getattr_maybe('__INIT__')
+        if w_init is not None:
+            assert w_init.color == 'blue' # XXX raise a proper error message
+            self.vm.call_function(w_init, [self.w_mod])
+
         return self.w_mod
 
     def make_modinit(self) -> ast.FuncDef:
@@ -59,7 +65,7 @@ class ModuleGen:
         return ast.FuncDef(
             loc = loc,
             color = 'blue',
-            name = f'__INIT__',
+            name = f'__INIT0__',
             args = [],
             return_type = ast.Name(loc=loc, id='object'),
             body = [],

--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -56,6 +56,7 @@ class ModuleGen:
         # call the __INIT__, if present
         w_init = self.w_mod.getattr_maybe('__INIT__')
         if w_init is not None:
+            assert isinstance(w_init, W_ASTFunc)
             assert w_init.color == "blue"
             self.vm.call_function(w_init, [self.w_mod])
         #

--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -39,9 +39,9 @@ class ModuleGen:
         self.w_mod = W_Module(self.vm, self.modname, str(self.file_spy))
         self.vm.register_module(self.w_mod)
         #
-        # Synthesize and execute the __INIT__ function to populate the module
+        # Synthesize and execute the fake '@module' function to populate the mod
         w_functype = W_FuncType.parse('def() -> void')
-        fqn = FQN(modname=self.modname, attr='__INIT0__')
+        fqn = FQN(modname=self.modname, attr='@module')
         modinit_funcdef = self.make_modinit()
         closure = ()
         w_INIT = W_ASTFunc(w_functype, fqn, modinit_funcdef, closure)
@@ -66,7 +66,7 @@ class ModuleGen:
         return ast.FuncDef(
             loc = loc,
             color = 'blue',
-            name = f'__INIT0__',
+            name = f'@module',
             args = [],
             return_type = ast.Name(loc=loc, id='object'),
             body = [],

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -615,11 +615,13 @@ class TestBasic(CompilerTest):
     def test___INIT__(self):
         mod = self.compile(
         """
+        x: i32 = 0
+
         def get_x() -> i32:
             return x
 
         @blue
-        def __INIT__(mod):
+        def __INIT__(mod) -> void: # XXX
             mod.x = 42
         """)
         vm = self.vm

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -615,15 +615,13 @@ class TestBasic(CompilerTest):
     def test___INIT__(self):
         mod = self.compile(
         """
-        from types import module
-
         x: i32 = 0
 
         def get_x() -> i32:
             return x
 
         @blue
-        def __INIT__(mod: module) -> void: # XXX
+        def __INIT__(mod) -> void: # XXX
             mod.x = 42
         """)
         vm = self.vm

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -621,7 +621,7 @@ class TestBasic(CompilerTest):
             return x
 
         @blue
-        def __INIT__(mod) -> void: # XXX
+        def __INIT__(mod):
             mod.x = 42
         """)
         vm = self.vm

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -628,6 +628,18 @@ class TestBasic(CompilerTest):
         assert mod.x == 42
         assert mod.get_x() == 42
 
+    def test_wrong__INIT__(self):
+        # NOTE: this error is always eager because it happens at import time
+        src = """
+        def __INIT__(mod: dynamic) -> void:
+            pass
+        """
+        errors = expect_errors(
+            "the __INIT__ function must be @blue",
+            ("function defined here", "def __INIT__(mod: dynamic) -> void")
+        )
+        self.compile_raises(src, "", errors, error_reporting="eager")
+
     def test_setattr_error(self):
         src = """
         def foo() -> void:

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -611,3 +611,17 @@ class TestBasic(CompilerTest):
             ('this is `object`', 'x'),
             )
         self.compile_raises(src, "foo", errors)
+
+    def test___INIT__(self):
+        mod = self.compile(
+        """
+        def get_x() -> i32:
+            return x
+
+        @blue
+        def __INIT__(mod):
+            mod.x = 42
+        """)
+        vm = self.vm
+        assert mod.x == 42
+        assert mod.get_x() == 42

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -627,3 +627,17 @@ class TestBasic(CompilerTest):
         vm = self.vm
         assert mod.x == 42
         assert mod.get_x() == 42
+
+    def test_setattr_error(self):
+        src = """
+        def foo() -> void:
+            s: str = "hello"
+            s.x = 42
+
+        """
+        errors = expect_errors(
+            "type `str` does not support assignment to attribute 'x'",
+            ("this is `str`", 's'),
+            ("this is `i32`", '42'),
+        )
+        self.compile_raises(src, "foo", errors)

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -615,13 +615,15 @@ class TestBasic(CompilerTest):
     def test___INIT__(self):
         mod = self.compile(
         """
+        from types import module
+
         x: i32 = 0
 
         def get_x() -> i32:
             return x
 
         @blue
-        def __INIT__(mod) -> void: # XXX
+        def __INIT__(mod: module) -> void: # XXX
             mod.x = 42
         """)
         vm = self.vm

--- a/spy/tests/compiler/test_dynamic.py
+++ b/spy/tests/compiler/test_dynamic.py
@@ -120,3 +120,16 @@ class TestDynamic(CompilerTest):
         msg = 'cannot call objects of type `str`'
         with pytest.raises(SPyTypeError, match=msg):
             mod.foo()
+
+
+    def test_setattr(self):
+        mod = self.compile(
+        """
+        x: i32 = 0
+
+        @blue
+        def __INIT__(mod: dynamic) -> void:
+            mod.x = 42
+        """)
+        vm = self.vm
+        assert mod.x == 42

--- a/spy/tests/compiler/test_dynamic.py
+++ b/spy/tests/compiler/test_dynamic.py
@@ -121,7 +121,6 @@ class TestDynamic(CompilerTest):
         with pytest.raises(SPyTypeError, match=msg):
             mod.foo()
 
-
     def test_setattr(self):
         mod = self.compile(
         """
@@ -133,3 +132,17 @@ class TestDynamic(CompilerTest):
         """)
         vm = self.vm
         assert mod.x == 42
+
+    def test_wrong_setattr(self):
+        if self.backend == 'doppler':
+            pytest.skip("fixme")
+
+        mod = self.compile(
+        """
+        def foo() -> void:
+            obj: dynamic = "hello"
+            obj.x = 42
+        """)
+        msg = "type `str` does not support assignment to attribute 'x'"
+        with pytest.raises(SPyTypeError, match=msg):
+            mod.foo()

--- a/spy/tests/compiler/test_dynamic.py
+++ b/spy/tests/compiler/test_dynamic.py
@@ -127,7 +127,7 @@ class TestDynamic(CompilerTest):
         x: i32 = 0
 
         @blue
-        def __INIT__(mod: dynamic) -> void:
+        def __INIT__(mod: dynamic):
             mod.x = 42
         """)
         vm = self.vm

--- a/spy/tests/test_backend_spy.py
+++ b/spy/tests/test_backend_spy.py
@@ -125,6 +125,14 @@ class TestSPyBackend(CompilerTest):
         self.compile(src)
         self.assert_dump(src)
 
+    def test_setattr(self):
+        src = """
+        def foo() -> void:
+            x.foo = 42
+        """
+        self.compile(src)
+        self.assert_dump(src)
+
     def test_if(self):
         src = """
         def foo() -> void:

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -766,3 +766,18 @@ class TestParser:
         )
         """
         self.assert_dump(stmt, expected)
+
+    def test_SetAttr(self):
+        mod = self.parse("""
+        def foo() -> void:
+            a.b = 42
+        """)
+        stmt = mod.get_funcdef('foo').body[0]
+        expected = """
+        SetAttr(
+            target=Name(id='a'),
+            attr='b',
+            value=Constant(value=42),
+        )
+        """
+        self.assert_dump(stmt, expected)

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -154,6 +154,13 @@ class ASTFrame:
         else:
             assert False, 'closures not implemented yet'
 
+    def exec_stmt_SetAttr(self, node: ast.SetAttr) -> None:
+        w_opimpl = self.t.expr_opimpl[node]
+        w_target = self.eval_expr(node.target)
+        w_attr = self.vm.wrap(node.attr)
+        w_value = self.eval_expr(node.value)
+        self.vm.call_function(w_opimpl, [w_target, w_attr, w_value])
+
     def exec_stmt_StmtExpr(self, stmt: ast.StmtExpr) -> None:
         self.eval_expr(stmt.value)
 

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -126,7 +126,7 @@ class ASTFrame:
 
         # if the current func is __INIT__, then we are creating a module-level
         # global. Else, it's a closure
-        is_global = self.w_func.fqn.attr == '__INIT__'
+        is_global = self.w_func.fqn.attr == '__INIT0__'
         modname = self.w_func.fqn.modname # the module of the "outer" function
         fqn = self.vm.get_unique_FQN(modname=modname, attr=funcdef.name,
                                      is_global=is_global)

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -155,7 +155,7 @@ class ASTFrame:
             assert False, 'closures not implemented yet'
 
     def exec_stmt_SetAttr(self, node: ast.SetAttr) -> None:
-        w_opimpl = self.t.expr_opimpl[node]
+        w_opimpl = self.t.opimpl[node]
         w_target = self.eval_expr(node.target)
         w_attr = self.vm.wrap(node.attr)
         w_value = self.eval_expr(node.value)
@@ -211,7 +211,7 @@ class ASTFrame:
             return w_value
 
     def eval_expr_BinOp(self, binop: ast.BinOp) -> W_Object:
-        w_opimpl = self.t.expr_opimpl[binop]
+        w_opimpl = self.t.opimpl[binop]
         assert w_opimpl, 'bug in the typechecker'
         w_l = self.eval_expr(binop.left)
         w_r = self.eval_expr(binop.right)
@@ -250,7 +250,7 @@ class ASTFrame:
         return w_res
 
     def eval_expr_GetItem(self, op: ast.GetItem) -> W_Object:
-        w_opimpl = self.t.expr_opimpl[op]
+        w_opimpl = self.t.opimpl[op]
         w_val = self.eval_expr(op.value)
         w_i = self.eval_expr(op.index)
         w_res = self.vm.call_function(w_opimpl, [w_val, w_i])
@@ -262,7 +262,7 @@ class ASTFrame:
         #
         #   1. "generic" impls, which are called with [w_val, w_attr]
         #   2. "specialized" impls, which are called with only [w_val]
-        w_opimpl = self.t.expr_opimpl[op]
+        w_opimpl = self.t.opimpl[op]
         w_val = self.eval_expr(op.value)
         w_attr = self.vm.wrap(op.attr)
         w_res = self.vm.call_function(w_opimpl, [w_val, w_attr])

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -58,7 +58,7 @@ class ASTFrame:
             #
             # we reached the end of the function. If it's void, we can return
             # None, else it's an error.
-            if self.w_func.w_functype.w_restype is B.w_void:
+            if self.w_func.w_functype.w_restype in (B.w_void, B.w_dynamic):
                 return B.w_None
             else:
                 loc = self.w_func.funcdef.loc.make_end_loc()

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -124,9 +124,9 @@ class ASTFrame:
         #
         # create the w_func
 
-        # if the current func is __INIT__, then we are creating a module-level
+        # if the current func is '@module', then we are creating a module-level
         # global. Else, it's a closure
-        is_global = self.w_func.fqn.attr == '__INIT0__'
+        is_global = self.w_func.fqn.attr == '@module'
         modname = self.w_func.fqn.modname # the module of the "outer" function
         fqn = self.vm.get_unique_FQN(modname=modname, attr=funcdef.name,
                                      is_global=is_global)

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -36,6 +36,11 @@ class W_Module(W_Object):
         assert isinstance(w_obj, W_ASTFunc)
         return w_obj
 
+    def setattr(self, attr: str, w_value: W_Object) -> None:
+        # XXX we should raise an exception if the attr doesn't exist
+        fqn = FQN(modname=self.name, attr=attr)
+        self.vm.store_global(fqn, w_value)
+
     def keys(self) -> Iterable[FQN]:
         for fqn in self.vm.globals_w.keys():
             if fqn.modname == self.name:

--- a/spy/vm/modules/operator/opimpl_dynamic.py
+++ b/spy/vm/modules/operator/opimpl_dynamic.py
@@ -62,5 +62,9 @@ def dynamic_setattr(vm: 'SPyVM', w_obj: W_Object, w_attr: W_Str,
     w_vtype = vm.dynamic_type(w_value)
     w_opimpl = OP.w_SETATTR.pyfunc(vm, w_otype, w_attr, w_vtype)
     if w_opimpl is B.w_NotImplemented:
-        raise SPyTypeError("cannot do setattr XXX")
+        o = w_otype.name
+        v = w_vtype.name
+        attr = vm.unwrap_str(w_attr)
+        msg = f"type `{o}` does not support assignment to attribute '{attr}'"
+        raise SPyTypeError(msg)
     return vm.call_function(w_opimpl, [w_obj, w_attr, w_value])

--- a/spy/vm/modules/operator/opimpl_dynamic.py
+++ b/spy/vm/modules/operator/opimpl_dynamic.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any
 from spy.errors import SPyTypeError
 from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type
+from spy.vm.str import W_Str
 from spy.vm.function import W_Func
 from . import OP
 if TYPE_CHECKING:
@@ -53,3 +54,13 @@ def dynamic_gt(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_Object:
 @OP.primitive('def(a: dynamic, b: dynamic) -> dynamic')
 def dynamic_ge(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_Object:
     return _dynamic_op(vm, OP.w_GE, w_a, w_b)
+
+@OP.primitive('def(o: dynamic, attr: str, v: dynamic) -> dynamic')
+def dynamic_setattr(vm: 'SPyVM', w_obj: W_Object, w_attr: W_Str,
+                    w_value: W_Object) -> W_Object:
+    w_otype = vm.dynamic_type(w_obj)
+    w_vtype = vm.dynamic_type(w_value)
+    w_opimpl = OP.w_SETATTR.pyfunc(vm, w_otype, w_attr, w_vtype)
+    if w_opimpl is B.w_NotImplemented:
+        raise SPyTypeError("cannot do setattr XXX")
+    return vm.call_function(w_opimpl, [w_obj, w_attr, w_value])

--- a/spy/vm/modules/operator/opimpl_misc.py
+++ b/spy/vm/modules/operator/opimpl_misc.py
@@ -17,3 +17,9 @@ def module_getattr(vm: 'SPyVM', w_mod: W_Module, w_attr: W_Str) -> W_Object:
     # the module getattrs are done in blue contexts are redshifted away.
     attr = vm.unwrap_str(w_attr)
     return w_mod.getattr(attr)
+
+@OP.primitive('def(m: module, attr: str, v: object) -> dynamic')
+def module_setattr(vm: 'SPyVM', w_mod: W_Module, w_attr: W_Str,
+                   w_value: W_Object) -> W_Object:
+    attr = vm.unwrap_str(w_attr)
+    w_mod.setattr(attr, w_value)

--- a/spy/vm/modules/operator/opimpl_misc.py
+++ b/spy/vm/modules/operator/opimpl_misc.py
@@ -23,3 +23,4 @@ def module_setattr(vm: 'SPyVM', w_mod: W_Module, w_attr: W_Str,
                    w_value: W_Object) -> W_Object:
     attr = vm.unwrap_str(w_attr)
     w_mod.setattr(attr, w_value)
+    return B.w_None

--- a/spy/vm/modules/operator/unaryop.py
+++ b/spy/vm/modules/operator/unaryop.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
 
-@OP.primitive('def(l: type, r: type) -> dynamic')
+@OP.primitive('def(v: type, i: type) -> dynamic')
 def GETITEM(vm: 'SPyVM', w_vtype: W_Type, w_itype: W_Type) -> W_Object:
     return MM.lookup('[]', w_vtype, w_itype)
 
@@ -19,4 +19,12 @@ def GETITEM(vm: 'SPyVM', w_vtype: W_Type, w_itype: W_Type) -> W_Object:
 def GETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str) -> W_Object:
     if w_type is W_Module._w:
         return OP.w_module_getattr
+    return B.w_NotImplemented
+
+
+@OP.primitive('def(t: type, attr: str, v: type) -> dynamic')
+def SETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str,
+            w_vtype: W_Type) -> W_Object:
+    if w_type is W_Module._w:
+        return OP.w_module_setattr
     return B.w_NotImplemented

--- a/spy/vm/modules/operator/unaryop.py
+++ b/spy/vm/modules/operator/unaryop.py
@@ -27,4 +27,6 @@ def SETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str,
             w_vtype: W_Type) -> W_Object:
     if w_type is W_Module._w:
         return OP.w_module_setattr
+    elif w_type is B.w_dynamic:
+        return OP.w_dynamic_setattr
     return B.w_NotImplemented

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -30,7 +30,7 @@ class TypeChecker:
     funcef: ast.FuncDef
     expr_types: dict[ast.Expr, tuple[Color, W_Type]]
     expr_conv: dict[ast.Expr, TypeConverter]
-    expr_opimpl: dict[ast.Expr, W_Func] # XXX this should be Node, not Expr
+    opimpl: dict[ast.Node, W_Func]
     locals_types_w: dict[str, W_Type]
 
 
@@ -40,7 +40,7 @@ class TypeChecker:
         self.funcdef = w_func.funcdef
         self.expr_types = {}
         self.expr_conv = {}
-        self.expr_opimpl = {}
+        self.opimpl = {}
         self.locals_types_w = {}
         self.declare_arguments()
 
@@ -212,7 +212,7 @@ class TypeChecker:
             err.add('error', f'this is `{vt}`', node.value.loc)
             raise err
         else:
-            self.expr_opimpl[node] = w_opimpl
+            self.opimpl[node] = w_opimpl
 
     # ==== expressions ====
 
@@ -277,7 +277,7 @@ class TypeChecker:
 
         assert isinstance(w_opimpl, W_Func)
         self.opimpl_check_args(w_opimpl, binop, [binop.left, binop.right])
-        self.expr_opimpl[binop] = w_opimpl
+        self.opimpl[binop] = w_opimpl
         w_restype = w_opimpl.w_functype.w_restype
         return color, w_restype
 
@@ -325,7 +325,7 @@ class TypeChecker:
             # XXX for now this is a special case, to check that `i` can be
             # converted to `i32`. Ideally, we should use the same mechanism
             # that we have already for calls
-            self.expr_opimpl[expr] = OP.w_str_getitem
+            self.opimpl[expr] = OP.w_str_getitem
             err = self.convert_type_maybe(expr.index, w_itype, B.w_i32)
             if err:
                 err.add('note', f'this is a `str`', expr.value.loc)
@@ -350,7 +350,7 @@ class TypeChecker:
             err.add('error', f'this is `{v}`', expr.value.loc)
             raise err
         else:
-            self.expr_opimpl[expr] = w_opimpl
+            self.opimpl[expr] = w_opimpl
             return color, w_opimpl.w_functype.w_restype
 
     def check_expr_Call(self, call: ast.Call) -> tuple[Color, W_Type]:

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -30,7 +30,7 @@ class TypeChecker:
     funcef: ast.FuncDef
     expr_types: dict[ast.Expr, tuple[Color, W_Type]]
     expr_conv: dict[ast.Expr, TypeConverter]
-    expr_opimpl: dict[ast.Expr, W_Func]
+    expr_opimpl: dict[ast.Expr, W_Func] # XXX this should be Node, not Expr
     locals_types_w: dict[str, W_Type]
 
 
@@ -196,6 +196,18 @@ class TypeChecker:
                 # first assignment, implicit declaration
                 self.declare_local(name, w_valuetype)
             self.typecheck_local(assign.value, name)
+
+    def check_stmt_SetAttr(self, node: ast.SetAttr) -> None:
+        _, w_type = self.check_expr(node.target)
+        _, w_vtype = self.check_expr(node.value)
+
+        w_opimpl = OP.w_SETATTR.pyfunc(self.vm, w_type, node.attr, w_vtype)
+        if w_opimpl is B.w_NotImplemented:
+            v = w_type.name
+            err = SPyTypeError(f"XXX'")
+            raise err
+        else:
+            self.expr_opimpl[node] = w_opimpl
 
     # ==== expressions ====
 

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -198,13 +198,18 @@ class TypeChecker:
             self.typecheck_local(assign.value, name)
 
     def check_stmt_SetAttr(self, node: ast.SetAttr) -> None:
-        _, w_type = self.check_expr(node.target)
+        _, w_otype = self.check_expr(node.target)
         _, w_vtype = self.check_expr(node.value)
 
-        w_opimpl = OP.w_SETATTR.pyfunc(self.vm, w_type, node.attr, w_vtype)
+        w_opimpl = OP.w_SETATTR.pyfunc(self.vm, w_otype, node.attr, w_vtype)
         if w_opimpl is B.w_NotImplemented:
-            v = w_type.name
-            err = SPyTypeError(f"XXX'")
+            ot = w_otype.name
+            vt = w_vtype.name
+            attr = node.attr
+            err = SPyTypeError(
+                f"type `{ot}` does not support assignment to attribute '{attr}'")
+            err.add('error', f'this is `{ot}`', node.target.loc)
+            err.add('error', f'this is `{vt}`', node.value.loc)
             raise err
         else:
             self.expr_opimpl[node] = w_opimpl


### PR DESCRIPTION
This PR adds to big functionalities together, because it's not possible to test one without the other.

* Basic support for setattr: we add support in the parser, typechecker, etc. for setattr, which is mapped to `operator.SETATTR`. Currently, the only object which supports it is `module`, which can be modified only before it's frozen

* Support for `__INIT__`: this is a special `@blue` function which is automatically called at import time, and that modules can use to do pre-redshift initialization

