### PR TITLE
Introduce W_OpImpl

### DIFF
--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -138,7 +138,7 @@ class FuncDoppler:
         v_attr = ast.Constant(node.loc, value=node.attr)
         v_value = self.shift_expr(node.value)
         w_opimpl = self.t.opimpl[node]
-        func = self.make_const(node.loc, w_opimpl)
+        func = self.make_const(node.loc, w_opimpl.w_func)
         call = ast.Call(node.loc, func, [v_target, v_attr, v_value])
         return [ast.StmtExpr(node.loc, call)]
 
@@ -186,7 +186,7 @@ class FuncDoppler:
         l = self.shift_expr(binop.left)
         r = self.shift_expr(binop.right)
         w_opimpl = self.t.opimpl[binop]
-        func = self.make_const(binop.loc, w_opimpl)
+        func = self.make_const(binop.loc, w_opimpl.w_func)
         return ast.Call(binop.loc, func, [l, r])
 
     shift_expr_Add = shift_expr_BinOp
@@ -204,20 +204,20 @@ class FuncDoppler:
         v = self.shift_expr(op.value)
         i = self.shift_expr(op.index)
         w_opimpl = self.t.opimpl[op]
-        func = self.make_const(op.loc, w_opimpl)
+        func = self.make_const(op.loc, w_opimpl.w_func)
         return ast.Call(op.loc, func, [v, i])
 
     def shift_expr_GetAttr(self, op: ast.GetAttr) -> ast.Expr:
         v = self.shift_expr(op.value)
         v_attr = ast.Constant(op.loc, value=op.attr)
         w_opimpl = self.t.opimpl[op]
-        func = self.make_const(op.loc, w_opimpl)
+        func = self.make_const(op.loc, w_opimpl.w_func)
         return ast.Call(op.loc, func, [v, v_attr])
 
     def shift_expr_Call(self, call: ast.Call) -> ast.Expr:
         if call in self.t.opimpl:
             w_opimpl = self.t.opimpl[call]
-            newfunc = self.make_const(call.loc, w_opimpl)
+            newfunc = self.make_const(call.loc, w_opimpl.w_func)
             extra_args = [self.shift_expr(call.func)]
         else:
             newfunc = self.shift_expr(call.func)
@@ -253,7 +253,7 @@ class FuncDoppler:
     def shift_expr_CallMethod(self, op: ast.CallMethod) -> ast.Expr:
         assert op in self.t.opimpl
         w_opimpl = self.t.opimpl[op]
-        v_func = self.make_const(op.loc, w_opimpl)
+        v_func = self.make_const(op.loc, w_opimpl.w_func)
         v_target = self.shift_expr(op.target)
         v_method = ast.Constant(op.loc, value=op.method)
         newargs_v = [v_target, v_method] + \

--- a/spy/tests/compiler/test_list.py
+++ b/spy/tests/compiler/test_list.py
@@ -3,7 +3,7 @@
 import pytest
 from spy.vm.b import B
 from spy.vm.object import W_Type
-from spy.vm.list import W_List__W_Type
+from spy.vm.list import W_List
 from spy.tests.support import CompilerTest, only_interp, no_C
 
 # Eventually we want to remove the @only_interp, but for now the C backend
@@ -34,7 +34,7 @@ class TestList(CompilerTest):
         w_make_list = mod.make_list.w_func
         w_list_type = self.vm.call_function(w_make_list, [B.w_type])
         assert isinstance(w_list_type, W_Type)
-        assert w_list_type.pyclass is W_List__W_Type
+        assert w_list_type.pyclass is W_List[W_Type]
         #
         w_list_f64a = self.vm.call_function(w_make_list, [B.w_f64])
         w_list_f64b = self.vm.call_function(w_make_list, [B.w_f64])

--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -4,6 +4,7 @@ from spy.vm.b import B
 from spy.vm.object import spytype, Member, Annotated
 from spy.vm.sig import spy_builtin
 from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_I32, W_Void
+from spy.vm.opimpl import W_OpImpl
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM
 from spy.tests.support import CompilerTest, no_C, expect_errors
@@ -25,11 +26,11 @@ class TestOp(CompilerTest):
 
             @staticmethod
             def op_GETITEM(vm: 'SPyVM', w_listtype: W_Type,
-                           w_itype: W_Type) -> W_Dynamic:
+                           w_itype: W_Type) -> W_OpImpl:
                 @spy_builtin(QN('ext::getitem'))
                 def getitem(vm: 'SPyVM', w_obj: W_MyClass, w_i: W_I32) -> W_I32:
                     return w_i
-                return vm.wrap(getitem)
+                return W_OpImpl(vm.wrap(getitem))
         # ========== /EXT module for this test =========
 
         self.vm.make_module(EXT)
@@ -59,11 +60,11 @@ class TestOp(CompilerTest):
 
             @staticmethod
             def op_GETITEM(vm: 'SPyVM', w_listtype: W_Type,
-                           w_itype: W_Type) -> W_Dynamic:
+                           w_itype: W_Type) -> W_OpImpl:
                 @spy_builtin(QN('ext::getitem'))
                 def getitem(vm: 'SPyVM', w_obj: W_MyClass) -> W_Void:
                     return B.w_None
-                return vm.wrap(getitem)
+                return W_OpImpl(vm.wrap(getitem))
         # ========== /EXT module for this test =========
 
         self.vm.make_module(EXT)

--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -30,7 +30,7 @@ class TestOp(CompilerTest):
                 @spy_builtin(QN('ext::getitem'))
                 def getitem(vm: 'SPyVM', w_obj: W_MyClass, w_i: W_I32) -> W_I32:
                     return w_i
-                return W_OpImpl(vm.wrap(getitem))
+                return W_OpImpl(vm.wrap_func(getitem))
         # ========== /EXT module for this test =========
 
         self.vm.make_module(EXT)
@@ -64,7 +64,7 @@ class TestOp(CompilerTest):
                 @spy_builtin(QN('ext::getitem'))
                 def getitem(vm: 'SPyVM', w_obj: W_MyClass) -> W_Void:
                     return B.w_None
-                return W_OpImpl(vm.wrap(getitem))
+                return W_OpImpl(vm.wrap_func(getitem))
         # ========== /EXT module for this test =========
 
         self.vm.make_module(EXT)

--- a/spy/tests/compiler/test_operator_attr.py
+++ b/spy/tests/compiler/test_operator_attr.py
@@ -4,6 +4,7 @@ from spy.vm.b import B
 from spy.vm.object import spytype, Member, Annotated
 from spy.vm.sig import spy_builtin
 from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_I32, W_Void
+from spy.vm.opimpl import W_OpImpl
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM
 from spy.tests.support import CompilerTest, no_C
@@ -57,34 +58,34 @@ class TestAttrOp(CompilerTest):
 
             @staticmethod
             def op_GETATTR(vm: 'SPyVM', w_type: W_Type,
-                           w_attr: W_Str) -> W_Dynamic:
+                           w_attr: W_Str) -> W_OpImpl:
                 attr = vm.unwrap_str(w_attr)
                 if attr == 'x':
                     @spy_builtin(QN('ext::getx'))
-                    def opimpl(vm: 'SPyVM', w_obj: W_MyClass,
-                                    w_attr: W_Str) -> W_I32:
+                    def fn(vm: 'SPyVM', w_obj: W_MyClass,
+                           w_attr: W_Str) -> W_I32:
                         return vm.wrap(w_obj.x)  # type: ignore
                 else:
                     @spy_builtin(QN('ext::getany'))
-                    def opimpl(vm: 'SPyVM', w_obj: W_MyClass,
+                    def fn(vm: 'SPyVM', w_obj: W_MyClass,
                                       w_attr: W_Str) -> W_Str:
                         attr = vm.unwrap_str(w_attr)
                         return vm.wrap(attr.upper() + '--42')  # type: ignore
-                return vm.wrap(opimpl)
+                return W_OpImpl(vm.wrap(fn))
 
             @staticmethod
             def op_SETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str,
-                           w_vtype: W_Type) -> W_Dynamic:
+                           w_vtype: W_Type) -> W_OpImpl:
                 attr = vm.unwrap_str(w_attr)
                 if attr == 'x':
                     @spy_builtin(QN('ext::setx'))
-                    def opimpl(vm: 'SPyVM', w_obj: W_MyClass,
+                    def fn(vm: 'SPyVM', w_obj: W_MyClass,
                                w_attr: W_Str, w_val: W_I32) -> W_Void:
                         w_obj.x = vm.unwrap_i32(w_val)
                         return B.w_None
-                    return vm.wrap(opimpl)
+                    return W_OpImpl(vm.wrap(fn))
                 else:
-                    return B.w_NotImplemented
+                    return W_OpImpl.NULL
         # ========== /EXT module for this test =========
 
         self.vm.make_module(EXT)

--- a/spy/tests/compiler/test_operator_attr.py
+++ b/spy/tests/compiler/test_operator_attr.py
@@ -71,7 +71,7 @@ class TestAttrOp(CompilerTest):
                                       w_attr: W_Str) -> W_Str:
                         attr = vm.unwrap_str(w_attr)
                         return vm.wrap(attr.upper() + '--42')  # type: ignore
-                return W_OpImpl(vm.wrap(fn))
+                return W_OpImpl(vm.wrap_func(fn))
 
             @staticmethod
             def op_SETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str,
@@ -83,7 +83,7 @@ class TestAttrOp(CompilerTest):
                                w_attr: W_Str, w_val: W_I32) -> W_Void:
                         w_obj.x = vm.unwrap_i32(w_val)
                         return B.w_None
-                    return W_OpImpl(vm.wrap(fn))
+                    return W_OpImpl(vm.wrap_func(fn))
                 else:
                     return W_OpImpl.NULL
         # ========== /EXT module for this test =========

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -35,7 +35,7 @@ class TestCallOp(CompilerTest):
                     y = vm.unwrap_i32(w_y)
                     res = w_obj.x + y
                     return vm.wrap(res) # type: ignore
-                return W_OpImpl(vm.wrap(call))
+                return W_OpImpl(vm.wrap_func(call))
         # ========== /EXT module for this test =========
         self.vm.make_module(EXT)
         mod = self.compile("""
@@ -69,7 +69,7 @@ class TestCallOp(CompilerTest):
                 def new(vm: 'SPyVM', w_cls: W_Type,
                         w_x: W_I32, w_y: W_I32) -> W_Point:
                     return W_Point(w_x, w_y)
-                return W_OpImpl(vm.wrap(new))
+                return W_OpImpl(vm.wrap_func(new))
         # ========== /EXT module for this test =========
         self.vm.make_module(EXT)
         mod = self.compile("""
@@ -139,7 +139,7 @@ class TestCallOp(CompilerTest):
                                w_arg: W_I32) -> W_I32:
                         y = vm.unwrap_i32(w_arg)
                         return vm.wrap(w_self.x + y)  # type: ignore
-                    return W_OpImpl(vm.wrap(fn))
+                    return W_OpImpl(vm.wrap_func(fn))
 
                 elif meth == 'sub':
                     @spy_builtin(QN('ext::meth_sub'))
@@ -147,7 +147,7 @@ class TestCallOp(CompilerTest):
                                w_arg: W_I32) -> W_I32:
                         y = vm.unwrap_i32(w_arg)
                         return vm.wrap(w_self.x - y)  # type: ignore
-                    return W_OpImpl(vm.wrap(fn))
+                    return W_OpImpl(vm.wrap_func(fn))
 
                 else:
                     return B.w_NotImplemented

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -4,6 +4,7 @@ from spy.vm.b import B
 from spy.vm.object import spytype, Member, Annotated
 from spy.vm.sig import spy_builtin
 from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_I32, W_Void
+from spy.vm.opimpl import W_OpImpl
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM
 from spy.tests.support import CompilerTest, no_C
@@ -28,13 +29,13 @@ class TestCallOp(CompilerTest):
 
             @staticmethod
             def op_CALL(vm: 'SPyVM', w_type: W_Type,
-                        w_argtypes: W_Dynamic) -> W_Dynamic:
+                        w_argtypes: W_Dynamic) -> W_OpImpl:
                 @spy_builtin(QN('ext::call'))
                 def call(vm: 'SPyVM', w_obj: W_Adder, w_y: W_I32) -> W_I32:
                     y = vm.unwrap_i32(w_y)
                     res = w_obj.x + y
                     return vm.wrap(res) # type: ignore
-                return vm.wrap(call)
+                return W_OpImpl(vm.wrap(call))
         # ========== /EXT module for this test =========
         self.vm.make_module(EXT)
         mod = self.compile("""
@@ -63,12 +64,12 @@ class TestCallOp(CompilerTest):
 
             @staticmethod
             def meta_op_CALL(vm: 'SPyVM', w_type: W_Type,
-                             w_argtypes: W_Dynamic) -> W_Dynamic:
+                             w_argtypes: W_Dynamic) -> W_OpImpl:
                 @spy_builtin(QN('ext::new'))
                 def new(vm: 'SPyVM', w_cls: W_Type,
                         w_x: W_I32, w_y: W_I32) -> W_Point:
                     return W_Point(w_x, w_y)
-                return vm.wrap(new)
+                return W_OpImpl(vm.wrap(new))
         # ========== /EXT module for this test =========
         self.vm.make_module(EXT)
         mod = self.compile("""
@@ -129,24 +130,24 @@ class TestCallOp(CompilerTest):
 
             @staticmethod
             def op_CALL_METHOD(vm: 'SPyVM', w_type: W_Type, w_method: W_Str,
-                               w_argtypes: W_Dynamic) -> W_Dynamic:
+                               w_argtypes: W_Dynamic) -> W_OpImpl:
 
                 meth = vm.unwrap_str(w_method)
                 if meth == 'add':
                     @spy_builtin(QN('ext::meth_add'))
-                    def opimpl(vm: 'SPyVM', w_self: W_Calc, w_method: W_Str,
+                    def fn(vm: 'SPyVM', w_self: W_Calc, w_method: W_Str,
                                w_arg: W_I32) -> W_I32:
                         y = vm.unwrap_i32(w_arg)
                         return vm.wrap(w_self.x + y)  # type: ignore
-                    return vm.wrap(opimpl)
+                    return W_OpImpl(vm.wrap(fn))
 
                 elif meth == 'sub':
                     @spy_builtin(QN('ext::meth_sub'))
-                    def opimpl(vm: 'SPyVM', w_self: W_Calc, w_method: W_Str,
+                    def fn(vm: 'SPyVM', w_self: W_Calc, w_method: W_Str,
                                w_arg: W_I32) -> W_I32:
                         y = vm.unwrap_i32(w_arg)
                         return vm.wrap(w_self.x - y)  # type: ignore
-                    return vm.wrap(opimpl)
+                    return W_OpImpl(vm.wrap(fn))
 
                 else:
                     return B.w_NotImplemented

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -171,14 +171,14 @@ class ASTFrame:
         w_target = self.eval_expr(node.target)
         w_attr = self.vm.wrap(node.attr)
         w_value = self.eval_expr(node.value)
-        self.vm.call_function(w_opimpl, [w_target, w_attr, w_value])
+        self.vm.call_function(w_opimpl.w_func, [w_target, w_attr, w_value])
 
     def exec_stmt_SetItem(self, node: ast.SetItem) -> None:
         w_opimpl = self.t.opimpl[node]
         w_target = self.eval_expr(node.target)
         w_index = self.eval_expr(node.index)
         w_value = self.eval_expr(node.value)
-        self.vm.call_function(w_opimpl, [w_target, w_index, w_value])
+        self.vm.call_function(w_opimpl.w_func, [w_target, w_index, w_value])
 
     def exec_stmt_StmtExpr(self, stmt: ast.StmtExpr) -> None:
         self.eval_expr(stmt.value)
@@ -234,7 +234,7 @@ class ASTFrame:
         assert w_opimpl, 'bug in the typechecker'
         w_l = self.eval_expr(binop.left)
         w_r = self.eval_expr(binop.right)
-        w_res = self.vm.call_function(w_opimpl, [w_l, w_r])
+        w_res = self.vm.call_function(w_opimpl.w_func, [w_l, w_r])
         return w_res
 
     eval_expr_Add = eval_expr_BinOp
@@ -260,7 +260,7 @@ class ASTFrame:
         w_opimpl = self.t.opimpl[call]
         w_target = self.eval_expr(call.func)
         args_w = [self.eval_expr(arg) for arg in call.args]
-        w_res = self.vm.call_function(w_opimpl, [w_target] + args_w)
+        w_res = self.vm.call_function(w_opimpl.w_func, [w_target] + args_w)
         return w_res
 
     def _eval_call_func(self, call: ast.Call, color: Color,
@@ -301,14 +301,15 @@ class ASTFrame:
         w_target = self.eval_expr(op.target)
         w_method = self.vm.wrap(op.method)
         arg_w = [self.eval_expr(arg) for arg in op.args]
-        w_res = self.vm.call_function(w_opimpl, [w_target, w_method] + arg_w)
+        w_res = self.vm.call_function(w_opimpl.w_func,
+                                      [w_target, w_method] + arg_w)
         return w_res
 
     def eval_expr_GetItem(self, op: ast.GetItem) -> W_Object:
         w_opimpl = self.t.opimpl[op]
         w_val = self.eval_expr(op.value)
         w_i = self.eval_expr(op.index)
-        w_res = self.vm.call_function(w_opimpl, [w_val, w_i])
+        w_res = self.vm.call_function(w_opimpl.w_func, [w_val, w_i])
         return w_res
 
     def eval_expr_GetAttr(self, op: ast.GetAttr) -> W_Object:
@@ -320,7 +321,7 @@ class ASTFrame:
         w_opimpl = self.t.opimpl[op]
         w_val = self.eval_expr(op.value)
         w_attr = self.vm.wrap(op.attr)
-        w_res = self.vm.call_function(w_opimpl, [w_val, w_attr])
+        w_res = self.vm.call_function(w_opimpl.w_func, [w_val, w_attr])
         return w_res
 
     def eval_expr_List(self, op: ast.List) -> W_Object:

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, no_type_check, Optional
+from typing import TYPE_CHECKING, Any, no_type_check, Optional, Type, ClassVar
 from spy.fqn import QN
 from spy.vm.object import (W_Object, spytype, W_Type, W_Dynamic, W_I32, W_Void,
                            W_Bool)
@@ -6,8 +6,39 @@ from spy.vm.sig import spy_builtin
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
+class Meta_W_List(type):
+    """
+    Some magic to be able to do e.g. W_List[W_MyClass].
+
+    W_List[] works only if the result was prebuilt by calling
+    W_List.make_prebuilt(W_MyClass).
+
+    It is guaranteed that make_list_type will use the prebuilt class, in
+    case it exists, i.e.:
+
+        make_list_type(vm, B.w_i32) is vm.wrap(W_List[W_I32])
+    """
+    CACHE: ClassVar[dict[Type[W_Object], 'Type[W_List]']] = {}
+
+    def __getitem__(self, itemcls: Type[W_Object]) -> 'Type[W_List]':
+        if itemcls in self.CACHE:
+            return self.CACHE[itemcls]
+        else:
+            n = itemcls.__name__
+            msg = (f"W_List[{n}] is not available. Make sure to build it by "
+                   f"calling W_List.make_prebuilt({n}) at import time")
+            raise ValueError(msg)
+
+    def make_prebuilt(self, itemcls: Type[W_Object]) -> None:
+        assert issubclass(itemcls, W_Object)
+        if itemcls not in self.CACHE:
+            W_MyList = _make_W_List(itemcls._w)
+            self.CACHE[itemcls] = W_MyList
+
+
+
 @spytype('list')
-class W_List(W_Object):
+class W_List(W_Object, metaclass=Meta_W_List):
     """
     The 'list' type.
 
@@ -25,10 +56,18 @@ class W_List(W_Object):
     """
     __spy_storage_category__ = 'reference'
 
+    @classmethod
+    def make_prebuilt(cls, itemcls: Type[W_Object]) -> None:
+        """
+        Just a shortcut to reach Meta_W_List more easily
+        """
+        type(cls).make_prebuilt(cls, itemcls)
+
     @staticmethod
     def meta_op_GETITEM(vm: 'SPyVM', w_type: W_Type,
                         w_vtype: W_Type) -> W_Dynamic:
         return vm.wrap(make_list_type)
+
 
 
 @spy_builtin(QN('__spy__::make_list_type'), color='blue')
@@ -41,26 +80,21 @@ def make_list_type(vm: 'SPyVM', w_list: W_Object, w_T: W_Type) -> W_Type:
 
     It is worth noting that to achieve that, we have two layers of caching:
 
-      - some "well known" specialized lists are createt in advance and
-        independently of the `vm`, because they are needed elsewhere. For
-        example, W_List__W_Type.  There is special logic to ensure that we
-        reuse them instead of recreating.
-
-      - for general types, we rely on the fact that `make_list_type` is blue.
+      - if we have a prebuilt list type, just use that
+      - for other types, we rely on the fact that `make_list_type` is blue.
     """
-    from spy.vm.b import B
-    assert w_list is B.w_list
-    if w_T is B.w_type:
-        return vm.wrap(W_List__W_Type)  # type: ignore
+    assert w_list is W_List._w
+    if w_T.pyclass in Meta_W_List.CACHE:
+        return vm.wrap(Meta_W_List.CACHE[w_T.pyclass])  # type: ignore
     pyclass = _make_W_List(w_T)
     return vm.wrap(pyclass)  # type: ignore
 
 
-def _make_W_List(w_T: W_Type) -> W_Type:
+def _make_W_List(w_T: W_Type) -> Type[W_List]:
     """
     DON'T CALL THIS DIRECTLY!
     You should call make_list_type instead, which knows how to deal with
-    "well-known lists".
+    prebuilt types.
     """
     T = w_T.pyclass
     app_name = f'list[{w_T.name}]'        # e.g. list[i32]
@@ -131,8 +165,4 @@ def _make_W_List(w_T: W_Type) -> W_Type:
                 return B.w_NotImplemented
 
     W_MyList.__name__ = W_MyList.__qualname__ = interp_name
-    return W_MyList        # type: ignore
-
-
-# well-known list types
-W_List__W_Type = _make_W_List(W_Type._w)
+    return W_MyList

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -66,7 +66,7 @@ class W_List(W_Object, metaclass=Meta_W_List):
     def meta_op_GETITEM(vm: 'SPyVM', w_type: W_Type,
                         w_vtype: W_Type) -> 'W_OpImpl':
         from spy.vm.opimpl import W_OpImpl
-        return W_OpImpl(vm.wrap(make_list_type))
+        return W_OpImpl(vm.wrap_func(make_list_type))
 
 
 
@@ -126,7 +126,7 @@ def _make_W_List(w_T: W_Type) -> Type[W_List]:
                 i = vm.unwrap_i32(w_i)
                 # XXX bound check?
                 return w_list.items_w[i]
-            return W_OpImpl(vm.wrap(getitem))
+            return W_OpImpl(vm.wrap_func(getitem))
 
         @staticmethod
         def op_SETITEM(vm: 'SPyVM', w_listtype: W_Type, w_itype: W_Type,
@@ -142,7 +142,7 @@ def _make_W_List(w_T: W_Type) -> Type[W_List]:
                 # XXX bound check?
                 w_list.items_w[i] = w_v
                 return B.w_None
-            return W_OpImpl(vm.wrap(setitem))
+            return W_OpImpl(vm.wrap_func(setitem))
 
         @staticmethod
         def op_EQ(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
@@ -162,7 +162,7 @@ def _make_W_List(w_T: W_Type) -> Type[W_List]:
                 return B.w_True
 
             if w_ltype is w_rtype:
-                return W_OpImpl(vm.wrap(eq))
+                return W_OpImpl(vm.wrap_func(eq))
             else:
                 return W_OpImpl.NULL
 

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -5,6 +5,7 @@ from spy.vm.object import W_Object, spytype, W_Type, W_Dynamic, W_Void
 from spy.vm.str import W_Str
 from spy.vm.function import W_ASTFunc
 from spy.vm.sig import spy_builtin
+from spy.vm.opimpl import W_OpImpl
 
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -30,7 +31,7 @@ class W_Module(W_Object):
     # ==== operator impls =====
 
     @staticmethod
-    def op_GETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str) -> W_Dynamic:
+    def op_GETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str) -> W_OpImpl:
         """
         XXX this is wrong: ideally, we should create a new subtype for each
         module, where every member has its own static type.
@@ -40,22 +41,22 @@ class W_Module(W_Object):
         away.
         """
         @spy_builtin(QN('builtins::module_getattr'))
-        def opimpl(vm: 'SPyVM', w_mod: W_Module, w_attr: W_Str) -> W_Dynamic:
+        def fn(vm: 'SPyVM', w_mod: W_Module, w_attr: W_Str) -> W_Dynamic:
             attr = vm.unwrap_str(w_attr)
             return w_mod.getattr(attr)
-        return vm.wrap(opimpl)
+        return W_OpImpl(vm.wrap(fn))
 
 
     @staticmethod
     def op_SETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str,
-                   w_vtype: W_Type) -> W_Dynamic:
+                   w_vtype: W_Type) -> W_OpImpl:
         @spy_builtin(QN('builtins::module_setattr'))
-        def opimpl(vm: 'SPyVM', w_mod: W_Module, w_attr:
+        def fn(vm: 'SPyVM', w_mod: W_Module, w_attr:
                    W_Str, w_val: W_Dynamic) -> W_Void:
             attr = vm.unwrap_str(w_attr)
             w_mod.setattr(attr, w_val)
             return B.w_None
-        return vm.wrap(opimpl)
+        return W_OpImpl(vm.wrap(fn))
 
     # ==== public interp-level API ====
 

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -44,7 +44,7 @@ class W_Module(W_Object):
         def fn(vm: 'SPyVM', w_mod: W_Module, w_attr: W_Str) -> W_Dynamic:
             attr = vm.unwrap_str(w_attr)
             return w_mod.getattr(attr)
-        return W_OpImpl(vm.wrap(fn))
+        return W_OpImpl(vm.wrap_func(fn))
 
 
     @staticmethod
@@ -56,7 +56,7 @@ class W_Module(W_Object):
             attr = vm.unwrap_str(w_attr)
             w_mod.setattr(attr, w_val)
             return B.w_None
-        return W_OpImpl(vm.wrap(fn))
+        return W_OpImpl(vm.wrap_func(fn))
 
     # ==== public interp-level API ====
 

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -17,7 +17,6 @@ JSFFI = ModuleRegistry('jsffi', '<jsffi>')
 @JSFFI.spytype('JsRef')
 class W_JsRef(W_Object):
 
-    # XXX we can use proper types insead of string?
     @staticmethod
     def op_GETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str) -> W_OpImpl:
         # this is a horrible hack (see also cwriter.fmt_expr_Call)

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -29,7 +29,7 @@ class W_JsRef(W_Object):
         @spy_builtin(QN(f'jsffi::getattr_{attr}'))
         def fn(vm: 'SPyVM', w_self: W_JsRef, w_attr: W_Str) -> W_JsRef:
             return js_getattr(vm, w_self, w_attr)
-        return W_OpImpl(vm.wrap(fn))
+        return W_OpImpl(vm.wrap_func(fn))
 
     @staticmethod
     def op_SETATTR(vm: 'SPyVM', w_type: 'W_Type', w_attr: 'W_Str',
@@ -41,7 +41,7 @@ class W_JsRef(W_Object):
         def fn(vm: 'SPyVM', w_self: W_JsRef, w_attr: W_Str,
                w_val: W_JsRef) -> None:
             js_setattr(vm, w_self, w_attr, w_val)
-        return W_OpImpl(vm.wrap(fn))
+        return W_OpImpl(vm.wrap_func(fn))
 
     @staticmethod
     def op_CALL_METHOD(vm: 'SPyVM', w_type: 'W_Type', w_method: 'W_Str',

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -4,12 +4,10 @@ from spy.fqn import QN
 from spy.vm.b import B
 from spy.vm.object import spytype, Member, Annotated
 from spy.vm.w import (W_Func, W_Type, W_Object, W_I32, W_F64, W_Void, W_Str,
-                      W_Dynamic)
+                      W_Dynamic, W_List, W_FuncType, W_OpImpl)
 from spy.vm.sig import spy_builtin
-from spy.vm.function import W_Func, W_FuncType
 from spy.vm.registry import ModuleRegistry
 from spy.vm.modules.types import W_TypeDef
-from spy.vm.opimpl import W_OpImpl
 
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -21,8 +21,7 @@ class W_JsRef(W_Object):
 
     # XXX we can use proper types insead of string?
     @staticmethod
-    def op_GETATTR(vm: 'SPyVM', w_type: 'W_Type',
-                   w_attr: 'W_Str') -> W_OpImpl:
+    def op_GETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str) -> W_OpImpl:
         # this is a horrible hack (see also cwriter.fmt_expr_Call)
         attr = vm.unwrap_str(w_attr)
 
@@ -32,8 +31,8 @@ class W_JsRef(W_Object):
         return W_OpImpl(vm.wrap_func(fn))
 
     @staticmethod
-    def op_SETATTR(vm: 'SPyVM', w_type: 'W_Type', w_attr: 'W_Str',
-                   w_vtype: 'W_Type') -> W_OpImpl:
+    def op_SETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str,
+                   w_vtype: W_Type) -> W_OpImpl:
         # this is a horrible hack (see also cwriter.fmt_expr_Call)
         attr = vm.unwrap_str(w_attr)
 
@@ -44,8 +43,8 @@ class W_JsRef(W_Object):
         return W_OpImpl(vm.wrap_func(fn))
 
     @staticmethod
-    def op_CALL_METHOD(vm: 'SPyVM', w_type: 'W_Type', w_method: 'W_Str',
-                       w_argtypes: 'W_Dynamic') -> W_OpImpl:
+    def op_CALL_METHOD(vm: 'SPyVM', w_type: W_Type, w_method: W_Str,
+                       w_argtypes: W_Dynamic) -> W_OpImpl:
         argtypes_w = vm.unwrap(w_argtypes)
         n = len(argtypes_w)
         if n == 1:

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -9,6 +9,7 @@ from spy.vm.sig import spy_builtin
 from spy.vm.function import W_Func, W_FuncType
 from spy.vm.registry import ModuleRegistry
 from spy.vm.modules.types import W_TypeDef
+from spy.vm.opimpl import W_OpImpl
 
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -18,36 +19,37 @@ JSFFI = ModuleRegistry('jsffi', '<jsffi>')
 @JSFFI.spytype('JsRef')
 class W_JsRef(W_Object):
 
+    # XXX we can use proper types insead of string?
     @staticmethod
     def op_GETATTR(vm: 'SPyVM', w_type: 'W_Type',
-                   w_attr: 'W_Str') -> 'W_Dynamic':
+                   w_attr: 'W_Str') -> W_OpImpl:
         # this is a horrible hack (see also cwriter.fmt_expr_Call)
         attr = vm.unwrap_str(w_attr)
 
         @spy_builtin(QN(f'jsffi::getattr_{attr}'))
-        def opimpl(vm: 'SPyVM', w_self: W_JsRef, w_attr: W_Str) -> W_JsRef:
+        def fn(vm: 'SPyVM', w_self: W_JsRef, w_attr: W_Str) -> W_JsRef:
             return js_getattr(vm, w_self, w_attr)
-        return vm.wrap(opimpl)
+        return W_OpImpl(vm.wrap(fn))
 
     @staticmethod
     def op_SETATTR(vm: 'SPyVM', w_type: 'W_Type', w_attr: 'W_Str',
-                   w_vtype: 'W_Type') -> 'W_Dynamic':
+                   w_vtype: 'W_Type') -> W_OpImpl:
         # this is a horrible hack (see also cwriter.fmt_expr_Call)
         attr = vm.unwrap_str(w_attr)
 
         @spy_builtin(QN(f'jsffi::setattr_{attr}'))
-        def opimpl(vm: 'SPyVM', w_self: W_JsRef, w_attr: W_Str,
-                   w_val: W_JsRef) -> None:
+        def fn(vm: 'SPyVM', w_self: W_JsRef, w_attr: W_Str,
+               w_val: W_JsRef) -> None:
             js_setattr(vm, w_self, w_attr, w_val)
-        return vm.wrap(opimpl)
+        return W_OpImpl(vm.wrap(fn))
 
     @staticmethod
     def op_CALL_METHOD(vm: 'SPyVM', w_type: 'W_Type', w_method: 'W_Str',
-                       w_argtypes: 'W_Dynamic') -> 'W_Dynamic':
+                       w_argtypes: 'W_Dynamic') -> W_OpImpl:
         argtypes_w = vm.unwrap(w_argtypes)
         n = len(argtypes_w)
         if n == 1:
-            return JSFFI.w_call_method_1
+            return W_OpImpl(JSFFI.w_call_method_1)
         else:
             raise Exception(
                 f"unsupported number of arguments for CALL_METHOD: {n}"

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -32,6 +32,7 @@ def GETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str) -> W_OpImpl:
         w_getattr = w_type.w_getattr
         assert isinstance(w_getattr, W_Func)
         w_func = vm.call_function(w_getattr, [w_type, w_attr])
+        assert isinstance(w_func, W_Func)
         # XXX: ideally, we should be able to return directly an W_OpImpl from
         # applevel
         return W_OpImpl(w_func)
@@ -56,6 +57,7 @@ def SETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str,
         w_setattr = w_type.w_setattr
         assert isinstance(w_setattr, W_Func)
         w_func = vm.call_function(w_setattr, [w_type, w_attr, w_vtype])
+        assert isinstance(w_func, W_Func)
         return W_OpImpl(w_func)
 
     return W_OpImpl.NULL

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -78,7 +78,7 @@ def opimpl_member(kind: OpKind, vm: 'SPyVM', w_type: W_Type,
         def opimpl_get(vm: 'SPyVM', w_obj: W_Class, w_attr: W_Str) -> W_Value:
             return getattr(w_obj, field)
 
-        return W_OpImpl(vm.wrap(opimpl_get))
+        return W_OpImpl(vm.wrap_func(opimpl_get))
 
     elif kind == 'set':
         @no_type_check
@@ -87,7 +87,7 @@ def opimpl_member(kind: OpKind, vm: 'SPyVM', w_type: W_Type,
                        w_val: W_Value) -> W_Void:
             setattr(w_obj, field, w_val)
 
-        return W_OpImpl(vm.wrap(opimpl_set))
+        return W_OpImpl(vm.wrap_func(opimpl_set))
 
     else:
         assert False, f'Invalid OpKind: {kind}'

--- a/spy/vm/modules/operator/binop.py
+++ b/spy/vm/modules/operator/binop.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 from spy.vm.b import B
 from spy.vm.object import W_Dynamic, W_Type
+from spy.vm.opimpl import W_OpImpl
 from . import OP
 from .multimethod import MultiMethodTable
 if TYPE_CHECKING:
@@ -74,19 +75,19 @@ MM.register_partial('>=', 'dynamic', OP.w_dynamic_ge)
 
 
 @OP.builtin(color='blue')
-def ADD(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
+def ADD(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
     return MM.lookup('+', w_ltype, w_rtype)
 
 @OP.builtin(color='blue')
-def SUB(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
+def SUB(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
     return MM.lookup('-', w_ltype, w_rtype)
 
 @OP.builtin(color='blue')
-def MUL(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
+def MUL(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
     return MM.lookup('*', w_ltype, w_rtype)
 
 @OP.builtin(color='blue')
-def DIV(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
+def DIV(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
     return MM.lookup('/', w_ltype, w_rtype)
 
 def can_use_reference_eq(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> bool:
@@ -99,41 +100,41 @@ def can_use_reference_eq(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> bool:
     return w_common is not B.w_object and w_common.is_reference_type(vm)
 
 @OP.builtin(color='blue')
-def EQ(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
+def EQ(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
     pyclass = w_ltype.pyclass
     if pyclass.has_meth_overriden('op_EQ'):
         return pyclass.op_EQ(vm, w_ltype, w_rtype)
     elif can_use_reference_eq(vm, w_ltype, w_rtype):
-        return OP.w_object_is
+        return W_OpImpl(OP.w_object_is)
     else:
         return MM.lookup('==', w_ltype, w_rtype)
 
 @OP.builtin(color='blue')
-def NE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
+def NE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
     if can_use_reference_eq(vm, w_ltype, w_rtype):
-        return OP.w_object_isnot
+        return W_OpImpl(OP.w_object_isnot)
     return MM.lookup('!=', w_ltype, w_rtype)
 
 @OP.builtin(color='blue')
-def UNIVERSAL_EQ(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
-    return OP.w_object_universal_eq
+def UNIVERSAL_EQ(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
+    return W_OpImpl(OP.w_object_universal_eq)
 
 @OP.builtin(color='blue')
-def UNIVERSAL_NE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
-    return OP.w_object_universal_ne
+def UNIVERSAL_NE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
+    return W_OpImpl(OP.w_object_universal_ne)
 
 @OP.builtin(color='blue')
-def LT(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
+def LT(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
     return MM.lookup('<', w_ltype, w_rtype)
 
 @OP.builtin(color='blue')
-def LE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
+def LE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
     return MM.lookup('<=', w_ltype, w_rtype)
 
 @OP.builtin(color='blue')
-def GT(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
+def GT(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
     return MM.lookup('>', w_ltype, w_rtype)
 
 @OP.builtin(color='blue')
-def GE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_Dynamic:
+def GE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
     return MM.lookup('>=', w_ltype, w_rtype)

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type, W_Dynamic
 from spy.vm.str import W_Str
+from spy.vm.opimpl import W_OpImpl
 
 from . import OP
 from .binop import MM
@@ -9,18 +10,18 @@ if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
 @OP.builtin(color='blue')
-def CALL(vm: 'SPyVM', w_type: W_Type, w_argtypes: W_Object) -> W_Dynamic:
+def CALL(vm: 'SPyVM', w_type: W_Type, w_argtypes: W_Object) -> W_OpImpl:
     pyclass = w_type.pyclass
     if w_type is B.w_dynamic:
         raise NotImplementedError("implement me")
     elif pyclass.has_meth_overriden('op_CALL'):
         return pyclass.op_CALL(vm, w_type, w_argtypes)
-    return B.w_NotImplemented
+    return W_OpImpl.NULL
 
 @OP.builtin(color='blue')
 def CALL_METHOD(vm: 'SPyVM', w_type: W_Type, w_method: W_Str,
-                w_argtypes: W_Object) -> W_Dynamic:
+                w_argtypes: W_Object) -> W_OpImpl:
     pyclass = w_type.pyclass
     if pyclass.has_meth_overriden('op_CALL_METHOD'):
         return pyclass.op_CALL_METHOD(vm, w_type, w_method, w_argtypes)
-    return B.w_NotImplemented
+    return W_OpImpl.NULL

--- a/spy/vm/modules/operator/itemop.py
+++ b/spy/vm/modules/operator/itemop.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 from spy.vm.b import B
 from spy.vm.object import W_Type, W_Dynamic
+from spy.vm.opimpl import W_OpImpl
 
 from . import OP
 if TYPE_CHECKING:
@@ -8,12 +9,12 @@ if TYPE_CHECKING:
 
 
 @OP.builtin(color='blue')
-def GETITEM(vm: 'SPyVM', w_type: W_Type, w_itype: W_Type) -> W_Dynamic:
+def GETITEM(vm: 'SPyVM', w_type: W_Type, w_itype: W_Type) -> W_OpImpl:
     pyclass = w_type.pyclass
     if pyclass.has_meth_overriden('op_GETITEM'):
         return pyclass.op_GETITEM(vm, w_type, w_itype)
 
-    return B.w_NotImplemented
+    return W_OpImpl.NULL
 
 @OP.builtin(color='blue')
 def SETITEM(vm: 'SPyVM', w_type: W_Type, w_itype: W_Type,
@@ -22,4 +23,4 @@ def SETITEM(vm: 'SPyVM', w_type: W_Type, w_itype: W_Type,
     if pyclass.has_meth_overriden('op_SETITEM'):
         return pyclass.op_SETITEM(vm, w_type, w_itype, w_vtype)
 
-    return B.w_NotImplemented
+    return W_OpImpl.NULL

--- a/spy/vm/modules/operator/multimethod.py
+++ b/spy/vm/modules/operator/multimethod.py
@@ -19,6 +19,7 @@ from typing import Optional
 from spy.vm.b import B
 from spy.vm.object import W_Type, W_Object
 from spy.vm.function import W_Func
+from spy.vm.opimpl import W_OpImpl
 
 KeyType = tuple[str, Optional[W_Type], Optional[W_Type]]
 
@@ -39,26 +40,26 @@ class MultiMethodTable:
                  op: str,
                  ltype: Optional[str],
                  rtype: Optional[str],
-                 w_impl: W_Object) -> None:
-        assert isinstance(w_impl, W_Func)
+                 w_func: W_Object) -> None:
+        assert isinstance(w_func, W_Func)
         w_ltype = parse_type(ltype)
         w_rtype = parse_type(rtype)
         key = (op, w_ltype, w_rtype)
         assert key not in self.impls
-        self.impls[key] = w_impl
+        self.impls[key] = w_func
 
-    def register_partial(self, op: str, atype: str, w_impl: W_Object) -> None:
-        self.register(op, atype, None, w_impl)
-        self.register(op, None, atype, w_impl)
+    def register_partial(self, op: str, atype: str, w_func: W_Object) -> None:
+        self.register(op, atype, None, w_func)
+        self.register(op, None, atype, w_func)
 
-    def lookup(self, op: str, w_ltype: W_Type, w_rtype: W_Type) -> W_Object:
+    def lookup(self, op: str, w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
         keys = [
             (op, w_ltype, w_rtype),  # most precise lookup
             (op, w_ltype, None),     # less precise ones
             (op, None,    w_rtype),
         ]
         for key in keys:
-            w_opimpl = self.impls.get(key)
-            if w_opimpl:
-                return w_opimpl
-        return B.w_NotImplemented
+            w_func = self.impls.get(key)
+            if w_func:
+                return W_OpImpl(w_func)
+        return W_OpImpl(None)

--- a/spy/vm/modules/operator/opimpl_dynamic.py
+++ b/spy/vm/modules/operator/opimpl_dynamic.py
@@ -4,6 +4,7 @@ from spy.vm.b import B
 from spy.vm.object import W_Dynamic, W_Type
 from spy.vm.str import W_Str
 from spy.vm.function import W_Func
+from spy.vm.opimpl import W_OpImpl
 from . import OP
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -14,13 +15,13 @@ def _dynamic_op(vm: 'SPyVM', w_op: W_Func,
     w_ltype = vm.dynamic_type(w_a)
     w_rtype = vm.dynamic_type(w_b)
     w_opimpl = vm.call_function(w_op, [w_ltype, w_rtype])
-    if w_opimpl is B.w_NotImplemented:
+    assert isinstance(w_opimpl, W_OpImpl)
+    if w_opimpl.is_null():
         token = OP.to_token(w_op)
         l = w_ltype.name
         r = w_rtype.name
         raise SPyTypeError(f'cannot do `{l}` {token} `{r}`')
-    assert isinstance(w_opimpl, W_Func)
-    return vm.call_function(w_opimpl, [w_a, w_b])
+    return vm.call_function(w_opimpl.w_func, [w_a, w_b])
 
 
 @OP.builtin
@@ -62,11 +63,11 @@ def dynamic_setattr(vm: 'SPyVM', w_obj: W_Dynamic, w_attr: W_Str,
     w_otype = vm.dynamic_type(w_obj)
     w_vtype = vm.dynamic_type(w_value)
     w_opimpl = vm.call_function(OP.w_SETATTR, [w_otype, w_attr, w_vtype])
-    if w_opimpl is B.w_NotImplemented:
+    assert isinstance(w_opimpl, W_OpImpl)
+    if w_opimpl.is_null():
         o = w_otype.name
         v = w_vtype.name
         attr = vm.unwrap_str(w_attr)
         msg = f"type `{o}` does not support assignment to attribute '{attr}'"
         raise SPyTypeError(msg)
-    assert isinstance(w_opimpl, W_Func)
-    return vm.call_function(w_opimpl, [w_obj, w_attr, w_value])
+    return vm.call_function(w_opimpl.w_func, [w_obj, w_attr, w_value])

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -8,6 +8,7 @@ from spy.vm.b import B
 from spy.vm.object import W_Type, W_Object, spytype, W_Dynamic, W_Void, Member
 from spy.vm.str import W_Str
 from spy.vm.function import W_Func
+from spy.vm.opimpl import W_OpImpl
 from spy.vm.registry import ModuleRegistry
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -36,8 +37,8 @@ class W_TypeDef(W_Type):
     def __init__(self, name: str, w_origintype: W_Type) -> None:
         super().__init__(name, w_origintype.pyclass)
         self.w_origintype = w_origintype
-        self.w_getattr = B.w_NotImplemented
-        self.w_setattr = B.w_NotImplemented
+        self.w_getattr = W_OpImpl.NULL
+        self.w_setattr = W_OpImpl.NULL
 
     @staticmethod
     def spy_new(vm: 'SPyVM', w_cls: W_Type, w_name: W_Str,

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -52,6 +52,7 @@ from spy.fqn import QN
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
     from spy.vm.str import W_Str
+    from spy.vm.opimpl import W_OpImpl
 
 # Basic setup of the object model: <object> and <type>
 # =====================================================
@@ -380,7 +381,7 @@ def synthesize_meta_op_CALL(pyclass: Type[W_Object]) -> Any:
         qn = QN(modname='ext', attr='new') # XXX what modname should we use?
         # manually apply the @spy_builtin decorator to the spy_new function
         spyfunc = spy_builtin(qn)(spy_new)
-        return W_OpImpl(vm.wrap(spyfunc))
+        return W_OpImpl(vm.wrap_func(spyfunc))
 
     return meta_op_CALL
 

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -137,37 +137,37 @@ class W_Object:
         return True
 
     @staticmethod
-    def op_EQ(vm: 'SPyVM', w_tself: 'W_Type', w_tother: 'W_Type') -> 'W_Dynamic':
+    def op_EQ(vm: 'SPyVM', w_tself: 'W_Type', w_tother: 'W_Type') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
     @staticmethod
     def op_GETATTR(vm: 'SPyVM', w_type: 'W_Type',
-                   w_attr: 'W_Str') -> 'W_Dynamic':
+                   w_attr: 'W_Str') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
     @staticmethod
     def op_SETATTR(vm: 'SPyVM', w_type: 'W_Type', w_attr: 'W_Str',
-                   w_vtype: 'W_Type') -> 'W_Dynamic':
+                   w_vtype: 'W_Type') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
     @staticmethod
     def op_GETITEM(vm: 'SPyVM', w_type: 'W_Type',
-                   w_vtype: 'W_Type') -> 'W_Dynamic':
+                   w_vtype: 'W_Type') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
     @staticmethod
     def op_SETITEM(vm: 'SPyVM', w_type: 'W_Type', w_itype: 'W_Type',
-                   w_vtype: 'W_Type') -> 'W_Dynamic':
+                   w_vtype: 'W_Type') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
     @staticmethod
     def op_CALL(vm: 'SPyVM', w_type: 'W_Type',
-                w_argtypes: 'W_Dynamic') -> 'W_Dynamic':
+                w_argtypes: 'W_Dynamic') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
     @staticmethod
     def op_CALL_METHOD(vm: 'SPyVM', w_type: 'W_Type', w_method: 'W_Str',
-                       w_argtypes: 'W_Dynamic') -> 'W_Dynamic':
+                       w_argtypes: 'W_Dynamic') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
 
@@ -369,17 +369,18 @@ def synthesize_meta_op_CALL(pyclass: Type[W_Object]) -> Any:
     W_Foo. Once we have done that, we can manually apply @spy_builtin and
     finally vm.wrap() it.
     """
+    from spy.vm.opimpl import W_OpImpl
     from spy.vm.sig import spy_builtin
     assert hasattr(pyclass, 'spy_new')
     spy_new = pyclass.spy_new
 
     def meta_op_CALL(vm: 'SPyVM', w_type: W_Type,
-                     w_argtypes: W_Dynamic) -> W_Dynamic:
+                     w_argtypes: W_Dynamic) -> W_OpImpl:
         fix_annotations(spy_new, {pyclass.__name__: pyclass})
         qn = QN(modname='ext', attr='new') # XXX what modname should we use?
         # manually apply the @spy_builtin decorator to the spy_new function
         spyfunc = spy_builtin(qn)(spy_new)
-        return vm.wrap(spyfunc)
+        return W_OpImpl(vm.wrap(spyfunc))
 
     return meta_op_CALL
 

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -12,14 +12,14 @@ class W_OpImpl(W_Object):
     def __init__(self, w_func: Optional[W_Func]) -> None:
         self._w_func = w_func
 
-    def __repr__(self):
-        if self.is_null():
+    def __repr__(self) -> str:
+        if self._w_func is None:
             return f"<spy OpImpl NULL>"
         else:
             qn = self._w_func.qn
             return f"<spy OpImpl {qn}>"
 
-    def is_null(self):
+    def is_null(self) -> bool:
         return self._w_func is None
 
     @property

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -1,0 +1,35 @@
+from typing import Annotated, Optional, ClassVar
+from spy import ast
+from spy.vm.object import Member, W_Type, W_Object, spytype
+from spy.vm.function import W_Func
+from spy.vm.list import W_List
+
+@spytype('OpImpl')
+class W_OpImpl(W_Object):
+    NULL: ClassVar['W_OpImpl']
+    _w_func: Optional[W_Func]
+
+    def __init__(self, w_func: Optional[W_Func]) -> None:
+        self._w_func = w_func
+
+    def __repr__(self):
+        if self.is_null():
+            return f"<spy OpImpl NULL>"
+        else:
+            qn = self._w_func.qn
+            return f"<spy OpImpl {qn}>"
+
+    def is_null(self):
+        return self._w_func is None
+
+    @property
+    def w_func(self) -> W_Func:
+        assert self._w_func is not None
+        return self._w_func
+
+    @property
+    def w_restype(self) -> W_Type:
+        return self.w_func.w_functype.w_restype
+
+
+W_OpImpl.NULL = W_OpImpl(None)

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -75,7 +75,7 @@ class W_Str(W_Object):
             assert isinstance(w_i, W_I32)
             ptr_c = vm.ll.call('spy_str_getitem', w_s.ptr, w_i.value)
             return W_Str.from_ptr(vm, ptr_c)
-        return W_OpImpl(vm.wrap(str_getitem))
+        return W_OpImpl(vm.wrap_func(str_getitem))
 
     @staticmethod
     def meta_op_CALL(vm: 'SPyVM', w_type: W_Type,
@@ -83,7 +83,7 @@ class W_Str(W_Object):
         from spy.vm.b import B
         argtypes_w = vm.unwrap(w_argtypes)
         if argtypes_w == [W_I32]:
-            return W_OpImpl(vm.wrap(int2str))
+            return W_OpImpl(vm.wrap_func(int2str))
         else:
             return W_OpImpl.NULL
 

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -3,6 +3,7 @@ from spy.llwasm import LLWasmInstance
 from spy.fqn import QN
 from spy.vm.object import W_Object, W_Type, W_Dynamic, spytype, W_I32
 from spy.vm.sig import spy_builtin
+from spy.vm.opimpl import W_OpImpl
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
@@ -67,24 +68,24 @@ class W_Str(W_Object):
         return self._as_str()
 
     @staticmethod
-    def op_GETITEM(vm: 'SPyVM', w_type: W_Type, w_vtype: W_Type) -> W_Dynamic:
+    def op_GETITEM(vm: 'SPyVM', w_type: W_Type, w_vtype: W_Type) -> W_OpImpl:
         @spy_builtin(QN('operator::str_getitem'))
         def str_getitem(vm: 'SPyVM', w_s: W_Str, w_i: W_I32) -> W_Str:
             assert isinstance(w_s, W_Str)
             assert isinstance(w_i, W_I32)
             ptr_c = vm.ll.call('spy_str_getitem', w_s.ptr, w_i.value)
             return W_Str.from_ptr(vm, ptr_c)
-        return vm.wrap(str_getitem)
+        return W_OpImpl(vm.wrap(str_getitem))
 
     @staticmethod
     def meta_op_CALL(vm: 'SPyVM', w_type: W_Type,
-                     w_argtypes: W_Dynamic) -> W_Dynamic:
+                     w_argtypes: W_Dynamic) -> W_OpImpl:
         from spy.vm.b import B
         argtypes_w = vm.unwrap(w_argtypes)
         if argtypes_w == [W_I32]:
-            return vm.wrap(int2str)
+            return W_OpImpl(vm.wrap(int2str))
         else:
-            return B.w_NotImplemented
+            return W_OpImpl.NULL
 
 
 @spy_builtin(QN('builtins::int2str'))

--- a/spy/vm/tuple.py
+++ b/spy/vm/tuple.py
@@ -30,7 +30,7 @@ class W_Tuple(W_Object):
     @staticmethod
     def op_GETITEM(vm: 'SPyVM', w_tupletype: W_Type,
                    w_itype: W_Type) -> W_OpImpl:
-        return W_OpImpl(vm.wrap(tuple_getitem))
+        return W_OpImpl(vm.wrap_func(tuple_getitem))
 
 
 

--- a/spy/vm/tuple.py
+++ b/spy/vm/tuple.py
@@ -3,6 +3,7 @@ from spy.fqn import QN
 from spy.vm.object import (W_Object, spytype, W_Type, W_Dynamic, W_I32, W_Void,
                            W_Bool)
 from spy.vm.sig import spy_builtin
+from spy.vm.opimpl import W_OpImpl
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
@@ -28,8 +29,8 @@ class W_Tuple(W_Object):
 
     @staticmethod
     def op_GETITEM(vm: 'SPyVM', w_tupletype: W_Type,
-                   w_itype: W_Type) -> W_Dynamic:
-        return vm.wrap(tuple_getitem)
+                   w_itype: W_Type) -> W_OpImpl:
+        return W_OpImpl(vm.wrap(tuple_getitem))
 
 
 

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -6,7 +6,7 @@ from spy.irgen.symtable import Symbol, Color
 from spy.errors import (SPyTypeError, SPyNameError, maybe_plural)
 from spy.location import Loc
 from spy.vm.object import W_Object, W_Type
-from spy.vm.list import W_List__W_Type
+from spy.vm.list import W_List
 from spy.vm.function import W_FuncType, W_ASTFunc, W_Func
 from spy.vm.b import B
 from spy.vm.modules.operator import OP
@@ -17,6 +17,8 @@ from spy.vm.modules.types import W_TypeDef
 from spy.util import magic_dispatch
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
+
+W_List.make_prebuilt(W_Type) # make it possible to use W_List[W_Type]
 
 # DispatchKind is a property of an OPERATOR and can be:
 #
@@ -515,7 +517,7 @@ class TypeChecker:
     def _check_expr_call_generic(self, call: ast.Call) -> tuple[Color, W_Type]:
         _, w_otype = self.check_expr(call.func)
         argtypes_w = [self.check_expr(arg)[1] for arg in call.args]
-        w_argtypes = W_List__W_Type(argtypes_w) # type: ignore
+        w_argtypes = W_List[W_Type](argtypes_w) # type: ignore
         w_opimpl = self.vm.call_function(OP.w_CALL, [w_otype, w_argtypes])
         newargs = [call.func] + call.args
         errmsg = 'cannot call objects of type `{0}`'
@@ -598,7 +600,7 @@ class TypeChecker:
         _, w_otype = self.check_expr(op.target)
         w_method = self.vm.wrap(op.method)
         argtypes_w = [self.check_expr(arg)[1] for arg in op.args]
-        w_argtypes = W_List__W_Type(argtypes_w) # type: ignore
+        w_argtypes = W_List[W_Type](argtypes_w) # type: ignore
         w_opimpl = self.vm.call_function(OP.w_CALL_METHOD,
                                          [w_otype, w_method, w_argtypes])
         w_method = self.vm.wrap(op.method)

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -6,6 +6,7 @@ from spy.irgen.symtable import Symbol, Color
 from spy.errors import (SPyTypeError, SPyNameError, maybe_plural)
 from spy.location import Loc
 from spy.vm.object import W_Object, W_Type
+from spy.vm.opimpl import W_OpImpl
 from spy.vm.list import W_List
 from spy.vm.function import W_FuncType, W_ASTFunc, W_Func
 from spy.vm.b import B
@@ -45,7 +46,7 @@ class TypeChecker:
     funcef: ast.FuncDef
     expr_types: dict[ast.Expr, tuple[Color, W_Type]]
     expr_conv: dict[ast.Expr, TypeConverter]
-    opimpl: dict[ast.Node, W_Func]
+    opimpl: dict[ast.Node, W_OpImpl]
     locals_types_w: dict[str, W_Type]
 
 
@@ -269,6 +270,7 @@ class TypeChecker:
         w_attr = self.vm.wrap(node.attr)
         w_opimpl = self.vm.call_function(OP.w_SETATTR,
                                          [w_otype, w_attr, w_vtype])
+        assert isinstance(w_opimpl, W_OpImpl)
         errmsg = ("type `{0}` does not support assignment to attribute '%s'" %
                   node.attr)
         self.opimpl_typecheck(
@@ -279,7 +281,6 @@ class TypeChecker:
             dispatch = 'single',
             errmsg = errmsg
         )
-        assert isinstance(w_opimpl, W_Func)
         self.opimpl[node] = w_opimpl
 
     def check_stmt_SetItem(self, node: ast.SetItem) -> None:
@@ -370,6 +371,7 @@ class TypeChecker:
         color, w_vtype = self.check_expr(expr.value)
         w_attr = self.vm.wrap(expr.attr)
         w_opimpl = self.vm.call_function(OP.w_GETATTR, [w_vtype, w_attr])
+        assert isinstance(w_opimpl, W_OpImpl)
         self.opimpl_typecheck(
             w_opimpl,
             expr,
@@ -378,9 +380,8 @@ class TypeChecker:
             dispatch = 'single',
             errmsg = "type `{0}` has no attribute '%s'" % expr.attr
         )
-        assert isinstance(w_opimpl, W_Func)
         self.opimpl[expr] = w_opimpl
-        return color, w_opimpl.w_functype.w_restype
+        return color, w_opimpl.w_restype
 
     def OP_dispatch(self, w_OP: Any, node: ast.Node, args: list[ast.Expr],
                     *,
@@ -415,16 +416,17 @@ class TypeChecker:
         # step 2: call OP() and get w_opimpl
         assert w_OP.color == 'blue', f'{w_OP.qn} is not blue'
         w_opimpl = self.vm.call_function(w_OP, argtypes_w) # type: ignore
+        assert isinstance(w_opimpl, W_OpImpl)
 
         # step 3: check that we can call the returned w_opimpl
         self.opimpl_typecheck(w_opimpl, node, args, argtypes_w,
                               dispatch=dispatch, errmsg=errmsg)
-        assert isinstance(w_opimpl, W_Func)
+        assert isinstance(w_opimpl, W_OpImpl)
         self.opimpl[node] = w_opimpl
-        return color, w_opimpl.w_functype.w_restype
+        return color, w_opimpl.w_func.w_functype.w_restype
 
     def opimpl_typecheck(self,
-                         w_opimpl: W_Object,
+                         w_opimpl: W_OpImpl,
                          node: ast.Node,
                          args: Sequence[ast.Expr | None],
                          argtypes_w: list[W_Type],
@@ -439,7 +441,7 @@ class TypeChecker:
         `dispatch` is used only for diagnostics: if it's 'single' we will
         report the type of the first operand, else of all operands.
         """
-        if w_opimpl is B.w_NotImplemented:
+        if w_opimpl.is_null():
             typenames = [w_t.name for w_t in argtypes_w]
             errmsg = errmsg.format(*typenames)
             err = SPyTypeError(errmsg)
@@ -464,8 +466,7 @@ class TypeChecker:
                         err.add('error', f'this is `{t}`', arg.loc)
             raise err
 
-        assert isinstance(w_opimpl, W_Func)
-        w_functype = w_opimpl.w_functype
+        w_functype = w_opimpl.w_func.w_functype
 
         self.call_typecheck(
             w_functype,
@@ -519,17 +520,18 @@ class TypeChecker:
         argtypes_w = [self.check_expr(arg)[1] for arg in call.args]
         w_argtypes = W_List[W_Type](argtypes_w) # type: ignore
         w_opimpl = self.vm.call_function(OP.w_CALL, [w_otype, w_argtypes])
+        assert isinstance(w_opimpl, W_OpImpl)
         newargs = [call.func] + call.args
         errmsg = 'cannot call objects of type `{0}`'
         self.opimpl_typecheck(w_opimpl, call, newargs,
                               [w_otype] + argtypes_w,
                               dispatch='single',
                               errmsg=errmsg)
-        assert isinstance(w_opimpl, W_Func)
         self.opimpl[call] = w_opimpl
         # XXX I'm not sure that the color is correct here. We need to think
         # more.
-        return w_opimpl.w_functype.color, w_opimpl.w_functype.w_restype
+        w_functype = w_opimpl.w_func.w_functype
+        return w_functype.color, w_functype.w_restype
 
     def call_typecheck(self,
                        w_functype: W_FuncType,
@@ -603,6 +605,7 @@ class TypeChecker:
         w_argtypes = W_List[W_Type](argtypes_w) # type: ignore
         w_opimpl = self.vm.call_function(OP.w_CALL_METHOD,
                                          [w_otype, w_method, w_argtypes])
+        assert isinstance(w_opimpl, W_OpImpl)
         w_method = self.vm.wrap(op.method)
         m = ast.Constant(op.loc, value=w_method)
         newargs = [op.target, m] + op.args
@@ -611,11 +614,11 @@ class TypeChecker:
                               [w_otype, B.w_str] + argtypes_w,
                               dispatch='single',
                               errmsg=errmsg)
-        assert isinstance(w_opimpl, W_Func)
         self.opimpl[op] = w_opimpl
         # XXX I'm not sure that the color is correct here. We need to think
         # more.
-        return w_opimpl.w_functype.color, w_opimpl.w_functype.w_restype
+        w_functype = w_opimpl.w_func.w_functype
+        return w_functype.color, w_functype.w_restype
 
     def check_expr_List(self, listop: ast.List) -> tuple[Color, W_Type]:
         w_itemtype = None

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -269,6 +269,11 @@ class SPyVM:
         raise Exception(f"Cannot wrap interp-level objects " +
                         f"of type {value.__class__.__name__}")
 
+    def wrap_func(self, value: Any) -> W_Func:
+        w_func = self.wrap(value)
+        assert isinstance(w_func, W_Func)
+        return w_func
+
     def unwrap(self, w_value: W_Object) -> Any:
         """
         Useful for tests: magic funtion which wraps the given app-level w_

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -14,6 +14,7 @@ from spy.vm.b import B
 from spy.vm.sig import SPyBuiltin
 from spy.vm.function import W_FuncType, W_Func, W_ASTFunc, W_BuiltinFunc
 from spy.vm.module import W_Module
+from spy.vm.opimpl import W_OpImpl
 from spy.vm.registry import ModuleRegistry
 from spy.vm.bluecache import BlueCache
 
@@ -319,12 +320,12 @@ class SPyVM:
         w_ta = self.dynamic_type(w_a)
         w_tb = self.dynamic_type(w_b)
         w_opimpl = self.call_function(OPERATOR.w_EQ, [w_ta, w_tb])
-        if w_opimpl is B.w_NotImplemented:
+        assert isinstance(w_opimpl, W_OpImpl)
+        if w_opimpl.is_null():
             # XXX: the logic to produce a good error message should be in a
             # single place
             raise SPyTypeError("Cannot do ==")
-        assert isinstance(w_opimpl, W_Func)
-        w_res = self.call_function(w_opimpl, [w_a, w_b])
+        w_res = self.call_function(w_opimpl.w_func, [w_a, w_b])
         assert isinstance(w_res, W_Bool)
         return w_res
 
@@ -335,12 +336,12 @@ class SPyVM:
         w_ta = self.dynamic_type(w_a)
         w_tb = self.dynamic_type(w_b)
         w_opimpl = self.call_function(OPERATOR.w_NE, [w_ta, w_tb])
-        if w_opimpl is B.w_NotImplemented:
+        assert isinstance(w_opimpl, W_OpImpl)
+        if w_opimpl.is_null():
             # XXX: the logic to produce a good error message should be in a
             # single place
             raise SPyTypeError("Cannot do !=")
-        assert isinstance(w_opimpl, W_Func)
-        w_res = self.call_function(w_opimpl, [w_a, w_b])
+        w_res = self.call_function(w_opimpl.w_func, [w_a, w_b])
         assert isinstance(w_res, W_Bool)
         return w_res
 
@@ -351,11 +352,11 @@ class SPyVM:
         w_tobj = self.dynamic_type(w_obj)
         w_ti = self.dynamic_type(w_i)
         w_opimpl = self.call_function(OPERATOR.w_GETITEM, [w_tobj, w_ti])
-        if w_opimpl is B.w_NotImplemented:
+        assert isinstance(w_opimpl, W_OpImpl)
+        if w_opimpl.is_null():
             # XXX see also eq and ne
             raise SPyTypeError("Cannot do []")
-        assert isinstance(w_opimpl, W_Func)
-        return self.call_function(w_opimpl, [w_obj, w_i])
+        return self.call_function(w_opimpl.w_func, [w_obj, w_i])
 
     def universal_eq(self, w_a: W_Dynamic, w_b: W_Dynamic) -> W_Bool:
         """
@@ -403,13 +404,13 @@ class SPyVM:
         w_ta = self.dynamic_type(w_a)
         w_tb = self.dynamic_type(w_b)
         w_opimpl = self.call_function(OPERATOR.w_EQ, [w_ta, w_tb])
-        if w_opimpl is B.w_NotImplemented:
+        assert isinstance(w_opimpl, W_OpImpl)
+        if w_opimpl.is_null():
             # sanity check: EQ between objects of the same type should always
             # be possible. If it's not, it means that we forgot to implement it
             assert w_ta is not w_tb, f'EQ missing on type `{w_ta.name}`'
             return B.w_False
-        assert isinstance(w_opimpl, W_Func)
-        w_res = self.call_function(w_opimpl, [w_a, w_b])
+        w_res = self.call_function(w_opimpl.w_func, [w_a, w_b])
         assert isinstance(w_res, W_Bool)
         return w_res
 

--- a/spy/vm/w.py
+++ b/spy/vm/w.py
@@ -8,3 +8,5 @@ from spy.vm.module import W_Module
 from spy.vm.object import (W_Bool, W_F64, W_I32, W_Object, W_Type, W_Void,
                            W_Dynamic, spytype)
 from spy.vm.str import W_Str
+from spy.vm.list import W_List
+from spy.vm.opimpl import W_OpImpl


### PR DESCRIPTION
This is a big refactoring, but doesn't add any new functionality.

Refactor the signature of `OPERATOR`s: instead of returning a function, they now return a `W_OpImpl`, which at the moment is just a simple wrapper around a function.

`W_OpImpl` will get new features later.