### PR TITLE
Add support for str(i32)

### DIFF
--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -376,6 +376,11 @@ class CFuncWriter:
             l, r = [self.fmt_expr(arg) for arg in call.args]
             return C.BinOp(op, l, r)
 
+        if call.func.fqn == FQN.parse("builtins::int2str"):
+            c_name = call.func.fqn.c_name
+            c_arg = self.fmt_expr(call.args[1])
+            return C.Call(c_name, [c_arg])
+
         # the default case is to call a function with the corresponding name
         c_name = call.func.fqn.c_name
         c_args = [self.fmt_expr(arg) for arg in call.args]

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -377,6 +377,10 @@ class CFuncWriter:
             return C.BinOp(op, l, r)
 
         if call.func.fqn == FQN.parse("builtins::int2str"):
+            # special case: remove the first param (this is the 'str' type)
+            arg0 = call.args[0]
+            assert (isinstance(arg0, ast.FQNConst) and
+                    arg0.fqn == FQN.parse("builtins::str"))
             c_name = call.func.fqn.c_name
             c_arg = self.fmt_expr(call.args[1])
             return C.Call(c_name, [c_arg])

--- a/spy/libspy/include/spy/str.h
+++ b/spy/libspy/include/spy/str.h
@@ -30,6 +30,10 @@ spy_str_ne(spy_Str *a, spy_Str *b) {
 spy_Str *
 WASM_EXPORT(spy_str_getitem)(spy_Str *s, int32_t i);
 
+spy_Str *
+WASM_EXPORT(spy_builtins$int2str)(int32_t x);
+
+
 #define spy_operator$str_add spy_str_add
 #define spy_operator$str_mul spy_str_mul
 #define spy_operator$str_eq  spy_str_eq

--- a/spy/libspy/src/str.c
+++ b/spy/libspy/src/str.c
@@ -53,3 +53,20 @@ spy_str_getitem(spy_Str *s, int32_t i) {
     buf[0] = s->utf8[i];
     return res;
 }
+
+#include <stdio.h>
+
+spy_Str *
+spy_builtins$int2str(int32_t x) {
+    char buf[1024];
+    size_t length = 0;
+    if (x < 10) {
+        buf[0] = '0' + x;
+        length = 1;
+    }
+
+    spy_Str *res = spy_str_alloc(length);
+    char *outbuf = (char*)res->utf8;
+    outbuf[0] = buf[0];
+    return res;
+}

--- a/spy/libspy/src/str.c
+++ b/spy/libspy/src/str.c
@@ -54,29 +54,8 @@ spy_str_getitem(spy_Str *s, int32_t i) {
     return res;
 }
 
-#ifdef SPY_TARGET_WASM32
-
-// hacky implementation
-spy_Str *
-spy_builtins$int2str(int32_t x) {
-    char buf[1024];
-    size_t length = 0;
-    if (x < 10) {
-        buf[0] = '0' + x;
-        length = 1;
-    }
-
-    spy_Str *res = spy_str_alloc(length);
-    char *outbuf = (char*)res->utf8;
-    outbuf[0] = buf[0];
-    return res;
-}
-
-#else
-
-#include <stdio.h>
-#include <string.h>
-
+// XXX probably it would be better to implement it directly, instead of
+// bringing in all the code needed to support sprintf()
 spy_Str *
 spy_builtins$int2str(int32_t x) {
     char buf[1024];
@@ -88,4 +67,3 @@ spy_builtins$int2str(int32_t x) {
     memcpy(outbuf, buf, length);
     return res;
 }
-#endif

--- a/spy/libspy/src/str.c
+++ b/spy/libspy/src/str.c
@@ -54,7 +54,7 @@ spy_str_getitem(spy_Str *s, int32_t i) {
     return res;
 }
 
-#ifdef SPY_WASM
+#ifdef SPY_TARGET_WASM32
 
 // hacky implementation
 spy_Str *

--- a/spy/libspy/src/str.c
+++ b/spy/libspy/src/str.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include "spy.h"
 
 spy_Str *

--- a/spy/libspy/src/str.c
+++ b/spy/libspy/src/str.c
@@ -54,8 +54,9 @@ spy_str_getitem(spy_Str *s, int32_t i) {
     return res;
 }
 
-#include <stdio.h>
+#ifdef SPY_WASM
 
+// hacky implementation
 spy_Str *
 spy_builtins$int2str(int32_t x) {
     char buf[1024];
@@ -70,3 +71,21 @@ spy_builtins$int2str(int32_t x) {
     outbuf[0] = buf[0];
     return res;
 }
+
+#else
+
+#include <stdio.h>
+#include <string.h>
+
+spy_Str *
+spy_builtins$int2str(int32_t x) {
+    char buf[1024];
+    snprintf(buf, 1024, "%d", x);
+    size_t length = strlen(buf);
+
+    spy_Str *res = spy_str_alloc(length);
+    char *outbuf = (char*)res->utf8;
+    memcpy(outbuf, buf, length);
+    return res;
+}
+#endif

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -684,3 +684,13 @@ class TestBasic(CompilerTest):
 
         out, err = capsys.readouterr()
         assert out == '1\n2\n'
+
+    def test_str2i32(self):
+        mod = self.compile("""
+        def foo(x: i32) -> str:
+            return str(x)
+        """)
+        #
+        assert mod.foo(0) == '0'
+        assert mod.foo(9) == '9'
+        assert mod.foo(123) == '123'

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -1,5 +1,3 @@
-#4414886654598415780
-
 import pytest
 from spy.fqn import QN
 from spy.vm.b import B
@@ -51,6 +49,8 @@ class TestCallOp(CompilerTest):
         """)
         x = mod.foo(5, 7)
         assert x == 12
+
+
 
     def test_call_type(self):
         # ========== EXT module for this test ==========

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -19,6 +19,8 @@ def ll_spy_Str_new(ll: LLWasmInstance, s: str) -> int:
     ll.mem.write(ptr+4, utf8)
     return ptr
 
+
+
 @spytype('str')
 class W_Str(W_Object):
     """
@@ -79,10 +81,12 @@ class W_Str(W_Object):
         from spy.vm.b import B
         argtypes_w = vm.unwrap(w_argtypes)
         if argtypes_w == [W_I32]:
-            @spy_builtin(QN('builtins::int2str'))
-            def opimpl(vm: 'SPyVM', w_cls: W_Type, w_x: W_I32) -> W_Str:
-                x = vm.unwrap_i32(w_x)
-                return vm.wrap(str(x))
-            return vm.wrap(opimpl)
+            return vm.wrap(int2str)
         else:
             return B.w_NotImplemented
+
+
+@spy_builtin(QN('builtins::int2str'))
+def int2str(vm: 'SPyVM', w_cls: W_Type, w_x: W_I32) -> W_Str:
+    x = vm.unwrap_i32(w_x)
+    return vm.wrap(str(x))

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -73,3 +73,15 @@ class W_Str(W_Object):
             ptr_c = vm.ll.call('spy_str_getitem', w_s.ptr, w_i.value)
             return W_Str.from_ptr(vm, ptr_c)
         return vm.wrap(str_getitem)
+
+    def meta_op_CALL(vm: 'SPyVM', w_type: W_Type,
+                     w_argtypes: W_Dynamic) -> W_Dynamic:
+        from spy.vm.b import B
+        argtypes_w = vm.unwrap(w_argtypes)
+        if argtypes_w == [W_I32]:
+            @spy_builtin(QN('builtins::int2str'))
+            def opimpl(vm: 'SPyVM', w_cls: W_Type, w_s: W_I32) -> W_Str:
+                import pdb;pdb.set_trace()
+            return vm.wrap(opimpl)
+        else:
+            return B.w_NotImplemented

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -76,6 +76,7 @@ class W_Str(W_Object):
             return W_Str.from_ptr(vm, ptr_c)
         return vm.wrap(str_getitem)
 
+    @staticmethod
     def meta_op_CALL(vm: 'SPyVM', w_type: W_Type,
                      w_argtypes: W_Dynamic) -> W_Dynamic:
         from spy.vm.b import B
@@ -89,4 +90,4 @@ class W_Str(W_Object):
 @spy_builtin(QN('builtins::int2str'))
 def int2str(vm: 'SPyVM', w_cls: W_Type, w_x: W_I32) -> W_Str:
     x = vm.unwrap_i32(w_x)
-    return vm.wrap(str(x))
+    return vm.wrap(str(x))  # type: ignore

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -80,8 +80,9 @@ class W_Str(W_Object):
         argtypes_w = vm.unwrap(w_argtypes)
         if argtypes_w == [W_I32]:
             @spy_builtin(QN('builtins::int2str'))
-            def opimpl(vm: 'SPyVM', w_cls: W_Type, w_s: W_I32) -> W_Str:
-                import pdb;pdb.set_trace()
+            def opimpl(vm: 'SPyVM', w_cls: W_Type, w_x: W_I32) -> W_Str:
+                x = vm.unwrap_i32(w_x)
+                return vm.wrap(str(x))
             return vm.wrap(opimpl)
         else:
             return B.w_NotImplemented


### PR DESCRIPTION
...but in order to do that, we had to improve several things. In particular, now op.CALL can return an opimpl, and the doppler now needs to support it.

It turns out that `test_operator_call::test_call_instance` needs that logic, but earlier it was passing "by chance" because the blue call was not redshifted aways and thus was still present (and the interpreter was able to run that).
