### PR TITLE
Introduce TypeDef, and support for __getattr__ and __setattr__

### DIFF
--- a/spy/backend/c/context.py
+++ b/spy/backend/c/context.py
@@ -4,6 +4,7 @@ from spy.vm.b import B
 from spy.vm.object import W_Type
 from spy.vm.function import W_FuncType
 from spy.vm.modules.rawbuffer import RB
+from spy.vm.modules.types import W_TypeDef
 
 @dataclass
 class C_Type:
@@ -63,6 +64,8 @@ class Context:
         self._d[RB.w_RawBuffer] = C_Type('spy_RawBuffer *')
 
     def w2c(self, w_type: W_Type) -> C_Type:
+        if isinstance(w_type, W_TypeDef):
+            w_type = w_type.w_origintype
         if w_type in self._d:
             return self._d[w_type]
         raise NotImplementedError(f'Cannot translate type {w_type} to C')

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -10,6 +10,7 @@ from spy.vm.module import W_Module
 from spy.vm.function import W_ASTFunc, W_BuiltinFunc, W_FuncType
 from spy.vm.vm import SPyVM
 from spy.vm.b import B
+from spy.vm.modules.types import TYPES
 from spy.textbuilder import TextBuilder
 from spy.backend.c.context import Context, C_Type, C_Function
 from spy.backend.c import c_ast as C
@@ -89,10 +90,15 @@ class CModuleWriter:
 
     def declare_variable(self, fqn: FQN, w_obj: W_Object) -> None:
         w_type = self.ctx.vm.dynamic_type(w_obj)
-        c_type = self.ctx.w2c(w_type)
         if w_type is B.w_i32:
             intval = self.ctx.vm.unwrap(w_obj)
+            c_type = self.ctx.w2c(w_type)
             self.out_globals.wl(f'{c_type} {fqn.c_name} = {intval};')
+        elif w_type is TYPES.w_TypeDef:
+            # XXX: for now, we just ignore global TypeDefs, since they are not
+            # needed. But in general, we need a way to emit prebuilt
+            # constants.
+            pass
         else:
             raise NotImplementedError('WIP')
 

--- a/spy/backend/c/wrapper.py
+++ b/spy/backend/c/wrapper.py
@@ -12,6 +12,7 @@ from spy.vm.function import W_Func, W_FuncType
 from spy.vm.vm import SPyVM
 from spy.vm.b import B
 from spy.vm.modules.rawbuffer import RB
+from spy.vm.modules.types import W_TypeDef
 
 class WasmModuleWrapper:
     vm: SPyVM
@@ -92,6 +93,9 @@ class WasmFuncWrapper:
         wasm_args = self.from_py_args(py_args)
         res = self.ll.call(self.c_name, *wasm_args)
         w_type = self.w_functype.w_restype
+        if isinstance(w_type, W_TypeDef):
+            w_type = w_type.w_origintype
+        #
         if w_type is B.w_void:
             assert res is None
             return None

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -118,6 +118,16 @@ class FuncDoppler:
         else:
             assert False, 'implement me'
 
+    def shift_stmt_SetAttr(self, node: ast.SetAttr) -> list[ast.Stmt]:
+        v_target = self.shift_expr(node.target)
+        v_attr = ast.Constant(node.loc, value=node.attr)
+        v_value = self.shift_expr(node.value)
+        w_opimpl = self.t.opimpl[node]
+        assert w_opimpl.fqn is not None
+        func = self.make_const(node.loc, w_opimpl)
+        call = ast.Call(node.loc, func, [v_target, v_attr, v_value])
+        return [ast.StmtExpr(node.loc, call)]
+
     def shift_stmt_StmtExpr(self, stmt: ast.StmtExpr) -> list[ast.Stmt]:
         newvalue = self.shift_expr(stmt.value)
         return [stmt.replace(value=newvalue)]

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -170,6 +170,14 @@ class FuncDoppler:
         func = ast.FQNConst(op.loc, w_opimpl.fqn)
         return ast.Call(op.loc, func, [v, i])
 
+    def shift_expr_GetAttr(self, op: ast.GetAttr) -> ast.Expr:
+        v = self.shift_expr(op.value)
+        v_attr = ast.Constant(op.loc, value=op.attr)
+        w_opimpl = self.t.opimpl[op]
+        assert w_opimpl.fqn is not None
+        func = ast.FQNConst(op.loc, w_opimpl.fqn)
+        return ast.Call(op.loc, func, [v, v_attr])
+
     def shift_expr_Call(self, call: ast.Call) -> ast.Expr:
         # XXX: this assumes that it's a direct call (i.e., call.func is a
         # ast.Name). We probably need to adapt for indirect calls, when we

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -2,6 +2,7 @@ from typing import Any, Optional, TYPE_CHECKING
 from types import NoneType
 from fixedint import FixedInt
 from spy import ast
+from spy.location import Loc
 from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type
 from spy.vm.function import W_ASTFunc, W_BuiltinFunc
@@ -50,13 +51,23 @@ class FuncDoppler:
 
     def blue_eval(self, expr: ast.Expr) -> ast.Expr:
         w_val = self.blue_frame.eval_expr(expr)
+        return self.make_const(expr.loc, w_val)
+
+    def make_const(self, loc: Loc, w_val: W_Object) -> ast.Expr:
+        """
+        Create an AST node to represent a constant of the given w_val.
+
+        For primitive types, it's easy, we can just reuse ast.Constant.
+        For non primitive types, we assign an unique FQN to the w_val, and we
+        return ast.FQNConst.
+        """
         w_type = self.vm.dynamic_type(w_val)
         if w_type in (B.w_i32, B.w_f64, B.w_bool, B.w_str, B.w_void):
             # this is a primitive, we can just use ast.Constant
             value = self.vm.unwrap(w_val)
             if isinstance(value, FixedInt): # type: ignore
                 value = int(value)
-            return ast.Constant(expr.loc, value)
+            return ast.Constant(loc, value)
 
         # this is a non-primitive prebuilt constant. If it doesn't have an FQN
         # yet, we need to assign it one. For now we know how to do it only for
@@ -64,14 +75,14 @@ class FuncDoppler:
         fqn = self.vm.reverse_lookup_global(w_val)
         if fqn is None:
             if isinstance(w_val, W_ASTFunc):
-                # it's a closure, let's assign it an FQN and add it to the globals
+                # it's a closure, let's assign it an FQN and add to the globals
                 fqn = w_val.fqn
                 self.vm.add_global(fqn, None, w_val)
             else:
                 assert False, 'implement me'
 
         assert fqn is not None
-        return ast.FQNConst(expr.loc, fqn)
+        return ast.FQNConst(loc, fqn)
 
     # =========
 
@@ -148,7 +159,7 @@ class FuncDoppler:
         r = self.shift_expr(binop.right)
         w_opimpl = self.t.opimpl[binop]
         assert w_opimpl.fqn is not None
-        func = ast.FQNConst(binop.loc, w_opimpl.fqn)
+        func = self.make_const(binop.loc, w_opimpl)
         return ast.Call(binop.loc, func, [l, r])
 
     shift_expr_Add = shift_expr_BinOp
@@ -167,7 +178,7 @@ class FuncDoppler:
         i = self.shift_expr(op.index)
         w_opimpl = self.t.opimpl[op]
         assert w_opimpl.fqn is not None
-        func = ast.FQNConst(op.loc, w_opimpl.fqn)
+        func = self.make_const(op.loc, w_opimpl)
         return ast.Call(op.loc, func, [v, i])
 
     def shift_expr_GetAttr(self, op: ast.GetAttr) -> ast.Expr:
@@ -175,7 +186,7 @@ class FuncDoppler:
         v_attr = ast.Constant(op.loc, value=op.attr)
         w_opimpl = self.t.opimpl[op]
         assert w_opimpl.fqn is not None
-        func = ast.FQNConst(op.loc, w_opimpl.fqn)
+        func = self.make_const(op.loc, w_opimpl)
         return ast.Call(op.loc, func, [v, v_attr])
 
     def shift_expr_Call(self, call: ast.Call) -> ast.Expr:

--- a/spy/tests/compiler/test_typedef.py
+++ b/spy/tests/compiler/test_typedef.py
@@ -61,13 +61,20 @@ class TestTypeDef(CompilerTest):
         mod = self.compile("""
         from types import makeTypeDef
 
+        # XXX temporary workaround: currently there is a bug and we don't
+        # assign a FQN to getattr_double if it's defined inside makeMyInt, we
+        # should move it inside when the bug is fixed
+        def getattr_double(self: i32, attr: str) -> i32:
+            i: i32 = self
+            return i * 2
+
         @blue
         def makeMyInt():
             MyInt = makeTypeDef('MyInt', i32)
 
-            def getattr_double(self: MyInt, attr: str) -> i32:
-                i: i32 = self
-                return i * 2
+            ## def getattr_double(self: MyInt, attr: str) -> i32:
+            ##     i: i32 = self
+            ##     return i * 2
 
             @blue
             def __getattr__(self, attr):

--- a/spy/tests/compiler/test_typedef.py
+++ b/spy/tests/compiler/test_typedef.py
@@ -65,6 +65,24 @@ class TestTypeDef(CompilerTest):
         w_res = self.vm.call_function(w_getattr, [B.w_None])
         assert w_res is B.w_NotImplemented
 
+    @only_interp
+    def test_metaclass_getattr(self):
+        """
+        Test that we can succesfully get attributes on the typedef itself
+        """
+        mod = self.compile("""
+        from types import makeTypeDef
+
+        @blue
+        def foo():
+            MyInt = makeTypeDef('MyInt', i32)
+            MyInt.__getattr__ = 42
+            return MyInt.__getattr__
+        """)
+        w_foo = mod.foo.w_func
+        w_res = self.vm.call_function(w_foo, [])
+        assert self.vm.unwrap(w_res) == 42
+
     def test_getattr(self):
         mod = self.compile("""
         from types import makeTypeDef

--- a/spy/tests/compiler/test_typedef.py
+++ b/spy/tests/compiler/test_typedef.py
@@ -61,20 +61,13 @@ class TestTypeDef(CompilerTest):
         mod = self.compile("""
         from types import makeTypeDef
 
-        # XXX temporary workaround: currently there is a bug and we don't
-        # assign a FQN to getattr_double if it's defined inside makeMyInt, we
-        # should move it inside when the bug is fixed
-        def getattr_double(self: i32, attr: str) -> i32:
-            i: i32 = self
-            return i * 2
-
         @blue
         def makeMyInt():
             MyInt = makeTypeDef('MyInt', i32)
 
-            ## def getattr_double(self: MyInt, attr: str) -> i32:
-            ##     i: i32 = self
-            ##     return i * 2
+            def getattr_double(self: MyInt, attr: str) -> i32:
+                i: i32 = self
+                return i * 2
 
             @blue
             def __getattr__(self, attr):

--- a/spy/tests/compiler/test_typedef.py
+++ b/spy/tests/compiler/test_typedef.py
@@ -18,13 +18,21 @@ class TestTypeDef(CompilerTest):
         from types import makeTypeDef
         MyInt = makeTypeDef('MyInt', i32)
 
+        # this should go away and become MyInt.cast_from
+        def MyInt_cast_from(x: i32) -> MyInt:
+            return x
+
+        # same as above
+        def MyInt_cast_to(x: MyInt) -> i32:
+            return x
+
         def foo() -> MyInt:
-            x: MyInt = 42 # i32 -> MyInt
+            x: MyInt = MyInt_cast_from(42)
             return x
 
         def bar() -> i32:
-            x: MyInt = 43 # i32 -> MyInt
-            return x      # MyInt -> i32
+            x: MyInt = MyInt_cast_from(43)
+            return MyInt_cast_to(x)
         """)
         assert mod.foo() == 42
         assert mod.bar() == 43

--- a/spy/tests/compiler/test_typedef.py
+++ b/spy/tests/compiler/test_typedef.py
@@ -1,19 +1,23 @@
 import re
 import pytest
 from spy.errors import SPyTypeError
+from spy.fqn import FQN
 from spy.vm.b import B
-from spy.tests.support import CompilerTest, skip_backends,  expect_errors
+from spy.vm.function import W_ASTFunc
+from spy.vm.modules.types import W_TypeDef
+from spy.tests.support import (CompilerTest, skip_backends,  expect_errors,
+                               only_interp)
 
 @skip_backends("C", reason="implement me")
-class TestTypedef(CompilerTest):
+class TestTypeDef(CompilerTest):
 
     def test_cast_from_and_to(self):
-        # XXX: for now we allow implicit coversion between a Typedef and it's
+        # XXX: for now we allow implicit coversion between a TypeDef and it's
         # origin type because it's simpler, but eventually we want a more
-        # explicit way, e.g. Typedef.cast or something like that.
+        # explicit way, e.g. TypeDef.cast or something like that.
         mod = self.compile("""
-        from types import Typedef
-        MyInt = Typedef('MyInt', i32)
+        from types import makeTypeDef
+        MyInt = makeTypeDef('MyInt', i32)
 
         def foo() -> MyInt:
             x: MyInt = 42 # i32 -> MyInt
@@ -22,7 +26,38 @@ class TestTypedef(CompilerTest):
         def bar() -> i32:
             x: MyInt = 43 # i32 -> MyInt
             return x      # MyInt -> i32
-
         """)
         assert mod.foo() == 42
         assert mod.bar() == 43
+
+    #@only_interp
+    def test_metaclass_setattr(self):
+        """
+        Test that we can succesfully set attributes on the typedef itself
+        """
+        if self.backend != 'interp':
+            pytest.skip()
+
+        mod = self.compile("""
+        from types import makeTypeDef
+
+        @blue
+        def makeMyInt():
+            MyInt = makeTypeDef('MyInt', i32)
+
+            @blue
+            def __getattr__(attr):
+                return NotImplemented
+
+            MyInt.__getattr__ = __getattr__
+            return MyInt
+        """)
+
+        w_makeMyInt = mod.makeMyInt.w_func
+        w_MyInt = self.vm.call_function(w_makeMyInt, [])
+        assert isinstance(w_MyInt, W_TypeDef)
+        w_getattr = w_MyInt.w_getattr
+        assert isinstance(w_getattr, W_ASTFunc)
+        assert w_getattr.fqn == FQN("test::__getattr__#0")
+        w_res = self.vm.call_function(w_getattr, [B.w_None])
+        assert w_res is B.w_NotImplemented

--- a/spy/tests/compiler/test_typedef.py
+++ b/spy/tests/compiler/test_typedef.py
@@ -8,7 +8,6 @@ from spy.vm.modules.types import W_TypeDef
 from spy.tests.support import (CompilerTest, skip_backends,  expect_errors,
                                only_interp)
 
-@skip_backends("C", reason="implement me")
 class TestTypeDef(CompilerTest):
 
     def test_cast_from_and_to(self):
@@ -30,14 +29,11 @@ class TestTypeDef(CompilerTest):
         assert mod.foo() == 42
         assert mod.bar() == 43
 
-    #@only_interp
+    @only_interp
     def test_metaclass_setattr(self):
         """
         Test that we can succesfully set attributes on the typedef itself
         """
-        if self.backend != 'interp':
-            pytest.skip()
-
         mod = self.compile("""
         from types import makeTypeDef
 

--- a/spy/tests/compiler/test_typedef.py
+++ b/spy/tests/compiler/test_typedef.py
@@ -1,0 +1,28 @@
+import re
+import pytest
+from spy.errors import SPyTypeError
+from spy.vm.b import B
+from spy.tests.support import CompilerTest, skip_backends,  expect_errors
+
+@skip_backends("C", reason="implement me")
+class TestTypedef(CompilerTest):
+
+    def test_cast_from_and_to(self):
+        # XXX: for now we allow implicit coversion between a Typedef and it's
+        # origin type because it's simpler, but eventually we want a more
+        # explicit way, e.g. Typedef.cast or something like that.
+        mod = self.compile("""
+        from types import Typedef
+        MyInt = Typedef('MyInt', i32)
+
+        def foo() -> MyInt:
+            x: MyInt = 42 # i32 -> MyInt
+            return x
+
+        def bar() -> i32:
+            x: MyInt = 43 # i32 -> MyInt
+            return x      # MyInt -> i32
+
+        """)
+        assert mod.foo() == 42
+        assert mod.bar() == 43

--- a/spy/vm/modules/operator/opimpl_misc.py
+++ b/spy/vm/modules/operator/opimpl_misc.py
@@ -24,3 +24,9 @@ def module_setattr(vm: 'SPyVM', w_mod: W_Module, w_attr: W_Str,
     attr = vm.unwrap_str(w_attr)
     w_mod.setattr(attr, w_value)
     return B.w_None
+
+
+@OP.primitive('def(obj: object, attr: str, v: object) -> dynamic')
+def generic_setattr(vm: 'SPyVM', w_obj: W_Object, w_attr: W_Str,
+                    w_value: W_Object) -> W_Object:
+    return w_obj.spy_setattr(vm, w_attr, w_value)

--- a/spy/vm/modules/operator/opimpl_misc.py
+++ b/spy/vm/modules/operator/opimpl_misc.py
@@ -26,6 +26,10 @@ def module_setattr(vm: 'SPyVM', w_mod: W_Module, w_attr: W_Str,
     return B.w_None
 
 
+@OP.primitive('def(obj: object, attr: str) -> dynamic')
+def generic_getattr(vm: 'SPyVM', w_obj: W_Object, w_attr: W_Str) -> W_Object:
+    return w_obj.spy_getattr(vm, w_attr)
+
 @OP.primitive('def(obj: object, attr: str, v: object) -> dynamic')
 def generic_setattr(vm: 'SPyVM', w_obj: W_Object, w_attr: W_Str,
                     w_value: W_Object) -> W_Object:

--- a/spy/vm/modules/operator/unaryop.py
+++ b/spy/vm/modules/operator/unaryop.py
@@ -3,6 +3,7 @@ from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type
 from spy.vm.module import W_Module
 from spy.vm.str import W_Str
+from spy.vm.modules.types import W_TypeDef
 
 from . import OP
 from .binop import MM
@@ -29,4 +30,6 @@ def SETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str,
         return OP.w_module_setattr
     elif w_type is B.w_dynamic:
         return OP.w_dynamic_setattr
+    elif w_type is W_TypeDef._w:
+        return OP.w_generic_setattr
     return B.w_NotImplemented

--- a/spy/vm/modules/operator/unaryop.py
+++ b/spy/vm/modules/operator/unaryop.py
@@ -20,6 +20,10 @@ def GETITEM(vm: 'SPyVM', w_vtype: W_Type, w_itype: W_Type) -> W_Object:
 def GETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str) -> W_Object:
     if w_type is W_Module._w:
         return OP.w_module_getattr
+    elif w_type is B.w_dynamic:
+        raise NotImplementedError("implement me")
+    elif w_type is W_TypeDef._w:
+        raise NotImplementedError("implement me")
     elif isinstance(w_type, W_TypeDef) and w_type.w_getattr is not None:
         w_opimpl = vm.call_function(w_type.w_getattr, [w_type, w_attr])
         return w_opimpl
@@ -35,4 +39,7 @@ def SETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str,
         return OP.w_dynamic_setattr
     elif w_type is W_TypeDef._w:
         return OP.w_generic_setattr
+    elif isinstance(w_type, W_TypeDef) and w_type.w_setattr is not None:
+        w_opimpl = vm.call_function(w_type.w_setattr, [w_type, w_attr, w_vtype])
+        return w_opimpl
     return B.w_NotImplemented

--- a/spy/vm/modules/operator/unaryop.py
+++ b/spy/vm/modules/operator/unaryop.py
@@ -20,6 +20,9 @@ def GETITEM(vm: 'SPyVM', w_vtype: W_Type, w_itype: W_Type) -> W_Object:
 def GETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str) -> W_Object:
     if w_type is W_Module._w:
         return OP.w_module_getattr
+    elif isinstance(w_type, W_TypeDef) and w_type.w_getattr is not None:
+        w_opimpl = vm.call_function(w_type.w_getattr, [w_type, w_attr])
+        return w_opimpl
     return B.w_NotImplemented
 
 

--- a/spy/vm/modules/operator/unaryop.py
+++ b/spy/vm/modules/operator/unaryop.py
@@ -23,7 +23,7 @@ def GETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str) -> W_Object:
     elif w_type is B.w_dynamic:
         raise NotImplementedError("implement me")
     elif w_type is W_TypeDef._w:
-        raise NotImplementedError("implement me")
+        return OP.w_generic_getattr
     elif isinstance(w_type, W_TypeDef) and w_type.w_getattr is not None:
         w_opimpl = vm.call_function(w_type.w_getattr, [w_type, w_attr])
         return w_opimpl

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -2,39 +2,51 @@
 SPy `types` module.
 """
 
-from dataclasses import dataclass
 from spy.vm.module import W_Module
-from spy.vm.object import W_Type, W_Object
+from spy.vm.object import W_Type, W_Object, spytype
 from spy.vm.str import W_Str
+from spy.vm.function import W_Func
 from spy.vm.registry import ModuleRegistry
 
 TYPES = ModuleRegistry('types', '<types>')
 TYPES.add('module', W_Module._w)
 
-@dataclass
-class W_Typedef(W_Type):
+
+@spytype('TypeDef')
+class W_TypeDef(W_Type):
     """
-    A Typedef is a purely static alias for another type (called "origin
+    A TypeDef is a purely static alias for another type (called "origin
     type").
 
-    Objects can be converted from and to the Typedef, but the object itself
+    Objects can be converted from and to the TypeDef, but the object itself
     will remain unchanged (and it's dynamic type will stay the same).
 
-    The point of a Typedef is to be able to override special methods such as
+    The point of a TypeDef is to be able to override special methods such as
     __getattr__ and __setattr__
     """
     w_origintype: W_Type
+    w_getattr: W_Func
 
     def __init__(self, name: str, w_origintype: W_Type) -> None:
         super().__init__(name, w_origintype.pyclass)
         self.w_origintype = w_origintype
+        self.w_getattr = None
 
     def __repr__(self) -> str:
         r = f"<spy type '{self.name}' (typedef of '{self.w_origintype.name}')>"
         return r
 
+    def spy_setattr(self, vm: 'SPyVM', w_attr: str, w_val: W_Object) -> W_Object:
+        attr = vm.unwrap_str(w_attr)
+        if attr == '__getattr__':
+            self.w_getattr = w_val
+            return
+        raise Exception(f"invalid attribute: {attr}") # XXX better error
 
-@TYPES.primitive('def(name: str, t: type) -> type')
-def Typedef(vm: 'SPyVM', w_name: W_Str, w_origintype: W_Type) -> W_Type:
+
+TYPES.add('TypeDef', W_TypeDef._w)
+
+@TYPES.primitive('def(name: str, t: type) -> TypeDef')
+def makeTypeDef(vm: 'SPyVM', w_name: W_Str, w_origintype: W_Type) -> W_TypeDef:
     name = vm.unwrap_str(w_name)
-    return W_Typedef(name, w_origintype)
+    return W_TypeDef(name, w_origintype)

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -26,11 +26,13 @@ class W_TypeDef(W_Type):
     """
     w_origintype: W_Type
     w_getattr: W_Func
+    w_setattr = W_Func
 
     def __init__(self, name: str, w_origintype: W_Type) -> None:
         super().__init__(name, w_origintype.pyclass)
         self.w_origintype = w_origintype
         self.w_getattr = None
+        self.w_setattr = None
 
     def __repr__(self) -> str:
         r = f"<spy type '{self.name}' (typedef of '{self.w_origintype.name}')>"
@@ -40,6 +42,9 @@ class W_TypeDef(W_Type):
         attr = vm.unwrap_str(w_attr)
         if attr == '__getattr__':
             self.w_getattr = w_val
+            return
+        elif attr == '__setattr__':
+            self.w_setattr = w_val
             return
         raise Exception(f"invalid attribute: {attr}") # XXX better error
 

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -38,6 +38,14 @@ class W_TypeDef(W_Type):
         r = f"<spy type '{self.name}' (typedef of '{self.w_origintype.name}')>"
         return r
 
+    def spy_getattr(self, vm: 'SPyVM', w_attr: str) -> W_Object:
+        attr = vm.unwrap_str(w_attr)
+        if attr == '__getattr__':
+            return self.w_getattr
+        elif attr == '__setattr__':
+            return self.w_setattr
+        raise Exception(f"invalid attribute: {attr}") # XXX better error
+
     def spy_setattr(self, vm: 'SPyVM', w_attr: str, w_val: W_Object) -> W_Object:
         attr = vm.unwrap_str(w_attr)
         if attr == '__getattr__':

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -2,9 +2,39 @@
 SPy `types` module.
 """
 
+from dataclasses import dataclass
 from spy.vm.module import W_Module
+from spy.vm.object import W_Type, W_Object
+from spy.vm.str import W_Str
 from spy.vm.registry import ModuleRegistry
 
 TYPES = ModuleRegistry('types', '<types>')
-
 TYPES.add('module', W_Module._w)
+
+@dataclass
+class W_Typedef(W_Type):
+    """
+    A Typedef is a purely static alias for another type (called "origin
+    type").
+
+    Objects can be converted from and to the Typedef, but the object itself
+    will remain unchanged (and it's dynamic type will stay the same).
+
+    The point of a Typedef is to be able to override special methods such as
+    __getattr__ and __setattr__
+    """
+    w_origintype: W_Type
+
+    def __init__(self, name: str, w_origintype: W_Type) -> None:
+        super().__init__(name, w_origintype.pyclass)
+        self.w_origintype = w_origintype
+
+    def __repr__(self) -> str:
+        r = f"<spy type '{self.name}' (typedef of '{self.w_origintype.name}')>"
+        return r
+
+
+@TYPES.primitive('def(name: str, t: type) -> type')
+def Typedef(vm: 'SPyVM', w_name: W_Str, w_origintype: W_Type) -> W_Type:
+    name = vm.unwrap_str(w_name)
+    return W_Typedef(name, w_origintype)

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -351,7 +351,8 @@ class TypeChecker:
 
     def check_expr_GetAttr(self, expr: ast.GetAttr) -> tuple[Color, W_Type]:
         color, w_vtype = self.check_expr(expr.value)
-        w_opimpl = OP.w_GETATTR.pyfunc(self.vm, w_vtype, expr.attr)
+        w_attr = self.vm.wrap(expr.attr)
+        w_opimpl = OP.w_GETATTR.pyfunc(self.vm, w_vtype, w_attr)
         if w_opimpl is B.w_NotImplemented:
             v = w_vtype.name
             err = SPyTypeError(f"type `{v}` has no attribute '{expr.attr}'")

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -10,7 +10,7 @@ from spy.vm.function import W_FuncType, W_ASTFunc, W_Func
 from spy.vm.b import B
 from spy.vm.modules.operator import OP
 from spy.vm.typeconverter import TypeConverter, DynamicCast, NumericConv
-from spy.vm.modules.types import W_Typedef
+from spy.vm.modules.types import W_TypeDef
 from spy.util import magic_dispatch
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -110,11 +110,11 @@ class TypeChecker:
             # numeric conversion
             self.expr_conv[expr] = NumericConv(w_type=w_exp, w_fromtype=w_got)
             return None
-        elif isinstance(w_exp, W_Typedef) and w_exp.w_origintype is w_got:
-            # conversion from the origin type to its Typedef, nothing to do
+        elif isinstance(w_exp, W_TypeDef) and w_exp.w_origintype is w_got:
+            # conversion from the origin type to its TypeDef, nothing to do
             return None
-        elif isinstance(w_got, W_Typedef) and w_got.w_origintype is w_exp:
-            # conversion from a Typedef to its origin type, nothing to do
+        elif isinstance(w_got, W_TypeDef) and w_got.w_origintype is w_exp:
+            # conversion from a TypeDef to its origin type, nothing to do
             return None
 
         # mismatched types

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -10,6 +10,7 @@ from spy.vm.function import W_FuncType, W_ASTFunc, W_Func
 from spy.vm.b import B
 from spy.vm.modules.operator import OP
 from spy.vm.typeconverter import TypeConverter, DynamicCast, NumericConv
+from spy.vm.modules.types import W_Typedef
 from spy.util import magic_dispatch
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -109,6 +110,13 @@ class TypeChecker:
             # numeric conversion
             self.expr_conv[expr] = NumericConv(w_type=w_exp, w_fromtype=w_got)
             return None
+        elif isinstance(w_exp, W_Typedef) and w_exp.w_origintype is w_got:
+            # conversion from the origin type to its Typedef, nothing to do
+            return None
+        elif isinstance(w_got, W_Typedef) and w_got.w_origintype is w_exp:
+            # conversion from a Typedef to its origin type, nothing to do
+            return None
+
         # mismatched types
         err = SPyTypeError('mismatched types')
         got = w_got.name

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -203,7 +203,8 @@ class TypeChecker:
         _, w_otype = self.check_expr(node.target)
         _, w_vtype = self.check_expr(node.value)
 
-        w_opimpl = OP.w_SETATTR.pyfunc(self.vm, w_otype, node.attr, w_vtype)
+        w_attr = self.vm.wrap(node.attr)
+        w_opimpl = OP.w_SETATTR.pyfunc(self.vm, w_otype, w_attr, w_vtype)
         if w_opimpl is B.w_NotImplemented:
             ot = w_otype.name
             vt = w_vtype.name

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -110,12 +110,6 @@ class TypeChecker:
             # numeric conversion
             self.expr_conv[expr] = NumericConv(w_type=w_exp, w_fromtype=w_got)
             return None
-        elif isinstance(w_exp, W_TypeDef) and w_exp.w_origintype is w_got:
-            # conversion from the origin type to its TypeDef, nothing to do
-            return None
-        elif isinstance(w_got, W_TypeDef) and w_got.w_origintype is w_exp:
-            # conversion from a TypeDef to its origin type, nothing to do
-            return None
 
         # mismatched types
         err = SPyTypeError('mismatched types')

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -159,8 +159,12 @@ class SPyVM:
         assert isinstance(w_sub, W_Type)
         if w_super is B.w_dynamic:
             return True
+        #
+        if isinstance(w_sub, W_TypeDef):
+            w_sub = w_sub.w_origintype
         if isinstance(w_super, W_TypeDef):
             w_super = w_super.w_origintype
+        #
         w_class = w_sub
         while w_class is not B.w_None:
             if w_class is w_super:

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -16,7 +16,7 @@ from spy.vm.registry import ModuleRegistry
 
 from spy.vm.modules.builtins import BUILTINS
 from spy.vm.modules.operator import OPERATOR
-from spy.vm.modules.types import TYPES
+from spy.vm.modules.types import TYPES, W_TypeDef
 from spy.vm.modules.rawbuffer import RAW_BUFFER
 
 class SPyVM:
@@ -159,6 +159,8 @@ class SPyVM:
         assert isinstance(w_sub, W_Type)
         if w_super is B.w_dynamic:
             return True
+        if isinstance(w_super, W_TypeDef):
+            w_super = w_super.w_origintype
         w_class = w_sub
         while w_class is not B.w_None:
             if w_class is w_super:

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -160,6 +160,10 @@ class SPyVM:
         if w_super is B.w_dynamic:
             return True
         #
+        # XXX: these are needed to support automatic conversion from/to a
+        # TypeDef and its origin type. For now it's fine, but eventually we
+        # want to allow only explicit conversions. See
+        # TestTypeDef.test_cast_from_to.
         if isinstance(w_sub, W_TypeDef):
             w_sub = w_sub.w_origintype
         if isinstance(w_super, W_TypeDef):


### PR DESCRIPTION
This is a breakthrough.

This PR introduces `TypeDef`, which makes it possible to define a static-type alias of another type. The big news is that you can attach custom (blue) `__getattr__` and `__setattr__` to the typedef, and these calls will be redshifted away.

It needs more polishing: currently we support implicit conversion from and to the TypeDef, but only because we don't support enough of the language to have a better way. Ideally, I would like a `cast[T]` function.