### PR TITLE
Refactor typechecking of calls and operators

### DIFF
--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -1,0 +1,85 @@
+import pytest
+from spy.fqn import QN
+from spy.vm.b import B
+from spy.vm.object import spytype, Member, Annotated
+from spy.vm.function import spy_builtin
+from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_I32, W_Void
+from spy.vm.registry import ModuleRegistry
+from spy.vm.vm import SPyVM
+from spy.tests.support import CompilerTest, no_C, expect_errors
+
+@no_C
+class TestAttrOp(CompilerTest):
+    SKIP_SPY_BACKEND_SANITY_CHECK = True
+
+    def test_opimpl_type_mismatch(self):
+        # ========== EXT module for this test ==========
+        EXT = ModuleRegistry('ext', '<ext>')
+
+        @spytype('MyClass')
+        class W_MyClass(W_Object):
+
+            @staticmethod
+            def op_GETITEM(vm: 'SPyVM', w_listtype: W_Type,
+                           w_itype: W_Type) -> W_Dynamic:
+                @spy_builtin(QN('ext::getitem'))
+                def getitem(vm: 'SPyVM', w_obj: W_MyClass, w_i: W_I32) -> W_I32:
+                    return w_i
+                return vm.wrap(getitem)
+
+        EXT.add('MyClass', W_MyClass._w)
+
+        @EXT.builtin
+        def make(vm: 'SPyVM') -> W_MyClass:
+            return W_MyClass()
+        # ========== /EXT module for this test =========
+
+        self.vm.make_module(EXT)
+
+        src = """
+        from ext import make, MyClass
+
+        def foo() -> i32:
+            obj: MyClass = make()
+            return obj['hello']
+        """
+        errors = expect_errors(
+            'mismatched types',
+            ('expected `i32`, got `str`', "'hello'"),
+        )
+        self.compile_raises(src, "foo", errors)
+
+    def test_opimpl_wrong_argcount(self):
+        # ========== EXT module for this test ==========
+        EXT = ModuleRegistry('ext', '<ext>')
+
+        @spytype('MyClass')
+        class W_MyClass(W_Object):
+
+            @staticmethod
+            def op_GETITEM(vm: 'SPyVM', w_listtype: W_Type,
+                           w_itype: W_Type) -> W_Dynamic:
+                @spy_builtin(QN('ext::getitem'))
+                def getitem(vm: 'SPyVM', w_obj: W_MyClass) -> W_Void:
+                    return B.w_None
+                return vm.wrap(getitem)
+
+        EXT.add('MyClass', W_MyClass._w)
+
+        @EXT.builtin
+        def make(vm: 'SPyVM') -> W_MyClass:
+            return W_MyClass()
+        # ========== /EXT module for this test =========
+
+        self.vm.make_module(EXT)
+        src = """
+        from ext import make, MyClass
+
+        def foo() -> i32:
+            obj: MyClass = make()
+            return obj[0]
+        """
+        errors = expect_errors(
+            'this function takes 1 argument but 2 arguments were supplied',
+        )
+        self.compile_raises(src, "foo", errors)

--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -9,7 +9,7 @@ from spy.vm.vm import SPyVM
 from spy.tests.support import CompilerTest, no_C, expect_errors
 
 @no_C
-class TestAttrOp(CompilerTest):
+class TestOp(CompilerTest):
     SKIP_SPY_BACKEND_SANITY_CHECK = True
 
     def test_opimpl_type_mismatch(self):

--- a/spy/tests/support.py
+++ b/spy/tests/support.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, no_type_check
 import textwrap
 from contextlib import contextmanager
 import pytest
@@ -67,6 +67,7 @@ def skip_backends(*backends_to_skip: Backend, reason=''):
         return pytest.mark.parametrize('compiler_backend', new_backends)(func)
     return decorator
 
+@no_type_check
 def parametrize_compiler_backend(params, func):
     deco = pytest.mark.parametrize(
         'compiler_backend',

--- a/spy/tests/support.py
+++ b/spy/tests/support.py
@@ -67,19 +67,24 @@ def skip_backends(*backends_to_skip: Backend, reason=''):
         return pytest.mark.parametrize('compiler_backend', new_backends)(func)
     return decorator
 
+def parametrize_compiler_backend(params, func):
+    deco = pytest.mark.parametrize(
+        'compiler_backend',
+        params_with_marks(params)
+    )
+    return deco(func)
+
 def no_backend(func):
-    return pytest.mark.parametrize('compiler_backend', [''])(func)
+    return parametrize_compiler_backend([''], func)
 
 def only_interp(func):
-    return pytest.mark.parametrize('compiler_backend', ['interp'])(func)
+    return parametrize_compiler_backend(['interp'], func)
 
 def only_C(func):
-    return pytest.mark.parametrize('compiler_backend', ['C'])(func)
+    return parametrize_compiler_backend(['C'], func)
 
 def no_C(func):
-    return pytest.mark.parametrize('compiler_backend',
-                                   ['interp', 'doppler'])(func)
-
+    return parametrize_compiler_backend(['interp', 'doppler'], func)
 
 
 @pytest.mark.usefixtures('init')

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -345,10 +345,11 @@ class TypeChecker:
             color = maybe_blue(color, c1)
 
         # step 2: call OP() and get w_opimpl
-        w_opimpl = w_OP.pyfunc(self.vm, *argtypes_w)
+        w_opimpl = self.vm.call_function(w_OP, argtypes_w) # type: ignore
 
         # step 3: check that we can call the returned w_opimpl
         self.opimpl_typecheck(w_opimpl, args, argtypes_w, errmsg=errmsg)
+        assert isinstance(w_opimpl, W_Func)
         self.opimpl[node] = w_opimpl
         return color, w_opimpl.w_functype.w_restype
 

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -314,19 +314,7 @@ class TypeChecker:
         icolor, w_itype = self.check_expr(expr.index)
         color = maybe_blue(vcolor, icolor)
         w_opimpl = OP.w_GETITEM.pyfunc(self.vm, w_vtype, w_itype)
-        if (isinstance(w_opimpl, W_Func) and
-            w_opimpl.qn == QN('operator::str_getitem')):
-            # XXX for now this is a special case, to check that `i` can be
-            # converted to `i32`. Ideally, we should use the same mechanism
-            # that we have already for calls
-            self.opimpl[expr] = w_opimpl
-            err = self.convert_type_maybe(expr.index, w_itype, B.w_i32)
-            if err:
-                err.add('note', f'this is a `str`', expr.value.loc)
-                raise err
-            return color, B.w_str
-        elif w_opimpl is not B.w_NotImplemented:
-            # this should be merged with the 'then' above
+        if w_opimpl is not B.w_NotImplemented:
             self.opimpl_typecheck(w_opimpl, expr, [expr.value, expr.index])
             self.opimpl[expr] = w_opimpl
             return color, w_opimpl.w_functype.w_restype

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, NoReturn, Any
+from typing import TYPE_CHECKING, Optional, NoReturn, Any, Sequence
 from types import NoneType
 from spy import ast
 from spy.fqn import QN, FQN
@@ -347,7 +347,7 @@ class TypeChecker:
 
     def opimpl_typecheck(self,
                          w_opimpl: W_Object,
-                         args: list[ast.Expr],
+                         args: Sequence[ast.Expr | None],
                          argtypes_w: list[W_Type],
                          *,
                          errmsg: str,
@@ -395,11 +395,13 @@ class TypeChecker:
         # check types
         assert len(args) == got
         for i in range(got):
+            arg = args[i]
+            w_argtype = argtypes_w[i]
             w_exp_type = w_functype.params[i].w_type
-            if args[i] is None:
-                assert argtypes_w[i] == w_exp_type
+            if arg is None:
+                assert w_argtype == w_exp_type
             else:
-                err = self.convert_type_maybe(args[i], argtypes_w[i], w_exp_type)
+                err = self.convert_type_maybe(arg, w_argtype, w_exp_type)
                 if err:
                     raise err
 

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -357,6 +357,7 @@ class TypeChecker:
 
         Maybe we could reduce a bit the code duplication in the future.
         """
+        err: Optional[SPyTypeError] = None
         w_functype = w_opimpl.w_functype
         argtypes_w = [self.check_expr(arg)[1] for arg in args]
         #

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -364,21 +364,26 @@ class TypeChecker:
         operates on an AST node (and thus has more Loc info for better
         diagnostics).
 
+        Ideally, in case of user-defined opimpls, we would like to show
+        diagnostic with locations, but we don't have it at the moment.
+
         Maybe we could reduce a bit the code duplication in the future.
         """
         w_functype = w_opimpl.w_functype
         argtypes_w = [self.check_expr(arg)[1] for arg in args]
-        got_nargs = len(argtypes_w)
-        exp_nargs = len(w_functype.params)
-        if got_nargs != exp_nargs:
-            # XXX write a test
+        #
+        # check number of arguments
+        got = len(argtypes_w)
+        exp = len(w_functype.params)
+        if got != exp:
             takes = maybe_plural(exp, f'takes {exp} argument')
             supplied = maybe_plural(got,
                                     f'1 argument was supplied',
                                     f'{got} arguments were supplied')
             err = SPyTypeError(f'this function {takes} but {supplied}')
             raise err
-
+        #
+        # check types
         for i, (param, w_arg_type) in enumerate(zip(w_functype.params,
                                                     argtypes_w)):
             err = self.convert_type_maybe(args[i], w_arg_type, param.w_type)


### PR DESCRIPTION
This PR is a huge improvement in code quality and simplification.

The typechecking code for calls and opimpls was very similar, both in concrete and in principle. The big difference is that for calls we can provide better diagnostics.

This PR make sure that we use the same code for both: by doing so, we also ensure that we do proper typecking on the opimpls returned by operators.
