### PR TITLE
Introduce the CALL operator

### DIFF
--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -298,8 +298,8 @@ class TestBasic(CompilerTest):
         """
         errors = expect_errors(
             'cannot call objects of type `i32`',
-            ('this is not a function', 'x'),
-            ('variable defined here', 'x: i32 = 0'),
+            ('this is `i32`', 'x'),
+            #('variable defined here', 'x: i32 = 0'), # XXX re-enable
         )
         self.compile_raises(src, "foo", errors)
 
@@ -516,9 +516,8 @@ class TestBasic(CompilerTest):
             bar(42, True)
         """
         errors = expect_errors(
-            'cannot do `i32`[`bool`]',
+            'cannot do `i32`[...]',
             ('this is `i32`', 'a'),
-            ('this is `bool`', 'i'),
             )
         self.compile_raises(src, "foo", errors)
 
@@ -662,7 +661,6 @@ class TestBasic(CompilerTest):
         errors = expect_errors(
             "type `str` does not support assignment to attribute 'x'",
             ("this is `str`", 's'),
-            ("this is `i32`", '42'),
         )
         self.compile_raises(src, "foo", errors)
 

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -299,7 +299,7 @@ class TestBasic(CompilerTest):
         errors = expect_errors(
             'cannot call objects of type `i32`',
             ('this is `i32`', 'x'),
-            #('variable defined here', 'x: i32 = 0'), # XXX re-enable
+            ('`x` defined here', 'x: i32 = 0'),
         )
         self.compile_raises(src, "foo", errors)
 

--- a/spy/tests/compiler/test_list.py
+++ b/spy/tests/compiler/test_list.py
@@ -18,6 +18,7 @@ class TestList(CompilerTest):
         w_list_i32 = self.vm.call_function(w_foo, [])
         assert isinstance(w_list_i32, W_Type)
         assert w_list_i32.name == 'list[i32]'
+        assert w_list_i32.pyclass.__name__ == 'W_List[W_I32]'
 
     def test_literal(self):
         mod = self.compile(

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -1,0 +1,53 @@
+#4414886654598415780
+
+import pytest
+from spy.fqn import QN
+from spy.vm.b import B
+from spy.vm.object import spytype, Member, Annotated
+from spy.vm.function import spy_builtin
+from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_I32, W_Void
+from spy.vm.list import W_BaseList
+from spy.vm.registry import ModuleRegistry
+from spy.vm.vm import SPyVM
+from spy.tests.support import CompilerTest, no_C
+
+@no_C
+class TestCallOp(CompilerTest):
+    SKIP_SPY_BACKEND_SANITY_CHECK = True
+
+    def test_call_instance(self):
+        # ========== EXT module for this test ==========
+        EXT = ModuleRegistry('ext', '<ext>')
+
+        @spytype('Adder')
+        class W_Adder(W_Object):
+
+            def __init__(self, x: int) -> None:
+                self.x = x
+
+            @staticmethod
+            def op_CALL(vm: 'SPyVM', w_type: W_Type,
+                        w_argtypes: W_BaseList) -> W_Dynamic:
+                @spy_builtin(QN('ext::call'))
+                def call(vm: 'SPyVM', w_obj: W_Adder, w_y: W_I32) -> W_I32:
+                    y = vm.unwrap_i32(w_y)
+                    res = w_obj.x + y
+                    return vm.wrap(res)
+                return vm.wrap(call)
+
+        EXT.add('Adder', W_Adder._w)
+
+        @EXT.builtin
+        def make(vm: 'SPyVM', w_x: W_I32) -> W_Adder:
+            return W_Adder(vm.unwrap_i32(w_x))
+        # ========== /EXT module for this test =========
+        self.vm.make_module(EXT)
+        mod = self.compile("""
+        from ext import make, Adder
+
+        def foo(x: i32, y: i32) -> i32:
+            obj: Adder = make(x)
+            return obj(y)
+        """)
+        x = mod.foo(5, 7)
+        assert x == 12

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -27,12 +27,12 @@ class TestCallOp(CompilerTest):
 
             @staticmethod
             def op_CALL(vm: 'SPyVM', w_type: W_Type,
-                        w_argtypes: W_BaseList) -> W_Dynamic:
+                        w_argtypes: W_Dynamic) -> W_Dynamic:
                 @spy_builtin(QN('ext::call'))
                 def call(vm: 'SPyVM', w_obj: W_Adder, w_y: W_I32) -> W_I32:
                     y = vm.unwrap_i32(w_y)
                     res = w_obj.x + y
-                    return vm.wrap(res)
+                    return vm.wrap(res) # type: ignore
                 return vm.wrap(call)
 
         EXT.add('Adder', W_Adder._w)

--- a/spy/vm/modules/operator/__init__.py
+++ b/spy/vm/modules/operator/__init__.py
@@ -74,7 +74,7 @@ from . import opimpl_dynamic # side effects
 from . import binop          # side effects
 from . import attrop         # side effects
 from . import itemop         # side effects
-
+from . import callop         # side effects
 
 # fill the _from_token dict
 OP._from_token.update({

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -1,0 +1,17 @@
+from typing import TYPE_CHECKING
+from spy.vm.b import B
+from spy.vm.object import W_Object, W_Type, W_Dynamic
+
+from . import OP
+from .binop import MM
+if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
+
+@OP.builtin
+def CALL(vm: 'SPyVM', w_type: W_Type, w_argtypes: W_Object) -> W_Dynamic:
+    pyclass = w_type.pyclass
+    if w_type is B.w_dynamic:
+        raise NotImplementedError("implement me")
+    elif pyclass.has_meth_overriden('op_CALL'):
+        return pyclass.op_CALL(vm, w_type, w_argtypes)
+    return B.w_NotImplemented

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -133,6 +133,11 @@ class W_Object:
                    w_vtype: 'W_Type') -> 'W_Dynamic':
         raise NotImplementedError('this should never be called')
 
+    @staticmethod
+    def op_CALL(vm: 'SPyVM', w_type: 'W_Type',
+                w_argtypes: 'W_Object') -> 'W_Dynamic':
+        raise NotImplementedError('this should never be called')
+
 
 class W_Type(W_Object):
     """

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -135,7 +135,7 @@ class W_Object:
 
     @staticmethod
     def op_CALL(vm: 'SPyVM', w_type: 'W_Type',
-                w_argtypes: 'W_Object') -> 'W_Dynamic':
+                w_argtypes: 'W_Dynamic') -> 'W_Dynamic':
         raise NotImplementedError('this should never be called')
 
 

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -400,6 +400,7 @@ class TypeChecker:
             errmsg = errmsg.format(*typenames)
             err = SPyTypeError(errmsg)
             if dispatch == 'single':
+                assert args[0] is not None
                 t = argtypes_w[0].name
                 err.add('error', f'this is `{t}`', args[0].loc)
             else:
@@ -443,6 +444,7 @@ class TypeChecker:
 
     def _check_expr_call_func(self, call: ast.Call) -> tuple[Color, W_Type]:
         color, w_functype = self.check_expr(call.func)
+        assert isinstance(w_functype, W_FuncType)
         argtypes_w = [self.check_expr(arg)[1] for arg in call.args]
         call_loc = call.func.loc
         sym = self.name2sym_maybe(call.func)
@@ -463,7 +465,7 @@ class TypeChecker:
         argtypes_w = [self.check_expr(arg)[1] for arg in call.args]
 
         w_List_of_Type = make_W_List(self.vm, B.w_type)
-        w_argtypes = w_List_of_Type.pyclass(argtypes_w)
+        w_argtypes = w_List_of_Type.pyclass(argtypes_w) # type: ignore
         w_opimpl = self.vm.call_function(OP.w_CALL, [w_otype, w_argtypes])
         newargs = [call.func] + call.args
         errmsg = 'cannot call objects of type `{0}`'

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -400,10 +400,19 @@ class TypeChecker:
             errmsg = errmsg.format(*typenames)
             err = SPyTypeError(errmsg)
             if dispatch == 'single':
+                # for single dispatch ops, NotImplemented means that the
+                # target doesn't support this operation: so we just report its
+                # type and possibly its definition
                 assert args[0] is not None
+                target = args[0]
                 t = argtypes_w[0].name
-                err.add('error', f'this is `{t}`', args[0].loc)
-            else:
+                err.add('error', f'this is `{t}`', target.loc)
+                sym = self.name2sym_maybe(target)
+                if sym:
+                    err.add('note', f'`{target.id}` defined here', sym.loc)
+            else:x
+                # for multi dispatch ops, all operands are equally important
+                # for finding the opimpl: we report all of them
                 for arg, w_argtype in zip(args, argtypes_w):
                     if arg is not None:
                         t = w_argtype.name

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -6,7 +6,7 @@ from spy.irgen.symtable import Symbol, Color
 from spy.errors import (SPyTypeError, SPyNameError, maybe_plural)
 from spy.location import Loc
 from spy.vm.object import W_Object, W_Type
-from spy.vm.list import make_W_List
+from spy.vm.list import make_W_List, W_List__W_Type
 from spy.vm.function import W_FuncType, W_ASTFunc, W_Func
 from spy.vm.b import B
 from spy.vm.modules.operator import OP
@@ -463,9 +463,7 @@ class TypeChecker:
     def _check_expr_call_generic(self, call: ast.Call) -> tuple[Color, W_Type]:
         color, w_otype = self.check_expr(call.func)
         argtypes_w = [self.check_expr(arg)[1] for arg in call.args]
-
-        w_List_of_Type = make_W_List(self.vm, B.w_type)
-        w_argtypes = w_List_of_Type.pyclass(argtypes_w) # type: ignore
+        w_argtypes = W_List__W_Type(argtypes_w) # type: ignore
         w_opimpl = self.vm.call_function(OP.w_CALL, [w_otype, w_argtypes])
         newargs = [call.func] + call.args
         errmsg = 'cannot call objects of type `{0}`'
@@ -571,5 +569,5 @@ class TypeChecker:
         #
         # XXX we need to handle empty lists
         assert w_itemtype is not None
-        w_listype = make_W_List(self.vm, w_itemtype)
-        return color, w_listype
+        w_listtype = self.vm.wrap(make_W_List(self.vm, w_itemtype))
+        return color, w_listtype

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -512,19 +512,6 @@ class TypeChecker:
                     err.add('note', 'function defined here', def_loc)
                 raise err
 
-    # XXX kill me when we have restored the proper diagnostics
-    def _call_error_non_callable(self,
-                                 w_type: W_Type,
-                                 def_loc: Optional[Loc],
-                                 call_loc: Optional[Loc],
-                                 ) -> NoReturn:
-        err = SPyTypeError(f'cannot call objects of type `{w_type.name}`')
-        if call_loc:
-            err.add('error', 'this is not a function', call_loc)
-        if def_loc:
-            err.add('note', 'variable defined here', def_loc)
-        raise err
-
     def _call_error_wrong_argcount(self, got: int, exp: int,
                                    *,
                                    def_loc: Optional[Loc],
@@ -539,7 +526,6 @@ class TypeChecker:
         err = SPyTypeError(f'this function {takes} but {supplied}')
         #
         # if we know the call_loc, we can add more detailed errors
-
         if call_loc:
             assert argnodes is not None
             if got < exp:


### PR DESCRIPTION
Ideally, we would like to be able to call functions by just using their CALL operator, but this is not supported yet. To make it practical, for now we just special-case functions.