### PR TITLE
Add support for instantiating types via CALL operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ libspy.wasm
 *.o
 tmp/
 tmp_*
+all.sh
+comp.sh
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -2,7 +2,7 @@ import pytest
 from spy.fqn import QN
 from spy.vm.b import B
 from spy.vm.object import spytype, Member, Annotated
-from spy.vm.function import spy_builtin
+from spy.vm.sig import spy_builtin
 from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_I32, W_Void
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM

--- a/spy/tests/compiler/test_operator_attr.py
+++ b/spy/tests/compiler/test_operator_attr.py
@@ -2,7 +2,7 @@ import pytest
 from spy.fqn import QN
 from spy.vm.b import B
 from spy.vm.object import spytype, Member, Annotated
-from spy.vm.function import spy_builtin
+from spy.vm.sig import spy_builtin
 from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_I32, W_Void
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -65,10 +65,9 @@ class TestCallOp(CompilerTest):
                 self.w_x = w_x
                 self.w_y = w_y
 
-            # XXX I don't like to be forced to write op_NEW here: spytype has
-            # all the information needed to syntethize one.
             @staticmethod
-            def op_NEW(vm: 'SPyVM') -> W_Dynamic:
+            def meta_op_CALL(vm: 'SPyVM', w_type: W_Type,
+                             w_argtypes: W_Dynamic) -> W_Dynamic:
                 @spy_builtin(QN('ext::new'))
                 def new(vm: 'SPyVM', w_cls: W_Type,
                         w_x: W_I32, w_y: W_I32) -> W_Point:

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -82,6 +82,7 @@ class TestCallOp(CompilerTest):
         mod = self.compile("""
         from ext import Point
 
+        @blue
         def foo(x: i32, y: i32) -> i32:
             p = Point(x, y)
             return p.x * 10 + p.y

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -88,3 +88,36 @@ class TestCallOp(CompilerTest):
         """)
         res = mod.foo(3, 6)
         assert res == 36
+
+    def test_spy_new(self):
+        # ========== EXT module for this test ==========
+        EXT = ModuleRegistry('ext', '<ext>')
+
+        @spytype('Point')
+        class W_Point(W_Object):
+            w_x: Annotated[W_I32, Member('x')]
+            w_y: Annotated[W_I32, Member('y')]
+
+            def __init__(self, w_x: W_I32, w_y: W_I32) -> None:
+                self.w_x = w_x
+                self.w_y = w_y
+
+            @staticmethod
+            def spy_new(vm: 'SPyVM', w_cls: W_Type,
+                        w_x: W_I32, w_y: W_I32) -> 'W_Point':
+                return W_Point(w_x, w_y)
+
+        EXT.add('Point', W_Point._w)
+
+        # ========== /EXT module for this test =========
+        self.vm.make_module(EXT)
+        mod = self.compile("""
+        from ext import Point
+
+        @blue
+        def foo(x: i32, y: i32) -> i32:
+            p = Point(x, y)
+            return p.x * 10 + p.y
+        """)
+        res = mod.foo(3, 6)
+        assert res == 36

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -4,7 +4,7 @@ import pytest
 from spy.fqn import QN
 from spy.vm.b import B
 from spy.vm.object import spytype, Member, Annotated
-from spy.vm.function import spy_builtin
+from spy.vm.sig import spy_builtin
 from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_I32, W_Void
 from spy.vm.list import W_BaseList
 from spy.vm.registry import ModuleRegistry

--- a/spy/tests/vm/test_function.py
+++ b/spy/tests/vm/test_function.py
@@ -1,9 +1,7 @@
 import pytest
 from spy.vm.vm import SPyVM
 from spy.vm.b import B
-from spy.vm.w import W_FuncType, W_I32, W_BuiltinFunc, W_Dynamic
-from spy.fqn import FQN, QN
-from spy.vm.function import W_FuncType, spy_builtin
+from spy.vm.w import W_FuncType, W_I32
 
 class TestFunction:
 
@@ -23,51 +21,3 @@ class TestFunction:
         assert w_ft == W_FuncType.make(x=B.w_str,
                                            y=B.w_i32,
                                            w_restype=B.w_i32)
-
-
-    def test_spy_builtin(self):
-        vm = SPyVM()
-
-        @spy_builtin(QN('test::foo'))
-        def foo(vm: 'SPyVM', w_x: W_I32) -> W_I32:
-            x = vm.unwrap_i32(w_x)
-            return vm.wrap(x*2)  # type: ignore
-
-        w_x = foo(vm, vm.wrap(21))
-        assert vm.unwrap_i32(w_x) == 42
-
-        w_foo = vm.wrap(foo)
-        assert isinstance(w_foo, W_BuiltinFunc)
-        assert w_foo.qn == QN('test::foo')
-        w_y = vm.call_function(w_foo, [vm.wrap(10)])
-        assert vm.unwrap_i32(w_y) == 20
-
-    def test_spy_builtin_errors(self):
-        with pytest.raises(ValueError,
-                           match="The first param should be 'vm: SPyVM'."):
-            @spy_builtin(QN('test::foo'))
-            def foo() -> W_I32:  # type: ignore
-                pass
-
-        with pytest.raises(ValueError,
-                           match="The first param should be 'vm: SPyVM'."):
-            @spy_builtin(QN('test::foo'))
-            def foo(w_x: W_I32) -> W_I32:  # type: ignore
-                pass
-
-        with pytest.raises(ValueError, match="Invalid param: 'x: int'"):
-            @spy_builtin(QN('test::foo'))
-            def foo(vm: 'SPyVM', x: int) -> W_I32:  # type: ignore
-                pass
-
-        with pytest.raises(ValueError, match="Invalid return type"):
-            @spy_builtin(QN('test::foo'))
-            def foo(vm: 'SPyVM') -> int:  # type: ignore
-                pass
-
-    def test_spy_builtin_dynamic(self):
-        vm = SPyVM()
-        @spy_builtin(QN('test::foo'))
-        def foo(vm: 'SPyVM', w_x: W_Dynamic) -> W_Dynamic:  # type: ignore
-            pass
-        assert foo.w_functype.name == 'def(x: dynamic) -> dynamic'

--- a/spy/tests/vm/test_sig.py
+++ b/spy/tests/vm/test_sig.py
@@ -1,0 +1,54 @@
+import pytest
+from spy.vm.vm import SPyVM
+from spy.vm.w import W_FuncType, W_I32, W_BuiltinFunc, W_Dynamic
+from spy.fqn import QN
+from spy.vm.sig import spy_builtin
+
+class TestSig:
+
+    def test_spy_builtin(self):
+        vm = SPyVM()
+
+        @spy_builtin(QN('test::foo'))
+        def foo(vm: 'SPyVM', w_x: W_I32) -> W_I32:
+            x = vm.unwrap_i32(w_x)
+            return vm.wrap(x*2)  # type: ignore
+
+        w_x = foo(vm, vm.wrap(21))
+        assert vm.unwrap_i32(w_x) == 42
+
+        w_foo = vm.wrap(foo)
+        assert isinstance(w_foo, W_BuiltinFunc)
+        assert w_foo.qn == QN('test::foo')
+        w_y = vm.call_function(w_foo, [vm.wrap(10)])
+        assert vm.unwrap_i32(w_y) == 20
+
+    def test_spy_builtin_errors(self):
+        with pytest.raises(ValueError,
+                           match="The first param should be 'vm: SPyVM'."):
+            @spy_builtin(QN('test::foo'))
+            def foo() -> W_I32:  # type: ignore
+                pass
+
+        with pytest.raises(ValueError,
+                           match="The first param should be 'vm: SPyVM'."):
+            @spy_builtin(QN('test::foo'))
+            def foo(w_x: W_I32) -> W_I32:  # type: ignore
+                pass
+
+        with pytest.raises(ValueError, match="Invalid param: 'x: int'"):
+            @spy_builtin(QN('test::foo'))
+            def foo(vm: 'SPyVM', x: int) -> W_I32:  # type: ignore
+                pass
+
+        with pytest.raises(ValueError, match="Invalid return type"):
+            @spy_builtin(QN('test::foo'))
+            def foo(vm: 'SPyVM') -> int:  # type: ignore
+                pass
+
+    def test_spy_builtin_dynamic(self):
+        vm = SPyVM()
+        @spy_builtin(QN('test::foo'))
+        def foo(vm: 'SPyVM', w_x: W_Dynamic) -> W_Dynamic:  # type: ignore
+            pass
+        assert foo.w_functype.name == 'def(x: dynamic) -> dynamic'

--- a/spy/tests/vm/test_sig.py
+++ b/spy/tests/vm/test_sig.py
@@ -1,10 +1,17 @@
 import pytest
 from spy.vm.vm import SPyVM
-from spy.vm.w import W_FuncType, W_I32, W_BuiltinFunc, W_Dynamic
+from spy.vm.w import W_FuncType, W_I32, W_BuiltinFunc, W_Dynamic, W_Str
+from spy.vm.b import B
 from spy.fqn import QN
-from spy.vm.sig import spy_builtin
+from spy.vm.sig import spy_builtin, functype_from_sig
 
 class TestSig:
+
+    def test_functype_from_sig(self):
+        def foo(vm: 'SPyVM', w_x: W_I32) -> W_Str:
+            pass
+        w_functype = functype_from_sig(foo)
+        assert w_functype == W_FuncType.parse('def(x: i32) -> str')
 
     def test_spy_builtin(self):
         vm = SPyVM()
@@ -52,3 +59,15 @@ class TestSig:
         def foo(vm: 'SPyVM', w_x: W_Dynamic) -> W_Dynamic:  # type: ignore
             pass
         assert foo.w_functype.name == 'def(x: dynamic) -> dynamic'
+
+    def test_return_None(self):
+        vm = SPyVM()
+        @spy_builtin(QN('test::foo'))
+        def foo(vm: 'SPyVM') -> None:
+            pass
+        assert foo.w_functype.name == 'def() -> void'
+        assert foo(vm) is None
+        #
+        w_foo = vm.wrap(foo)
+        w_res = vm.call_function(w_foo, [])
+        assert w_res is B.w_None

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -178,6 +178,23 @@ class W_BuiltinFunc(W_Func):
 
 
 def spy_builtin(qn: QN) -> Callable:
+    """
+    Decorator to make an interp-level function wrappable by the VM.
+
+    Example of usage:
+
+        @spy_builtin(QN("foo::hello"))
+        def hello(vm: 'SPyVM', w_x: W_I32) -> W_Str:
+            ...
+
+        w_hello = vm.wrap(hello)
+        assert isinstance(w_hello, W_BuiltinFunc)
+        assert w_hello.qn == QN("foo::hello")
+
+    The w_functype of the wrapped function is automatically computed by
+    inspectng the signature of the interp-level function. The first parameter
+    MUST be 'vm'.
+    """
     # this is B.w_dynamic (we cannot use B due to circular imports)
     B_w_dynamic = w_DynamicType
 

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -7,7 +7,7 @@ from spy.vm.object import W_Object, W_Type, W_Void
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
-# XXX document
+# we cannot import B due to circular imports, let's fake it
 B_w_Void = W_Void._w
 
 # dictionary which contains local vars in an ASTFrame. The type is defined

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -3,9 +3,12 @@ from typing import TYPE_CHECKING, Any, Optional, Callable
 from spy import ast
 from spy.ast import Color
 from spy.fqn import QN
-from spy.vm.object import W_Object, W_Type
+from spy.vm.object import W_Object, W_Type, W_Void
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
+
+# XXX document
+B_w_Void = W_Void._w
 
 # dictionary which contains local vars in an ASTFrame. The type is defined
 # here because it's also used by W_ASTFunc.closure.
@@ -173,7 +176,7 @@ class W_BuiltinFunc(W_Func):
         return f"<spy function '{self.qn}' (builtin)>"
 
     def spy_call(self, vm: 'SPyVM', args_w: list[W_Object]) -> W_Object:
-        return self.pyfunc(vm, *args_w)
-
-
-# =======
+        w_res = self.pyfunc(vm, *args_w)
+        if w_res is None and self.w_functype.w_restype is B_w_Void:
+            return vm.wrap(None)
+        return w_res

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -1,10 +1,9 @@
 from dataclasses import dataclass
-import inspect
 from typing import TYPE_CHECKING, Any, Optional, Callable
 from spy import ast
 from spy.ast import Color
-from spy.fqn import QN, FQN
-from spy.vm.object import W_Object, W_Type, W_Dynamic, w_DynamicType
+from spy.fqn import QN
+from spy.vm.object import W_Object, W_Type
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
@@ -177,67 +176,4 @@ class W_BuiltinFunc(W_Func):
         return self.pyfunc(vm, *args_w)
 
 
-def spy_builtin(qn: QN) -> Callable:
-    """
-    Decorator to make an interp-level function wrappable by the VM.
-
-    Example of usage:
-
-        @spy_builtin(QN("foo::hello"))
-        def hello(vm: 'SPyVM', w_x: W_I32) -> W_Str:
-            ...
-
-        w_hello = vm.wrap(hello)
-        assert isinstance(w_hello, W_BuiltinFunc)
-        assert w_hello.qn == QN("foo::hello")
-
-    The w_functype of the wrapped function is automatically computed by
-    inspectng the signature of the interp-level function. The first parameter
-    MUST be 'vm'.
-    """
-    # this is B.w_dynamic (we cannot use B due to circular imports)
-    B_w_dynamic = w_DynamicType
-
-    def is_W_class(x: Any) -> bool:
-        return isinstance(x, type) and issubclass(x, W_Object)
-
-    def to_spy_FuncParam(p: Any) -> FuncParam:
-        if p.name.startswith('w_'):
-            name = p.name[2:]
-        else:
-            name = p.name
-        #
-        pyclass = p.annotation
-        if pyclass is W_Dynamic:
-            return FuncParam(name, B_w_dynamic)
-        elif issubclass(pyclass, W_Object):
-            return FuncParam(name, pyclass._w)
-        else:
-            raise ValueError(f"Invalid param: '{p}'")
-
-    def decorator(fn: Callable) -> Callable:
-        sig = inspect.signature(fn)
-        params = list(sig.parameters.values())
-        if len(params) == 0:
-            msg = (f"The first param should be 'vm: SPyVM'. Got nothing")
-            raise ValueError(msg)
-        if (params[0].name != 'vm' or
-            params[0].annotation != 'SPyVM'):
-            msg = (f"The first param should be 'vm: SPyVM'. Got '{params[0]}'")
-            raise ValueError(msg)
-
-        func_params = [to_spy_FuncParam(p) for p in params[1:]]
-        ret = sig.return_annotation
-        if ret is W_Dynamic:
-            w_restype = B_w_dynamic
-        elif is_W_class(ret):
-            w_restype = ret._w
-        else:
-            raise ValueError(f"Invalid return type: '{sig.return_annotation}'")
-
-        w_functype = W_FuncType(func_params, w_restype)
-        fn._w = W_BuiltinFunc(w_functype, qn, fn)  # type: ignore
-        fn.w_functype = w_functype  # type: ignore
-        return fn
-
-    return decorator
+# =======

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any, no_type_check
 from spy.fqn import QN
 from spy.vm.object import W_Object, spytype, W_Type, W_Dynamic, W_I32, W_Void
-from spy.vm.function import spy_builtin
+from spy.vm.sig import spy_builtin
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -3,7 +3,8 @@ from spy.fqn import QN, FQN
 from spy.vm.b import B
 from spy.vm.object import W_Object, spytype, W_Type, W_Dynamic, W_Void
 from spy.vm.str import W_Str
-from spy.vm.function import W_ASTFunc, spy_builtin
+from spy.vm.function import W_ASTFunc
+from spy.vm.sig import spy_builtin
 
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -4,7 +4,8 @@ from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type, W_Dynamic, W_Void
 from spy.vm.module import W_Module
 from spy.vm.str import W_Str
-from spy.vm.function import W_Func, spy_builtin
+from spy.vm.function import W_Func
+from spy.vm.sig import spy_builtin
 from spy.vm.modules.types import W_TypeDef
 
 from . import OP

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -262,7 +262,34 @@ def _get_member_maybe(t: Any) -> Optional[Member]:
 
 def make_metaclass(name: str, pyclass: Type[W_Object]) -> Type[W_Type]:
     """
-    XXX write docs
+    Synthetize an app-level metaclass for the corresponding interp-level
+    pyclass.
+
+    Example:
+
+    @spytype('Foo')
+    class W_Foo(W_Object):
+        pass
+
+    this automatically creates:
+
+    class W_Meta_Foo(W_Type):
+        ...
+
+    The relationship between Foo and Meta_Foo is the following:
+
+    w_Foo = vm.wrap(W_Foo)
+    w_Meta_Foo = vm.wrap(W_Meta_Foo)
+    assert vm.dynamic_type(w_Foo) is w_Meta_Foo
+
+    W_Foo can customize the behavior of the metaclass in various ways:
+
+    1. by using `op_meta_*` operators: these automatically becomes operators
+       of the metaclass. In particular, `op_meta_CALL` is used to create
+       app-level instances of w_Foo.
+
+    2. by using `spy_new`, which automatically syntethize an appropriare
+       op_meta_CALL. This is just for convenience.
     """
     metaname = f'Meta_{name}'
 

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -262,7 +262,7 @@ def _get_member_maybe(t: Any) -> Optional[Member]:
 
 def make_metaclass(name: str, pyclass: Type[W_Object]) -> Type[W_Type]:
     """
-    Synthetize an app-level metaclass for the corresponding interp-level
+    Synthesize an app-level metaclass for the corresponding interp-level
     pyclass.
 
     Example:
@@ -288,7 +288,7 @@ def make_metaclass(name: str, pyclass: Type[W_Object]) -> Type[W_Type]:
        of the metaclass. In particular, `op_meta_CALL` is used to create
        app-level instances of w_Foo.
 
-    2. by using `spy_new`, which automatically syntethize an appropriare
+    2. by using `spy_new`, which automatically synthesize an appropriare
        op_meta_CALL. This is just for convenience.
     """
     metaname = f'Meta_{name}'
@@ -300,7 +300,7 @@ def make_metaclass(name: str, pyclass: Type[W_Object]) -> Type[W_Type]:
     if hasattr(pyclass, 'meta_op_CALL'):
         W_MetaType.op_CALL = pyclass.meta_op_CALL
     elif hasattr(pyclass, 'spy_new'):
-        W_MetaType.op_CALL = syntethize_meta_op_CALL(pyclass)
+        W_MetaType.op_CALL = synthesize_meta_op_CALL(pyclass)
 
     W_MetaType._w = W_Type(metaname, W_MetaType)
     return W_MetaType
@@ -315,7 +315,7 @@ def fix_annotations(fn: Any, types: dict[str, type]) -> None:
             newT = types[T]
             fn.__annotations__[key] = newT
 
-def syntethize_meta_op_CALL(pyclass: Type[W_Object]) -> Any:
+def synthesize_meta_op_CALL(pyclass: Type[W_Object]) -> Any:
     """
     Given a pyclass which implements spy_new, create an op_CALL for the
     corresponding metaclass. Example:

--- a/spy/vm/registry.py
+++ b/spy/vm/registry.py
@@ -1,7 +1,8 @@
 from typing import Callable, Optional, TYPE_CHECKING, Any
 from dataclasses import dataclass
 from spy.fqn import QN
-from spy.vm.function import W_FuncType, W_BuiltinFunc, spy_builtin
+from spy.vm.function import W_FuncType, W_BuiltinFunc
+from spy.vm.sig import spy_builtin
 from spy.vm.object import W_Object
 
 class ModuleRegistry:

--- a/spy/vm/sig.py
+++ b/spy/vm/sig.py
@@ -1,20 +1,20 @@
 import inspect
 from typing import TYPE_CHECKING, Any, Callable
 from spy.fqn import QN
-from spy.vm.object import W_Object, W_Type, W_Dynamic, w_DynamicType
+from spy.vm.object import W_Object, W_Type, W_Dynamic, w_DynamicType, W_Void
 from spy.vm.function import FuncParam, W_FuncType, W_BuiltinFunc
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
+# we cannot import B due to circular imports, let's fake it
+B_w_dynamic = w_DynamicType
+B_w_Void = W_Void._w
 
 def is_W_class(x: Any) -> bool:
     return isinstance(x, type) and issubclass(x, W_Object)
 
 
 def to_spy_FuncParam(p: Any) -> FuncParam:
-    # this is B.w_dynamic (we cannot use B due to circular imports)
-    B_w_dynamic = w_DynamicType
-
     if p.name.startswith('w_'):
         name = p.name[2:]
     else:
@@ -30,9 +30,6 @@ def to_spy_FuncParam(p: Any) -> FuncParam:
 
 
 def functype_from_sig(fn: Callable) -> W_FuncType:
-    # this is B.w_dynamic (we cannot use B due to circular imports)
-    B_w_dynamic = w_DynamicType
-
     sig = inspect.signature(fn)
     params = list(sig.parameters.values())
     if len(params) == 0:
@@ -45,7 +42,9 @@ def functype_from_sig(fn: Callable) -> W_FuncType:
 
     func_params = [to_spy_FuncParam(p) for p in params[1:]]
     ret = sig.return_annotation
-    if ret is W_Dynamic:
+    if ret is None:
+        w_restype = B_w_Void
+    elif ret is W_Dynamic:
         w_restype = B_w_dynamic
     elif is_W_class(ret):
         w_restype = ret._w

--- a/spy/vm/sig.py
+++ b/spy/vm/sig.py
@@ -1,0 +1,81 @@
+import inspect
+from typing import TYPE_CHECKING, Any, Callable
+from spy.fqn import QN
+from spy.vm.object import W_Object, W_Type, W_Dynamic, w_DynamicType
+from spy.vm.function import FuncParam, W_FuncType, W_BuiltinFunc
+if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
+
+
+def is_W_class(x: Any) -> bool:
+    return isinstance(x, type) and issubclass(x, W_Object)
+
+
+def to_spy_FuncParam(p: Any) -> FuncParam:
+    # this is B.w_dynamic (we cannot use B due to circular imports)
+    B_w_dynamic = w_DynamicType
+
+    if p.name.startswith('w_'):
+        name = p.name[2:]
+    else:
+        name = p.name
+    #
+    pyclass = p.annotation
+    if pyclass is W_Dynamic:
+        return FuncParam(name, B_w_dynamic)
+    elif issubclass(pyclass, W_Object):
+        return FuncParam(name, pyclass._w)
+    else:
+        raise ValueError(f"Invalid param: '{p}'")
+
+
+def functype_from_sig(fn: Callable) -> W_FuncType:
+    # this is B.w_dynamic (we cannot use B due to circular imports)
+    B_w_dynamic = w_DynamicType
+
+    sig = inspect.signature(fn)
+    params = list(sig.parameters.values())
+    if len(params) == 0:
+        msg = (f"The first param should be 'vm: SPyVM'. Got nothing")
+        raise ValueError(msg)
+    if (params[0].name != 'vm' or
+        params[0].annotation != 'SPyVM'):
+        msg = (f"The first param should be 'vm: SPyVM'. Got '{params[0]}'")
+        raise ValueError(msg)
+
+    func_params = [to_spy_FuncParam(p) for p in params[1:]]
+    ret = sig.return_annotation
+    if ret is W_Dynamic:
+        w_restype = B_w_dynamic
+    elif is_W_class(ret):
+        w_restype = ret._w
+    else:
+        raise ValueError(f"Invalid return type: '{sig.return_annotation}'")
+
+    return W_FuncType(func_params, w_restype)
+
+
+def spy_builtin(qn: QN) -> Callable:
+    """
+    Decorator to make an interp-level function wrappable by the VM.
+
+    Example of usage:
+
+        @spy_builtin(QN("foo::hello"))
+        def hello(vm: 'SPyVM', w_x: W_I32) -> W_Str:
+            ...
+
+        w_hello = vm.wrap(hello)
+        assert isinstance(w_hello, W_BuiltinFunc)
+        assert w_hello.qn == QN("foo::hello")
+
+    The w_functype of the wrapped function is automatically computed by
+    inspectng the signature of the interp-level function. The first parameter
+    MUST be 'vm'.
+    """
+    def decorator(fn: Callable) -> Callable:
+        w_functype = functype_from_sig(fn)
+        fn._w = W_BuiltinFunc(w_functype, qn, fn)  # type: ignore
+        fn.w_functype = w_functype  # type: ignore
+        return fn
+    return decorator

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Any
 from spy.llwasm import LLWasmInstance
 from spy.fqn import QN
 from spy.vm.object import W_Object, W_Type, W_Dynamic, spytype, W_I32
-from spy.vm.function import spy_builtin
+from spy.vm.sig import spy_builtin
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -470,7 +470,7 @@ class TypeChecker:
         return rescolor, w_functype.w_restype
 
     def _check_expr_call_generic(self, call: ast.Call) -> tuple[Color, W_Type]:
-        color, w_otype = self.check_expr(call.func)
+        _, w_otype = self.check_expr(call.func)
         argtypes_w = [self.check_expr(arg)[1] for arg in call.args]
         w_argtypes = W_List__W_Type(argtypes_w) # type: ignore
         w_opimpl = self.vm.call_function(OP.w_CALL, [w_otype, w_argtypes])
@@ -482,7 +482,9 @@ class TypeChecker:
                               errmsg=errmsg)
         assert isinstance(w_opimpl, W_Func)
         self.opimpl[call] = w_opimpl
-        return color, w_opimpl.w_functype.w_restype
+        # XXX I'm not sure that the color is correct here. We need to think
+        # more.
+        return w_opimpl.w_functype.color, w_opimpl.w_functype.w_restype
 
     def call_typecheck(self,
                        w_functype: W_FuncType,

--- a/spy/vm/w.py
+++ b/spy/vm/w.py
@@ -2,8 +2,8 @@
 This is just to make it easier to import all the various W_* classes
 """
 
-from spy.vm.function import (W_Func, W_FuncType, W_ASTFunc, W_BuiltinFunc,
-                             spy_builtin)
+from spy.vm.function import W_Func, W_FuncType, W_ASTFunc, W_BuiltinFunc
+from spy.vm.sig import spy_builtin
 from spy.vm.module import W_Module
 from spy.vm.object import (W_Bool, W_F64, W_I32, W_Object, W_Type, W_Void,
                            W_Dynamic, spytype)


### PR DESCRIPTION
Make it possible to call types to instantiate them.

In order to do this, we need to create a corresponding metaclass for each type. For example:

```
class W_Foo(W_Object):
    ...
```

automatically creates `W_MetaFoo(T_Type)`. See the docstring of `create_metaclass` for more details.