### PR TITLE
Refactor list types

### DIFF
--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -4,7 +4,7 @@ from spy.fqn import FQN
 from spy.vm.vm import SPyVM
 from spy.vm.object import W_Object, W_Type
 from spy.vm.function import W_ASTFunc, FuncParam
-from spy.vm.list import W_BaseList
+from spy.vm.list import W_List
 from spy.util import magic_dispatch
 from spy.textbuilder import TextBuilder
 
@@ -54,7 +54,7 @@ class SPyBackend:
         return ', '.join(l)
 
     def fmt_w_obj(self, w_obj: W_Object) -> str:
-        if isinstance(w_obj, W_Type) and issubclass(w_obj.pyclass, W_BaseList):
+        if isinstance(w_obj, W_Type) and issubclass(w_obj.pyclass, W_List):
             # this is a ugly special case for now, we need to find a better
             # solution
             return w_obj.name

--- a/spy/tests/compiler/test_list.py
+++ b/spy/tests/compiler/test_list.py
@@ -3,6 +3,7 @@
 import pytest
 from spy.vm.b import B
 from spy.vm.object import W_Type
+from spy.vm.list import W_List__W_Type
 from spy.tests.support import CompilerTest, only_interp, no_C
 
 # Eventually we want to remove the @only_interp, but for now the C backend
@@ -22,6 +23,21 @@ class TestList(CompilerTest):
         assert isinstance(w_list_i32, W_Type)
         assert w_list_i32.name == 'list[i32]'
         assert w_list_i32.pyclass.__name__ == 'W_List[W_I32]'
+
+    def test_cached_generic(self):
+        mod = self.compile(
+        """
+        @blue
+        def make_list(T: type):
+            return list[T]
+        """)
+        w_make_list = mod.make_list.w_func
+        w_list_type = self.vm.call_function(w_make_list, [B.w_type])
+        assert w_list_type.pyclass is W_List__W_Type
+        #
+        w_list_f64a = self.vm.call_function(w_make_list, [B.w_f64])
+        w_list_f64b = self.vm.call_function(w_make_list, [B.w_f64])
+        assert w_list_f64a is w_list_f64b
 
     def test_generalize_literal(self):
         mod = self.compile(

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -4,7 +4,6 @@ from spy.vm.b import B
 from spy.vm.object import spytype, Member, Annotated
 from spy.vm.sig import spy_builtin
 from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_I32, W_Void
-from spy.vm.list import W_BaseList
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM
 from spy.tests.support import CompilerTest, no_C

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -10,7 +10,7 @@ from spy.irgen.symtable import Symbol, Color
 from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type
 from spy.vm.function import W_Func, W_FuncType, W_ASTFunc, Namespace
-from spy.vm.list import W_BaseList
+from spy.vm.list import W_List
 from spy.vm.typechecker import TypeChecker
 from spy.vm.typeconverter import TypeConverter
 from spy.util import magic_dispatch
@@ -310,5 +310,5 @@ class ASTFrame:
     def eval_expr_List(self, op: ast.List) -> W_Object:
         color, w_listtype = self.t.check_expr(op)
         items_w = [self.eval_expr(item) for item in op.items]
-        assert issubclass(w_listtype.pyclass, W_BaseList)
+        assert issubclass(w_listtype.pyclass, W_List)
         return w_listtype.pyclass(items_w) # type: ignore

--- a/spy/vm/b.py
+++ b/spy/vm/b.py
@@ -19,7 +19,7 @@ from spy.vm.registry import ModuleRegistry
 from spy.vm.object import (W_Object, W_Type, w_DynamicType, W_Void, W_I32,
                            W_F64, W_Bool, W_NotImplementedType)
 from spy.vm.str import W_Str
-from spy.vm.list import W_ListFactory
+from spy.vm.list import W_List
 
 
 BUILTINS = ModuleRegistry('builtins', '<builtins>')
@@ -33,7 +33,7 @@ B.add('i32', W_I32._w)
 B.add('f64', W_F64._w)
 B.add('bool', W_Bool._w)
 B.add('str', W_Str._w)
-B.add('list', W_ListFactory())
+B.add('list', W_List()) # XXX we want to move op_GETITEM to the metatype
 B.add('None', W_Void._w_singleton)
 B.add('True', W_Bool._w_singleton_True)
 B.add('False', W_Bool._w_singleton_False)

--- a/spy/vm/b.py
+++ b/spy/vm/b.py
@@ -33,7 +33,7 @@ B.add('i32', W_I32._w)
 B.add('f64', W_F64._w)
 B.add('bool', W_Bool._w)
 B.add('str', W_Str._w)
-B.add('list', W_List()) # XXX we want to move op_GETITEM to the metatype
+B.add('list', W_List._w)
 B.add('None', W_Void._w_singleton)
 B.add('True', W_Bool._w_singleton_True)
 B.add('False', W_Bool._w_singleton_False)

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -6,8 +6,11 @@ from spy.vm.sig import spy_builtin
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
-@spytype('ListFactory')
-class W_ListFactory(W_Object):
+@spytype('list')
+class W_List(W_Object):
+    """
+    Base class for all list types
+    """
     __spy_storage_category__ = 'reference'
 
     @staticmethod
@@ -15,9 +18,8 @@ class W_ListFactory(W_Object):
         return vm.wrap(make_list_type)
 
 
-
 @spy_builtin(QN('__spy__::make_list_type'), color='blue')
-def make_list_type(vm: 'SPyVM', w_self: W_ListFactory, w_T: W_Type) -> W_Type:
+def make_list_type(vm: 'SPyVM', w_self: W_List, w_T: W_Type) -> W_Type:
     """
     Create a concrete W_List class specialized for W_Type.
     """
@@ -26,9 +28,6 @@ def make_list_type(vm: 'SPyVM', w_self: W_ListFactory, w_T: W_Type) -> W_Type:
         return vm.wrap(W_List__W_Type)
     pyclass = _make_W_List(w_T)
     return vm.wrap(pyclass)  # type: ignore
-
-class W_BaseList(W_Object):
-    pass
 
 
 def _make_W_List(w_T: W_Type) -> W_Type:
@@ -42,7 +41,7 @@ def _make_W_List(w_T: W_Type) -> W_Type:
     interp_name = f'W_List[{T.__name__}]' # e.g. W_List[W_I32]
 
     @spytype(app_name)
-    class W_List(W_BaseList):
+    class W_MyList(W_List):
         items_w: list[W_Object]
 
         def __init__(self, items_w: list[W_Object]):
@@ -61,7 +60,7 @@ def _make_W_List(w_T: W_Type) -> W_Type:
                        w_itype: W_Type) -> W_Dynamic:
             @no_type_check
             @spy_builtin(QN('operator::list_getitem'))
-            def getitem(vm: 'SPyVM', w_list: W_List, w_i: W_I32) -> T:
+            def getitem(vm: 'SPyVM', w_list: W_MyList, w_i: W_I32) -> T:
                 i = vm.unwrap_i32(w_i)
                 # XXX bound check?
                 return w_list.items_w[i]
@@ -74,7 +73,7 @@ def _make_W_List(w_T: W_Type) -> W_Type:
 
             @no_type_check
             @spy_builtin(QN('operator::list_setitem'))
-            def setitem(vm: 'SPyVM', w_list: W_List, w_i: W_I32,
+            def setitem(vm: 'SPyVM', w_list: W_MyList, w_i: W_I32,
                         w_v: T) -> W_Void:
                 assert isinstance(w_v, T)
                 i = vm.unwrap_i32(w_i)
@@ -86,11 +85,11 @@ def _make_W_List(w_T: W_Type) -> W_Type:
         @staticmethod
         def op_EQ(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
             from spy.vm.b import B
-            assert w_ltype.pyclass is W_List
+            assert w_ltype.pyclass is W_MyList
 
             @no_type_check
             @spy_builtin(QN('operator::list_eq'))
-            def eq(vm: 'SPyVM', w_l1: W_List, w_l2: W_List) -> W_Bool:
+            def eq(vm: 'SPyVM', w_l1: W_MyList, w_l2: W_MyList) -> W_Bool:
                 items1_w = w_l1.items_w
                 items2_w = w_l2.items_w
                 if len(items1_w) != len(items2_w):
@@ -105,8 +104,8 @@ def _make_W_List(w_T: W_Type) -> W_Type:
             else:
                 return B.w_NotImplemented
 
-    W_List.__name__ = W_List.__qualname__ = interp_name
-    return W_List        # type: ignore
+    W_MyList.__name__ = W_MyList.__qualname__ = interp_name
+    return W_MyList        # type: ignore
 
 
 # well-known list types

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -9,21 +9,23 @@ if TYPE_CHECKING:
 @spytype('list')
 class W_List(W_Object):
     """
-    Base class for all list types
+    The 'list' object.
     """
     __spy_storage_category__ = 'reference'
 
     @staticmethod
-    def op_GETITEM(vm: 'SPyVM', w_type: W_Type, w_vtype: W_Type) -> W_Dynamic:
+    def meta_op_GETITEM(vm: 'SPyVM', w_type: W_Type,
+                        w_vtype: W_Type) -> W_Dynamic:
         return vm.wrap(make_list_type)
 
 
 @spy_builtin(QN('__spy__::make_list_type'), color='blue')
-def make_list_type(vm: 'SPyVM', w_self: W_List, w_T: W_Type) -> W_Type:
+def make_list_type(vm: 'SPyVM', w_list: W_Object, w_T: W_Type) -> W_Type:
     """
     Create a concrete W_List class specialized for W_Type.
     """
     from spy.vm.b import B
+    assert w_list is B.w_list
     if w_T is B.w_type:
         return vm.wrap(W_List__W_Type)
     pyclass = _make_W_List(w_T)

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -7,7 +7,6 @@ from spy.vm.w import (W_Func, W_Type, W_Object, W_I32, W_F64, W_Void, W_Str,
                       W_Dynamic)
 from spy.vm.sig import spy_builtin
 from spy.vm.function import W_Func, W_FuncType
-from spy.vm.list import make_W_List
 from spy.vm.registry import ModuleRegistry
 
 from spy.vm.modules.types import W_TypeDef

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -321,6 +321,9 @@ def make_metaclass(name: str, pyclass: Type[W_Object]) -> Type[W_Type]:
     elif hasattr(pyclass, 'spy_new'):
         W_MetaType.op_CALL = synthesize_meta_op_CALL(pyclass)  # type: ignore
 
+    if hasattr(pyclass, 'meta_op_GETITEM'):
+        W_MetaType.op_GETITEM = pyclass.meta_op_GETITEM  # type: ignore
+
     W_MetaType._w = W_Type(metaname, W_MetaType)
     return W_MetaType
 

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -6,7 +6,7 @@ from spy.irgen.symtable import Symbol, Color
 from spy.errors import (SPyTypeError, SPyNameError, maybe_plural)
 from spy.location import Loc
 from spy.vm.object import W_Object, W_Type
-from spy.vm.list import make_W_List, W_List__W_Type
+from spy.vm.list import W_List__W_Type
 from spy.vm.function import W_FuncType, W_ASTFunc, W_Func
 from spy.vm.b import B
 from spy.vm.modules.operator import OP
@@ -602,6 +602,5 @@ class TypeChecker:
         #
         # XXX we need to handle empty lists
         assert w_itemtype is not None
-        w_listtype = self.vm.wrap(make_W_List(self.vm, w_itemtype))
-        assert isinstance(w_listtype, W_Type)
+        w_listtype = self.vm.make_list_type(w_itemtype)
         return color, w_listtype

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -306,6 +306,9 @@ class SPyVM:
         return w_func.spy_call(self, args_w)
 
     def eq(self, w_a: W_Dynamic, w_b: W_Dynamic) -> W_Bool:
+        # FIXME: we need a more structured way of implementing operators
+        # inside the vm, and possibly share the code with typechecker and
+        # ASTFrame. See also vm.ne and vm.getitem
         w_ta = self.dynamic_type(w_a)
         w_tb = self.dynamic_type(w_b)
         w_opimpl = self.call_function(OPERATOR.w_EQ, [w_ta, w_tb])
@@ -319,6 +322,9 @@ class SPyVM:
         return w_res
 
     def ne(self, w_a: W_Dynamic, w_b: W_Dynamic) -> W_Bool:
+        # FIXME: we need a more structured way of implementing operators
+        # inside the vm, and possibly share the code with typechecker and
+        # ASTFrame. See also vm.ne and vm.getitem
         w_ta = self.dynamic_type(w_a)
         w_tb = self.dynamic_type(w_b)
         w_opimpl = self.call_function(OPERATOR.w_NE, [w_ta, w_tb])
@@ -330,6 +336,19 @@ class SPyVM:
         w_res = self.call_function(w_opimpl, [w_a, w_b])
         assert isinstance(w_res, W_Bool)
         return w_res
+
+    def getitem(self, w_obj: W_Dynamic, w_i: W_Dynamic) -> W_Dynamic:
+        # FIXME: we need a more structured way of implementing operators
+        # inside the vm, and possibly share the code with typechecker and
+        # ASTFrame. See also vm.ne and vm.getitem
+        w_tobj = self.dynamic_type(w_obj)
+        w_ti = self.dynamic_type(w_i)
+        w_opimpl = self.call_function(OPERATOR.w_GETITEM, [w_tobj, w_ti])
+        if w_opimpl is B.w_NotImplemented:
+            # XXX see also eq and ne
+            raise SPyTypeError("Cannot do []")
+        assert isinstance(w_opimpl, W_Func)
+        return self.call_function(w_opimpl, [w_obj, w_i])
 
     def universal_eq(self, w_a: W_Dynamic, w_b: W_Dynamic) -> W_Bool:
         """
@@ -389,3 +408,6 @@ class SPyVM:
 
     def universal_ne(self, w_a: W_Dynamic, w_b: W_Dynamic) -> W_Bool:
         return self.universal_eq(w_a, w_b).not_(self)
+
+    def make_list_type(self, w_T: W_Type) -> W_Type:
+        return self.getitem(B.w_list, w_T)


### PR DESCRIPTION
This PR cleans and improves the implementation of `list`.
In particular:

1. kill `ListFactory`: thanks to support for metatypes, we can now implement the app-level `list` and the interp-level `W_List`, and use `W_List.meta_op_GETITEM` to allows things like `list[i32]`.

2. kill the ugly manual `CACHE`. Now that we support blue builtins, we can rely on  standard blue caching mechanism.
