### PR TITLE
Add a basic tuple type

### DIFF
--- a/spy/ast.py
+++ b/spy/ast.py
@@ -458,6 +458,11 @@ class Assign(Stmt):
     value: Expr
 
 @dataclass(eq=False)
+class UnpackAssign(Stmt):
+    targets: list[str]
+    value: Expr
+
+@dataclass(eq=False)
 class SetAttr(Stmt):
     target_loc: Loc = field(repr=False)
     target: Expr

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Optional, Iterator, Any, Literal, Sequence
+from typing import Optional, Iterator, Any, Literal
 import pprint
 import ast as py_ast
 import dataclasses
@@ -464,8 +464,8 @@ class UnpackAssign(Stmt):
     value: Expr
 
     @property
-    def targlocs(self) -> Sequence[tuple[str, Loc]]:
-        return zip(self.targets, self.target_locs)
+    def targlocs(self) -> list[tuple[str, Loc]]:
+        return list(zip(self.targets, self.target_locs))
 
 
 @dataclass(eq=False)

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Optional, Iterator, Any, Literal
+from typing import Optional, Iterator, Any, Literal, Sequence
 import pprint
 import ast as py_ast
 import dataclasses
@@ -459,8 +459,14 @@ class Assign(Stmt):
 
 @dataclass(eq=False)
 class UnpackAssign(Stmt):
+    target_locs: list[Loc] = field(repr=False)
     targets: list[str]
     value: Expr
+
+    @property
+    def targlocs(self) -> Sequence[tuple[str, Loc]]:
+        return zip(self.targets, self.target_locs)
+
 
 @dataclass(eq=False)
 class SetAttr(Stmt):

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -225,6 +225,11 @@ class List(Expr):
     items: list[Expr]
 
 @dataclass(eq=False)
+class Tuple(Expr):
+    precedence = 17
+    items: list[Expr]
+
+@dataclass(eq=False)
 class Call(Expr):
     precedence = 16
     func: Expr

--- a/spy/ast_dump.py
+++ b/spy/ast_dump.py
@@ -33,7 +33,8 @@ class Dumper(TextBuilder):
                  ) -> None:
         super().__init__(use_colors=use_colors)
         self.highlight = highlight
-        self.fields_to_ignore = ('loc', 'target_loc', 'loc_asname')
+        self.fields_to_ignore = ('loc', 'target_loc', 'target_locs',
+                                 'loc_asname')
 
     def dump_anything(self, obj: Any) -> None:
         if isinstance(obj, spy.ast.Node):

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -250,3 +250,8 @@ class SPyBackend:
         itemlist = [self.fmt_expr(it) for it in node.items]
         items = ', '.join(itemlist)
         return f'[{items}]'
+
+    def fmt_expr_Tuple(self, node: ast.Tuple) -> str:
+        itemlist = [self.fmt_expr(it) for it in node.items]
+        items = ', '.join(itemlist)
+        return f'({items})'

--- a/spy/irgen/scope.py
+++ b/spy/irgen/scope.py
@@ -180,16 +180,24 @@ class ScopeAnalyzer:
         self.pop_scope()
 
     def declare_Assign(self, assign: ast.Assign) -> None:
+        self._declare_target_maybe(assign.target, assign.target_loc,
+                                   assign.value)
+
+    def declare_UnpackAssign(self, unpack: ast.UnpackAssign) -> None:
+        for target, loc in unpack.targlocs:
+            self._declare_target_maybe(target, loc, unpack.value)
+
+    def _declare_target_maybe(self, target: str, target_loc: Loc,
+                              value: ast.Expr) -> None:
         # if target name does not exist elsewhere, we treat it as an implicit
         # declaration
-        name = assign.target
-        level, sym = self.lookup(name)
+        level, sym = self.lookup(target)
         if sym is None:
             # we don't have an explicit type annotation: we consider the
             # "value" to be the type_loc, because it's where the type will be
             # computed from
-            type_loc = assign.value.loc
-            self.add_name(name, 'red', assign.loc, type_loc)
+            type_loc = value.loc
+            self.add_name(target, 'red', target_loc, type_loc)
 
     # ===
 

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -321,11 +321,14 @@ class Parser:
             )
         elif isinstance(py_target, py_ast.Tuple):
             targets = []
+            target_locs = []
             for item in py_target.elts:
                 assert isinstance(item, py_ast.Name)
                 targets.append(item.id)
+                target_locs.append(item.loc)
             return spy.ast.UnpackAssign(
                 loc = py_node.loc,
+                target_locs = target_locs,
                 targets = targets,
                 value = self.from_py_expr(py_node.value)
             )

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -380,6 +380,10 @@ class Parser:
         items = [self.from_py_expr(py_item) for py_item in py_node.elts]
         return spy.ast.List(py_node.loc, items)
 
+    def from_py_expr_Tuple(self, py_node: py_ast.Tuple) -> spy.ast.Tuple:
+        items = [self.from_py_expr(py_item) for py_item in py_node.elts]
+        return spy.ast.Tuple(py_node.loc, items)
+
     def from_py_expr_BinOp(self, py_node: py_ast.BinOp) -> spy.ast.BinOp:
         left = self.from_py_expr(py_node.left)
         right = self.from_py_expr(py_node.right)

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -319,6 +319,16 @@ class Parser:
                 index = self.from_py_expr(py_target.slice),
                 value = self.from_py_expr(py_node.value)
             )
+        elif isinstance(py_target, py_ast.Tuple):
+            targets = []
+            for item in py_target.elts:
+                assert isinstance(item, py_ast.Name)
+                targets.append(item.id)
+            return spy.ast.UnpackAssign(
+                loc = py_node.loc,
+                targets = targets,
+                value = self.from_py_expr(py_node.value)
+            )
         else:
             self.unsupported(py_target, 'assign to complex expressions')
 

--- a/spy/tests/compiler/test_tuple.py
+++ b/spy/tests/compiler/test_tuple.py
@@ -1,7 +1,7 @@
 import pytest
 from spy.errors import SPyRuntimeError
 from spy.vm.b import B
-from spy.tests.support import CompilerTest, only_interp
+from spy.tests.support import CompilerTest, only_interp, expect_errors
 
 # Eventually we want to remove the @only_interp, but for now the C backend
 # doesn't support lists
@@ -54,3 +54,14 @@ class TestTuple(CompilerTest):
         msg = "Wrong number of values to unpack: expected 3, got 2"
         with pytest.raises(SPyRuntimeError, match=msg):
             mod.foo()
+
+    def test_unpacking_wrong_type(self):
+        src = """
+        def foo() -> void:
+            a, b, c = 42
+        """
+        errors = expect_errors(
+            '`i32` does not support unpacking',
+            ('this is `i32`', '42'),
+        )
+        self.compile_raises(src, 'foo', errors)

--- a/spy/tests/compiler/test_tuple.py
+++ b/spy/tests/compiler/test_tuple.py
@@ -1,4 +1,5 @@
 import pytest
+from spy.errors import SPyRuntimeError
 from spy.vm.b import B
 from spy.tests.support import CompilerTest, only_interp
 
@@ -40,3 +41,16 @@ class TestTuple(CompilerTest):
         """)
         x = mod.foo()
         assert x == 3
+
+    def test_unpacking_wrong_number(self):
+        mod = self.compile(
+        """
+        def make_tuple() -> tuple:
+            return 1, 2
+
+        def foo() -> void:
+            a, b, c = make_tuple()
+        """)
+        msg = "Wrong number of values to unpack: expected 3, got 2"
+        with pytest.raises(SPyRuntimeError, match=msg):
+            mod.foo()

--- a/spy/tests/compiler/test_tuple.py
+++ b/spy/tests/compiler/test_tuple.py
@@ -15,3 +15,16 @@ class TestTuple(CompilerTest):
         """)
         tup = mod.foo()
         assert tup == (1, 2, 'hello')
+
+    def test_unpacking(self):
+        mod = self.compile(
+        """
+        def make_tuple() -> dynamic:
+            return 1, 2, 'hello'
+
+        def foo() -> i32:
+            a, b, c = make_tuple()
+            return a + b
+        """)
+        x = mod.foo()
+        assert x == 3

--- a/spy/tests/compiler/test_tuple.py
+++ b/spy/tests/compiler/test_tuple.py
@@ -1,0 +1,17 @@
+import pytest
+from spy.vm.b import B
+from spy.tests.support import CompilerTest, only_interp
+
+# Eventually we want to remove the @only_interp, but for now the C backend
+# doesn't support lists
+@only_interp
+class TestTuple(CompilerTest):
+
+    def test_literal(self):
+        mod = self.compile(
+        """
+        def foo() -> dynamic:
+            return 1, 2, 'hello'
+        """)
+        tup = mod.foo()
+        assert tup == (1, 2, 'hello')

--- a/spy/tests/compiler/test_tuple.py
+++ b/spy/tests/compiler/test_tuple.py
@@ -28,10 +28,10 @@ class TestTuple(CompilerTest):
         y = mod.foo(2)
         assert y == 'hello'
 
-    def xtest_unpacking(self):
+    def test_unpacking(self):
         mod = self.compile(
         """
-        def make_tuple() -> dynamic:
+        def make_tuple() -> tuple:
             return 1, 2, 'hello'
 
         def foo() -> i32:

--- a/spy/tests/compiler/test_tuple.py
+++ b/spy/tests/compiler/test_tuple.py
@@ -16,7 +16,19 @@ class TestTuple(CompilerTest):
         tup = mod.foo()
         assert tup == (1, 2, 'hello')
 
-    def test_unpacking(self):
+    def test_getitem(self):
+        mod = self.compile(
+        """
+        def foo(i: i32) -> dynamic:
+            tup = 1, 2, 'hello'
+            return tup[i]
+        """)
+        x = mod.foo(0)
+        assert x == 1
+        y = mod.foo(2)
+        assert y == 'hello'
+
+    def xtest_unpacking(self):
         mod = self.compile(
         """
         def make_tuple() -> dynamic:

--- a/spy/tests/test_backend_spy.py
+++ b/spy/tests/test_backend_spy.py
@@ -170,6 +170,14 @@ class TestSPyBackend(CompilerTest):
         self.compile(src)
         self.assert_dump(src)
 
+    def test_tuple_literal(self):
+        src = """
+        def foo() -> tuple:
+            return (1, 2, 3)
+        """
+        self.compile(src)
+        self.assert_dump(src)
+
     def test_zz_sanity_check(self):
         """
         This is a hack.

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -423,6 +423,25 @@ class TestParser:
         """
         self.assert_dump(stmt, expected)
 
+    def test_Tuple(self):
+        mod = self.parse("""
+        def foo() -> void:
+            return 1, 2, 3
+        """)
+        stmt = mod.get_funcdef('foo').body[0]
+        expected = """
+        Return(
+            value=Tuple(
+                items=[
+                    Constant(value=1),
+                    Constant(value=2),
+                    Constant(value=3),
+                ],
+            ),
+        )
+        """
+        self.assert_dump(stmt, expected)
+
     @pytest.mark.parametrize("op", "+ - * / // % ** << >> | ^ & @".split())
     def test_BinOp(self, op):
         # map the operator to the spy.ast class name

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -589,13 +589,31 @@ class TestParser:
     def test_Assign_unsupported_2(self):
         src = """
         def foo() -> void:
-            a, b = 1, 2
+            [a, b] = 1, 2
         """
         self.expect_errors(
             src,
             "not implemented yet: assign to complex expressions",
-            ("this is not supported", "a, b"),
+            ("this is not supported", "[a, b]"),
         )
+
+    def test_UnpackAssign(self):
+        mod = self.parse("""
+        def foo() -> void:
+            a, b, c = x
+        """)
+        stmt = mod.get_funcdef('foo').body[0]
+        expected = """
+        UnpackAssign(
+            targets=[
+                'a',
+                'b',
+                'c',
+            ],
+            value=Name(id='x'),
+        )
+        """
+        self.assert_dump(stmt, expected)
 
     def test_Call(self):
         mod = self.parse("""

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -143,7 +143,12 @@ class ASTFrame:
     def exec_stmt_UnpackAssign(self, unpack: ast.UnpackAssign) -> None:
         w_tup = self.eval_expr(unpack.value)
         assert isinstance(w_tup, W_Tuple)
-        assert len(w_tup.items_w) == len(unpack.targets) # XXX proper error
+        exp = len(unpack.targets)
+        got = len(w_tup.items_w)
+        if exp != got:
+            raise SPyRuntimeError(
+                f"Wrong number of values to unpack: expected {exp}, got {got}"
+            )
         for target, w_val in zip(unpack.targets, w_tup.items_w):
             self._exec_assign(target, w_val)
 

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -11,6 +11,7 @@ from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type
 from spy.vm.function import W_Func, W_FuncType, W_ASTFunc, Namespace
 from spy.vm.list import W_List
+from spy.vm.tuple import W_Tuple
 from spy.vm.typechecker import TypeChecker
 from spy.vm.typeconverter import TypeConverter
 from spy.util import magic_dispatch
@@ -312,3 +313,9 @@ class ASTFrame:
         items_w = [self.eval_expr(item) for item in op.items]
         assert issubclass(w_listtype.pyclass, W_List)
         return w_listtype.pyclass(items_w) # type: ignore
+
+    def eval_expr_Tuple(self, op: ast.Tuple) -> W_Object:
+        color, w_tupletype = self.t.check_expr(op)
+        assert w_tupletype is B.w_tuple
+        items_w = [self.eval_expr(item) for item in op.items]
+        return W_Tuple(items_w)

--- a/spy/vm/b.py
+++ b/spy/vm/b.py
@@ -20,6 +20,7 @@ from spy.vm.object import (W_Object, W_Type, w_DynamicType, W_Void, W_I32,
                            W_F64, W_Bool, W_NotImplementedType)
 from spy.vm.str import W_Str
 from spy.vm.list import W_List
+from spy.vm.tuple import W_Tuple
 
 
 BUILTINS = ModuleRegistry('builtins', '<builtins>')
@@ -34,6 +35,7 @@ B.add('f64', W_F64._w)
 B.add('bool', W_Bool._w)
 B.add('str', W_Str._w)
 B.add('list', W_List._w)
+B.add('tuple', W_Tuple._w)
 B.add('None', W_Void._w_singleton)
 B.add('True', W_Bool._w_singleton_True)
 B.add('False', W_Bool._w_singleton_False)

--- a/spy/vm/tuple.py
+++ b/spy/vm/tuple.py
@@ -1,0 +1,27 @@
+from typing import TYPE_CHECKING, Any, no_type_check, Optional
+from spy.fqn import QN
+from spy.vm.object import (W_Object, spytype, W_Type, W_Dynamic, W_I32, W_Void,
+                           W_Bool)
+from spy.vm.sig import spy_builtin
+if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
+
+@spytype('tuple')
+class W_Tuple(W_Object):
+    """
+    This is not the "real" tuple type that we will have in SPy.
+
+    It's a trimmed-down "dynamic" tuple, which can contain an arbitrary number
+    of items of arbitrary types. It is meant to be used in blue code, and we
+    need it to bootstrap SPy.
+
+    Eventally, it will become a "real" type-safe, generic type.
+    """
+
+    items_w: list[W_Object]
+
+    def __init__(self, items_w: list[W_Object]) -> None:
+        self.items_w = items_w
+
+    def spy_unwrap(self, vm: 'SPyVM') -> tuple:
+        return tuple([vm.unwrap(w_item) for w_item in self.items_w])

--- a/spy/vm/tuple.py
+++ b/spy/vm/tuple.py
@@ -25,3 +25,16 @@ class W_Tuple(W_Object):
 
     def spy_unwrap(self, vm: 'SPyVM') -> tuple:
         return tuple([vm.unwrap(w_item) for w_item in self.items_w])
+
+    @staticmethod
+    def op_GETITEM(vm: 'SPyVM', w_tupletype: W_Type,
+                   w_itype: W_Type) -> W_Dynamic:
+        return vm.wrap(tuple_getitem)
+
+
+
+@spy_builtin(QN('operator::tuple_getitem'))
+def tuple_getitem(vm: 'SPyVM', w_tup: W_Tuple, w_i: W_I32) -> W_Dynamic:
+    i = vm.unwrap_i32(w_i)
+    # XXX bound check?
+    return w_tup.items_w[i]

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -606,3 +606,10 @@ class TypeChecker:
         assert w_itemtype is not None
         w_listtype = self.vm.make_list_type(w_itemtype)
         return color, w_listtype
+
+    def check_expr_Tuple(self, tupleop: ast.Tuple) -> tuple[Color, W_Type]:
+        color: Color = 'blue'
+        for item in tupleop.items:
+            c1, w_t1 = self.check_expr(item)
+            color = maybe_blue(color, c1)
+        return color, B.w_tuple

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -217,25 +217,45 @@ class TypeChecker:
     def check_stmt_While(self, while_node: ast.While) -> None:
         self.typecheck_bool(while_node.test)
 
-    def check_stmt_Assign(self, assign: ast.Assign) -> None:
-        name = assign.target
-        sym = self.funcdef.symtable.lookup(name)
+    def _check_assign(self, target: str, target_loc: Loc,
+                      expr: ast.Expr) -> None:
+        sym = self.funcdef.symtable.lookup(target)
         if sym.is_global and sym.color == 'blue':
             err = SPyTypeError("invalid assignment target")
-            err.add('error', f'{sym.name} is const', assign.target_loc)
+            err.add('error', f'{sym.name} is const', target_loc)
             err.add('note', 'const declared here', sym.loc)
             err.add('note',
                     f'help: declare it as variable: `var {sym.name} ...`',
                     sym.loc)
             raise err
 
-        _, w_valuetype = self.check_expr(assign.value)
-
         if sym.is_local:
-            if name not in self.locals_types_w:
+            if target not in self.locals_types_w:
                 # first assignment, implicit declaration
-                self.declare_local(name, w_valuetype)
-            self.typecheck_local(assign.value, name)
+                _, w_valuetype = self.check_expr(expr)
+                self.declare_local(target, w_valuetype)
+            self.typecheck_local(expr, target)
+
+    def check_stmt_Assign(self, assign: ast.Assign) -> None:
+        _, w_valuetype = self.check_expr(assign.value)
+        self._check_assign(assign.target, assign.target_loc, assign.value)
+
+    def check_stmt_UnpackAssign(self, unpack: ast.UnpackAssign) -> None:
+        _, w_valuetype = self.check_expr(unpack.value)
+        assert w_valuetype is B.w_tuple # XXX better error
+
+        for i, (target, target_loc) in enumerate(unpack.targlocs):
+            # we need an expression which has the type of each individual item
+            # of the tuple. The easiest way is to synthetize a GetItem
+            expr = ast.GetItem(
+                loc = unpack.value.loc,
+                value = unpack.value,
+                index = ast.Constant(
+                    loc = unpack.value.loc,
+                    value = i
+                )
+            )
+            self._check_assign(target, target_loc, expr)
 
     def check_stmt_SetAttr(self, node: ast.SetAttr) -> None:
         _, w_otype = self.check_expr(node.target)

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -242,7 +242,11 @@ class TypeChecker:
 
     def check_stmt_UnpackAssign(self, unpack: ast.UnpackAssign) -> None:
         _, w_valuetype = self.check_expr(unpack.value)
-        assert w_valuetype is B.w_tuple # XXX better error
+        if w_valuetype is not B.w_tuple:
+            t = w_valuetype.name
+            err = SPyTypeError(f'`{t}` does not support unpacking')
+            err.add('error', f'this is `{t}`', unpack.value.loc)
+            raise err
 
         for i, (target, target_loc) in enumerate(unpack.targlocs):
             # we need an expression which has the type of each individual item


### PR DESCRIPTION
This PR adds basic support for tuples:
  - parser support for tuple literals and unpacking assignment
  - symytable/typechecker/astframe support for unpacking assignment
  - a super simple W_Tuple type, which is supposed to be used only in blue code and for bootstrapping