### PR TITLE
Introduce storage categories and universal equality

### DIFF
--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -696,7 +696,7 @@ class TestBasic(CompilerTest):
         assert mod.foo(123) == '123'
 
     @no_C
-    def test_generic_equality(self):
+    def test_eq_reference_types(self):
         mod = self.compile("""
         @blue
         def type_eq(x: type, y: type) -> bool:

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -694,3 +694,19 @@ class TestBasic(CompilerTest):
         assert mod.foo(0) == '0'
         assert mod.foo(9) == '9'
         assert mod.foo(123) == '123'
+
+    @no_C
+    def test_generic_equality(self):
+        mod = self.compile("""
+        @blue
+        def type_eq(x: type, y: type) -> bool:
+            return x == y
+
+        @blue
+        def type_ne(x: type, y: type) -> bool:
+            return x != y
+        """)
+        assert mod.type_eq(B.w_i32, B.w_i32) == True
+        assert mod.type_eq(B.w_i32, B.w_str) == False
+        assert mod.type_ne(B.w_i32, B.w_i32) == False
+        assert mod.type_ne(B.w_i32, B.w_str) == True

--- a/spy/vm/bluecache.py
+++ b/spy/vm/bluecache.py
@@ -39,6 +39,6 @@ class BlueCache:
         if len(args1_w) != len(args2_w):
             return False
         for w_a, w_b in zip(args1_w, args2_w):
-            if self.vm.is_False(self.vm.eq(w_a, w_b)):
+            if self.vm.is_False(self.vm.universal_eq(w_a, w_b)):
                 return False
         return True

--- a/spy/vm/modules/operator/__init__.py
+++ b/spy/vm/modules/operator/__init__.py
@@ -70,6 +70,7 @@ OP = OPERATOR
 from . import opimpl_i32     # side effects
 from . import opimpl_f64     # side effects
 from . import opimpl_str     # side effects
+from . import opimpl_object  # side effects
 from . import opimpl_dynamic # side effects
 from . import binop          # side effects
 from . import attrop         # side effects

--- a/spy/vm/modules/operator/binop.py
+++ b/spy/vm/modules/operator/binop.py
@@ -103,6 +103,14 @@ def NE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
     return MM.lookup('!=', w_ltype, w_rtype)
 
 @OP.builtin
+def UNIVERSAL_EQ(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
+    return OP.w_object_universal_eq
+
+@OP.builtin
+def UNIVERSAL_NE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
+    return OP.w_object_universal_ne
+
+@OP.builtin
 def LT(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
     return MM.lookup('<', w_ltype, w_rtype)
 

--- a/spy/vm/modules/operator/binop.py
+++ b/spy/vm/modules/operator/binop.py
@@ -92,10 +92,14 @@ def DIV(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
 
 @OP.builtin
 def EQ(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
+    if w_ltype is w_rtype and w_ltype.is_reference_type(vm):
+        return OP.w_object_is
     return MM.lookup('==', w_ltype, w_rtype)
 
 @OP.builtin
 def NE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
+    if w_ltype is w_rtype and w_ltype.is_reference_type(vm):
+        return OP.w_object_isnot
     return MM.lookup('!=', w_ltype, w_rtype)
 
 @OP.builtin

--- a/spy/vm/modules/operator/opimpl_dynamic.py
+++ b/spy/vm/modules/operator/opimpl_dynamic.py
@@ -33,11 +33,12 @@ def dynamic_mul(vm: 'SPyVM', w_a: W_Dynamic, w_b: W_Dynamic) -> W_Dynamic:
 
 @OP.builtin
 def dynamic_eq(vm: 'SPyVM', w_a: W_Dynamic, w_b: W_Dynamic) -> W_Dynamic:
-    return _dynamic_op(vm, OP.w_EQ, w_a, w_b)
+    # NOTE: == between dynamic uses UNIVERSAL_EQ
+    return _dynamic_op(vm, OP.w_UNIVERSAL_EQ, w_a, w_b)
 
 @OP.builtin
 def dynamic_ne(vm: 'SPyVM', w_a: W_Dynamic, w_b: W_Dynamic) -> W_Dynamic:
-    return _dynamic_op(vm, OP.w_NE, w_a, w_b)
+    return _dynamic_op(vm, OP.w_UNIVERSAL_NE, w_a, w_b)
 
 @OP.builtin
 def dynamic_lt(vm: 'SPyVM', w_a: W_Dynamic, w_b: W_Dynamic) -> W_Dynamic:

--- a/spy/vm/modules/operator/opimpl_object.py
+++ b/spy/vm/modules/operator/opimpl_object.py
@@ -1,0 +1,15 @@
+from typing import TYPE_CHECKING, Any
+from spy.vm.b import B
+from spy.vm.object import W_Object, W_Bool
+from . import OP
+if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
+
+
+@OP.builtin
+def object_is(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_Bool:
+    return vm.wrap(w_a is w_b)
+
+@OP.builtin
+def object_isnot(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_Bool:
+    return vm.wrap(w_a is not w_b)

--- a/spy/vm/modules/operator/opimpl_object.py
+++ b/spy/vm/modules/operator/opimpl_object.py
@@ -13,3 +13,11 @@ def object_is(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_Bool:
 @OP.builtin
 def object_isnot(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_Bool:
     return vm.wrap(w_a is not w_b)
+
+@OP.builtin
+def object_universal_eq(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_Bool:
+    return vm.universal_eq(w_a, w_b)
+
+@OP.builtin
+def object_universal_ne(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_Bool:
+    return vm.universal_ne(w_a, w_b)

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -475,6 +475,12 @@ class W_Bool(W_Object):
     def spy_unwrap(self, vm: 'SPyVM') -> bool:
         return self.value
 
+    def not_(self, vm: 'SPyVM') -> 'W_Bool':
+        if self.value:
+            return W_Bool._w_singleton_False
+        else:
+            return W_Bool._w_singleton_True
+
 W_Bool._w_singleton_True = W_Bool._make_singleton(True)
 W_Bool._w_singleton_False = W_Bool._make_singleton(False)
 

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -63,6 +63,12 @@ class W_Object:
     _w: ClassVar['W_Type']                         # set later by @spytype
     __spy_members__: ClassVar['dict[str, Member]'] # set later by @spytype
 
+    # Storage category:
+    #   - 'value': compares by value, don't have an identity, 'is' is
+    #     forbidden. E.g., i32, f64, str.
+    #   - 'reference': compare by identity
+    __spy_storage_category__ = 'value'
+
     def __repr__(self) -> str:
         typename = self._w.name
         addr = f'0x{id(self):x}'
@@ -169,6 +175,7 @@ class W_Type(W_Object):
 
     name: str
     pyclass: Type[W_Object]
+    __spy_storage_category__ = 'reference'
 
     def __init__(self, name: str, pyclass: Type[W_Object]):
         assert issubclass(pyclass, W_Object)
@@ -188,6 +195,9 @@ class W_Type(W_Object):
 
     def spy_unwrap(self, vm: 'SPyVM') -> Type[W_Object]:
         return self.pyclass
+
+    def is_reference_type(self, vm: 'SPyVM') -> bool:
+        return self.pyclass.__spy_storage_category__ == 'reference'
 
 W_Object._w = W_Type('object', W_Object)
 W_Object.__spy_members__ = {}

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -221,7 +221,9 @@ class SPyVM:
         into the most appropriate app-level W_* object.
         """
         T = type(value)
-        if value is None:
+        if isinstance(value, W_Object):
+            return value
+        elif value is None:
             return B.w_None
         elif T in (int, fixedint.Int32):
             return W_I32(value)


### PR DESCRIPTION
This PR introduces the concepts of "storage categories" and "universal equality".
As a result, we are able to fix one of the 3 "FIXME" which were introduced by PR #58.

Storage category is used to distinguish between "value types" and "reference types":

  - value types: (e.g. i32, f64, but also str and eventually user-defined structs) don't have the concept of identity and the operator `is` is forbidden on them (well, it will be, since `is` has not been implemented yet).
    This is a departure from Python semantics, but arguably using `is` on primitive types is almost always wrong and leads to subtle bugs (such as `if x is 'hello'` or `if x is 42`, which might or might not work depending on the phase of the moon).

  - reference types: objects have an identity and `is` can be used. Moreover, by default `==` is implemented in term of `is` for them.

On top of that, we introduce the concept of "universal equality". This tries to find a balance between what you would expect in a statically typed language and the usual Python semantics.
The TL;DR version is:

- equality (or "strict equality") is permitted only if types are related. E.g. doing `42 == "hello"` is a TypeError. This is what you would expect by a statically typed language.

- universal equality is more relaxed: it allows to compare objects of different types, and e.g. `42` is not equal to `"hello"`. This is closer to Python semantics and it's useful when writing generic code, e.g. if the objects are used as keys for a cache, or similar.

The trick is that when types are statically known, the token `==` corresponds to strict equality. Thus, the following code raises TypeError (either at runtime or compile time, depending on lazy vs eager errors):
```python
a: i32 = 42
b: str = "hello"
print(a == b)
```

But if the types are `dynamic`, then we switch to universal equality. So the following prints `False`:
```python
a: dynamic = 42
b: dynamic = "hello"
print(a == b)
```

Eventually, it will be possible to explicitly call universal vs strict equality by calling `operator.eq` and `operator.universal_eq`, but these has not been implemented yet.

Armed with this, we can kill this horrible hack:
https://github.com/spylang/spy/blob/c58a82f1881432f72e00f89c5bd74423fb9fde46/spy/vm/vm.py#L293-L301 

Now `bluecache.looukup` uses universal equality to compare arguments.