### PR TITLE
Kill the generic versions of opimpl_getattr and opimpl_setattr

### DIFF
--- a/spy/tests/compiler/test_operator_single.py
+++ b/spy/tests/compiler/test_operator_single.py
@@ -37,7 +37,7 @@ class TestOperatorSingle(CompilerTest):
                     def opimpl(vm: 'SPyVM', w_obj: W_MyClass,
                                       w_attr: W_Str) -> W_Str:
                         attr = vm.unwrap_str(w_attr)
-                        return vm.wrap(attr.upper() + '--42')
+                        return vm.wrap(attr.upper() + '--42')  # type: ignore
                 return vm.wrap(opimpl)
 
             @staticmethod

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -5,7 +5,6 @@ from spy import ast
 from spy.ast import Color
 from spy.fqn import FQN
 from spy.vm.object import W_Object, W_Type, W_Dynamic, w_DynamicType
-from spy.vm.module import W_Module
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 

--- a/spy/vm/modules/operator/__init__.py
+++ b/spy/vm/modules/operator/__init__.py
@@ -71,7 +71,6 @@ from . import opimpl_i32     # side effects
 from . import opimpl_f64     # side effects
 from . import opimpl_str     # side effects
 from . import opimpl_dynamic # side effects
-from . import opimpl_misc    # side effects
 from . import binop          # side effects
 from . import unaryop        # side effects
 

--- a/spy/vm/modules/operator/opimpl_misc.py
+++ b/spy/vm/modules/operator/opimpl_misc.py
@@ -1,8 +1,0 @@
-from typing import TYPE_CHECKING
-from spy.vm.b import B
-from spy.vm.object import W_Object, W_Void, W_Dynamic
-from spy.vm.str import W_Str
-from spy.vm.module import W_Module
-from . import OP
-if TYPE_CHECKING:
-    from spy.vm.vm import SPyVM

--- a/spy/vm/modules/operator/opimpl_misc.py
+++ b/spy/vm/modules/operator/opimpl_misc.py
@@ -6,14 +6,3 @@ from spy.vm.module import W_Module
 from . import OP
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
-
-
-@OP.builtin
-def generic_getattr(vm: 'SPyVM', w_obj: W_Object, w_attr: W_Str) -> W_Dynamic:
-    return w_obj.opimpl_getattr(vm, w_attr)
-
-@OP.builtin
-def generic_setattr(vm: 'SPyVM', w_obj: W_Object, w_attr: W_Str,
-                    w_value: W_Object) -> W_Void:
-    w_obj.opimpl_setattr(vm, w_attr, w_value)
-    return B.w_None

--- a/spy/vm/modules/operator/unaryop.py
+++ b/spy/vm/modules/operator/unaryop.py
@@ -24,8 +24,6 @@ def GETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str) -> W_Dynamic:
         raise NotImplementedError("implement me")
     elif pyclass.has_meth_overriden('op_GETATTR'):
         return pyclass.op_GETATTR(vm, w_type, w_attr)
-    elif pyclass.has_meth_overriden('opimpl_getattr'):
-        return OP.w_generic_getattr
 
     # XXX refactor
     if isinstance(w_type, W_TypeDef) and w_type.w_getattr is not None:
@@ -45,8 +43,6 @@ def SETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str,
         return OP.w_dynamic_setattr
     elif pyclass.has_meth_overriden('op_SETATTR'):
         return pyclass.op_SETATTR(vm, w_type, w_attr, w_vtype)
-    elif pyclass.has_meth_overriden('opimpl_setattr'):
-        return OP.w_generic_setattr
 
     # XXX refactor
     if isinstance(w_type, W_TypeDef) and w_type.w_setattr is not None:

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -94,16 +94,9 @@ class W_Object:
     #     opimpl = operator.GETATTR(static_type(obj), 'a')
     #     return opimpl(obj, 'a')
     #
-    # Subclasses of W_Object have two different options to implement their own
-    # semantics for the operators:
-    #
-    #   1. The can implement the operator itself, by overriding op_GETATTR:
-    #      this must be a *static method* on the class, and must return an
-    #      opimpl.
-    #
-    #   2. For convenience, subclasses can also decide to implement
-    #      opimpl_getattr: in this case, the default logic for op_GETATTR is
-    #      to simply return that opimpl.
+    # Subclasses of W_Object can implement their own operator by overriding
+    # the various op_GETATTR & co.  These must be *static methods* on the
+    # class, and must return an opimpl.
     #
     # The actual logic for the SPy VM resides in the 'operator' module (see
     # spy/vm/modules/operator).
@@ -123,16 +116,9 @@ class W_Object:
                    w_attr: 'W_Str') -> 'W_Object':
         raise NotImplementedError('this should never be called')
 
-    def opimpl_getattr(self, vm: 'SPyVM', w_attr: 'W_Str') -> 'W_Object':
-        raise NotImplementedError('this should never be called')
-
     @staticmethod
     def op_SETATTR(vm: 'SPyVM', w_type: 'W_Type', w_attr: 'W_Str',
                    w_vtype: 'W_Type') -> 'W_Object':
-        raise NotImplementedError('this should never be called')
-
-    def opimpl_setattr(self, vm: 'SPyVM', w_attr: 'W_Str',
-                       w_val: 'W_Object') -> None:
         raise NotImplementedError('this should never be called')
 
 

--- a/spy/vm/w.py
+++ b/spy/vm/w.py
@@ -2,8 +2,9 @@
 This is just to make it easier to import all the various W_* classes
 """
 
-from spy.vm.function import W_Func, W_FuncType, W_ASTFunc, W_BuiltinFunc
+from spy.vm.function import (W_Func, W_FuncType, W_ASTFunc, W_BuiltinFunc,
+                             spy_builtin)
 from spy.vm.module import W_Module
 from spy.vm.object import (W_Bool, W_F64, W_I32, W_Object, W_Type, W_Void,
-                           W_Dynamic)
+                           W_Dynamic, spytype)
 from spy.vm.str import W_Str


### PR DESCRIPTION
They cause more troubles than advantages.

The main reason for having them was to implement W_Module.op_GETATTR, but now we can use @spy_builtin instead.