### PR TITLE
Introduce CALL_METHOD as a 1st-class operator

### DIFF
--- a/spy/ast.py
+++ b/spy/ast.py
@@ -232,7 +232,7 @@ class Call(Expr):
 
 @dataclass(eq=False)
 class CallMethod(Expr):
-    precedence = 16 # XXX?
+    precedence = 17 # higher than GetAttr
     target: Expr
     method: str
     args: list[Expr]

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -231,6 +231,13 @@ class Call(Expr):
     args: list[Expr]
 
 @dataclass(eq=False)
+class CallMethod(Expr):
+    precedence = 16 # XXX?
+    target: Expr
+    method: str
+    args: list[Expr]
+
+@dataclass(eq=False)
 class GetAttr(Expr):
     precedence = 16
     value: Expr

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -230,6 +230,13 @@ class SPyBackend:
             args = ', '.join(arglist)
             return f'{name}({args})'
 
+    def fmt_expr_CallMethod(self, callm: ast.CallMethod) -> str:
+        t = self.fmt_expr(callm.target)
+        m = callm.method
+        arglist = [self.fmt_expr(arg) for arg in callm.args]
+        args = ', '.join(arglist)
+        return f'{t}.{m}({args})'
+
     def fmt_expr_GetItem(self, getitem: ast.GetItem) -> str:
         v = self.fmt_expr(getitem.value)
         i = self.fmt_expr(getitem.index)

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -242,7 +242,6 @@ class FuncDoppler:
         return call.replace(func=newfunc)
 
     def shift_expr_CallMethod(self, cm: ast.CallMethod) -> ast.Expr:
-        # XXX write a test for this
         assert cm in self.t.opimpl
         w_opimpl = self.t.opimpl[cm]
         v_func = self.make_const(cm.loc, w_opimpl)

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -241,12 +241,12 @@ class FuncDoppler:
         newfunc = call.func.replace(fqn=fqn)
         return call.replace(func=newfunc)
 
-    def shift_expr_CallMethod(self, cm: ast.CallMethod) -> ast.Expr:
-        assert cm in self.t.opimpl
-        w_opimpl = self.t.opimpl[cm]
-        v_func = self.make_const(cm.loc, w_opimpl)
-        v_target = self.shift_expr(cm.target)
-        v_method = ast.Constant(cm.loc, value=cm.method)
+    def shift_expr_CallMethod(self, op: ast.CallMethod) -> ast.Expr:
+        assert op in self.t.opimpl
+        w_opimpl = self.t.opimpl[op]
+        v_func = self.make_const(op.loc, w_opimpl)
+        v_target = self.shift_expr(op.target)
+        v_method = ast.Constant(op.loc, value=op.method)
         newargs_v = [v_target, v_method] + \
-            [self.shift_expr(arg) for arg in cm.args]
-        return ast.Call(cm.loc, v_func, newargs_v)
+            [self.shift_expr(arg) for arg in op.args]
+        return ast.Call(op.loc, v_func, newargs_v)

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -240,3 +240,14 @@ class FuncDoppler:
 
         newfunc = call.func.replace(fqn=fqn)
         return call.replace(func=newfunc)
+
+    def shift_expr_CallMethod(self, cm: ast.CallMethod) -> ast.Expr:
+        # XXX write a test for this
+        assert cm in self.t.opimpl
+        w_opimpl = self.t.opimpl[cm]
+        v_func = self.make_const(cm.loc, w_opimpl)
+        v_target = self.shift_expr(cm.target)
+        v_method = ast.Constant(cm.loc, value=cm.method)
+        newargs_v = [v_target, v_method] + \
+            [self.shift_expr(arg) for arg in cm.args]
+        return ast.Call(cm.loc, v_func, newargs_v)

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -428,7 +428,8 @@ class Parser:
         assert spy_cls is not None, f'Unkown operator: {opname}'
         return spy_cls(py_node.loc, left, right)
 
-    def from_py_expr_Call(self, py_node: py_ast.Call) -> spy.ast.Call:
+    def from_py_expr_Call(self, py_node: py_ast.Call
+                          ) -> spy.ast.Call|spy.ast.CallMethod:
         if py_node.keywords:
             self.unsupported(py_node.keywords[0], 'keyword arguments')
         func = self.from_py_expr(py_node.func)

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -431,8 +431,18 @@ class Parser:
     def from_py_expr_Call(self, py_node: py_ast.Call) -> spy.ast.Call:
         if py_node.keywords:
             self.unsupported(py_node.keywords[0], 'keyword arguments')
-        return spy.ast.Call(
-            loc = py_node.loc,
-            func = self.from_py_expr(py_node.func),
-            args = [self.from_py_expr(py_arg) for py_arg in py_node.args]
-        )
+        func = self.from_py_expr(py_node.func)
+        args = [self.from_py_expr(py_arg) for py_arg in py_node.args]
+        if isinstance(func, spy.ast.GetAttr):
+            return spy.ast.CallMethod(
+                loc = py_node.loc,
+                target = func.value,
+                method = func.attr,
+                args = args
+            )
+        else:
+            return spy.ast.Call(
+                loc = py_node.loc,
+                func = func,
+                args = args
+            )

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -142,7 +142,7 @@ class TestCallOp(CompilerTest):
                     def opimpl(vm: 'SPyVM', w_self: W_Calc, w_method: W_Str,
                                w_arg: W_I32) -> W_I32:
                         y = vm.unwrap_i32(w_arg)
-                        return vm.wrap(w_self.x + y)
+                        return vm.wrap(w_self.x + y)  # type: ignore
                     return vm.wrap(opimpl)
 
                 elif meth == 'sub':
@@ -150,7 +150,7 @@ class TestCallOp(CompilerTest):
                     def opimpl(vm: 'SPyVM', w_self: W_Calc, w_method: W_Str,
                                w_arg: W_I32) -> W_I32:
                         y = vm.unwrap_i32(w_arg)
-                        return vm.wrap(w_self.x - y)
+                        return vm.wrap(w_self.x - y)  # type: ignore
                     return vm.wrap(opimpl)
 
                 else:

--- a/spy/tests/test_backend_spy.py
+++ b/spy/tests/test_backend_spy.py
@@ -109,6 +109,14 @@ class TestSPyBackend(CompilerTest):
         self.compile(src)
         self.assert_dump(src)
 
+    def test_callmethod(self):
+        src = """
+        def foo() -> i32:
+            return x.bar(1, 2, 3)
+        """
+        self.compile(src)
+        self.assert_dump(src)
+
     def test_getitem(self):
         src = """
         def foo() -> void:

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -609,6 +609,26 @@ class TestParser:
             ("this is not supported", "x=3"),
         )
 
+    def test_CallMethod(self):
+        mod = self.parse("""
+        def foo() -> i32:
+            return a.b(1, 2)
+        """)
+        stmt = mod.get_funcdef('foo').body[0]
+        expected = """
+        Return(
+            value=CallMethod(
+                target=Name(id='a'),
+                method='b',
+                args=[
+                    Constant(value=1),
+                    Constant(value=2),
+                ],
+            ),
+        )
+        """
+        self.assert_dump(stmt, expected)
+
     def test_If(self):
         mod = self.parse("""
         def foo() -> i32:

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -267,11 +267,11 @@ class ASTFrame:
         w_res = self.vm.call_function(w_func, args_w)
         return w_res
 
-    def eval_expr_CallMethod(self, cm: ast.CallMethod) -> W_Object:
-        w_opimpl = self.t.opimpl[cm]
-        w_target = self.eval_expr(cm.target)
-        w_method = self.vm.wrap(cm.method)
-        arg_w = [self.eval_expr(arg) for arg in cm.args]
+    def eval_expr_CallMethod(self, op: ast.CallMethod) -> W_Object:
+        w_opimpl = self.t.opimpl[op]
+        w_target = self.eval_expr(op.target)
+        w_method = self.vm.wrap(op.method)
+        arg_w = [self.eval_expr(arg) for arg in op.args]
         w_res = self.vm.call_function(w_opimpl, [w_target, w_method] + arg_w)
         return w_res
 

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -267,6 +267,14 @@ class ASTFrame:
         w_res = self.vm.call_function(w_func, args_w)
         return w_res
 
+    def eval_expr_CallMethod(self, cm: ast.CallMethod) -> W_Object:
+        w_opimpl = self.t.opimpl[cm]
+        w_target = self.eval_expr(cm.target)
+        w_method = self.vm.wrap(cm.method)
+        arg_w = [self.eval_expr(arg) for arg in cm.args]
+        w_res = self.vm.call_function(w_opimpl, [w_target, w_method] + arg_w)
+        return w_res
+
     def eval_expr_GetItem(self, op: ast.GetItem) -> W_Object:
         w_opimpl = self.t.opimpl[op]
         w_val = self.eval_expr(op.value)

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type, W_Dynamic
+from spy.vm.str import W_Str
 
 from . import OP
 from .binop import MM
@@ -14,4 +15,12 @@ def CALL(vm: 'SPyVM', w_type: W_Type, w_argtypes: W_Object) -> W_Dynamic:
         raise NotImplementedError("implement me")
     elif pyclass.has_meth_overriden('op_CALL'):
         return pyclass.op_CALL(vm, w_type, w_argtypes)
+    return B.w_NotImplemented
+
+@OP.builtin
+def CALL_METHOD(vm: 'SPyVM', w_type: W_Type, w_method: W_Str,
+                w_argtypes: W_Object) -> W_Dynamic:
+    pyclass = w_type.pyclass
+    if pyclass.has_meth_overriden('op_CALL_METHOD'):
+        return pyclass.op_CALL_METHOD(vm, w_type, w_method, w_argtypes)
     return B.w_NotImplemented

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -154,6 +154,11 @@ class W_Object:
                 w_argtypes: 'W_Dynamic') -> 'W_Dynamic':
         raise NotImplementedError('this should never be called')
 
+    @staticmethod
+    def op_CALL_METHOD(vm: 'SPyVM', w_type: 'W_Type', w_method: 'W_Str',
+                       w_argtypes: 'W_Dynamic') -> 'W_Dynamic':
+        raise NotImplementedError('this should never be called')
+
 
 class W_Type(W_Object):
     """

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -560,7 +560,8 @@ class TypeChecker:
         w_opimpl = self.vm.call_function(OP.w_CALL_METHOD,
                                          [w_otype, w_method, w_argtypes])
         w_method = self.vm.wrap(op.method)
-        newargs = [op.target, w_method] + op.args
+        m = ast.Constant(op.loc, value=w_method)
+        newargs = [op.target, m] + op.args
         errmsg = 'cannot call methods on type `{0}`'
         self.opimpl_typecheck(w_opimpl, op, newargs,
                               [w_otype, B.w_str] + argtypes_w,

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -552,6 +552,26 @@ class TypeChecker:
             err.add('note', 'function defined here', def_loc)
         raise err
 
+    def check_expr_CallMethod(self, op: ast.CallMethod) -> tuple[Color, W_Type]:
+        _, w_otype = self.check_expr(op.target)
+        w_method = self.vm.wrap(op.method)
+        argtypes_w = [self.check_expr(arg)[1] for arg in op.args]
+        w_argtypes = W_List__W_Type(argtypes_w) # type: ignore
+        w_opimpl = self.vm.call_function(OP.w_CALL_METHOD,
+                                         [w_otype, w_method, w_argtypes])
+        w_method = self.vm.wrap(op.method)
+        newargs = [op.target, w_method] + op.args
+        errmsg = 'cannot call methods on type `{0}`'
+        self.opimpl_typecheck(w_opimpl, op, newargs,
+                              [w_otype, B.w_str] + argtypes_w,
+                              dispatch='single',
+                              errmsg=errmsg)
+        assert isinstance(w_opimpl, W_Func)
+        self.opimpl[op] = w_opimpl
+        # XXX I'm not sure that the color is correct here. We need to think
+        # more.
+        return w_opimpl.w_functype.color, w_opimpl.w_functype.w_restype
+
     def check_expr_List(self, listop: ast.List) -> tuple[Color, W_Type]:
         w_itemtype = None
         color: Color = 'red' # XXX should be blue?


### PR DESCRIPTION
This is a bit of a departure from the standard Python semantics but I believe it makes many common patterns easier to write (and possibly more efficient).

Normally, the pattern `a.b(...)` is parsed as a `Call(GetAttr(), ...)`, but with this PR we special-case this syntax and we produce `CallMethod(...)`. Objects can then implement their own operator to implement it.

This will be useful for example to implement a Javascript FFI, because JS doesn't have the concept of bound methods.

In the future, we will probably implement a default `CALL_METHOD` which is implemented in terms of getattr+call.

 