### PR TITLE
Introduce the @spy_builtin decorator

### DIFF
--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -265,6 +265,17 @@ class TestBasic(CompilerTest):
         )
         self.compile_raises(src, "foo", errors)
 
+    @pytest.mark.skip(reason="the result of op.ADD should be blue but it's red")
+    def test_explicit_BinOp(self):
+        mod = self.compile("""
+        import operator as op
+
+        def foo(x: i32, y: i32) -> i32:
+            return op.ADD(i32, i32)(x, y)
+        """)
+        assert mod.foo(3, 5) == 8
+
+
     def test_function_call(self):
         mod = self.compile("""
         def foo(x: i32, y: i32, z: i32) -> i32:

--- a/spy/tests/compiler/test_operator_single.py
+++ b/spy/tests/compiler/test_operator_single.py
@@ -1,7 +1,7 @@
 import pytest
 from spy.fqn import FQN
 from spy.vm.b import B
-from spy.vm.object import W_Type, W_Object, spytype
+from spy.vm.object import W_Type, W_Object, W_Dynamic, spytype
 from spy.vm.str import W_Str
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM
@@ -38,8 +38,8 @@ class TestOperatorSingle(CompilerTest):
 
         EXT.add('MyClass', W_MyClass._w)
 
-        @EXT.primitive('def() -> dynamic')
-        def make(vm: 'SPyVM') -> W_Object:
+        @EXT.builtin
+        def make(vm: 'SPyVM') -> W_Dynamic:
             return W_MyClass()  # type: ignore
         # ========== /EXT module for this test =========
 

--- a/spy/tests/vm/test_function.py
+++ b/spy/tests/vm/test_function.py
@@ -1,7 +1,7 @@
 import pytest
 from spy.vm.vm import SPyVM
 from spy.vm.b import B
-from spy.vm.w import W_FuncType, W_I32, W_BuiltinFunc
+from spy.vm.w import W_FuncType, W_I32, W_BuiltinFunc, W_Dynamic
 from spy.fqn import FQN
 from spy.vm.function import W_FuncType, spy_builtin
 
@@ -64,3 +64,10 @@ class TestFunction:
             @spy_builtin(FQN('test::foo'))
             def foo(vm: 'SPyVM') -> int:
                 pass
+
+    def test_spy_builtin_dynamic(self):
+        vm = SPyVM()
+        @spy_builtin(FQN('test::foo'))
+        def foo(vm: 'SPyVM', w_x: W_Dynamic) -> W_Dynamic:
+            pass
+        assert foo.w_functype.name == 'def(x: dynamic) -> dynamic'

--- a/spy/tests/vm/test_function.py
+++ b/spy/tests/vm/test_function.py
@@ -31,7 +31,7 @@ class TestFunction:
         @spy_builtin(FQN('test::foo'))
         def foo(vm: 'SPyVM', w_x: W_I32) -> W_I32:
             x = vm.unwrap_i32(w_x)
-            return vm.wrap(x*2)
+            return vm.wrap(x*2)  # type: ignore
 
         w_x = foo(vm, vm.wrap(21))
         assert vm.unwrap_i32(w_x) == 42
@@ -46,28 +46,28 @@ class TestFunction:
         with pytest.raises(ValueError,
                            match="The first param should be 'vm: SPyVM'."):
             @spy_builtin(FQN('test::foo'))
-            def foo() -> W_I32:
+            def foo() -> W_I32:  # type: ignore
                 pass
 
         with pytest.raises(ValueError,
                            match="The first param should be 'vm: SPyVM'."):
             @spy_builtin(FQN('test::foo'))
-            def foo(w_x: W_I32) -> W_I32:
+            def foo(w_x: W_I32) -> W_I32:  # type: ignore
                 pass
 
         with pytest.raises(ValueError, match="Invalid param: 'x: int'"):
             @spy_builtin(FQN('test::foo'))
-            def foo(vm: 'SPyVM', x: int) -> W_I32:
+            def foo(vm: 'SPyVM', x: int) -> W_I32:  # type: ignore
                 pass
 
         with pytest.raises(ValueError, match="Invalid return type"):
             @spy_builtin(FQN('test::foo'))
-            def foo(vm: 'SPyVM') -> int:
+            def foo(vm: 'SPyVM') -> int:  # type: ignore
                 pass
 
     def test_spy_builtin_dynamic(self):
         vm = SPyVM()
         @spy_builtin(FQN('test::foo'))
-        def foo(vm: 'SPyVM', w_x: W_Dynamic) -> W_Dynamic:
+        def foo(vm: 'SPyVM', w_x: W_Dynamic) -> W_Dynamic:  # type: ignore
             pass
         assert foo.w_functype.name == 'def(x: dynamic) -> dynamic'

--- a/spy/tests/vm/test_function.py
+++ b/spy/tests/vm/test_function.py
@@ -41,3 +41,26 @@ class TestFunction:
         assert w_foo.fqn == FQN('test::foo')
         w_y = vm.call_function(w_foo, [vm.wrap(10)])
         assert vm.unwrap_i32(w_y) == 20
+
+    def test_spy_builtin_errors(self):
+        with pytest.raises(ValueError,
+                           match="The first param should be 'vm: SPyVM'."):
+            @spy_builtin(FQN('test::foo'))
+            def foo() -> W_I32:
+                pass
+
+        with pytest.raises(ValueError,
+                           match="The first param should be 'vm: SPyVM'."):
+            @spy_builtin(FQN('test::foo'))
+            def foo(w_x: W_I32) -> W_I32:
+                pass
+
+        with pytest.raises(ValueError, match="Invalid param: 'x: int'"):
+            @spy_builtin(FQN('test::foo'))
+            def foo(vm: 'SPyVM', x: int) -> W_I32:
+                pass
+
+        with pytest.raises(ValueError, match="Invalid return type"):
+            @spy_builtin(FQN('test::foo'))
+            def foo(vm: 'SPyVM') -> int:
+                pass

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Optional, Callable
 from spy import ast
 from spy.ast import Color
 from spy.fqn import FQN
-from spy.vm.object import W_Object, W_Type
+from spy.vm.object import W_Object, W_Type, W_Dynamic
 from spy.vm.module import W_Module
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -182,14 +182,24 @@ class W_BuiltinFunc(W_Func):
         return self.pyfunc(vm, *args_w)
 
 
-def spy_builtin(fqn: FQN):
-    def to_spy_FuncParam(p: Any) -> FuncParam:
-        pyclass = p.annotation
-        if not issubclass(pyclass, W_Object):
-            raise ValueError(f"Invalid param: '{p}'")
-        return FuncParam(p.name, pyclass._w)
+def spy_builtin(fqn: FQN) -> Callable:
+    from spy.vm.b import B
 
-    def decorator(fn):
+    def to_spy_FuncParam(p: Any) -> FuncParam:
+        if p.name.startswith('w_'):
+            name = p.name[2:]
+        else:
+            name = p.name
+        #
+        pyclass = p.annotation
+        if pyclass is W_Dynamic:
+            return FuncParam(name, B.w_dynamic)
+        elif issubclass(pyclass, W_Object):
+            return FuncParam(name, pyclass._w)
+        else:
+            raise ValueError(f"Invalid param: '{p}'")
+
+    def decorator(fn: Callable) -> Callable:
         sig = inspect.signature(fn)
         params = list(sig.parameters.values())
         if len(params) == 0:
@@ -201,11 +211,16 @@ def spy_builtin(fqn: FQN):
             raise ValueError(msg)
 
         func_params = [to_spy_FuncParam(p) for p in params[1:]]
-        if not issubclass(sig.return_annotation, W_Object):
-            raise ValueError(f"Invalid return type: '{sig.return_annotation}'")
-        w_restype = sig.return_annotation._w
-        w_functype = W_FuncType(func_params, w_restype)
 
+        ret = sig.return_annotation
+        if ret is W_Dynamic:
+            w_restype = B.w_dynamic
+        elif issubclass(ret, W_Object):
+            w_restype = ret._w
+        else:
+            raise ValueError(f"Invalid return type: '{sig.return_annotation}'")
+
+        w_functype = W_FuncType(func_params, w_restype)
         fn._w = W_BuiltinFunc(w_functype, fqn, fn)
         fn.w_functype = w_functype
         return fn

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -224,8 +224,8 @@ def spy_builtin(fqn: FQN) -> Callable:
             raise ValueError(f"Invalid return type: '{sig.return_annotation}'")
 
         w_functype = W_FuncType(func_params, w_restype)
-        fn._w = W_BuiltinFunc(w_functype, fqn, fn)
-        fn.w_functype = w_functype
+        fn._w = W_BuiltinFunc(w_functype, fqn, fn)  # type: ignore
+        fn.w_functype = w_functype  # type: ignore
         return fn
 
     return decorator

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -60,16 +60,11 @@ class W_FuncType(W_Type):
         case of wrong inputs.
         """
         from spy.vm.b import B
-        from spy.vm.modules.types import TYPES
-        from spy.vm.modules.rawbuffer import RAW_BUFFER
 
         def parse_type(s: str) -> Any:
-            # XXX this is a quick hack to support `module` and `RawBuffer`,
-            # but we need a better solution
             attr = f'w_{s}'
-            for mod in (B, TYPES, RAW_BUFFER):
-                if hasattr(mod, attr):
-                    return getattr(mod, attr)
+            if hasattr(B, attr):
+                return getattr(B, attr)
             assert False, f'Cannot find type {s}'
 
         args, res = map(str.strip, s.split('->'))

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -183,8 +183,6 @@ class W_BuiltinFunc(W_Func):
 
 
 def spy_builtin(fqn: FQN):
-    from spy.vm.vm import SPyVM
-
     def to_spy_FuncParam(p: Any) -> FuncParam:
         pyclass = p.annotation
         if not issubclass(pyclass, W_Object):
@@ -198,7 +196,7 @@ def spy_builtin(fqn: FQN):
             msg = (f"The first param should be 'vm: SPyVM'. Got nothing")
             raise ValueError(msg)
         if (params[0].name != 'vm' or
-            params[0].annotation not in (SPyVM, 'SPyVM')):
+            params[0].annotation != 'SPyVM'):
             msg = (f"The first param should be 'vm: SPyVM'. Got '{params[0]}'")
             raise ValueError(msg)
 

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -5,7 +5,7 @@ The first half is in vm/b.py. See its docstring for more details.
 """
 
 from typing import TYPE_CHECKING, Any
-from spy.vm.object import W_I32, W_F64, W_Bool, W_Object, W_Void
+from spy.vm.object import W_I32, W_F64, W_Bool, W_Dynamic, W_Void
 from spy.vm.str import W_Str
 from spy.vm.b import BUILTINS, B
 
@@ -14,14 +14,14 @@ if TYPE_CHECKING:
 
 PY_PRINT = print  # type: ignore
 
-@BUILTINS.primitive('def(x: i32) -> i32')
+@BUILTINS.builtin
 def abs(vm: 'SPyVM', w_x: W_I32) -> W_I32:
     x = vm.unwrap_i32(w_x)
     res = vm.ll.call('spy_builtins__abs', x)
     return vm.wrap(res) # type: ignore
 
-@BUILTINS.primitive('def(x: dynamic) -> void')
-def print(vm: 'SPyVM', w_x: W_Object) -> W_Void:
+@BUILTINS.builtin
+def print(vm: 'SPyVM', w_x: W_Dynamic) -> W_Void:
     """
     Super minimal implementation of print().
 

--- a/spy/vm/modules/operator/binop.py
+++ b/spy/vm/modules/operator/binop.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 from spy.vm.b import B
-from spy.vm.object import W_Object, W_Type
+from spy.vm.object import W_Dynamic, W_Type
 from . import OP
 from .multimethod import MultiMethodTable
 if TYPE_CHECKING:
@@ -75,42 +75,42 @@ MM.register_partial('>=', 'dynamic', OP.w_dynamic_ge)
 
 
 # XXX these should be labeled as 'blue'
-@OP.primitive('def(l: type, r: type) -> dynamic')
-def ADD(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Object:
+@OP.builtin
+def ADD(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
     return MM.lookup('+', w_ltype, w_rtype)
 
-@OP.primitive('def(l: type, r: type) -> dynamic')
-def SUB(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Object:
+@OP.builtin
+def SUB(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
     return MM.lookup('-', w_ltype, w_rtype)
 
-@OP.primitive('def(l: type, r: type) -> dynamic')
-def MUL(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Object:
+@OP.builtin
+def MUL(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
     return MM.lookup('*', w_ltype, w_rtype)
 
-@OP.primitive('def(l: type, r: type) -> dynamic')
-def DIV(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Object:
+@OP.builtin
+def DIV(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
     return MM.lookup('/', w_ltype, w_rtype)
 
-@OP.primitive('def(l: type, r: type) -> dynamic')
-def EQ(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Object:
+@OP.builtin
+def EQ(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
     return MM.lookup('==', w_ltype, w_rtype)
 
-@OP.primitive('def(l: type, r: type) -> dynamic')
-def NE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Object:
+@OP.builtin
+def NE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
     return MM.lookup('!=', w_ltype, w_rtype)
 
-@OP.primitive('def(l: type, r: type) -> dynamic')
-def LT(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Object:
+@OP.builtin
+def LT(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
     return MM.lookup('<', w_ltype, w_rtype)
 
-@OP.primitive('def(l: type, r: type) -> dynamic')
-def LE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Object:
+@OP.builtin
+def LE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
     return MM.lookup('<=', w_ltype, w_rtype)
 
-@OP.primitive('def(l: type, r: type) -> dynamic')
-def GT(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Object:
+@OP.builtin
+def GT(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
     return MM.lookup('>', w_ltype, w_rtype)
 
-@OP.primitive('def(l: type, r: type) -> dynamic')
-def GE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Object:
+@OP.builtin
+def GE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
     return MM.lookup('>=', w_ltype, w_rtype)

--- a/spy/vm/modules/operator/opimpl_dynamic.py
+++ b/spy/vm/modules/operator/opimpl_dynamic.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any
 from spy.errors import SPyTypeError
 from spy.vm.b import B
-from spy.vm.object import W_Object, W_Type
+from spy.vm.object import W_Dynamic, W_Type
 from spy.vm.str import W_Str
 from spy.vm.function import W_Func
 from . import OP
@@ -9,8 +9,8 @@ if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
 def _dynamic_op(vm: 'SPyVM', w_op: W_Func,
-                w_a: W_Object, w_b: W_Object,
-                ) -> W_Object:
+                w_a: W_Dynamic, w_b: W_Dynamic,
+                ) -> W_Dynamic:
     w_ltype = vm.dynamic_type(w_a)
     w_rtype = vm.dynamic_type(w_b)
     w_opimpl = vm.call_function(w_op, [w_ltype, w_rtype])
@@ -23,41 +23,41 @@ def _dynamic_op(vm: 'SPyVM', w_op: W_Func,
     return vm.call_function(w_opimpl, [w_a, w_b])
 
 
-@OP.primitive('def(a: dynamic, b: dynamic) -> dynamic')
-def dynamic_add(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_Object:
+@OP.builtin
+def dynamic_add(vm: 'SPyVM', w_a: W_Dynamic, w_b: W_Dynamic) -> W_Dynamic:
     return _dynamic_op(vm, OP.w_ADD, w_a, w_b)
 
-@OP.primitive('def(a: dynamic, b: dynamic) -> dynamic')
-def dynamic_mul(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_Object:
+@OP.builtin
+def dynamic_mul(vm: 'SPyVM', w_a: W_Dynamic, w_b: W_Dynamic) -> W_Dynamic:
     return _dynamic_op(vm, OP.w_MUL, w_a, w_b)
 
-@OP.primitive('def(a: dynamic, b: dynamic) -> dynamic')
-def dynamic_eq(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_Object:
+@OP.builtin
+def dynamic_eq(vm: 'SPyVM', w_a: W_Dynamic, w_b: W_Dynamic) -> W_Dynamic:
     return _dynamic_op(vm, OP.w_EQ, w_a, w_b)
 
-@OP.primitive('def(a: dynamic, b: dynamic) -> dynamic')
-def dynamic_ne(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_Object:
+@OP.builtin
+def dynamic_ne(vm: 'SPyVM', w_a: W_Dynamic, w_b: W_Dynamic) -> W_Dynamic:
     return _dynamic_op(vm, OP.w_NE, w_a, w_b)
 
-@OP.primitive('def(a: dynamic, b: dynamic) -> dynamic')
-def dynamic_lt(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_Object:
+@OP.builtin
+def dynamic_lt(vm: 'SPyVM', w_a: W_Dynamic, w_b: W_Dynamic) -> W_Dynamic:
     return _dynamic_op(vm, OP.w_LT, w_a, w_b)
 
-@OP.primitive('def(a: dynamic, b: dynamic) -> dynamic')
-def dynamic_le(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_Object:
+@OP.builtin
+def dynamic_le(vm: 'SPyVM', w_a: W_Dynamic, w_b: W_Dynamic) -> W_Dynamic:
     return _dynamic_op(vm, OP.w_LE, w_a, w_b)
 
-@OP.primitive('def(a: dynamic, b: dynamic) -> dynamic')
-def dynamic_gt(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_Object:
+@OP.builtin
+def dynamic_gt(vm: 'SPyVM', w_a: W_Dynamic, w_b: W_Dynamic) -> W_Dynamic:
     return _dynamic_op(vm, OP.w_GT, w_a, w_b)
 
-@OP.primitive('def(a: dynamic, b: dynamic) -> dynamic')
-def dynamic_ge(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_Object:
+@OP.builtin
+def dynamic_ge(vm: 'SPyVM', w_a: W_Dynamic, w_b: W_Dynamic) -> W_Dynamic:
     return _dynamic_op(vm, OP.w_GE, w_a, w_b)
 
-@OP.primitive('def(o: dynamic, attr: str, v: dynamic) -> dynamic')
-def dynamic_setattr(vm: 'SPyVM', w_obj: W_Object, w_attr: W_Str,
-                    w_value: W_Object) -> W_Object:
+@OP.builtin
+def dynamic_setattr(vm: 'SPyVM', w_obj: W_Dynamic, w_attr: W_Str,
+                    w_value: W_Dynamic) -> W_Dynamic:
     w_otype = vm.dynamic_type(w_obj)
     w_vtype = vm.dynamic_type(w_value)
     w_opimpl = OP.w_SETATTR.pyfunc(vm, w_otype, w_attr, w_vtype)

--- a/spy/vm/modules/operator/opimpl_f64.py
+++ b/spy/vm/modules/operator/opimpl_f64.py
@@ -16,42 +16,42 @@ def _f64_op(vm: 'SPyVM', w_a: W_Object, w_b: W_Object, fn: Any) -> Any:
     res = fn(a, b)
     return vm.wrap(res)
 
-@OP.primitive('def(a: f64, b: f64) -> f64')
+@OP.builtin
 def f64_add(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_F64:
     return _f64_op(vm, w_a, w_b, lambda a, b: a + b)
 
-@OP.primitive('def(a: f64, b: f64) -> f64')
+@OP.builtin
 def f64_sub(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_F64:
     return _f64_op(vm, w_a, w_b, lambda a, b: a - b)
 
-@OP.primitive('def(a: f64, b: f64) -> f64')
+@OP.builtin
 def f64_mul(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_F64:
     return _f64_op(vm, w_a, w_b, lambda a, b: a * b)
 
-@OP.primitive('def(a: f64, b: f64) -> f64')
+@OP.builtin
 def f64_div(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_F64:
     return _f64_op(vm, w_a, w_b, lambda a, b: a / b)
 
-@OP.primitive('def(a: f64, b: f64) -> bool')
+@OP.builtin
 def f64_eq(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_Bool:
     return _f64_op(vm, w_a, w_b, lambda a, b: a == b)
 
-@OP.primitive('def(a: f64, b: f64) -> bool')
+@OP.builtin
 def f64_ne(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_Bool:
     return _f64_op(vm, w_a, w_b, lambda a, b: a != b)
 
-@OP.primitive('def(a: f64, b: f64) -> bool')
+@OP.builtin
 def f64_lt(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_Bool:
     return _f64_op(vm, w_a, w_b, lambda a, b: a < b)
 
-@OP.primitive('def(a: f64, b: f64) -> bool')
+@OP.builtin
 def f64_le(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_Bool:
     return _f64_op(vm, w_a, w_b, lambda a, b: a <= b)
 
-@OP.primitive('def(a: f64, b: f64) -> bool')
+@OP.builtin
 def f64_gt(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_Bool:
     return _f64_op(vm, w_a, w_b, lambda a, b: a > b)
 
-@OP.primitive('def(a: f64, b: f64) -> bool')
+@OP.builtin
 def f64_ge(vm: 'SPyVM', w_a: W_F64, w_b: W_F64) -> W_Bool:
     return _f64_op(vm, w_a, w_b, lambda a, b: a >= b)

--- a/spy/vm/modules/operator/opimpl_i32.py
+++ b/spy/vm/modules/operator/opimpl_i32.py
@@ -16,43 +16,43 @@ def _i32_op(vm: 'SPyVM', w_a: W_Object, w_b: W_Object, fn: Any) -> Any:
     res = fn(a, b)
     return vm.wrap(res)
 
-@OP.primitive('def(a: i32, b: i32) -> i32')
+@OP.builtin
 def i32_add(vm: 'SPyVM', w_a: W_I32, w_b: W_I32) -> W_I32:
     return _i32_op(vm, w_a, w_b, lambda a, b: a + b)
 
-@OP.primitive('def(a: i32, b: i32) -> i32')
+@OP.builtin
 def i32_sub(vm: 'SPyVM', w_a: W_I32, w_b: W_I32) -> W_I32:
     return _i32_op(vm, w_a, w_b, lambda a, b: a - b)
 
-@OP.primitive('def(a: i32, b: i32) -> i32')
+@OP.builtin
 def i32_mul(vm: 'SPyVM', w_a: W_I32, w_b: W_I32) -> W_I32:
     return _i32_op(vm, w_a, w_b, lambda a, b: a * b)
 
 # XXX: should we do floor division or float division?
-@OP.primitive('def(a: i32, b: i32) -> i32')
+@OP.builtin
 def i32_div(vm: 'SPyVM', w_a: W_I32, w_b: W_I32) -> W_I32:
     return _i32_op(vm, w_a, w_b, lambda a, b: a // b)
 
-@OP.primitive('def(a: i32, b: i32) -> bool')
+@OP.builtin
 def i32_eq(vm: 'SPyVM', w_a: W_I32, w_b: W_I32) -> W_Bool:
     return _i32_op(vm, w_a, w_b, lambda a, b: a == b)
 
-@OP.primitive('def(a: i32, b: i32) -> bool')
+@OP.builtin
 def i32_ne(vm: 'SPyVM', w_a: W_I32, w_b: W_I32) -> W_Bool:
     return _i32_op(vm, w_a, w_b, lambda a, b: a != b)
 
-@OP.primitive('def(a: i32, b: i32) -> bool')
+@OP.builtin
 def i32_lt(vm: 'SPyVM', w_a: W_I32, w_b: W_I32) -> W_Bool:
     return _i32_op(vm, w_a, w_b, lambda a, b: a < b)
 
-@OP.primitive('def(a: i32, b: i32) -> bool')
+@OP.builtin
 def i32_le(vm: 'SPyVM', w_a: W_I32, w_b: W_I32) -> W_Bool:
     return _i32_op(vm, w_a, w_b, lambda a, b: a <= b)
 
-@OP.primitive('def(a: i32, b: i32) -> bool')
+@OP.builtin
 def i32_gt(vm: 'SPyVM', w_a: W_I32, w_b: W_I32) -> W_Bool:
     return _i32_op(vm, w_a, w_b, lambda a, b: a > b)
 
-@OP.primitive('def(a: i32, b: i32) -> bool')
+@OP.builtin
 def i32_ge(vm: 'SPyVM', w_a: W_I32, w_b: W_I32) -> W_Bool:
     return _i32_op(vm, w_a, w_b, lambda a, b: a >= b)

--- a/spy/vm/modules/operator/opimpl_misc.py
+++ b/spy/vm/modules/operator/opimpl_misc.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 from spy.vm.b import B
-from spy.vm.object import W_Object
+from spy.vm.object import W_Object, W_Void, W_Dynamic
 from spy.vm.str import W_Str
 from spy.vm.module import W_Module
 from . import OP
@@ -8,11 +8,12 @@ if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
 
-@OP.primitive('def(obj: object, attr: str) -> dynamic')
-def generic_getattr(vm: 'SPyVM', w_obj: W_Object, w_attr: W_Str) -> W_Object:
+@OP.builtin
+def generic_getattr(vm: 'SPyVM', w_obj: W_Object, w_attr: W_Str) -> W_Dynamic:
     return w_obj.opimpl_getattr(vm, w_attr)
 
-@OP.primitive('def(obj: object, attr: str, v: object) -> void')
+@OP.builtin
 def generic_setattr(vm: 'SPyVM', w_obj: W_Object, w_attr: W_Str,
-                    w_value: W_Object) -> None:
+                    w_value: W_Object) -> W_Void:
     w_obj.opimpl_setattr(vm, w_attr, w_value)
+    return B.w_None

--- a/spy/vm/modules/operator/opimpl_str.py
+++ b/spy/vm/modules/operator/opimpl_str.py
@@ -7,35 +7,35 @@ if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
 
-@OP.primitive('def(a: str, b: str) -> str')
+@OP.builtin
 def str_add(vm: 'SPyVM', w_a: W_Str, w_b: W_Str) -> W_Str:
     assert isinstance(w_a, W_Str)
     assert isinstance(w_b, W_Str)
     ptr_c = vm.ll.call('spy_str_add', w_a.ptr, w_b.ptr)
     return W_Str.from_ptr(vm, ptr_c)
 
-@OP.primitive('def(s: str, n: i32) -> str')
+@OP.builtin
 def str_mul(vm: 'SPyVM', w_a: W_Str, w_b: W_I32) -> W_Str:
     assert isinstance(w_a, W_Str)
     assert isinstance(w_b, W_I32)
     ptr_c = vm.ll.call('spy_str_mul', w_a.ptr, w_b.value)
     return W_Str.from_ptr(vm, ptr_c)
 
-@OP.primitive('def(a: str, b: str) -> bool')
+@OP.builtin
 def str_eq(vm: 'SPyVM', w_a: W_Str, w_b: W_Str) -> W_Bool:
     assert isinstance(w_a, W_Str)
     assert isinstance(w_b, W_Str)
     res = vm.ll.call('spy_str_eq', w_a.ptr, w_b.ptr)
     return vm.wrap(bool(res))  # type: ignore
 
-@OP.primitive('def(a: str, b: str) -> bool')
+@OP.builtin
 def str_ne(vm: 'SPyVM', w_a: W_Str, w_b: W_Str) -> W_Bool:
     assert isinstance(w_a, W_Str)
     assert isinstance(w_b, W_Str)
     res = vm.ll.call('spy_str_eq', w_a.ptr, w_b.ptr)
     return vm.wrap(bool(not res))  # type: ignore
 
-@OP.primitive('def(s: str, i: i32) -> str')
+@OP.builtin
 def str_getitem(vm: 'SPyVM', w_s: W_Str, w_i: W_I32) -> W_Str:
     assert isinstance(w_s, W_Str)
     assert isinstance(w_i, W_I32)

--- a/spy/vm/modules/operator/unaryop.py
+++ b/spy/vm/modules/operator/unaryop.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 from spy.vm.b import B
-from spy.vm.object import W_Object, W_Type
+from spy.vm.object import W_Object, W_Type, W_Dynamic
 from spy.vm.module import W_Module
 from spy.vm.str import W_Str
 from spy.vm.function import W_Func
@@ -12,13 +12,13 @@ if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
 
-@OP.primitive('def(v: type, i: type) -> dynamic')
-def GETITEM(vm: 'SPyVM', w_vtype: W_Type, w_itype: W_Type) -> W_Object:
+@OP.builtin
+def GETITEM(vm: 'SPyVM', w_vtype: W_Type, w_itype: W_Type) -> W_Dynamic:
     return MM.lookup('[]', w_vtype, w_itype)
 
 
-@OP.primitive('def(t: type, attr: str) -> dynamic')
-def GETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str) -> W_Object:
+@OP.builtin
+def GETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str) -> W_Dynamic:
     pyclass = w_type.pyclass
     if w_type is B.w_dynamic:
         raise NotImplementedError("implement me")
@@ -37,9 +37,9 @@ def GETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str) -> W_Object:
     return B.w_NotImplemented
 
 
-@OP.primitive('def(t: type, attr: str, v: type) -> dynamic')
+@OP.builtin
 def SETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str,
-            w_vtype: W_Type) -> W_Object:
+            w_vtype: W_Type) -> W_Dynamic:
     pyclass = w_type.pyclass
     if w_type is B.w_dynamic:
         return OP.w_dynamic_setattr

--- a/spy/vm/modules/rawbuffer.py
+++ b/spy/vm/modules/rawbuffer.py
@@ -5,9 +5,8 @@ SPy `rawbuffer` module.
 from typing import TYPE_CHECKING
 import struct
 from spy.vm.b import B
-from spy.vm.function import W_Func
-from spy.vm.object import W_Type, W_Object, spytype, W_I32, W_F64, W_Void
-from spy.vm.str import W_Str
+from spy.vm.object import spytype
+from spy.vm.w import W_Func, W_Type, W_Object, W_I32, W_F64, W_Void, W_Str
 from spy.vm.registry import ModuleRegistry
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -26,12 +25,12 @@ class W_RawBuffer(W_Object):
 
 RB.add('RawBuffer', W_RawBuffer._w)
 
-@RB.primitive('def(size: i32) -> RawBuffer')
+@RB.builtin
 def rb_alloc(vm: 'SPyVM', w_size: W_I32) -> W_RawBuffer:
     size = vm.unwrap_i32(w_size)
     return W_RawBuffer(size)
 
-@RB.primitive('def(rb: RawBuffer, offset: i32, val: i32) -> void')
+@RB.builtin
 def rb_set_i32(vm: 'SPyVM', w_rb: W_RawBuffer,
                w_offset: W_I32, w_val: W_I32) -> W_Void:
     offset = vm.unwrap_i32(w_offset)
@@ -39,13 +38,13 @@ def rb_set_i32(vm: 'SPyVM', w_rb: W_RawBuffer,
     struct.pack_into('i', w_rb.buf, offset, val)
     return B.w_None
 
-@RB.primitive('def(rb: RawBuffer, offset: i32) -> i32')
+@RB.builtin
 def rb_get_i32(vm: 'SPyVM', w_rb: W_RawBuffer, w_offset: W_I32) -> W_I32:
     offset = vm.unwrap_i32(w_offset)
     val = struct.unpack_from('i', w_rb.buf, offset)[0]
     return vm.wrap(val)  # type: ignore
 
-@RB.primitive('def(rb: RawBuffer, offset: i32, val: f64) -> void')
+@RB.builtin
 def rb_set_f64(vm: 'SPyVM', w_rb: W_RawBuffer,
                w_offset: W_I32, w_val: W_F64) -> W_Void:
     offset = vm.unwrap_i32(w_offset)
@@ -53,7 +52,7 @@ def rb_set_f64(vm: 'SPyVM', w_rb: W_RawBuffer,
     struct.pack_into('d', w_rb.buf, offset, val)
     return B.w_None
 
-@RB.primitive('def(rb: RawBuffer, offset: i32) -> f64')
+@RB.builtin
 def rb_get_f64(vm: 'SPyVM', w_rb: W_RawBuffer, w_offset: W_I32) -> W_F64:
     offset = vm.unwrap_i32(w_offset)
     val = struct.unpack_from('d', w_rb.buf, offset)[0]

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -64,7 +64,7 @@ class W_TypeDef(W_Type):
 
 TYPES.add('TypeDef', W_TypeDef._w)
 
-@TYPES.primitive('def(name: str, t: type) -> TypeDef')
+@TYPES.builtin
 def makeTypeDef(vm: 'SPyVM', w_name: W_Str, w_origintype: W_Type) -> W_TypeDef:
     name = vm.unwrap_str(w_name)
     return W_TypeDef(name, w_origintype)

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -45,7 +45,7 @@ basically a thin wrapper around the correspindig interp-level W_* class.
 """
 
 import fixedint
-from typing import TYPE_CHECKING, ClassVar, Type, Any
+from typing import TYPE_CHECKING, ClassVar, Type, Any, Annotated
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
     from spy.vm.str import W_Str
@@ -197,8 +197,15 @@ W_Type._w = W_Type('type', W_Type)
 #    x + 1 # compile-time error: cannot do `<object> + <i32>`
 #    y + 1 # succeeds, but the dispatch is done at runtime
 #    z + 1 # runtime error: cannot do `<i32> + <str>`
+#
+# Since it's a compile-time only concept, it doesn't have a corresponding
+# W_Dynamic interp-level class. However, we still provide W_Dynamic as an
+# annotated version of W_Object: from the mypy static typing point of view,
+# it's equivalent to W_Object, but it is recognized by @spy_builtin to
+# generate the "correct" w_functype signature.
 
-w_DynamicType = W_Type('dynamic', W_Object)
+w_DynamicType = W_Type('dynamic', W_Object) # this is B.w_dynamic
+W_Dynamic = Annotated[W_Object, 'W_Dynamic']
 
 
 # Other types

--- a/spy/vm/registry.py
+++ b/spy/vm/registry.py
@@ -39,19 +39,6 @@ class ModuleRegistry:
         setattr(self, f'w_{attr}', w_obj)
         self.content.append((fqn, w_obj))
 
-    def primitive(self, sig: str, name: Optional[str] = None) -> Callable:
-        w_functype = W_FuncType.parse(sig)
-
-        def decorator(pyfunc: Callable) -> Callable:
-            attr = name or pyfunc.__name__
-            fqn = FQN(modname=self.modname, attr=attr)
-            w_func = W_BuiltinFunc(w_functype, fqn, pyfunc)
-            setattr(self, f'w_{attr}', w_func)
-            self.content.append((fqn, w_func))
-            return pyfunc
-
-        return decorator
-
     def builtin(self, pyfunc: Callable) -> Callable:
         attr = pyfunc.__name__
         fqn = FQN(modname=self.modname, attr=attr)

--- a/spy/vm/registry.py
+++ b/spy/vm/registry.py
@@ -44,7 +44,7 @@ class ModuleRegistry:
         fqn = FQN(modname=self.modname, attr=attr)
         # apply the @spy_builtin decorator to pyfunc
         spy_builtin(fqn)(pyfunc)
-        w_func = pyfunc._w
+        w_func = pyfunc._w  # type: ignore
         setattr(self, f'w_{attr}', w_func)
         self.content.append((fqn, w_func))
         return pyfunc

--- a/spy/vm/registry.py
+++ b/spy/vm/registry.py
@@ -1,7 +1,7 @@
 from typing import Callable, Optional, TYPE_CHECKING, Any
 from dataclasses import dataclass
 from spy.fqn import FQN
-from spy.vm.function import W_FuncType, W_BuiltinFunc
+from spy.vm.function import W_FuncType, W_BuiltinFunc, spy_builtin
 from spy.vm.object import W_Object
 
 class ModuleRegistry:
@@ -51,3 +51,13 @@ class ModuleRegistry:
             return pyfunc
 
         return decorator
+
+    def builtin(self, pyfunc: Callable) -> Callable:
+        attr = pyfunc.__name__
+        fqn = FQN(modname=self.modname, attr=attr)
+        # apply the @spy_builtin decorator to pyfunc
+        spy_builtin(fqn)(pyfunc)
+        w_func = pyfunc._w
+        setattr(self, f'w_{attr}', w_func)
+        self.content.append((fqn, w_func))
+        return pyfunc

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -2,6 +2,7 @@ import py
 from typing import Any, Optional, Iterable
 import itertools
 from dataclasses import dataclass
+from types import FunctionType
 import fixedint
 from spy.fqn import FQN
 from spy import libspy
@@ -217,6 +218,8 @@ class SPyVM:
         elif T is str:
             return W_Str(self, value)
         elif isinstance(value, type) and issubclass(value, W_Object):
+            return value._w
+        elif isinstance(value, FunctionType) and hasattr(value, '_w'):
             return value._w
         raise Exception(f"Cannot wrap interp-level objects " +
                         f"of type {value.__class__.__name__}")

--- a/spy/vm/w.py
+++ b/spy/vm/w.py
@@ -4,5 +4,6 @@ This is just to make it easier to import all the various W_* classes
 
 from spy.vm.function import W_Func, W_FuncType, W_ASTFunc, W_BuiltinFunc
 from spy.vm.module import W_Module
-from spy.vm.object import W_Bool, W_F64, W_I32, W_Object, W_Type, W_Void
+from spy.vm.object import (W_Bool, W_F64, W_I32, W_Object, W_Type, W_Void,
+                           W_Dynamic)
 from spy.vm.str import W_Str

--- a/spy/vm/w.py
+++ b/spy/vm/w.py
@@ -1,0 +1,10 @@
+"""
+This is just to make it easier to import all the various W_* classes
+"""
+
+from spy.vm.function import W_Func, W_FuncType, W_ASTFunc, W_BuiltinFunc
+from spy.vm.module import W_Module
+from spy.vm.object import W_Bool, W_F64, W_I32, W_Object, W_Type, W_Void
+from spy.vm.str import W_Str
+from spy.vm.modules.types import W_TypeDef
+from spy.vm.modules.rawbuffer import W_RawBuffer

--- a/spy/vm/w.py
+++ b/spy/vm/w.py
@@ -6,5 +6,3 @@ from spy.vm.function import W_Func, W_FuncType, W_ASTFunc, W_BuiltinFunc
 from spy.vm.module import W_Module
 from spy.vm.object import W_Bool, W_F64, W_I32, W_Object, W_Type, W_Void
 from spy.vm.str import W_Str
-from spy.vm.modules.types import W_TypeDef
-from spy.vm.modules.rawbuffer import W_RawBuffer


### PR DESCRIPTION
`@spy_builtin` makes it possible to automatically wrap an interp-level function into an app-level function, and `vm.wrap()` works. The signature is automatically inferenced from the interp-level annotation.

This makes it possible to kill `ModuleRegistry.primitive`, which required to explicitly write the signature as a string.
