### PR TITLE
Improve ext modules

### DIFF
--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -16,7 +16,7 @@ class TestOp(CompilerTest):
         # ========== EXT module for this test ==========
         EXT = ModuleRegistry('ext', '<ext>')
 
-        @spytype('MyClass')
+        @EXT.spytype('MyClass')
         class W_MyClass(W_Object):
 
             @staticmethod
@@ -30,8 +30,6 @@ class TestOp(CompilerTest):
                 def getitem(vm: 'SPyVM', w_obj: W_MyClass, w_i: W_I32) -> W_I32:
                     return w_i
                 return vm.wrap(getitem)
-
-        EXT.add('MyClass', W_MyClass._w)
 
         # ========== /EXT module for this test =========
 

--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -30,7 +30,6 @@ class TestOp(CompilerTest):
                 def getitem(vm: 'SPyVM', w_obj: W_MyClass, w_i: W_I32) -> W_I32:
                     return w_i
                 return vm.wrap(getitem)
-
         # ========== /EXT module for this test =========
 
         self.vm.make_module(EXT)
@@ -51,8 +50,12 @@ class TestOp(CompilerTest):
         # ========== EXT module for this test ==========
         EXT = ModuleRegistry('ext', '<ext>')
 
-        @spytype('MyClass')
+        @EXT.spytype('MyClass')
         class W_MyClass(W_Object):
+
+            @staticmethod
+            def spy_new(vm: 'SPyVM', w_cls: W_Type) -> 'W_MyClass':
+                return W_MyClass()
 
             @staticmethod
             def op_GETITEM(vm: 'SPyVM', w_listtype: W_Type,
@@ -61,20 +64,14 @@ class TestOp(CompilerTest):
                 def getitem(vm: 'SPyVM', w_obj: W_MyClass) -> W_Void:
                     return B.w_None
                 return vm.wrap(getitem)
-
-        EXT.add('MyClass', W_MyClass._w)
-
-        @EXT.builtin
-        def make(vm: 'SPyVM') -> W_MyClass:
-            return W_MyClass()
         # ========== /EXT module for this test =========
 
         self.vm.make_module(EXT)
         src = """
-        from ext import make, MyClass
+        from ext import MyClass
 
         def foo() -> i32:
-            obj: MyClass = make()
+            obj = MyClass()
             return obj[0]
         """
         errors = expect_errors(

--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -20,6 +20,10 @@ class TestOp(CompilerTest):
         class W_MyClass(W_Object):
 
             @staticmethod
+            def spy_new(vm: 'SPyVM', w_cls: W_Type) -> 'W_MyClass':
+                return W_MyClass()
+
+            @staticmethod
             def op_GETITEM(vm: 'SPyVM', w_listtype: W_Type,
                            w_itype: W_Type) -> W_Dynamic:
                 @spy_builtin(QN('ext::getitem'))
@@ -29,18 +33,14 @@ class TestOp(CompilerTest):
 
         EXT.add('MyClass', W_MyClass._w)
 
-        @EXT.builtin
-        def make(vm: 'SPyVM') -> W_MyClass:
-            return W_MyClass()
         # ========== /EXT module for this test =========
 
         self.vm.make_module(EXT)
-
         src = """
-        from ext import make, MyClass
+        from ext import MyClass
 
         def foo() -> i32:
-            obj: MyClass = make()
+            obj = MyClass()
             return obj['hello']
         """
         errors = expect_errors(

--- a/spy/tests/compiler/test_operator_attr.py
+++ b/spy/tests/compiler/test_operator_attr.py
@@ -16,26 +16,24 @@ class TestAttrOp(CompilerTest):
         # ========== EXT module for this test ==========
         EXT = ModuleRegistry('ext', '<ext>')
 
-        @spytype('MyClass')
+        @EXT.spytype('MyClass')
         class W_MyClass(W_Object):
             w_x: Annotated[W_I32, Member('x')]
 
             def __init__(self) -> None:
                 self.w_x = W_I32(0)
 
-        EXT.add('MyClass', W_MyClass._w)
-
-        @EXT.builtin
-        def make(vm: 'SPyVM') -> W_MyClass:
-            return W_MyClass()
+            @staticmethod
+            def spy_new(vm: 'SPyVM', w_cls: W_Type) -> 'W_MyClass':
+                return W_MyClass()
         # ========== /EXT module for this test =========
         self.vm.make_module(EXT)
         mod = self.compile("""
-        from ext import make, MyClass
+        from ext import MyClass
 
         @blue
         def foo():
-            obj: MyClass = make()
+            obj =  MyClass()
             obj.x = 123
             return obj.x
         """)
@@ -47,11 +45,15 @@ class TestAttrOp(CompilerTest):
         # ========== EXT module for this test ==========
         EXT = ModuleRegistry('ext', '<ext>')
 
-        @spytype('MyClass')
+        @EXT.spytype('MyClass')
         class W_MyClass(W_Object):
 
             def __init__(self) -> None:
                 self.x = 0
+
+            @staticmethod
+            def spy_new(vm: 'SPyVM', w_cls: W_Type) -> 'W_MyClass':
+                return W_MyClass()
 
             @staticmethod
             def op_GETATTR(vm: 'SPyVM', w_type: W_Type,
@@ -83,32 +85,25 @@ class TestAttrOp(CompilerTest):
                     return vm.wrap(opimpl)
                 else:
                     return B.w_NotImplemented
-
-
-        EXT.add('MyClass', W_MyClass._w)
-
-        @EXT.builtin
-        def make(vm: 'SPyVM') -> W_MyClass:
-            return W_MyClass()  # type: ignore
         # ========== /EXT module for this test =========
 
         self.vm.make_module(EXT)
         mod = self.compile("""
-        from ext import make, MyClass
+        from ext import MyClass
 
         @blue
         def get_hello():
-            obj: MyClass = make()
+            obj = MyClass()
             return obj.hello
 
         @blue
         def get_x():
-            obj: MyClass = make()
+            obj = MyClass()
             return obj.x
 
         @blue
         def set_get_x():
-            obj: MyClass = make()
+            obj = MyClass()
             obj.x = 123
             return obj.x
         """)

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -16,11 +16,15 @@ class TestCallOp(CompilerTest):
         # ========== EXT module for this test ==========
         EXT = ModuleRegistry('ext', '<ext>')
 
-        @spytype('Adder')
+        @EXT.spytype('Adder')
         class W_Adder(W_Object):
 
             def __init__(self, x: int) -> None:
                 self.x = x
+
+            @staticmethod
+            def spy_new(vm: 'SPyVM', w_cls: W_Type, w_x: W_I32) -> 'W_Adder':
+                return W_Adder(vm.unwrap_i32(w_x))
 
             @staticmethod
             def op_CALL(vm: 'SPyVM', w_type: W_Type,
@@ -31,19 +35,13 @@ class TestCallOp(CompilerTest):
                     res = w_obj.x + y
                     return vm.wrap(res) # type: ignore
                 return vm.wrap(call)
-
-        EXT.add('Adder', W_Adder._w)
-
-        @EXT.builtin
-        def make(vm: 'SPyVM', w_x: W_I32) -> W_Adder:
-            return W_Adder(vm.unwrap_i32(w_x))
         # ========== /EXT module for this test =========
         self.vm.make_module(EXT)
         mod = self.compile("""
-        from ext import make, Adder
+        from ext import Adder
 
         def foo(x: i32, y: i32) -> i32:
-            obj: Adder = make(x)
+            obj = Adder(x)
             return obj(y)
         """)
         x = mod.foo(5, 7)
@@ -54,7 +52,7 @@ class TestCallOp(CompilerTest):
         # ========== EXT module for this test ==========
         EXT = ModuleRegistry('ext', '<ext>')
 
-        @spytype('Point')
+        @EXT.spytype('Point')
         class W_Point(W_Object):
             w_x: Annotated[W_I32, Member('x')]
             w_y: Annotated[W_I32, Member('y')]
@@ -71,9 +69,6 @@ class TestCallOp(CompilerTest):
                         w_x: W_I32, w_y: W_I32) -> W_Point:
                     return W_Point(w_x, w_y)
                 return vm.wrap(new)
-
-        EXT.add('Point', W_Point._w)
-
         # ========== /EXT module for this test =========
         self.vm.make_module(EXT)
         mod = self.compile("""
@@ -91,7 +86,7 @@ class TestCallOp(CompilerTest):
         # ========== EXT module for this test ==========
         EXT = ModuleRegistry('ext', '<ext>')
 
-        @spytype('Point')
+        @EXT.spytype('Point')
         class W_Point(W_Object):
             w_x: Annotated[W_I32, Member('x')]
             w_y: Annotated[W_I32, Member('y')]
@@ -104,9 +99,6 @@ class TestCallOp(CompilerTest):
             def spy_new(vm: 'SPyVM', w_cls: W_Type,
                         w_x: W_I32, w_y: W_I32) -> 'W_Point':
                 return W_Point(w_x, w_y)
-
-        EXT.add('Point', W_Point._w)
-
         # ========== /EXT module for this test =========
         self.vm.make_module(EXT)
         mod = self.compile("""
@@ -125,11 +117,15 @@ class TestCallOp(CompilerTest):
         # ========== EXT module for this test ==========
         EXT = ModuleRegistry('ext', '<ext>')
 
-        @spytype('Calc')
+        @EXT.spytype('Calc')
         class W_Calc(W_Object):
 
             def __init__(self, x: int) -> None:
                 self.x = x
+
+            @staticmethod
+            def spy_new(vm: 'SPyVM', w_cls: W_Type, w_x: W_I32) -> 'W_Calc':
+                return W_Calc(vm.unwrap_i32(w_x))
 
             @staticmethod
             def op_CALL_METHOD(vm: 'SPyVM', w_type: W_Type, w_method: W_Str,
@@ -154,20 +150,14 @@ class TestCallOp(CompilerTest):
 
                 else:
                     return B.w_NotImplemented
-
-        EXT.add('Calc', W_Calc._w)
-
-        @EXT.builtin
-        def make(vm: 'SPyVM', w_x: W_I32) -> W_Calc:
-            return W_Calc(vm.unwrap_i32(w_x))
         # ========== /EXT module for this test =========
 
         self.vm.make_module(EXT)
         mod = self.compile("""
-        from ext import make, Calc
+        from ext import Calc
 
         def foo(x: i32, y: i32, z: i32) -> i32:
-            obj: Calc = make(x)
+            obj = Calc(x)
             return obj.add(y) * 10 + obj.sub(z)
         """)
         x = mod.foo(5, 1, 2)

--- a/spy/tests/compiler/test_typedef.py
+++ b/spy/tests/compiler/test_typedef.py
@@ -15,8 +15,8 @@ class TestTypeDef(CompilerTest):
         # origin type because it's simpler, but eventually we want a more
         # explicit way, e.g. TypeDef.cast or something like that.
         mod = self.compile("""
-        from types import makeTypeDef
-        MyInt = makeTypeDef('MyInt', i32)
+        from types import TypeDef
+        MyInt = TypeDef('MyInt', i32)
 
         # this should go away and become MyInt.cast_from
         def MyInt_cast_from(x: i32) -> MyInt:
@@ -43,11 +43,11 @@ class TestTypeDef(CompilerTest):
         Test that we can succesfully set attributes on the typedef itself
         """
         mod = self.compile("""
-        from types import makeTypeDef
+        from types import TypeDef
 
         @blue
         def makeMyInt():
-            MyInt = makeTypeDef('MyInt', i32)
+            MyInt = TypeDef('MyInt', i32)
 
             @blue
             def __getattr__(attr):
@@ -71,11 +71,11 @@ class TestTypeDef(CompilerTest):
         Test that we can succesfully get attributes on the typedef itself
         """
         mod = self.compile("""
-        from types import makeTypeDef
+        from types import TypeDef
 
         @blue
         def foo():
-            MyInt = makeTypeDef('MyInt', i32)
+            MyInt = TypeDef('MyInt', i32)
             MyInt.__getattr__ = 42
             return MyInt.__getattr__
         """)
@@ -85,11 +85,11 @@ class TestTypeDef(CompilerTest):
 
     def test_getattr(self):
         mod = self.compile("""
-        from types import makeTypeDef
+        from types import TypeDef
 
         @blue
         def makeMyInt():
-            MyInt = makeTypeDef('MyInt', i32)
+            MyInt = TypeDef('MyInt', i32)
 
             def getattr_double(self: MyInt, attr: str) -> i32:
                 i: i32 = self
@@ -114,12 +114,12 @@ class TestTypeDef(CompilerTest):
 
     def test_setattr(self):
         mod = self.compile("""
-        from types import makeTypeDef
+        from types import TypeDef
         from rawbuffer import RawBuffer, rb_alloc, rb_get_i32, rb_set_i32
 
         @blue
         def makeBox():
-            Box = makeTypeDef('Box', RawBuffer)
+            Box = TypeDef('Box', RawBuffer)
 
             def getattr_x(self: Box, attr: str) -> i32:
                 buf: RawBuffer = self

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -8,7 +8,6 @@ from spy.vm.w import (W_Func, W_Type, W_Object, W_I32, W_F64, W_Void, W_Str,
 from spy.vm.sig import spy_builtin
 from spy.vm.function import W_Func, W_FuncType
 from spy.vm.registry import ModuleRegistry
-
 from spy.vm.modules.types import W_TypeDef
 
 if TYPE_CHECKING:
@@ -16,7 +15,7 @@ if TYPE_CHECKING:
 
 JSFFI = ModuleRegistry('jsffi', '<jsffi>')
 
-@spytype('JsRef')
+@JSFFI.spytype('JsRef')
 class W_JsRef(W_Object):
 
     @staticmethod
@@ -58,9 +57,6 @@ class W_JsRef(W_Object):
 def call_method_1(vm: 'SPyVM', w_self: W_JsRef, w_method: W_Str,
                   w_arg: W_JsRef) -> W_JsRef:
     return js_call_method_1(w_self, w_method, w_arg)
-
-
-JSFFI.add('JsRef', W_JsRef._w)
 
 @JSFFI.builtin
 def debug(vm: 'SPyVM', w_str: W_Str) -> None:

--- a/spy/vm/modules/rawbuffer.py
+++ b/spy/vm/modules/rawbuffer.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 RAW_BUFFER = RB = ModuleRegistry('rawbuffer', '<rawbuffer>')
 
-@spytype('RawBuffer')
+@RB.spytype('RawBuffer')
 class W_RawBuffer(W_Object):
     buf: bytearray
 
@@ -23,7 +23,6 @@ class W_RawBuffer(W_Object):
     def spy_unwrap(self, vm: 'SPyVM') -> bytearray:
         return self.buf
 
-RB.add('RawBuffer', W_RawBuffer._w)
 
 @RB.builtin
 def rb_alloc(vm: 'SPyVM', w_size: W_I32) -> W_RawBuffer:

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -39,12 +39,12 @@ class W_TypeDef(W_Type):
         self.w_getattr = B.w_NotImplemented
         self.w_setattr = B.w_NotImplemented
 
+    @staticmethod
+    def spy_new(vm: 'SPyVM', w_cls: W_Type, w_name: W_Str,
+                w_origintype: W_Type) -> 'W_TypeDef':
+        name = vm.unwrap_str(w_name)
+        return W_TypeDef(name, w_origintype)
+
     def __repr__(self) -> str:
         r = f"<spy type '{self.name}' (typedef of '{self.w_origintype.name}')>"
         return r
-
-
-@TYPES.builtin
-def makeTypeDef(vm: 'SPyVM', w_name: W_Str, w_origintype: W_Type) -> W_TypeDef:
-    name = vm.unwrap_str(w_name)
-    return W_TypeDef(name, w_origintype)

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -17,7 +17,7 @@ TYPES = ModuleRegistry('types', '<types>')
 TYPES.add('module', W_Module._w)
 
 
-@spytype('TypeDef')
+@TYPES.spytype('TypeDef')
 class W_TypeDef(W_Type):
     """
     A TypeDef is a purely static alias for another type (called "origin
@@ -43,7 +43,6 @@ class W_TypeDef(W_Type):
         r = f"<spy type '{self.name}' (typedef of '{self.w_origintype.name}')>"
         return r
 
-TYPES.add('TypeDef', W_TypeDef._w)
 
 @TYPES.builtin
 def makeTypeDef(vm: 'SPyVM', w_name: W_Str, w_origintype: W_Type) -> W_TypeDef:


### PR DESCRIPTION
Simplify and improve the usage of `ModuleRegistry`:
  - add `@MOD.spytype`
  - use `spy_new` everywhere and kill the ugly `make*` functions