### PR TITLE
Introduce the distinction between QN and FQN

### DIFF
--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -330,35 +330,37 @@ class CFuncWriter:
     fmt_expr_Gt = fmt_expr_BinOp
     fmt_expr_GtE = fmt_expr_BinOp
 
+
+    FQN2BinOp = {
+        FQN.parse('operator::i32_add'): '+',
+        FQN.parse('operator::i32_sub'): '-',
+        FQN.parse('operator::i32_mul'): '*',
+        FQN.parse('operator::i32_div'): '/', # XXX: floor or int division?
+        FQN.parse('operator::i32_eq') : '==',
+        FQN.parse('operator::i32_ne') : '!=',
+        FQN.parse('operator::i32_lt') : '<',
+        FQN.parse('operator::i32_le') : '<=',
+        FQN.parse('operator::i32_gt') : '>',
+        FQN.parse('operator::i32_ge') : '>=',
+        #
+        FQN.parse('operator::f64_add'): '+',
+        FQN.parse('operator::f64_sub'): '-',
+        FQN.parse('operator::f64_mul'): '*',
+        FQN.parse('operator::f64_div'): '/',
+        FQN.parse('operator::f64_eq') : '==',
+        FQN.parse('operator::f64_ne') : '!=',
+        FQN.parse('operator::f64_lt') : '<',
+        FQN.parse('operator::f64_le') : '<=',
+        FQN.parse('operator::f64_gt') : '>',
+        FQN.parse('operator::f64_ge') : '>=',
+    }
+
     def fmt_expr_Call(self, call: ast.Call) -> C.Expr:
         assert isinstance(call.func, ast.FQNConst), \
             'indirect calls are not supported yet'
 
         # some calls are special-cased and transformed into a C binop
-        binops = {
-            FQN('operator::i32_add'): '+',
-            FQN('operator::i32_sub'): '-',
-            FQN('operator::i32_mul'): '*',
-            FQN('operator::i32_div'): '/', # XXX: floor division or int division?
-            FQN('operator::i32_eq') : '==',
-            FQN('operator::i32_ne') : '!=',
-            FQN('operator::i32_lt') : '<',
-            FQN('operator::i32_le') : '<=',
-            FQN('operator::i32_gt') : '>',
-            FQN('operator::i32_ge') : '>=',
-            #
-            FQN('operator::f64_add'): '+',
-            FQN('operator::f64_sub'): '-',
-            FQN('operator::f64_mul'): '*',
-            FQN('operator::f64_div'): '/',
-            FQN('operator::f64_eq') : '==',
-            FQN('operator::f64_ne') : '!=',
-            FQN('operator::f64_lt') : '<',
-            FQN('operator::f64_le') : '<=',
-            FQN('operator::f64_gt') : '>',
-            FQN('operator::f64_ge') : '>=',
-        }
-        op = binops.get(call.func.fqn)
+        op = self.FQN2BinOp.get(call.func.fqn)
         if op is not None:
             assert len(call.args) == 2
             l, r = [self.fmt_expr(arg) for arg in call.args]

--- a/spy/backend/c/wrapper.py
+++ b/spy/backend/c/wrapper.py
@@ -28,7 +28,7 @@ class WasmModuleWrapper:
         return f"<WasmModuleWrapper 'self.ll.name'>"
 
     def __getattr__(self, attr: str) -> Any:
-        fqn = FQN(modname=self.modname, attr=attr)
+        fqn = FQN.make_global(modname=self.modname, attr=attr)
         wasm_obj = self.ll.get_export(fqn.c_name)
         if isinstance(wasm_obj, wasmtime.Func):
             return self.read_function(fqn)

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -27,13 +27,12 @@ class SPyBackend:
         w_mod = self.vm.modules_w[modname]
         for fqn, w_obj in w_mod.items_w():
             if isinstance(w_obj, W_ASTFunc) and w_obj.color == 'red':
-                self.dump_w_func(w_obj)
+                self.dump_w_func(fqn, w_obj)
                 self.out.wl()
         return self.out.build()
 
-    def dump_w_func(self, w_func: W_ASTFunc) -> None:
-        fqn = w_func.fqn
-        if fqn.uniq_suffix == '':
+    def dump_w_func(self, fqn: FQN, w_func: W_ASTFunc) -> None:
+        if fqn.suffix == '':
             # this is a global function, we can just use its name
             name = fqn.attr
         else:
@@ -175,27 +174,27 @@ class SPyBackend:
 
     # special cases
     FQN2BinOp = {
-        FQN('operator::i32_add'): ast.Add,
-        FQN('operator::i32_sub'): ast.Sub,
-        FQN('operator::i32_mul'): ast.Mul,
-        FQN('operator::i32_div'): ast.Div,
-        FQN('operator::i32_eq'): ast.Eq,
-        FQN('operator::i32_ne'): ast.NotEq,
-        FQN('operator::i32_lt'): ast.Lt,
-        FQN('operator::i32_le'): ast.LtE,
-        FQN('operator::i32_gt'): ast.Gt,
-        FQN('operator::i32_ge'): ast.GtE,
+        FQN.parse('operator::i32_add'): ast.Add,
+        FQN.parse('operator::i32_sub'): ast.Sub,
+        FQN.parse('operator::i32_mul'): ast.Mul,
+        FQN.parse('operator::i32_div'): ast.Div,
+        FQN.parse('operator::i32_eq'): ast.Eq,
+        FQN.parse('operator::i32_ne'): ast.NotEq,
+        FQN.parse('operator::i32_lt'): ast.Lt,
+        FQN.parse('operator::i32_le'): ast.LtE,
+        FQN.parse('operator::i32_gt'): ast.Gt,
+        FQN.parse('operator::i32_ge'): ast.GtE,
         #
-        FQN('operator::f64_add'): ast.Add,
-        FQN('operator::f64_sub'): ast.Sub,
-        FQN('operator::f64_mul'): ast.Mul,
-        FQN('operator::f64_div'): ast.Div,
-        FQN('operator::f64_eq'): ast.Eq,
-        FQN('operator::f64_ne'): ast.NotEq,
-        FQN('operator::f64_lt'): ast.Lt,
-        FQN('operator::f64_le'): ast.LtE,
-        FQN('operator::f64_gt'): ast.Gt,
-        FQN('operator::f64_ge'): ast.GtE,
+        FQN.parse('operator::f64_add'): ast.Add,
+        FQN.parse('operator::f64_sub'): ast.Sub,
+        FQN.parse('operator::f64_mul'): ast.Mul,
+        FQN.parse('operator::f64_div'): ast.Div,
+        FQN.parse('operator::f64_eq'): ast.Eq,
+        FQN.parse('operator::f64_ne'): ast.NotEq,
+        FQN.parse('operator::f64_lt'): ast.Lt,
+        FQN.parse('operator::f64_le'): ast.LtE,
+        FQN.parse('operator::f64_gt'): ast.Gt,
+        FQN.parse('operator::f64_ge'): ast.GtE,
     }
 
     def get_binop_maybe(self, func: ast.Expr) -> Optional[type[ast.BinOp]]:

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -36,13 +36,13 @@ class FuncDoppler:
             new_body += self.shift_stmt(stmt)
         new_funcdef = funcdef.replace(body=new_body)
         #
-        new_fqn = self.w_func.fqn # XXX
+        new_qn = self.w_func.qn
         # all the non-local lookups are redshifted into constants, so the
         # closure will be empty
         new_closure = ()
         w_newfunctype = self.w_func.w_functype
         w_newfunc = W_ASTFunc(
-            fqn = new_fqn,
+            qn = new_qn,
             closure = new_closure,
             w_functype = w_newfunctype,
             funcdef = new_funcdef,
@@ -76,7 +76,7 @@ class FuncDoppler:
         if fqn is None:
             if isinstance(w_val, W_ASTFunc):
                 # it's a closure, let's assign it an FQN and add to the globals
-                fqn = w_val.fqn
+                fqn = self.vm.get_FQN(w_val.qn, is_global=False)
                 self.vm.add_global(fqn, None, w_val)
             else:
                 assert False, 'implement me'
@@ -168,7 +168,6 @@ class FuncDoppler:
         l = self.shift_expr(binop.left)
         r = self.shift_expr(binop.right)
         w_opimpl = self.t.opimpl[binop]
-        assert w_opimpl.fqn is not None
         func = self.make_const(binop.loc, w_opimpl)
         return ast.Call(binop.loc, func, [l, r])
 

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -123,7 +123,6 @@ class FuncDoppler:
         v_attr = ast.Constant(node.loc, value=node.attr)
         v_value = self.shift_expr(node.value)
         w_opimpl = self.t.opimpl[node]
-        assert w_opimpl.fqn is not None
         func = self.make_const(node.loc, w_opimpl)
         call = ast.Call(node.loc, func, [v_target, v_attr, v_value])
         return [ast.StmtExpr(node.loc, call)]
@@ -186,7 +185,6 @@ class FuncDoppler:
         v = self.shift_expr(op.value)
         i = self.shift_expr(op.index)
         w_opimpl = self.t.opimpl[op]
-        assert w_opimpl.fqn is not None
         func = self.make_const(op.loc, w_opimpl)
         return ast.Call(op.loc, func, [v, i])
 
@@ -194,7 +192,6 @@ class FuncDoppler:
         v = self.shift_expr(op.value)
         v_attr = ast.Constant(op.loc, value=op.attr)
         w_opimpl = self.t.opimpl[op]
-        assert w_opimpl.fqn is not None
         func = self.make_const(op.loc, w_opimpl)
         return ast.Call(op.loc, func, [v, v_attr])
 

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -100,6 +100,19 @@ class FQN:
         """
         return cls.make(modname, attr, suffix="")
 
+    @classmethod
+    def parse(cls, s: str) -> 'FQN':
+        if '#' in s:
+            assert s.count('#') == 1
+            qn, suffix = s.split('#')
+        else:
+            qn = s
+            suffix = ""
+        #
+        assert qn.count('::') == 1
+        modname, attr = qn.split('::')
+        return FQN.make(modname=modname, attr=attr, suffix=suffix)
+
     @property
     def fullname(self) -> str:
         s = f'{self.modname}::{self.attr}'

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -68,12 +68,6 @@ class QN:
     def __hash__(self) -> int:
         return hash(self.fullname)
 
-    def is_module(self) -> bool:
-        return self.attr == ""
-
-    def is_object(self) -> bool:
-        return self.attr != ""
-
     @property
     def fullname(self) -> str:
         return f'{self.modname}::{self.attr}'
@@ -128,3 +122,9 @@ class FQN:
     @property
     def spy_name(self) -> str:
         return f'{self.modname}.{self.attr}'
+
+    def is_module(self) -> bool:
+        return self.attr == ""
+
+    def is_object(self) -> bool:
+        return self.attr != ""

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -78,7 +78,7 @@ class FQN:
     attr: str
     suffix: str
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         raise ValueError("You cannot instantiate an FQN directly. "
                          "Please use vm.get_FQN()")
 

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -136,10 +136,31 @@ class FQN:
 
     @property
     def c_name(self) -> str:
+        """
+        Return the C name for the corresponding FQN.
+
+        We need to do a bit of mangling:
+
+          - the modname part can be dotted: we replace '.' with '_'. Note that
+            this is potentially unsafe, because e.g. `a.b.c` and `a.b_c` would
+            result in the same C name.  This is not ideal but we will solve it
+            only if it becomes an actual issue in practice.
+
+          - for separating modname and attr, we use a '$'. Strictly speaking,
+            using a '$' in C identifiers is not supported by the standard, but
+            in reality it is supported by GCC, clang and MSVC. Again, we will
+            think of a different approach if it becomes an actual issue.
+
+        So e.g., the following FQN:
+            a.b.c::foo
+
+        Becomes:
+            spy_a_b_c$foo
+        """
         modname = self.modname.replace('.', '_')
-        cn = f'spy_{modname}__{self.attr}'
+        cn = f'spy_{modname}${self.attr}'
         if self.suffix != '':
-            cn += '__' + self.suffix
+            cn += '$' + self.suffix
         return cn
 
     @property

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -1,41 +1,46 @@
+"""
+(Fully) Qualified Names in SPy.
+
+A Qualified Name (QN) identifies a function or a class inside a namespace.
+
+A Fully Qualified Name (FQN) identifies an *unique* named object inside the
+current VM.
+
+The difference between QNs and FQNs becomes apparent for example with
+closures:
+
+@blue
+def make_fn(T):
+    def fn(x: T) -> T:
+        # QN is 'test::fn'
+        return ...
+    return fn
+
+fn_i32 = make_fn(i32)  # QN is 'test::fn', FQN is 'test::fn#1'
+fn_f64 = make_fn(f64)  # QN is 'test::fn', FQN is 'test::fn#2'
+
+Note that the QN is a property of the object, while the FQN basically
+identifies a global symbol.
+
+QN are formated as 'modname::attr', where 'modname' can be composed of
+multiple parts separated by dots (e.g. 'a.b.c').
+
+FQNs are formatted as 'modname::attr#suffix'.
+
+See also SPyVM.get_unique_FQN().
+"""
+
 from typing import Optional, Any
 
-class FQN:
-    """
-    Fully qualified name.
-
-    A FQN uniquely identify a named object inside the current VM. It is
-    formated as 'modname::attr', where 'modname' can be composed of multiple
-    parts separated by dots (e.g. 'a.b.c').
-
-    In some cases we might want to generate two FQN with the same
-    'modname::attr' part, but we still want them to be unique. In those cases,
-    we attach an uniq_suffix to them, and the FQN is formatted as
-    'modname::attr#suffix', e.g. 'test::foo#42'.
-
-    This hapens for example with closures:
-
-    @blue
-    def make_fn(T):
-        def fn(x: T) -> T:
-            return ...
-        return fn
-
-    fn_i32 = make_fn(i32)  # fqn is 'test::foo#1'
-    fn_f64 = make_fn(f64)  # fqn is 'test::foo#2'
-
-    See also SPyVM.get_unique_FQN().
-    """
+class QN:
     modname: str
     attr: str
-    uniq_suffix: str
 
     def __init__(self,
                  fullname: Optional[str] = None,
                  *,
                  modname: Optional[str] = None,
                  attr: Optional[str] = None,
-                 uniq_suffix: str = '',
                  ) -> None:
         if fullname is None:
             assert modname is not None
@@ -48,7 +53,55 @@ class FQN:
         #
         self.modname = modname
         self.attr = attr
-        self.uniq_suffix = uniq_suffix
+
+    def __repr__(self) -> str:
+        return f"QN({self.fullname!r})"
+
+    def __str__(self) -> str:
+        return self.fullname
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, QN):
+            return NotImplemented
+        return self.fullname == other.fullname
+
+    def __hash__(self) -> int:
+        return hash(self.fullname)
+
+    def is_module(self) -> bool:
+        return self.attr == ""
+
+    def is_object(self) -> bool:
+        return self.attr != ""
+
+    @property
+    def fullname(self) -> str:
+        return f'{self.modname}::{self.attr}'
+
+
+class FQN:
+    modname: str
+    attr: str
+    suffix: str
+
+    def __init__(self, *args, **kwargs):
+        raise ValueError("You cannot instantiate an FQN directly. "
+                         "Please use vm.get_FQN()")
+
+    @classmethod
+    def make(cls, modname: str, attr: str, suffix: str) -> 'FQN':
+        obj = cls.__new__(cls)
+        obj.modname = modname
+        obj.attr = attr
+        obj.suffix = suffix
+        return obj
+
+    @property
+    def fullname(self) -> str:
+        s = f'{self.modname}::{self.attr}'
+        if self.suffix != '':
+            s += '#' + self.suffix
+        return s
 
     def __repr__(self) -> str:
         return f"FQN({self.fullname!r})"
@@ -64,25 +117,12 @@ class FQN:
     def __hash__(self) -> int:
         return hash(self.fullname)
 
-    def is_module(self) -> bool:
-        return self.attr == ""
-
-    def is_object(self) -> bool:
-        return self.attr != ""
-
-    @property
-    def fullname(self) -> str:
-        fn = f'{self.modname}::{self.attr}'
-        if self.uniq_suffix != '':
-            fn += '#' + self.uniq_suffix
-        return fn
-
     @property
     def c_name(self) -> str:
         modname = self.modname.replace('.', '_')
         cn = f'spy_{modname}__{self.attr}'
-        if self.uniq_suffix != '':
-            cn += '__' + self.uniq_suffix
+        if self.suffix != '':
+            cn += '__' + self.suffix
         return cn
 
     @property

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -90,6 +90,16 @@ class FQN:
         obj.suffix = suffix
         return obj
 
+    @classmethod
+    def make_global(cls, modname: str, attr: str) -> 'FQN':
+        """
+        Return the FQN corresponding to a global name.
+
+        Until we have generics, global names are supposed to be unique, so we
+        can just use suffix=""
+        """
+        return cls.make(modname, attr, suffix="")
+
     @property
     def fullname(self) -> str:
         s = f'{self.modname}::{self.attr}'

--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -1,7 +1,7 @@
 import py
 from spy import ast
 from spy.location import Loc
-from spy.fqn import FQN
+from spy.fqn import QN
 from spy.irgen.scope import ScopeAnalyzer
 from spy.irgen.symtable import SymTable
 from spy.errors import SPyTypeError
@@ -41,10 +41,10 @@ class ModuleGen:
         #
         # Synthesize and execute the fake '@module' function to populate the mod
         w_functype = W_FuncType.parse('def() -> void')
-        fqn = FQN(modname=self.modname, attr='@module')
+        qn = QN(modname=self.modname, attr='@module')
         modinit_funcdef = self.make_modinit()
         closure = ()
-        w_INIT = W_ASTFunc(w_functype, fqn, modinit_funcdef, closure)
+        w_INIT = W_ASTFunc(w_functype, qn, modinit_funcdef, closure)
         frame = ASTFrame(self.vm, w_INIT)
         #
         for decl in self.mod.decls:
@@ -83,7 +83,7 @@ class ModuleGen:
         frame.exec_stmt_FuncDef(funcdef)
         w_func = frame.load_local(funcdef.name)
         assert isinstance(w_func, W_ASTFunc)
-        fqn = w_func.fqn
+        fqn = self.vm.get_FQN(w_func.qn, is_global=True)
         self.vm.add_global(fqn, None, w_func)
 
     def gen_GlobalVarDef(self, frame: ASTFrame, decl: ast.GlobalVarDef) -> None:

--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -89,8 +89,8 @@ class ModuleGen:
     def gen_GlobalVarDef(self, frame: ASTFrame, decl: ast.GlobalVarDef) -> None:
         vardef = decl.vardef
         assign = decl.assign
-        fqn = self.vm.get_unique_FQN(modname=self.modname, attr=vardef.name,
-                                     is_global=True)
+        fqn = self.vm.get_FQN(QN(modname=self.modname, attr=vardef.name),
+                              is_global=True)
         if isinstance(vardef.type, ast.Auto):
             # type inference
             w_val = frame.eval_expr(assign.value)

--- a/spy/irgen/scope.py
+++ b/spy/irgen/scope.py
@@ -118,7 +118,12 @@ class ScopeAnalyzer:
 
         if fqn is None and self.scope is self.mod_scope:
             # this is a module-level global. Let's give it a FQN
-            fqn = FQN(modname=self.mod_scope.name, attr=name)
+            #
+            # XXX this is not completely correct: in theory, it's up to the VM
+            # to compute the FQN: here we assume that it will use suffix=""
+            # for this module-level global, which is true for now, but it
+            # might not be in the future.
+            fqn = FQN.make(modname=self.mod_scope.name, attr=name, suffix="")
 
         sym = Symbol(name, color, loc=loc, type_loc=type_loc, fqn=fqn, level=0)
         self.scope.add(sym)

--- a/spy/irgen/scope.py
+++ b/spy/irgen/scope.py
@@ -118,12 +118,7 @@ class ScopeAnalyzer:
 
         if fqn is None and self.scope is self.mod_scope:
             # this is a module-level global. Let's give it a FQN
-            #
-            # XXX this is not completely correct: in theory, it's up to the VM
-            # to compute the FQN: here we assume that it will use suffix=""
-            # for this module-level global, which is true for now, but it
-            # might not be in the future.
-            fqn = FQN.make(modname=self.mod_scope.name, attr=name, suffix="")
+            fqn = FQN.make_global(modname=self.mod_scope.name, attr=name)
 
         sym = Symbol(name, color, loc=loc, type_loc=type_loc, fqn=fqn, level=0)
         self.scope.add(sym)

--- a/spy/libspy/include/spy/builtins.h
+++ b/spy/libspy/include/spy/builtins.h
@@ -4,6 +4,6 @@
 #include "spy.h"
 
 int32_t
-WASM_EXPORT(spy_builtins__abs)(int32_t x);
+WASM_EXPORT(spy_builtins$abs)(int32_t x);
 
 #endif /* SPY_BUILTIS_H */

--- a/spy/libspy/include/spy/rawbuffer.h
+++ b/spy/libspy/include/spy/rawbuffer.h
@@ -14,7 +14,7 @@ typedef struct {
 } spy_RawBuffer;
 
 static inline spy_RawBuffer *
-spy_rawbuffer__rb_alloc(size_t length) {
+spy_rawbuffer$rb_alloc(size_t length) {
     size_t size = sizeof(spy_RawBuffer) + length;
     spy_RawBuffer *rb = (spy_RawBuffer *)spy_GcAlloc(size).p;
     rb->length = length;
@@ -22,25 +22,25 @@ spy_rawbuffer__rb_alloc(size_t length) {
 }
 
 static inline void
-spy_rawbuffer__rb_set_i32(spy_RawBuffer *rb, int32_t offset, int32_t val) {
+spy_rawbuffer$rb_set_i32(spy_RawBuffer *rb, int32_t offset, int32_t val) {
     int32_t *p = (int32_t *)(rb->buf + offset);
     *p = val;
 }
 
 static inline int32_t
-spy_rawbuffer__rb_get_i32(spy_RawBuffer *rb, int32_t offset) {
+spy_rawbuffer$rb_get_i32(spy_RawBuffer *rb, int32_t offset) {
     int32_t *p = (int32_t *)(rb->buf + offset);
     return *p;
 }
 
 static inline void
-spy_rawbuffer__rb_set_f64(spy_RawBuffer *rb, int32_t offset, double val) {
+spy_rawbuffer$rb_set_f64(spy_RawBuffer *rb, int32_t offset, double val) {
     double *p = (double *)(rb->buf + offset);
     *p = val;
 }
 
 static inline double
-spy_rawbuffer__rb_get_f64(spy_RawBuffer *rb, int32_t offset) {
+spy_rawbuffer$rb_get_f64(spy_RawBuffer *rb, int32_t offset) {
     double *p = (double *)(rb->buf + offset);
     return *p;
 }

--- a/spy/libspy/include/spy/str.h
+++ b/spy/libspy/include/spy/str.h
@@ -30,10 +30,10 @@ spy_str_ne(spy_Str *a, spy_Str *b) {
 spy_Str *
 WASM_EXPORT(spy_str_getitem)(spy_Str *s, int32_t i);
 
-#define spy_operator__str_add spy_str_add
-#define spy_operator__str_mul spy_str_mul
-#define spy_operator__str_eq  spy_str_eq
-#define spy_operator__str_ne  spy_str_ne
-#define spy_operator__str_getitem spy_str_getitem
+#define spy_operator$str_add spy_str_add
+#define spy_operator$str_mul spy_str_mul
+#define spy_operator$str_eq  spy_str_eq
+#define spy_operator$str_ne  spy_str_ne
+#define spy_operator$str_getitem spy_str_getitem
 
 #endif /* SPY_STR_H */

--- a/spy/libspy/src/builtins.c
+++ b/spy/libspy/src/builtins.c
@@ -1,7 +1,7 @@
 #include "spy.h"
 
 int32_t
-spy_builtins__abs(int32_t x) {
+spy_builtins$abs(int32_t x) {
     if (x < 0)
         return -x;
     return x;

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -170,7 +170,7 @@ class Parser:
                            py_imp: py_ast.ImportFrom) -> list[spy.ast.Import]:
         res = []
         for py_alias in py_imp.names:
-            fqn = FQN(modname=py_imp.module, attr=py_alias.name)
+            fqn = FQN.make(modname=py_imp.module, attr=py_alias.name, suffix="")
             asname = py_alias.asname or py_alias.name
             res.append(spy.ast.Import(
                 loc = py_imp.loc,
@@ -183,7 +183,7 @@ class Parser:
     def from_py_Import(self, py_imp: py_ast.Import) -> list[spy.ast.Import]:
         res = []
         for py_alias in py_imp.names:
-            fqn = FQN(modname=py_alias.name, attr="")
+            fqn = FQN.make_global(modname=py_alias.name, attr="")
             asname = py_alias.asname or py_alias.name
             res.append(spy.ast.Import(
                 loc = py_imp.loc,

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -170,6 +170,7 @@ class Parser:
                            py_imp: py_ast.ImportFrom) -> list[spy.ast.Import]:
         res = []
         for py_alias in py_imp.names:
+            assert py_imp.module is not None
             fqn = FQN.make(modname=py_imp.module, attr=py_alias.name, suffix="")
             asname = py_alias.asname or py_alias.name
             res.append(spy.ast.Import(

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -599,7 +599,8 @@ class TestBasic(CompilerTest):
         """)
         vm = self.vm
         assert mod.x == 7
-        w_xtype = self.vm.globals_types[FQN("test::x")]
+        fqn = FQN.make_global("test", "x")
+        w_xtype = self.vm.globals_types[fqn]
         assert w_xtype is B.w_i32
 
     def test_getattr_module(self):

--- a/spy/tests/compiler/test_operator_attr.py
+++ b/spy/tests/compiler/test_operator_attr.py
@@ -1,5 +1,5 @@
 import pytest
-from spy.fqn import FQN
+from spy.fqn import QN
 from spy.vm.b import B
 from spy.vm.object import spytype, Member, Annotated
 from spy.vm.function import spy_builtin
@@ -58,12 +58,12 @@ class TestAttrOp(CompilerTest):
                            w_attr: W_Str) -> W_Dynamic:
                 attr = vm.unwrap_str(w_attr)
                 if attr == 'x':
-                    @spy_builtin(FQN('ext::getx'))
+                    @spy_builtin(QN('ext::getx'))
                     def opimpl(vm: 'SPyVM', w_obj: W_MyClass,
                                     w_attr: W_Str) -> W_I32:
                         return vm.wrap(w_obj.x)  # type: ignore
                 else:
-                    @spy_builtin(FQN('ext::getany'))
+                    @spy_builtin(QN('ext::getany'))
                     def opimpl(vm: 'SPyVM', w_obj: W_MyClass,
                                       w_attr: W_Str) -> W_Str:
                         attr = vm.unwrap_str(w_attr)
@@ -75,7 +75,7 @@ class TestAttrOp(CompilerTest):
                            w_vtype: W_Type) -> W_Dynamic:
                 attr = vm.unwrap_str(w_attr)
                 if attr == 'x':
-                    @spy_builtin(FQN('ext::setx'))
+                    @spy_builtin(QN('ext::setx'))
                     def opimpl(vm: 'SPyVM', w_obj: W_MyClass,
                                w_attr: W_Str, w_val: W_I32) -> W_Void:
                         w_obj.x = vm.unwrap_i32(w_val)

--- a/spy/tests/compiler/test_typedef.py
+++ b/spy/tests/compiler/test_typedef.py
@@ -1,7 +1,7 @@
 import re
 import pytest
 from spy.errors import SPyTypeError
-from spy.fqn import FQN
+from spy.fqn import QN
 from spy.vm.b import B
 from spy.vm.function import W_ASTFunc
 from spy.vm.modules.types import W_TypeDef
@@ -61,7 +61,7 @@ class TestTypeDef(CompilerTest):
         assert isinstance(w_MyInt, W_TypeDef)
         w_getattr = w_MyInt.w_getattr
         assert isinstance(w_getattr, W_ASTFunc)
-        assert w_getattr.fqn == FQN("test::__getattr__#0")
+        assert w_getattr.qn == QN("test::__getattr__")
         w_res = self.vm.call_function(w_getattr, [B.w_None])
         assert w_res is B.w_NotImplemented
 

--- a/spy/tests/test_backend_spy.py
+++ b/spy/tests/test_backend_spy.py
@@ -171,7 +171,7 @@ class TestSPyBackend(CompilerTest):
             for fqn, w_obj in mod.w_mod.items_w():
                 if isinstance(w_obj, W_ASTFunc):
                     try:
-                        b.dump_w_func(w_obj)
+                        b.dump_w_func(fqn, w_obj)
                     except NotImplementedError as exc:
                         print(src)
                         pytest.fail(str(exc))

--- a/spy/tests/test_fqn.py
+++ b/spy/tests/test_fqn.py
@@ -1,51 +1,64 @@
 import pytest
-from spy.fqn import FQN
+from spy.fqn import QN, FQN
 
-def test_init_fullname():
-    a = FQN("a.b.c::xxx")
+def test_QN_init_fullname():
+    a = QN("a.b.c::xxx")
     assert a.fullname == "a.b.c::xxx"
     assert a.modname == "a.b.c"
     assert a.attr == "xxx"
 
-def test_init_parts():
-    a = FQN(modname="a.b.c", attr="xxx")
+def test_QN_init_parts():
+    a = QN(modname="a.b.c", attr="xxx")
     assert a.fullname == "a.b.c::xxx"
     assert a.modname == "a.b.c"
     assert a.attr == "xxx"
 
-def test_wrong_init():
+def test_QN_wrong_init():
     with pytest.raises(AssertionError):
-        FQN("aaa")
+        QN("aaa")
     with pytest.raises(AssertionError):
-        FQN("aaa::bbb::ccc")
+        QN("aaa::bbb::ccc")
     with pytest.raises(AssertionError):
-        FQN("aaa::bbb", modname="aaa")
+        QN("aaa::bbb", modname="aaa")
     with pytest.raises(AssertionError):
-        FQN("aaa::bbb", attr="bbb")
+        QN("aaa::bbb", attr="bbb")
     with pytest.raises(AssertionError):
-        FQN()
+        QN()
     with pytest.raises(AssertionError):
-        FQN(modname="aaa")
+        QN(modname="aaa")
 
-def test_str_repr():
-    fqn = FQN("aaa::bbb")
-    assert repr(fqn) == "FQN('aaa::bbb')"
-    assert str(fqn) == 'aaa::bbb'
+def test_QN_str_repr():
+    a = QN("aaa::bbb")
+    assert repr(a) == "QN('aaa::bbb')"
+    assert str(a) == 'aaa::bbb'
 
-def test_hash_eq():
-    a = FQN("aaa::bbb")
-    b = FQN("aaa::bbb")
+def test_QN_hash_eq():
+    a = QN("aaa::bbb")
+    b = QN("aaa::bbb")
     assert a == b
     assert hash(a) == hash(b)
 
-def test_c_name():
-    a = FQN("a.b.c::xxx")
-    assert a.c_name == "spy_a_b_c__xxx"
+def test_FQN():
+    a = FQN.make("aaa", "bbb", suffix="0")
+    assert a.modname == "aaa"
+    assert a.attr == "bbb"
+    assert a.suffix == "0"
+    assert a.fullname == "aaa::bbb#0"
 
-def test_uniq_suffix():
-    a = FQN("aaa::bbb", uniq_suffix='0')
+def test_FQN_str():
+    a = FQN.make("aaa", "bbb", suffix='0')
     assert str(a) == "aaa::bbb#0"
     assert a.c_name == "spy_aaa__bbb__0"
-    b = FQN(modname="aaa", attr="bbb", uniq_suffix='i32')
-    assert str(b) == "aaa::bbb#i32"
-    assert b.c_name == "spy_aaa__bbb__i32"
+    b = FQN.make("aaa", "bbb", suffix='')
+    assert str(b) == "aaa::bbb"
+    assert b.c_name == "spy_aaa__bbb"
+
+def test_FQN_hash_eq():
+    a = FQN.make("aaa", "bbb", suffix="0")
+    b = FQN.make("aaa", "bbb", suffix="0")
+    assert a == b
+    assert hash(a) == hash(b)
+
+def test_FQN_c_name_dotted():
+    a = FQN.make("a.b.c", "xxx", suffix="0")
+    assert a.c_name == "spy_a_b_c__xxx__0"

--- a/spy/tests/test_fqn.py
+++ b/spy/tests/test_fqn.py
@@ -62,3 +62,14 @@ def test_FQN_hash_eq():
 def test_FQN_c_name_dotted():
     a = FQN.make("a.b.c", "xxx", suffix="0")
     assert a.c_name == "spy_a_b_c__xxx__0"
+
+def test_FQN_parse():
+    fqn = FQN.parse("aaa::bbb")
+    assert fqn.modname == "aaa"
+    assert fqn.attr == "bbb"
+    assert fqn.suffix == ""
+    #
+    fqn = FQN.parse("aaa::bbb#0")
+    assert fqn.modname == "aaa"
+    assert fqn.attr == "bbb"
+    assert fqn.suffix == "0"

--- a/spy/tests/test_fqn.py
+++ b/spy/tests/test_fqn.py
@@ -48,10 +48,10 @@ def test_FQN():
 def test_FQN_str():
     a = FQN.make("aaa", "bbb", suffix='0')
     assert str(a) == "aaa::bbb#0"
-    assert a.c_name == "spy_aaa__bbb__0"
+    assert a.c_name == "spy_aaa$bbb$0"
     b = FQN.make("aaa", "bbb", suffix='')
     assert str(b) == "aaa::bbb"
-    assert b.c_name == "spy_aaa__bbb"
+    assert b.c_name == "spy_aaa$bbb"
 
 def test_FQN_hash_eq():
     a = FQN.make("aaa", "bbb", suffix="0")
@@ -61,7 +61,7 @@ def test_FQN_hash_eq():
 
 def test_FQN_c_name_dotted():
     a = FQN.make("a.b.c", "xxx", suffix="0")
-    assert a.c_name == "spy_a_b_c__xxx__0"
+    assert a.c_name == "spy_a_b_c$xxx$0"
 
 def test_FQN_parse():
     fqn = FQN.parse("aaa::bbb")

--- a/spy/tests/test_scope.py
+++ b/spy/tests/test_scope.py
@@ -165,7 +165,8 @@ class TestScopeAnalyzer:
         """)
         scope = scopes.by_module()
         assert scope._symbols == {
-            'my_int': MatchSymbol('my_int', 'blue', fqn=FQN('builtins::i32')),
+            'my_int': MatchSymbol('my_int', 'blue',
+                                  fqn=FQN.parse('builtins::i32')),
         }
 
     def test_import_wrong_attribute(self):

--- a/spy/tests/vm/test_function.py
+++ b/spy/tests/vm/test_function.py
@@ -2,7 +2,7 @@ import pytest
 from spy.vm.vm import SPyVM
 from spy.vm.b import B
 from spy.vm.w import W_FuncType, W_I32, W_BuiltinFunc, W_Dynamic
-from spy.fqn import FQN
+from spy.fqn import FQN, QN
 from spy.vm.function import W_FuncType, spy_builtin
 
 class TestFunction:
@@ -28,7 +28,7 @@ class TestFunction:
     def test_spy_builtin(self):
         vm = SPyVM()
 
-        @spy_builtin(FQN('test::foo'))
+        @spy_builtin(QN('test::foo'))
         def foo(vm: 'SPyVM', w_x: W_I32) -> W_I32:
             x = vm.unwrap_i32(w_x)
             return vm.wrap(x*2)  # type: ignore
@@ -38,36 +38,36 @@ class TestFunction:
 
         w_foo = vm.wrap(foo)
         assert isinstance(w_foo, W_BuiltinFunc)
-        assert w_foo.fqn == FQN('test::foo')
+        assert w_foo.qn == QN('test::foo')
         w_y = vm.call_function(w_foo, [vm.wrap(10)])
         assert vm.unwrap_i32(w_y) == 20
 
     def test_spy_builtin_errors(self):
         with pytest.raises(ValueError,
                            match="The first param should be 'vm: SPyVM'."):
-            @spy_builtin(FQN('test::foo'))
+            @spy_builtin(QN('test::foo'))
             def foo() -> W_I32:  # type: ignore
                 pass
 
         with pytest.raises(ValueError,
                            match="The first param should be 'vm: SPyVM'."):
-            @spy_builtin(FQN('test::foo'))
+            @spy_builtin(QN('test::foo'))
             def foo(w_x: W_I32) -> W_I32:  # type: ignore
                 pass
 
         with pytest.raises(ValueError, match="Invalid param: 'x: int'"):
-            @spy_builtin(FQN('test::foo'))
+            @spy_builtin(QN('test::foo'))
             def foo(vm: 'SPyVM', x: int) -> W_I32:  # type: ignore
                 pass
 
         with pytest.raises(ValueError, match="Invalid return type"):
-            @spy_builtin(FQN('test::foo'))
+            @spy_builtin(QN('test::foo'))
             def foo(vm: 'SPyVM') -> int:  # type: ignore
                 pass
 
     def test_spy_builtin_dynamic(self):
         vm = SPyVM()
-        @spy_builtin(FQN('test::foo'))
+        @spy_builtin(QN('test::foo'))
         def foo(vm: 'SPyVM', w_x: W_Dynamic) -> W_Dynamic:  # type: ignore
             pass
         assert foo.w_functype.name == 'def(x: dynamic) -> dynamic'

--- a/spy/tests/vm/test_module.py
+++ b/spy/tests/vm/test_module.py
@@ -11,8 +11,8 @@ class TestModule:
         w_mod = W_Module(vm, 'mymod', 'mymod.spy')
         vm.register_module(w_mod)
         #
-        fqn_a = FQN('mymod::a')
-        fqn_b = FQN('mymod::b')
+        fqn_a = FQN.make('mymod', 'a', '')
+        fqn_b = FQN.make('mymod', 'b', '')
         w_a = vm.wrap(10)
         w_b = vm.wrap(20)
         vm.add_global(fqn_a, B.w_i32, w_a)

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -177,6 +177,9 @@ class TestVM:
             vm.call_function(w_abs, [w_x])
 
     def test_get_unique_FQN(self):
+        import pdb;pdb.set_trace()
+        XXX
+
         vm = SPyVM()
         w_mod = W_Module(vm, "test", "...")
         vm.register_module(w_mod)

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -181,12 +181,10 @@ class TestVM:
         w_mod = W_Module(vm, "test", "...")
         vm.register_module(w_mod)
         #
-        # the first global is "plain" (suffix=="")
         a = vm.get_FQN(QN("test::a"), is_global=True)
         assert a.fullname == "test::a"
-        # but if we add a conflicting global, we need to add a suffix
-        a1 = vm.get_FQN(QN("test::a"), is_global=True)
-        assert a1.fullname == "test::a#1"
+        with pytest.raises(AssertionError):
+            vm.get_FQN(QN("test::a"), is_global=True)
         #
         # for non-globals, we always put a suffix
         b0 = vm.get_FQN(QN("test::b"), is_global=False)

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -2,7 +2,7 @@ import fixedint
 import pytest
 from spy.vm.vm import SPyVM
 from spy.vm.b import B
-from spy.fqn import FQN
+from spy.fqn import QN, FQN
 from spy.errors import SPyTypeError
 from spy.vm.object import W_Object, W_Type, spytype, W_Void, W_I32, W_Bool
 from spy.vm.str import W_Str
@@ -176,26 +176,23 @@ class TestVM:
         with pytest.raises(SPyTypeError, match=msg):
             vm.call_function(w_abs, [w_x])
 
-    def test_get_unique_FQN(self):
-        import pdb;pdb.set_trace()
-        XXX
-
+    def test_get_FQN(self):
         vm = SPyVM()
         w_mod = W_Module(vm, "test", "...")
         vm.register_module(w_mod)
         #
-        a = vm.get_unique_FQN(modname="test", attr="a", is_global=True)
-        assert a == FQN("test::a")
+        # the first global is "plain" (suffix=="")
+        a = vm.get_FQN(QN("test::a"), is_global=True)
+        assert a.fullname == "test::a"
+        # but if we add a conflicting global, we need to add a suffix
+        a1 = vm.get_FQN(QN("test::a"), is_global=True)
+        assert a1.fullname == "test::a#1"
         #
-        with pytest.raises(AssertionError):
-            vm.get_unique_FQN(modname="test", attr="a", is_global=True)
-        #
-        b0 = vm.get_unique_FQN(modname="test", attr="b", is_global=False)
-        assert b0 == FQN("test::b", uniq_suffix="0")
-        assert str(b0) == "test::b#0"
-        b1 = vm.get_unique_FQN(modname="test", attr="b", is_global=False)
-        assert b1 == FQN("test::b", uniq_suffix='1')
-        assert str(b1) == "test::b#1"
+        # for non-globals, we always put a suffix
+        b0 = vm.get_FQN(QN("test::b"), is_global=False)
+        assert b0.fullname == "test::b#0"
+        b1 = vm.get_FQN(QN("test::b"), is_global=False)
+        assert b1.fullname == "test::b#1"
 
     def test_eq(self):
         vm = SPyVM()

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Any, Optional, NoReturn
 from types import NoneType
 from dataclasses import dataclass
 from spy import ast
-from spy.fqn import FQN
+from spy.fqn import FQN, QN
 from spy.location import Loc
 from spy.errors import (SPyRuntimeAbort, SPyTypeError, SPyNameError,
                         SPyRuntimeError, maybe_plural)
@@ -123,16 +123,11 @@ class ASTFrame:
         self.t.lazy_check_FuncDef(funcdef, w_functype)
         #
         # create the w_func
-
-        # if the current func is '@module', then we are creating a module-level
-        # global. Else, it's a closure
-        is_global = self.w_func.fqn.attr == '@module'
-        modname = self.w_func.fqn.modname # the module of the "outer" function
-        fqn = self.vm.get_unique_FQN(modname=modname, attr=funcdef.name,
-                                     is_global=is_global)
+        modname = self.w_func.qn.modname # the module of the "outer" function
+        qn = QN(modname=modname, attr=funcdef.name)
         # XXX we should capture only the names actually used in the inner func
         closure = self.w_func.closure + (self._locals,)
-        w_func = W_ASTFunc(w_functype, fqn, funcdef, closure)
+        w_func = W_ASTFunc(w_functype, qn, funcdef, closure)
         self.store_local(funcdef.name, w_func)
 
     def exec_stmt_VarDef(self, vardef: ast.VarDef) -> None:

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -39,7 +39,7 @@ class ASTFrame:
         self.t = TypeChecker(vm, self.w_func)
 
     def __repr__(self) -> str:
-        return f'<ASTFrame for {self.w_func.fqn}>'
+        return f'<ASTFrame for {self.w_func.qn}>'
 
     def store_local(self, name: str, w_value: W_Object) -> None:
         self._locals[name] = w_value

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -3,7 +3,7 @@ import inspect
 from typing import TYPE_CHECKING, Any, Optional, Callable
 from spy import ast
 from spy.ast import Color
-from spy.fqn import FQN
+from spy.fqn import QN, FQN
 from spy.vm.object import W_Object, W_Type, W_Dynamic, w_DynamicType
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -94,7 +94,6 @@ class W_FuncType(W_Type):
 
 class W_Func(W_Object):
     w_functype: W_FuncType
-    fqn: Optional[FQN]
 
     @property
     def color(self) -> Color:
@@ -163,23 +162,23 @@ class W_BuiltinFunc(W_Func):
     Builtin functions are implemented by calling an interp-level function
     (written in Python).
     """
-    fqn: FQN
+    qn: QN
     pyfunc: Callable
 
-    def __init__(self, w_functype: W_FuncType, fqn: FQN,
+    def __init__(self, w_functype: W_FuncType, qn: QN,
                  pyfunc: Callable) -> None:
         self.w_functype = w_functype
-        self.fqn = fqn
+        self.qn = qn
         self.pyfunc = pyfunc
 
     def __repr__(self) -> str:
-        return f"<spy function '{self.fqn}' (builtin)>"
+        return f"<spy function '{self.qn}' (builtin)>"
 
     def spy_call(self, vm: 'SPyVM', args_w: list[W_Object]) -> W_Object:
         return self.pyfunc(vm, *args_w)
 
 
-def spy_builtin(fqn: FQN) -> Callable:
+def spy_builtin(qn: QN) -> Callable:
     # this is B.w_dynamic (we cannot use B due to circular imports)
     B_w_dynamic = w_DynamicType
 
@@ -221,7 +220,7 @@ def spy_builtin(fqn: FQN) -> Callable:
             raise ValueError(f"Invalid return type: '{sig.return_annotation}'")
 
         w_functype = W_FuncType(func_params, w_restype)
-        fn._w = W_BuiltinFunc(w_functype, fqn, fn)  # type: ignore
+        fn._w = W_BuiltinFunc(w_functype, qn, fn)  # type: ignore
         fn.w_functype = w_functype  # type: ignore
         return fn
 

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -117,7 +117,7 @@ class W_Func(W_Object):
 
 
 class W_ASTFunc(W_Func):
-    fqn: FQN
+    qn: QN
     funcdef: ast.FuncDef
     closure: tuple[Namespace, ...]
     # types of local variables: this is non-None IIF the function has been
@@ -126,14 +126,14 @@ class W_ASTFunc(W_Func):
 
     def __init__(self,
                  w_functype: W_FuncType,
-                 fqn: FQN,
+                 qn: QN,
                  funcdef: ast.FuncDef,
                  closure: tuple[Namespace, ...],
                  *,
                  locals_types_w: Optional[dict[str, W_Type]] = None
                  ) -> None:
         self.w_functype = w_functype
-        self.fqn = fqn
+        self.qn = qn
         self.funcdef = funcdef
         self.closure = closure
         self.locals_types_w = locals_types_w
@@ -149,7 +149,7 @@ class W_ASTFunc(W_Func):
             extra = ' (blue)'
         else:
             extra = ''
-        return f"<spy function '{self.fqn}'{extra}>"
+        return f"<spy function '{self.qn}'{extra}>"
 
     def spy_call(self, vm: 'SPyVM', args_w: list[W_Object]) -> W_Object:
         from spy.vm.astframe import ASTFrame

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -1,5 +1,5 @@
 from typing import TYPE_CHECKING, Optional, Iterable
-from spy.fqn import FQN
+from spy.fqn import QN, FQN
 from spy.vm.b import B
 from spy.vm.object import W_Object, spytype, W_Type, W_Dynamic, W_Void
 from spy.vm.str import W_Str
@@ -38,7 +38,7 @@ class W_Module(W_Object):
         all the module getattrs are done in blue contexts are redshifted
         away.
         """
-        @spy_builtin(FQN('builtins::module_getattr'))
+        @spy_builtin(QN('builtins::module_getattr'))
         def opimpl(vm: 'SPyVM', w_mod: W_Module, w_attr: W_Str) -> W_Dynamic:
             attr = vm.unwrap_str(w_attr)
             return w_mod.getattr(attr)
@@ -48,7 +48,7 @@ class W_Module(W_Object):
     @staticmethod
     def op_SETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str,
                    w_vtype: W_Type) -> W_Dynamic:
-        @spy_builtin(FQN('builtins::module_setattr'))
+        @spy_builtin(QN('builtins::module_setattr'))
         def opimpl(vm: 'SPyVM', w_mod: W_Module, w_attr:
                    W_Str, w_val: W_Dynamic) -> W_Void:
             attr = vm.unwrap_str(w_attr)
@@ -75,7 +75,7 @@ class W_Module(W_Object):
 
     def setattr(self, attr: str, w_value: W_Object) -> None:
         # XXX we should raise an exception if the attr doesn't exist
-        fqn = FQN(modname=self.name, attr=attr)
+        fqn = FQN.make_global(modname=self.name, attr=attr)
         self.vm.store_global(fqn, w_value)
 
     def keys(self) -> Iterable[FQN]:

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -59,7 +59,7 @@ class W_Module(W_Object):
     # ==== public interp-level API ====
 
     def getattr_maybe(self, attr: str) -> Optional[W_Object]:
-        fqn = FQN.make(modname=self.name, attr=attr, suffix="")
+        fqn = FQN.make_global(modname=self.name, attr=attr)
         return self.vm.lookup_global(fqn)
 
     def getattr(self, attr: str) -> W_Object:

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -59,7 +59,7 @@ class W_Module(W_Object):
     # ==== public interp-level API ====
 
     def getattr_maybe(self, attr: str) -> Optional[W_Object]:
-        fqn = FQN(modname=self.name, attr=attr)
+        fqn = FQN.make(modname=self.name, attr=attr, suffix="")
         return self.vm.lookup_global(fqn)
 
     def getattr(self, attr: str) -> W_Object:

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -17,7 +17,7 @@ PY_PRINT = print  # type: ignore
 @BUILTINS.builtin
 def abs(vm: 'SPyVM', w_x: W_I32) -> W_I32:
     x = vm.unwrap_i32(w_x)
-    res = vm.ll.call('spy_builtins__abs', x)
+    res = vm.ll.call('spy_builtins$abs', x)
     return vm.wrap(res) # type: ignore
 
 @BUILTINS.builtin

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -1,5 +1,5 @@
 from typing import TYPE_CHECKING, Literal, no_type_check
-from spy.fqn import FQN
+from spy.fqn import QN
 from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type, W_Dynamic, W_Void
 from spy.vm.module import W_Module
@@ -72,24 +72,20 @@ def opimpl_member(kind: OpKind, vm: 'SPyVM', w_type: W_Type,
     W_Value = member.w_type.pyclass
     field = member.field # the interp-level name of the attr (e.g, 'w_x')
 
-    # XXX FQN is wrong because it uses the type name as the modname. We
-    # need to rethink how FQNs are computed
+    # XXX QNs are slightly wrong because they uses the type name as the
+    # modname. We need to rethink how QNs are computed
 
     if kind == 'get':
-        fqn = FQN(modname=w_type.name, attr=f"__get_{attr}__")
-
         @no_type_check
-        @spy_builtin(fqn)
+        @spy_builtin(QN(modname=w_type.name, attr=f"__get_{attr}__"))
         def opimpl_get(vm: 'SPyVM', w_obj: W_Class, w_attr: W_Str) -> W_Value:
             return getattr(w_obj, field)
 
         return vm.wrap(opimpl_get)
 
     elif kind == 'set':
-        fqn = FQN(modname=w_type.name, attr=f"__set_{attr}__")
-
         @no_type_check
-        @spy_builtin(fqn)
+        @spy_builtin(QN(modname=w_type.name, attr=f"__set_{attr}__"))
         def opimpl_set(vm: 'SPyVM', w_obj: W_Class, w_attr: W_Str,
                        w_val: W_Value) -> W_Void:
             setattr(w_obj, field, w_val)

--- a/spy/vm/registry.py
+++ b/spy/vm/registry.py
@@ -1,6 +1,6 @@
 from typing import Callable, Optional, TYPE_CHECKING, Any
 from dataclasses import dataclass
-from spy.fqn import FQN
+from spy.fqn import QN
 from spy.vm.function import W_FuncType, W_BuiltinFunc, spy_builtin
 from spy.vm.object import W_Object
 
@@ -12,7 +12,7 @@ class ModuleRegistry:
     """
     modname: str
     filepath: str
-    content: list[tuple[FQN, W_Object]]
+    content: list[tuple[QN, W_Object]]
 
     def __init__(self, modname: str, filepath: str) -> None:
         self.modname = modname
@@ -35,16 +35,16 @@ class ModuleRegistry:
             """
 
     def add(self, attr: str, w_obj: W_Object) -> None:
-        fqn = FQN(modname=self.modname, attr=attr)
+        qn = QN(modname=self.modname, attr=attr)
         setattr(self, f'w_{attr}', w_obj)
-        self.content.append((fqn, w_obj))
+        self.content.append((qn, w_obj))
 
     def builtin(self, pyfunc: Callable) -> Callable:
         attr = pyfunc.__name__
-        fqn = FQN(modname=self.modname, attr=attr)
+        qn = QN(modname=self.modname, attr=attr)
         # apply the @spy_builtin decorator to pyfunc
-        spy_builtin(fqn)(pyfunc)
+        spy_builtin(qn)(pyfunc)
         w_func = pyfunc._w  # type: ignore
         setattr(self, f'w_{attr}', w_func)
-        self.content.append((fqn, w_func))
+        self.content.append((qn, w_func))
         return pyfunc

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -4,7 +4,7 @@ import itertools
 from dataclasses import dataclass
 from types import FunctionType
 import fixedint
-from spy.fqn import FQN
+from spy.fqn import QN, FQN
 from spy import libspy
 from spy.doppler import redshift
 from spy.errors import SPyTypeError
@@ -96,21 +96,24 @@ class SPyVM:
     def make_module(self, reg: ModuleRegistry) -> None:
         w_mod = W_Module(self, reg.modname, reg.filepath)
         self.register_module(w_mod)
-        for fqn, w_obj in reg.content:
+        for qn, w_obj in reg.content:
+            fqn = self.get_FQN(qn, is_global=True)
             w_type = self.dynamic_type(w_obj)
             self.add_global(fqn, w_type, w_obj)
 
-    def get_unique_FQN(self, *, modname: str, attr: str, is_global: bool) -> FQN:
-        # if it's a global, we can create a "plain" FQN (e.g. `test::hello`)
-        # which MUST be unique. If it's a closurwe, we attach a progressive ID
-        # to create an unique FQN (e.g., `test::hello#42`)
+    def get_FQN(self, qn: QN, *, is_global: bool) -> FQN:
+        # XXX write better
+        # if it's a global, we first try to create a "plain" FQN (i.e. without
+        # suffix, e.g. `test::hello`) which MUST be unique. If it's a
+        # closurwe, we always attach a progressive ID (e.g. `test::hello#42`)
         if is_global:
-            fqn = FQN(modname=modname, attr=attr)
+            # XXX what happens if we try to add the same global twice?
+            fqn = FQN.make(modname=qn.modname, attr=qn.attr, suffix="")
         else:
             # XXX this is potentially quadratic if we create tons of
             # conflicting FQNs, but for now we don't care
             for n in itertools.count():
-                fqn = FQN(modname=modname, attr=attr, uniq_suffix=str(n))
+                fqn = FQN(modname=modname, attr=attr, suffix=str(n))
                 if fqn not in self.unique_fqns:
                     break
         assert fqn not in self.unique_fqns
@@ -122,6 +125,7 @@ class SPyVM:
                    w_type: Optional[W_Type],
                    w_value: W_Object
                    ) -> None:
+        assert isinstance(fqn, FQN)
         assert fqn.modname in self.modules_w
         assert fqn not in self.globals_w
         assert fqn not in self.globals_types
@@ -133,9 +137,11 @@ class SPyVM:
         self.globals_w[fqn] = w_value
 
     def lookup_global_type(self, fqn: FQN) -> Optional[W_Type]:
+        assert isinstance(fqn, FQN)
         return self.globals_types.get(fqn)
 
     def lookup_global(self, fqn: FQN) -> Optional[W_Object]:
+        assert isinstance(fqn, FQN)
         if fqn.is_module():
             return self.modules_w.get(fqn.modname)
         else:
@@ -150,6 +156,7 @@ class SPyVM:
         return None
 
     def store_global(self, fqn: FQN, w_value: W_Object) -> None:
+        assert isinstance(fqn, FQN)
         w_type = self.globals_types[fqn]
         assert self.isinstance(w_value, w_type)
         self.globals_w[fqn] = w_value

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -116,6 +116,7 @@ class SPyVM:
         # conflicting FQNs, but for now we don't care
         for n in itertools.count():
             if is_global and n == 0:
+                # this needs to be kept in sync with FQN.make_global()
                 suffix = ""
             else:
                 suffix = str(n)

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -105,25 +105,22 @@ class SPyVM:
         """
         Get an unique FQN from a QN.
 
-        The algorithm is simple: to compute an unique suffix, we just
-        increment a numeric counter.
+        Module-level names are considered "global": their FQN will get an
+        empty suffix and must be unique. It is an error to try to "get_FQN()"
+        the same global twice.
 
-        is_global is needed only for cosmetic reasons: until we implement
-        generics, global functions are always unique anyway, so we can just
-        use an empty suffix and have a better name in the resulting C source.
+        For non globals (e.g., closures) the algorithm is simple: to compute
+        an unique suffix, we just increment a numeric counter.
         """
-        # XXX this is potentially quadratic if we create tons of
-        # conflicting FQNs, but for now we don't care
-        for n in itertools.count():
-            if is_global and n == 0:
-                # this needs to be kept in sync with FQN.make_global()
-                suffix = ""
-            else:
-                suffix = str(n)
-            fqn = FQN.make(modname=qn.modname, attr=qn.attr, suffix=suffix)
-            if fqn not in self.unique_fqns:
-                break
-
+        if is_global:
+            fqn = FQN.make_global(modname=qn.modname, attr=qn.attr)
+        else:
+            # XXX this is potentially quadratic if we create tons of
+            # conflicting FQNs, but for now we don't care
+            for n in itertools.count():
+                fqn = FQN.make(modname=qn.modname, attr=qn.attr, suffix=str(n))
+                if fqn not in self.unique_fqns:
+                    break
         assert fqn not in self.unique_fqns
         self.unique_fqns.add(fqn)
         return fqn


### PR DESCRIPTION
Split the old FQN into two different types:

A Qualified Name (QN) locates a function or class inside the source code, e.g. `test::foo`.
A Fully Qualified Name (FQN) can exists only in the context of a specific VM and must be unique. You can have multiple FQNs mapping to the same QN, e.g. in case of closures: `test::foo#0`, `test::foo#1`, etc.

Among the other things, this makes much easier to write OPERATORS at interp level, because now we can just return an interp-level closure with a QN, and the doppler will take care of turning it into an FQN when appropriate.
