### PR TITLE
Target WASI instead of wasm32-freestanding

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ fixedint==0.2.0
 mypy==1.3.0
 typer==0.9.0
 untokenize==0.1.1
-ziglang==0.10.1.post1
+ziglang==0.13.0

--- a/spy/__main__.py
+++ b/spy/__main__.py
@@ -41,6 +41,7 @@ def main(filename: Path,
          redshift: boolopt("perform redshift and exit") = False,
          cwrite: boolopt("create the .c file and exit") = False,
          g: boolopt("generate debug symbols", names=['-g']) = False,
+         O: opt(int, "optimization level", names=['-O']) = 0,
          toolchain: opt(
              ToolchainType,
              "which compiler to use",
@@ -48,13 +49,15 @@ def main(filename: Path,
          ) = "zig",
          ) -> None:
     try:
-        do_main(filename, run, pyparse, parse, redshift, cwrite, g, toolchain)
+        do_main(filename, run, pyparse, parse, redshift, cwrite, g, O, toolchain)
     except SPyError as e:
         print(e.format(use_colors=True))
 
 def do_main(filename: Path, run: bool, pyparse: bool, parse: bool,
             redshift: bool,
-            cwrite: bool, debug_symbols: bool,
+            cwrite: bool,
+            debug_symbols: bool,
+            opt_level: int,
             toolchain: ToolchainType) -> None:
     if pyparse:
         do_pyparse(str(filename))
@@ -94,8 +97,11 @@ def do_main(filename: Path, run: bool, pyparse: bool, parse: bool,
     if cwrite:
         compiler.cwrite()
     else:
-        compiler.cbuild(debug_symbols=debug_symbols,
-                        toolchain_type=toolchain)
+        compiler.cbuild(
+            opt_level=opt_level,
+            debug_symbols=debug_symbols,
+            toolchain_type=toolchain
+        )
 
 if __name__ == '__main__':
     app()

--- a/spy/backend/c/wrapper.py
+++ b/spy/backend/c/wrapper.py
@@ -25,7 +25,7 @@ class WasmModuleWrapper:
         self.ll = LLSPyInstance.from_file(f)
 
     def __repr__(self) -> str:
-        return f"<WasmModuleWrapper 'self.ll.name'>"
+        return f"<WasmModuleWrapper '{self.ll.llmod.f}'>"
 
     def __getattr__(self, attr: str) -> Any:
         fqn = FQN.make_global(modname=self.modname, attr=attr)

--- a/spy/cbuild.py
+++ b/spy/cbuild.py
@@ -30,7 +30,9 @@ class Toolchain:
         libspy_a = spy.libspy.BUILD.join(self.TARGET, 'libspy.a')
         return [
             '-DSPY_TARGET_' + self.TARGET.upper(),
-            '-O3',
+            # XXX We don't want -O3 for tests, but we need to make it possible
+            # to enable it from the cmdline
+            #'-O3',
             '--std=c99',
             '-Werror=implicit-function-declaration',
             #'-Werror',

--- a/spy/cbuild.py
+++ b/spy/cbuild.py
@@ -18,7 +18,7 @@ def get_toolchain(toolchain: str) -> 'Toolchain':
 
 class Toolchain:
 
-    TARGET = '' # 'wasm', 'native', 'emscripten'
+    TARGET = '' # 'wasi', 'native', 'emscripten'
     EXE_FILENAME_EXT = ''
 
     @property
@@ -117,7 +117,7 @@ class Toolchain:
 
 class ZigToolchain(Toolchain):
 
-    TARGET = 'wasm32'
+    TARGET = 'wasi'
 
     def __init__(self) -> None:
         import ziglang  # type: ignore
@@ -131,10 +131,22 @@ class ZigToolchain(Toolchain):
 
     @property
     def WASM_CFLAGS(self) -> list[str]:
+        # XXX all of this is very messy.
+        #
+        # For WASI we have two "exec-model":
+        #   - "command": for standalone executables (this is the
+        #     default)
+        #   - "reactor": for staticaly-linked WASM modules which are called
+        #     from the outside.
+        #
+        # For our tests, we need "reactor", WHICH FOR NOW IS HARCODED HERE.
+        #
+        # More info:
+        #  https://clang.llvm.org/docs/ClangCommandLineReference.html#webassembly-driver
+        # https://clang.llvm.org/docs/ClangCommandLineReference.html#webassembly-driver
         return super().WASM_CFLAGS + [
-	    '--target=wasm32-freestanding',
-	    '-nostdlib',
-            '-shared',
+	    '--target=wasm32-wasi-musl',
+            '-mexec-model=reactor',
         ]
 
 

--- a/spy/cbuild.py
+++ b/spy/cbuild.py
@@ -29,6 +29,7 @@ class Toolchain:
     def CFLAGS(self) -> list[str]:
         libspy_a = spy.libspy.BUILD.join(self.TARGET, 'libspy.a')
         return [
+            '-DSPY_TARGET_' + self.TARGET.upper(),
             '-O3',
             '--std=c99',
             '-Werror=implicit-function-declaration',

--- a/spy/cbuild.py
+++ b/spy/cbuild.py
@@ -154,7 +154,7 @@ class ZigToolchain(Toolchain):
 
 class ClangToolchain(Toolchain):
 
-    TARGET = 'wasm32'
+    TARGET = 'wasi'
 
     @property
     def CC(self) -> list[str]:
@@ -163,9 +163,7 @@ class ClangToolchain(Toolchain):
     @property
     def WASM_CFLAGS(self) -> list[str]:
         return super().WASM_CFLAGS + [
-	    '--target=wasm32',
-	    '-nostdlib',
-            '-Wl,--no-entry',
+	    '-mexec-model=reactor',
         ]
 
 

--- a/spy/cbuild.py
+++ b/spy/cbuild.py
@@ -32,7 +32,7 @@ class Toolchain:
             '-DSPY_TARGET_' + self.TARGET.upper(),
             # XXX We don't want -O3 for tests, but we need to make it possible
             # to enable it from the cmdline
-            #'-O3',
+            '-O3',
             '--std=c99',
             '-Werror=implicit-function-declaration',
             #'-Werror',

--- a/spy/compiler.py
+++ b/spy/compiler.py
@@ -51,6 +51,7 @@ class Compiler:
         return self.file_c
 
     def cbuild(self, *,
+               opt_level: int = 0,
                debug_symbols: bool = False,
                toolchain_type: ToolchainType = ToolchainType.zig,
                ) -> py.path.local:
@@ -73,6 +74,7 @@ class Compiler:
             ]
             file_wasm = toolchain.c2wasm(file_c, self.file_wasm,
                                          exports=exports,
+                                         opt_level=opt_level,
                                          debug_symbols=debug_symbols)
             if DUMP_WASM:
                 print()
@@ -81,5 +83,7 @@ class Compiler:
             return file_wasm
         else:
             file_exe = self.file_wasm.new(ext=toolchain.EXE_FILENAME_EXT)
-            toolchain.c2exe(file_c, file_exe, debug_symbols=debug_symbols)
+            toolchain.c2exe(file_c, file_exe,
+                            opt_level=opt_level,
+                            debug_symbols=debug_symbols)
             return file_exe

--- a/spy/compiler.py
+++ b/spy/compiler.py
@@ -57,7 +57,7 @@ class Compiler:
         """
         file_c = self.cwrite()
         toolchain = get_toolchain(toolchain_type)
-        if toolchain.TARGET == 'wasm32':
+        if toolchain.TARGET == 'wasi':
             exports = [fqn.c_name for fqn in self.w_mod.keys()]
             file_wasm = toolchain.c2wasm(file_c, self.file_wasm,
                                          exports=exports,

--- a/spy/libspy/Makefile
+++ b/spy/libspy/Makefile
@@ -83,9 +83,6 @@ all:
 	make TARGET=emscripten
 	make TARGET=native
 
-# XXX: ideally, we would like to pass -Wl,--import-undefined to the linker,
-# but it's not currently supported by zig 0.13.0:
-# https://github.com/ziglang/zig/issues/20636
 build/wasi/libspy.wasm: build/$(TARGET)/libspy.a
 	$(CC) \
 		--target=wasm32-wasi-musl \

--- a/spy/libspy/Makefile
+++ b/spy/libspy/Makefile
@@ -29,6 +29,7 @@ else ifeq ($(TARGET), wasm32)
 
 	CFLAGS := \
 		$(CFLAGS) \
+		-DSPY_TARGET_WASM32 \
 		--target=wasm32-freestanding \
 		-nostdlib  \
 		-mmultivalue \
@@ -54,6 +55,7 @@ else ifeq ($(TARGET), emscripten)
 
 	CFLAGS := \
 		$(CFLAGS) \
+		-DSPY_TARGET_EMSCRIPTEN \
 		-mmultivalue \
 		-Xclang -target-abi \
 		-Xclang experimental-mv \
@@ -66,6 +68,10 @@ else ifeq ($(TARGET), native)
 	CC := cc
 	LD := ld
 	AR := ar
+
+	CFLAGS := \
+		$(CFLAGS) \
+		-DSPY_TARGET_NATIVE
 
 	.DEFAULT_GOAL := build/native/libspy.a
 

--- a/spy/libspy/Makefile
+++ b/spy/libspy/Makefile
@@ -1,7 +1,7 @@
 # Supported targets and compilers:
 #
 #   TARGET      TRIPLET                     COMPILER
-#   wasm32      wasm32-freestanding         zig cc
+#   wasi        wasm32-wasi-musl            zig cc
 #   emscripten  wasm32-unknown-emscripten   emcc
 #   native      x86_64-pc-linux-gnu (*)     cc
 #
@@ -21,17 +21,16 @@ CFLAGS := \
 ifeq ($(TARGET),)
 	.DEFAULT_GOAL := all
 
-# ---------- wasm32 target ----------
-else ifeq ($(TARGET), wasm32)
+# ---------- wasi target ----------
+else ifeq ($(TARGET), wasi)
 	CC := zig cc
 	LD := zig wasm-ld
 	AR := zig ar
 
 	CFLAGS := \
 		$(CFLAGS) \
-		-DSPY_TARGET_WASM32 \
-		--target=wasm32-freestanding \
-		-nostdlib  \
+		-DSPY_TARGET_WASI \
+		--target=wasm32-wasi-musl \
 		-mmultivalue \
 		-Xclang -target-abi \
 		-Xclang experimental-mv \
@@ -41,12 +40,7 @@ else ifeq ($(TARGET), wasm32)
 		--no-entry \
 		--import-memory
 
-	SRCS := \
-		$(SRCS) \
-		vendored/walloc/walloc.c \
-		src/libc.c
-
-	.DEFAULT_GOAL := build/wasm32/libspy.wasm
+	.DEFAULT_GOAL := build/wasi/libspy.wasm
 
 # -------- emscripten target --------
 else ifeq ($(TARGET), emscripten)
@@ -85,15 +79,18 @@ BUILD_DIR := build/$(TARGET)
 OBJS := $(patsubst %.c,$(BUILD_DIR)/%.o,$(SRCS))
 
 all:
-	make TARGET=wasm32
+	make TARGET=wasi
 	make TARGET=emscripten
 	make TARGET=native
 
-build/wasm32/libspy.wasm: build/$(TARGET)/libspy.a
-	$(LD) \
-		--no-entry \
-		--import-undefined \
-		--whole-archive \
+# XXX: ideally, we would like to pass -Wl,--import-undefined to the linker,
+# but it's not currently supported by zig 0.13.0:
+# https://github.com/ziglang/zig/issues/20636
+build/wasi/libspy.wasm: build/$(TARGET)/libspy.a
+	$(CC) \
+		--target=wasm32-wasi-musl \
+		-mexec-model=reactor \
+		-Wl,--whole-archive \
 		build/$(TARGET)/libspy.a \
 		-o $@
 
@@ -111,4 +108,4 @@ clean:
 	rm -rf build
 
 usage:
-	@echo "Usage: make TARGET=[wasm32|emscripten|native]"
+	@echo "Usage: make TARGET=[wasi|emscripten|native]"

--- a/spy/libspy/__init__.py
+++ b/spy/libspy/__init__.py
@@ -6,7 +6,7 @@ from spy.llwasm import LLWasmModule, LLWasmInstance, HostModule
 
 INCLUDE = spy.ROOT.join('libspy', 'include')
 BUILD = spy.ROOT.join('libspy', 'build')
-LIBSPY_WASM = spy.ROOT.join('libspy', 'build', 'wasm32', 'libspy.wasm')
+LIBSPY_WASM = spy.ROOT.join('libspy', 'build', 'wasi', 'libspy.wasm')
 
 LLMOD = LLWasmModule(LIBSPY_WASM)
 

--- a/spy/libspy/include/spy.h
+++ b/spy/libspy/include/spy.h
@@ -13,9 +13,13 @@
 
 #if defined(SPY_TARGET_NATIVE)
 #  define WASM_EXPORT(name) name
+#  define WASM_IMPORT(name) name
 # else
 #  define WASM_EXPORT(name) \
     __attribute__((export_name(#name))) \
+    name
+#  define WASM_IMPORT(name) \
+    __attribute__((import_module("env"), import_name(#name))) \
     name
 #endif
 

--- a/spy/libspy/include/spy.h
+++ b/spy/libspy/include/spy.h
@@ -6,13 +6,10 @@
 
 typedef __SIZE_TYPE__ size_t;
 
-#if defined(__linux__)
-#  define SPY_TARGET_NATIVE
-#elif defined(__EMSCRIPTEN__)
-#  define SPY_TARGET_EMSCRIPTEN
-#else
-#  define SPY_TARGET_WASM32
+#if defined(SPY_TARGET_WASM32) + defined(SPY_TARGET_EMSCRIPTEN) + defined(SPY_TARGET_NATIVE) == 0
+#  error "You must define one and exactly one of the SPY_TARGET_* macros"
 #endif
+
 
 #if defined(SPY_TARGET_NATIVE)
 #  define WASM_EXPORT(name) name

--- a/spy/libspy/include/spy.h
+++ b/spy/libspy/include/spy.h
@@ -3,10 +3,10 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
 
-typedef __SIZE_TYPE__ size_t;
-
-#if defined(SPY_TARGET_WASM32) + defined(SPY_TARGET_EMSCRIPTEN) + defined(SPY_TARGET_NATIVE) == 0
+#if defined(SPY_TARGET_WASI) + defined(SPY_TARGET_EMSCRIPTEN) + defined(SPY_TARGET_NATIVE) == 0
 #  error "You must define one and exactly one of the SPY_TARGET_* macros"
 #endif
 
@@ -18,26 +18,6 @@ typedef __SIZE_TYPE__ size_t;
     __attribute__((export_name(#name))) \
     name
 #endif
-
-#ifdef SPY_TARGET_WASM32
-static inline void *memcpy(void *dest, const void *src, size_t n) {
-    return __builtin_memcpy(dest, src, n);
-}
-
-static void _Noreturn abort(void) {
-    __builtin_trap();
-}
-#else
-#  include <stdlib.h>
-#  include <string.h>
-#endif
-
-// this is defined in libc.c. We cannot use __builtin_memcmp :(
-int memcmp(const void *s1, const void *s2, size_t n);
-
-// these are defined in walloc.c
-void *malloc(size_t size);
-void free(void *p);
 
 #include "spy/builtins.h"
 #include "spy/str.h"

--- a/spy/libspy/include/spy/builtins.h
+++ b/spy/libspy/include/spy/builtins.h
@@ -1,5 +1,5 @@
-#ifndef SPY_BUILTIS_H
-#define SPY_BUILTIS_H
+#ifndef SPY_BUILTINS_H
+#define SPY_BUILTINS_H
 
 #include "spy.h"
 #include "spy/str.h"
@@ -10,6 +10,7 @@ WASM_EXPORT(spy_builtins$abs)(int32_t x);
 int32_t
 WASM_EXPORT(spy_builtins$abs)(int32_t x);
 
+/*
 #ifndef SPY_TARGET_WASM32
 void spy_builtins$print_i32(int32_t x);
 void spy_builtins$print_f64(double x);
@@ -18,5 +19,6 @@ void spy_builtins$print_void(void);
 void spy_builtins$print_str(spy_Str *s);
 
 #endif
+*/
 
-#endif /* SPY_BUILTIS_H */
+#endif /* SPY_BUILTINS_H */

--- a/spy/libspy/include/spy/builtins.h
+++ b/spy/libspy/include/spy/builtins.h
@@ -10,15 +10,24 @@ WASM_EXPORT(spy_builtins$abs)(int32_t x);
 int32_t
 WASM_EXPORT(spy_builtins$abs)(int32_t x);
 
-/*
-#ifndef SPY_TARGET_WASM32
-void spy_builtins$print_i32(int32_t x);
-void spy_builtins$print_f64(double x);
-void spy_builtins$print_bool(bool x);
-void spy_builtins$print_void(void);
-void spy_builtins$print_str(spy_Str *s);
+void
+WASM_EXPORT(spy_builtins$print_i32)(int32_t x);
 
-#endif
-*/
+void
+WASM_EXPORT(spy_builtins$print_f64)(double x);
+
+void
+WASM_EXPORT(spy_builtins$print_bool)(bool x);
+
+void
+WASM_EXPORT(spy_builtins$print_void)(void);
+
+void
+WASM_EXPORT(spy_builtins$print_str)(spy_Str *s);
+
+// spy_flush is not a builtin, but we need it to flush stdout/stderr from
+// wastime, see e.g. test_basic.test_print
+void
+WASM_EXPORT(spy_flush)(void);
 
 #endif /* SPY_BUILTINS_H */

--- a/spy/libspy/include/spy/builtins.h
+++ b/spy/libspy/include/spy/builtins.h
@@ -7,9 +7,6 @@
 int32_t
 WASM_EXPORT(spy_builtins$abs)(int32_t x);
 
-int32_t
-WASM_EXPORT(spy_builtins$abs)(int32_t x);
-
 void
 WASM_EXPORT(spy_builtins$print_i32)(int32_t x);
 

--- a/spy/libspy/include/spy/debug.h
+++ b/spy/libspy/include/spy/debug.h
@@ -3,12 +3,23 @@
 
 #include "spy.h"
 
-/***** WASM imports, must be provided by the host *****/
-/* (In emscripten and native mode, these are implemented in debug.c) */
-void spy_debug_log(const char *s);
-void spy_debug_log_i32(const char *s, int32_t n);
-void spy_debug_set_panic_message(const char *s);
-/***** end of WASM imports *****/
+/* Debug utilities:
+  - In emscripten and native mode, these are implemented in debug.c
+  - In WASI mode, they must be provided by the host.
+
+TODO: ideally, we want TWO different WASI modes:
+  - for tests, we want the imports
+  - for standalone executables, we want debug.c
+*/
+#ifdef SPY_TARGET_WASI
+#  define IMP WASM_IMPORT
+#else
+#  define IMP(name) name
+#endif
+
+void IMP(spy_debug_log)(const char *s);
+void IMP(spy_debug_log_i32)(const char *s, int32_t n);
+void IMP(spy_debug_set_panic_message)(const char *s);
 
 static void inline spy_panic(const char *s) {
     spy_debug_log(s);

--- a/spy/libspy/src/builtins.c
+++ b/spy/libspy/src/builtins.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include "spy.h"
 
 int32_t
@@ -7,8 +8,6 @@ spy_builtins$abs(int32_t x) {
     return x;
 }
 
-#ifndef SPY_TARGET_WASM32
-#include <stdio.h>
 
 void spy_builtins$print_i32(int32_t x) {
     printf("%d\n", x);
@@ -35,4 +34,3 @@ void spy_builtins$print_str(spy_Str *s) {
         printf("%c", s->utf8[i]);
     printf("\n");
 }
-#endif

--- a/spy/libspy/src/builtins.c
+++ b/spy/libspy/src/builtins.c
@@ -34,3 +34,8 @@ void spy_builtins$print_str(spy_Str *s) {
         printf("%c", s->utf8[i]);
     printf("\n");
 }
+
+void spy_flush(void) {
+    fflush(stdout);
+    fflush(stderr);
+}

--- a/spy/libspy/src/debug.c
+++ b/spy/libspy/src/debug.c
@@ -1,7 +1,6 @@
 #include "spy.h"
 
-// XXXX
-#if !defined(SPY_TARGET_WASM32)
+#if !defined(SPY_TARGET_WASI)
 
 #include <stdio.h>
 #include <stdint.h>
@@ -18,4 +17,4 @@ void spy_debug_set_panic_message(const char *s) {
     printf("PANIC: %s\n", s);
 }
 
-#endif /* !defined(SPY_TARGET_WASM32) */
+#endif /* !defined(SPY_TARGET_WASI) */

--- a/spy/libspy/src/debug.c
+++ b/spy/libspy/src/debug.c
@@ -1,9 +1,8 @@
 #include "spy.h"
-
-#if !defined(SPY_TARGET_WASI)
-
 #include <stdio.h>
 #include <stdint.h>
+
+#if !defined(SPY_TARGET_WASI)
 
 void spy_debug_log(const char *s) {
     printf("%s\n", s);

--- a/spy/libspy/src/debug.c
+++ b/spy/libspy/src/debug.c
@@ -1,5 +1,6 @@
 #include "spy.h"
 
+// XXXX
 #if !defined(SPY_TARGET_WASM32)
 
 #include <stdio.h>

--- a/spy/libspy/src/str.c
+++ b/spy/libspy/src/str.c
@@ -1,5 +1,3 @@
-#include <stdio.h>
-#include <string.h>
 #include "spy.h"
 
 spy_Str *

--- a/spy/libspy/src/str.c
+++ b/spy/libspy/src/str.c
@@ -1,3 +1,5 @@
+#include <stdio.h>
+#include <string.h>
 #include "spy.h"
 
 spy_Str *

--- a/spy/tests/compiler/test_rawbuffer.py
+++ b/spy/tests/compiler/test_rawbuffer.py
@@ -6,6 +6,21 @@ from spy.tests.support import CompilerTest, skip_backends, no_backend
 
 class TestRawBuffer(CompilerTest):
 
+    # Workaround for a very strange behavior. If I use -O0, I get the
+    # following error:
+    #
+    #   wasmtime._trap.Trap: error while executing at wasm backtrace:
+    #       0:  0xb89 - spy_rawbuffer$rb_set_f64
+    #                       at .../spy/spy/libspy/include/spy/rawbuffer.h:39:8
+    #       1:  0x870 - spy_test$foo
+    #                       at /tmp/pytest-.../test_f64_C_0/test.spy:6:5
+    #   Caused by:
+    #       wasm trap: wasm `unreachable` instruction executed
+    #
+    # However, the code in rb_set_f64 looks correct, and with -O1 it works. I
+    # wonder whether this is a bug of clang and/or wasmtime.
+    OPT_LEVEL = 1
+
     def test_i32(self):
         mod = self.compile(
         """

--- a/spy/tests/support.py
+++ b/spy/tests/support.py
@@ -94,6 +94,8 @@ class CompilerTest:
     backend: Backend
     vm: SPyVM
 
+    OPT_LEVEL = 0
+
     @pytest.fixture(params=params_with_marks(ALL_BACKENDS))  # type: ignore
     def compiler_backend(self, request):
         return request.param
@@ -130,7 +132,7 @@ class CompilerTest:
     SKIP_SPY_BACKEND_SANITY_CHECK = False
     ALL_COMPILED_SOURCES: set[str] = set()
 
-    def compile(self, src: str, modname: str = 'test') -> Any:
+    def compile(self, src: str, modname: str = 'test', *, opt_level=0) -> Any:
         """
         Compile the W_Module into something which can be accessed and called by
         tests.
@@ -155,7 +157,7 @@ class CompilerTest:
         elif self.backend == 'C':
             self.vm.redshift()
             compiler = Compiler(self.vm, modname, self.builddir)
-            file_wasm = compiler.cbuild()
+            file_wasm = compiler.cbuild(opt_level=self.OPT_LEVEL)
             return WasmModuleWrapper(self.vm, modname, file_wasm)
         else:
             assert False, f'Unknown backend: {self.backend}'

--- a/spy/tests/test___main__.py
+++ b/spy/tests/test___main__.py
@@ -42,10 +42,6 @@ class TestMain:
         self.main_spy.write(textwrap.dedent("""
         def main() -> void:
             print("hello world")
-            print(42)
-            print(12.3)
-            print(True)
-            print(None)
         """))
 
     def run(self, *args: Any) -> Any:
@@ -104,14 +100,8 @@ class TestMain:
             assert main_js.exists()
             assert main_wasm.exists()
             cmd = f'node {main_js}'
+
+        # NOTE: getstatusoutput automatically strips the trailing \n
         status, out = getstatusoutput(cmd)
         assert status == 0
-        # NOTE: getstatusoutput automatically strips the trailing \n
-        # NOTE: float formatting is done by printf and it's different than
-        # the one that we get by Python in interp-mode. Too bad for now.
-        assert out == '\n'.join(["hello world",
-                                 "42",
-                                 "12.300000",
-                                 "True",
-                                 "None",
-                                 ])
+        assert out == "hello world"

--- a/spy/tests/test_libspy.py
+++ b/spy/tests/test_libspy.py
@@ -88,7 +88,7 @@ class TestLibSPy(CTest):
             spy_panic("don't panic!");
         }
         """
-        test_wasm = self.compile(src, exports=['crash', 'spy_panic_message'])
+        test_wasm = self.compile(src, exports=['crash'])
         ll = LLSPyInstance.from_file(test_wasm)
         with pytest.raises(SPyPanicError, match="don't panic!"):
             ll.call('crash')

--- a/spy/tests/test_llwasm.py
+++ b/spy/tests/test_llwasm.py
@@ -24,7 +24,9 @@ class TestLLWasm(CTest):
         """
         test_wasm = self.compile(src, exports=['add', 'x', 'y'])
         ll = LLWasmInstance.from_file(test_wasm)
-        assert ll.all_exports() == ['memory', '_initialize', 'add', 'x', 'y']
+        exports = ll.all_exports()
+        exports.sort()
+        assert exports == ['_initialize', 'add', 'memory', 'x', 'y']
 
     def test_read_global(self):
         src = r"""

--- a/spy/tests/test_llwasm.py
+++ b/spy/tests/test_llwasm.py
@@ -92,10 +92,11 @@ class TestLLWasm(CTest):
     def test_HostModule(self):
         src = r"""
         #include <stdint.h>
-        // WASM imports
-        int32_t add(int32_t x, int32_t y);
-        int32_t square(int32_t x);
-        void record(int32_t x);
+        #include "spy.h"
+
+        int32_t WASM_IMPORT(add)(int32_t x, int32_t y);
+        int32_t WASM_IMPORT(square)(int32_t x);
+        void WASM_IMPORT(record)(int32_t x);
 
         int32_t compute(void) {
             record(100);

--- a/spy/tests/test_llwasm.py
+++ b/spy/tests/test_llwasm.py
@@ -24,7 +24,7 @@ class TestLLWasm(CTest):
         """
         test_wasm = self.compile(src, exports=['add', 'x', 'y'])
         ll = LLWasmInstance.from_file(test_wasm)
-        assert ll.all_exports() == ['memory', 'add', 'x', 'y']
+        assert ll.all_exports() == ['memory', '_initialize', 'add', 'x', 'y']
 
     def test_read_global(self):
         src = r"""


### PR DESCRIPTION
wasm32-freestanding would be cool but it creates too many challenges for now.
It is easier to just support WASI and be able to rely on a libc.

This PR also updates the required version of zig, which in turn is more stricter about exported symbols.

Note that for now, we do NOT support creating wasi standalone executable: wasi is used only in "reactor mode" to compile our tests.
It should be easy to add support for executables in the future, but it would probably require a refactoring of `cbuild.py` and the concept of toolchain/targets.
