### PR TITLE
Introduce the first rough implementation of list

### DIFF
--- a/spy/ast.py
+++ b/spy/ast.py
@@ -453,6 +453,13 @@ class SetAttr(Stmt):
     value: Expr
 
 @dataclass(eq=False)
+class SetItem(Stmt):
+    target_loc: Loc = field(repr=False)
+    target: Expr
+    index: Expr
+    value: Expr
+
+@dataclass(eq=False)
 class If(Stmt):
     test: Expr
     then_body: list[Stmt]

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -311,6 +311,14 @@ class Parser:
                 attr = py_target.attr,
                 value = self.from_py_expr(py_node.value)
             )
+        elif isinstance(py_target, py_ast.Subscript):
+            return spy.ast.SetItem(
+                loc = py_node.loc,
+                target_loc = py_target.value.loc,
+                target = self.from_py_expr(py_target.value),
+                index = self.from_py_expr(py_target.slice),
+                value = self.from_py_expr(py_node.value)
+            )
         else:
             self.unsupported(py_target, 'assign to complex expressions')
 

--- a/spy/tests/compiler/test_list.py
+++ b/spy/tests/compiler/test_list.py
@@ -1,0 +1,18 @@
+#-*- encoding: utf-8 -*-
+
+import pytest
+from spy.tests.support import CompilerTest, no_C
+
+@no_C
+class TestList(CompilerTest):
+
+    def test_generic_type(self):
+        mod = self.compile(
+        """
+        @blue
+        def foo():
+            return list[i32]
+        """)
+        w_foo = mod.foo.w_func
+        w_list_type = self.vm.call_function(w_foo, [])
+        import pdb;pdb.set_trace()

--- a/spy/tests/compiler/test_list.py
+++ b/spy/tests/compiler/test_list.py
@@ -1,6 +1,7 @@
 #-*- encoding: utf-8 -*-
 
 import pytest
+from spy.vm.object import W_Type
 from spy.tests.support import CompilerTest, no_C
 
 @no_C
@@ -14,5 +15,6 @@ class TestList(CompilerTest):
             return list[i32]
         """)
         w_foo = mod.foo.w_func
-        w_list_type = self.vm.call_function(w_foo, [])
-        import pdb;pdb.set_trace()
+        w_list_i32 = self.vm.call_function(w_foo, [])
+        assert isinstance(w_list_i32, W_Type)
+        assert w_list_i32.name == 'list[i32]'

--- a/spy/tests/compiler/test_list.py
+++ b/spy/tests/compiler/test_list.py
@@ -2,9 +2,9 @@
 
 import pytest
 from spy.vm.object import W_Type
-from spy.tests.support import CompilerTest, no_C
+from spy.tests.support import CompilerTest, only_interp
 
-@no_C
+@only_interp
 class TestList(CompilerTest):
 
     def test_generic_type(self):
@@ -28,3 +28,13 @@ class TestList(CompilerTest):
         """)
         x = mod.foo()
         assert x == [1, 2, 3]
+
+    def test_getitem(self):
+        mod = self.compile(
+        """
+        def foo(i: i32) -> str:
+            x: list[str] = ["foo", "bar", "baz"]
+            return x[i]
+        """)
+        assert mod.foo(0) == "foo"
+        assert mod.foo(1) == "bar"

--- a/spy/tests/compiler/test_list.py
+++ b/spy/tests/compiler/test_list.py
@@ -42,7 +42,7 @@ class TestList(CompilerTest):
     def test_setitem(self):
         mod = self.compile(
         """
-        def foo(i: i32) -> i32:
+        def foo(i: i32) -> list[i32]:
             x: list[i32] = [0, 1, 2]
             x[i] = x[i] + 10
             return x

--- a/spy/tests/compiler/test_list.py
+++ b/spy/tests/compiler/test_list.py
@@ -38,3 +38,14 @@ class TestList(CompilerTest):
         """)
         assert mod.foo(0) == "foo"
         assert mod.foo(1) == "bar"
+
+    def test_setitem(self):
+        mod = self.compile(
+        """
+        def foo(i: i32) -> i32:
+            x: list[i32] = [0, 1, 2]
+            x[i] = x[i] + 10
+            return x
+        """)
+        assert mod.foo(0) == [10, 1, 2]
+        assert mod.foo(1) == [0, 11, 2]

--- a/spy/tests/compiler/test_list.py
+++ b/spy/tests/compiler/test_list.py
@@ -18,3 +18,13 @@ class TestList(CompilerTest):
         w_list_i32 = self.vm.call_function(w_foo, [])
         assert isinstance(w_list_i32, W_Type)
         assert w_list_i32.name == 'list[i32]'
+
+    def test_literal(self):
+        mod = self.compile(
+        """
+        def foo() -> list[i32]:
+            x: list[i32] = [1, 2, 3]
+            return x
+        """)
+        x = mod.foo()
+        assert x == [1, 2, 3]

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -271,6 +271,21 @@ class TestParser:
         """
         self.assert_dump(stmt, expected)
 
+    def test_SetItem(self):
+        mod = self.parse("""
+        def foo() -> void:
+            mylist[0] = 42
+        """)
+        stmt = mod.get_funcdef('foo').body[0]
+        expected = """
+        SetItem(
+            target=Name(id='mylist'),
+            index=Constant(value=0),
+            value=Constant(value=42),
+        )
+        """
+        self.assert_dump(stmt, expected)
+
     def test_VarDef(self):
         mod = self.parse("""
         def foo() -> void:

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -156,6 +156,13 @@ class ASTFrame:
         w_value = self.eval_expr(node.value)
         self.vm.call_function(w_opimpl, [w_target, w_attr, w_value])
 
+    def exec_stmt_SetItem(self, node: ast.SetItem) -> None:
+        w_opimpl = self.t.opimpl[node]
+        w_target = self.eval_expr(node.target)
+        w_index = self.eval_expr(node.index)
+        w_value = self.eval_expr(node.value)
+        self.vm.call_function(w_opimpl, [w_target, w_index, w_value])
+
     def exec_stmt_StmtExpr(self, stmt: ast.StmtExpr) -> None:
         self.eval_expr(stmt.value)
 

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -262,3 +262,8 @@ class ASTFrame:
         w_attr = self.vm.wrap(op.attr)
         w_res = self.vm.call_function(w_opimpl, [w_val, w_attr])
         return w_res
+
+    def eval_expr_List(self, op: ast.List) -> W_Object:
+        color, w_listtype = self.t.check_expr(op)
+        items_w = [self.eval_expr(item) for item in op.items]
+        return w_listtype.pyclass(items_w)

--- a/spy/vm/b.py
+++ b/spy/vm/b.py
@@ -19,7 +19,7 @@ from spy.vm.registry import ModuleRegistry
 from spy.vm.object import (W_Object, W_Type, w_DynamicType, W_Void, W_I32,
                            W_F64, W_Bool, W_NotImplementedType)
 from spy.vm.str import W_Str
-from spy.vm.list import W_GenericList
+from spy.vm.list import W_ListFactory
 
 
 BUILTINS = ModuleRegistry('builtins', '<builtins>')
@@ -33,7 +33,7 @@ B.add('i32', W_I32._w)
 B.add('f64', W_F64._w)
 B.add('bool', W_Bool._w)
 B.add('str', W_Str._w)
-B.add('list', W_GenericList._w)
+B.add('list', W_ListFactory())
 B.add('None', W_Void._w_singleton)
 B.add('True', W_Bool._w_singleton_True)
 B.add('False', W_Bool._w_singleton_False)

--- a/spy/vm/b.py
+++ b/spy/vm/b.py
@@ -19,6 +19,7 @@ from spy.vm.registry import ModuleRegistry
 from spy.vm.object import (W_Object, W_Type, w_DynamicType, W_Void, W_I32,
                            W_F64, W_Bool, W_NotImplementedType)
 from spy.vm.str import W_Str
+from spy.vm.list import W_GenericList
 
 
 BUILTINS = ModuleRegistry('builtins', '<builtins>')
@@ -32,6 +33,7 @@ B.add('i32', W_I32._w)
 B.add('f64', W_F64._w)
 B.add('bool', W_Bool._w)
 B.add('str', W_Str._w)
+B.add('list', W_GenericList._w)
 B.add('None', W_Void._w_singleton)
 B.add('True', W_Bool._w_singleton_True)
 B.add('False', W_Bool._w_singleton_False)

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -18,12 +18,29 @@ class W_ListFactory(W_Object):
         return vm.wrap(opimpl)
 
 
+# XXX this should be marked as '@interp_blue' and cached automatically by the
+# VM
+CACHE = {}
+
 def make_W_List(vm: 'SPyVM', w_t: W_Type) -> W_Type:
+    key = (vm, w_t)
+    if key in CACHE:
+        return CACHE[key]
+
     tname = w_t.name
     name = f'list[{tname}]'
 
     @spytype(name)
     class W_List(W_Object):
-        pass
+        items_w: list[W_Object]
 
-    return vm.wrap(W_List)
+        def __init__(self, items_w: list[W_Object]):
+            # XXX typecheck?
+            self.items_w = items_w
+
+        def spy_unwrap(self, vm: 'SPyVM') -> list[Any]:
+            return [vm.unwrap(w_item) for w_item in self.items_w]
+
+    w_result = vm.wrap(W_List)
+    CACHE[key] = w_result
+    return w_result

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Any
 from spy.fqn import QN
-from spy.vm.object import W_Object, spytype, W_Type, W_Dynamic, W_I32
+from spy.vm.object import W_Object, spytype, W_Type, W_Dynamic, W_I32, W_Void
 from spy.vm.function import spy_builtin
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -46,11 +46,26 @@ def make_W_List(vm: 'SPyVM', w_T: W_Type) -> W_Type:
         def op_GETITEM(vm: 'SPyVM', w_listtype: W_Type,
                        w_itype: W_Type) -> W_Dynamic:
             @spy_builtin(QN('operator::list_getitem'))
-            def list_getitem(vm: 'SPyVM', w_list: W_List, w_i: W_I32) -> T:
+            def getitem(vm: 'SPyVM', w_list: W_List, w_i: W_I32) -> T:
                 i = vm.unwrap_i32(w_i)
                 # XXX bound check?
                 return w_list.items_w[i]
-            return vm.wrap(list_getitem)
+            return vm.wrap(getitem)
+
+        @staticmethod
+        def op_SETITEM(vm: 'SPyVM', w_listtype: W_Type, w_itype: W_Type,
+                       w_vtype: W_Type) -> W_Dynamic:
+            from spy.vm.b import B
+
+            @spy_builtin(QN('operator::list_setitem'))
+            def setitem(vm: 'SPyVM', w_list: W_List, w_i: W_I32,
+                        w_v: T) -> W_Void:
+                assert isinstance(w_v, T)
+                i = vm.unwrap_i32(w_i)
+                # XXX bound check?
+                w_list.items_w[i] = w_v
+                return B.w_None
+            return vm.wrap(setitem)
 
     w_result = vm.wrap(W_List)
     CACHE[key] = w_result

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -1,0 +1,9 @@
+from typing import TYPE_CHECKING, Any
+from spy.vm.object import W_Object, spytype
+if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
+
+
+@spytype('list')
+class W_GenericList(W_Object):
+    pass

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -1,9 +1,29 @@
 from typing import TYPE_CHECKING, Any
-from spy.vm.object import W_Object, spytype
+from spy.fqn import QN
+from spy.vm.object import W_Object, spytype, W_Type, W_Dynamic
+from spy.vm.function import spy_builtin
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
+@spytype('ListFactory')
+class W_ListFactory(W_Object):
 
-@spytype('list')
-class W_GenericList(W_Object):
-    pass
+    @staticmethod
+    def op_GETITEM(vm: 'SPyVM', w_type: W_Type, w_vtype: W_Type) -> W_Dynamic:
+
+        @spy_builtin(QN('operator::ListFactory_getitem'))
+        def opimpl(vm: 'SPyVM', w_self: W_ListFactory, w_i: W_Type) -> W_Type:
+            return make_W_List(vm, w_i)
+
+        return vm.wrap(opimpl)
+
+
+def make_W_List(vm: 'SPyVM', w_t: W_Type) -> W_Type:
+    tname = w_t.name
+    name = f'list[{tname}]'
+
+    @spytype(name)
+    class W_List(W_Object):
+        pass
+
+    return vm.wrap(W_List)

--- a/spy/vm/modules/operator/itemop.py
+++ b/spy/vm/modules/operator/itemop.py
@@ -14,3 +14,12 @@ def GETITEM(vm: 'SPyVM', w_type: W_Type, w_itype: W_Type) -> W_Dynamic:
         return pyclass.op_GETITEM(vm, w_type, w_itype)
 
     return B.w_NotImplemented
+
+@OP.builtin
+def SETITEM(vm: 'SPyVM', w_type: W_Type, w_itype: W_Type,
+            w_vtype: W_Type) -> W_Dynamic:
+    pyclass = w_type.pyclass
+    if pyclass.has_meth_overriden('op_SETITEM'):
+        return pyclass.op_SETITEM(vm, w_type, w_itype, w_vtype)
+
+    return B.w_NotImplemented

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -128,6 +128,12 @@ class W_Object:
                    w_vtype: 'W_Type') -> 'W_Dynamic':
         raise NotImplementedError('this should never be called')
 
+    @staticmethod
+    def op_SETITEM(vm: 'SPyVM', w_type: 'W_Type', w_itype: 'W_Type',
+                   w_vtype: 'W_Type') -> 'W_Dynamic':
+        raise NotImplementedError('this should never be called')
+
+
 class W_Type(W_Object):
     """
     The default metaclass for SPy types.

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -336,7 +336,9 @@ class TypeChecker:
                 raise err
             return color, B.w_str
         elif w_opimpl is not B.w_NotImplemented:
-            assert False, 'unexpected opimpl?'
+            # this should be merged with the 'then' above
+            self.opimpl[expr] = w_opimpl
+            return color, w_opimpl.w_functype.w_restype
         else:
             v = w_vtype.name
             i = w_itype.name

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -6,6 +6,7 @@ from spy.irgen.symtable import Symbol, Color
 from spy.errors import (SPyTypeError, SPyNameError, maybe_plural)
 from spy.location import Loc
 from spy.vm.object import W_Object, W_Type
+from spy.vm.list import make_W_List
 from spy.vm.function import W_FuncType, W_ASTFunc, W_Func
 from spy.vm.b import B
 from spy.vm.modules.operator import OP
@@ -437,3 +438,19 @@ class TypeChecker:
         if sym:
             err.add('note', 'function defined here', sym.loc)
         raise err
+
+    def check_expr_List(self, listop: ast.List) -> tuple[Color, W_Type]:
+        w_itemtype = None
+        color = 'blue'
+        for item in listop.items:
+            c1, w_t1 = self.check_expr(item)
+            color = maybe_blue(color, c1)
+            if w_itemtype is None:
+                w_itemtype = w_t1
+            elif w_itemtype is not w_t1:
+                # XXX write it better and write a test
+                err = SPyTypeError("conflicting item types")
+                raise err
+        #
+        w_listype = make_W_List(self.vm, w_itemtype)
+        return color, w_listype

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -218,6 +218,19 @@ class TypeChecker:
         else:
             self.opimpl[node] = w_opimpl
 
+    def check_stmt_SetItem(self, node: ast.SetItem) -> None:
+        _, w_otype = self.check_expr(node.target)
+        _, w_itype = self.check_expr(node.index)
+        _, w_vtype = self.check_expr(node.value)
+
+        w_opimpl = OP.w_SETITEM.pyfunc(self.vm, w_otype, w_itype, w_vtype)
+        if w_opimpl is B.w_NotImplemented:
+            # XXX better error and write a test
+            err = SPyTypeError("setitem not implemented")
+            raise err
+        else:
+            self.opimpl[node] = w_opimpl
+
     # ==== expressions ====
 
     def check_expr_Name(self, name: ast.Name) -> tuple[Color, W_Type]:

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -441,7 +441,7 @@ class TypeChecker:
 
     def check_expr_List(self, listop: ast.List) -> tuple[Color, W_Type]:
         w_itemtype = None
-        color = 'blue'
+        color = 'red' # XXX should be blue?
         for item in listop.items:
             c1, w_t1 = self.check_expr(item)
             color = maybe_blue(color, c1)


### PR DESCRIPTION
First sketch of SPy list. This is far from being complete, but it's a start:

1. it's intended to work in interp-only mode. For compiled mode, we will write the code in SPy itself, but we need a list type at interp-time to be able to bootstrap
2. we just support getitem and setitem for now
3. we should improve error messages
4. we don't do any bound check, nor any test for negative indices

This PR is interesting because it introduces multiple features:
- parser support for `ast.SetItem`
- first example of generic type

