### PR TITLE
Introduce W_OpImpl.with_values

### DIFF
--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -205,7 +205,8 @@ class FuncDoppler:
         i = self.shift_expr(op.index)
         w_opimpl = self.t.opimpl[op]
         func = self.make_const(op.loc, w_opimpl.w_func)
-        return ast.Call(op.loc, func, [v, i])
+        args = w_opimpl.reorder([v, i])
+        return ast.Call(op.loc, func, args)
 
     def shift_expr_GetAttr(self, op: ast.GetAttr) -> ast.Expr:
         v = self.shift_expr(op.value)

--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -7,7 +7,7 @@ from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_I32, W_Void
 from spy.vm.opimpl import W_OpImpl, W_Value
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM
-from spy.tests.support import CompilerTest, no_C, expect_errors, skip_backends
+from spy.tests.support import CompilerTest, no_C, expect_errors
 
 @no_C
 class TestOp(CompilerTest):
@@ -80,7 +80,7 @@ class TestOp(CompilerTest):
         )
         self.compile_raises(src, "foo", errors)
 
-    def test_AbsVal(self):
+    def test_Values(self):
         if self.backend == 'doppler':
             pytest.skip('FIXME')
 
@@ -98,13 +98,12 @@ class TestOp(CompilerTest):
                 return W_MyClass(w_x)
 
             @staticmethod
-            def op_GETITEM(vm: 'SPyVM', wav_obj: W_Value,
-                           wav_i: W_Value) -> W_OpImpl:
-                assert isinstance(wav_obj, W_Value)
-                assert isinstance(wav_i, W_Value)
+            def op_GETITEM(vm: 'SPyVM', wv_obj: W_Value,
+                           wv_i: W_Value) -> W_OpImpl:
+                assert isinstance(wv_obj, W_Value)
+                assert isinstance(wv_i, W_Value)
                 # NOTE we are reversing the two!
-                return W_OpImpl.with_vals(EXT.w_sum, [wav_i, wav_obj])
-            op_GETITEM.use_absval = True
+                return W_OpImpl.with_vals(EXT.w_sum, [wv_i, wv_obj])
 
         @EXT.builtin
         def sum(vm: 'SPyVM', w_i: W_I32, w_obj: W_MyClass) -> W_I32:

--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -30,7 +30,7 @@ class TestOp(CompilerTest):
                 @spy_builtin(QN('ext::getitem'))
                 def getitem(vm: 'SPyVM', w_obj: W_MyClass, w_i: W_I32) -> W_I32:
                     return w_i
-                return W_OpImpl(vm.wrap_func(getitem))
+                return W_OpImpl.simple(vm.wrap_func(getitem))
         # ========== /EXT module for this test =========
 
         self.vm.make_module(EXT)
@@ -64,7 +64,7 @@ class TestOp(CompilerTest):
                 @spy_builtin(QN('ext::getitem'))
                 def getitem(vm: 'SPyVM', w_obj: W_MyClass) -> W_Void:
                     return B.w_None
-                return W_OpImpl(vm.wrap_func(getitem))
+                return W_OpImpl.simple(vm.wrap_func(getitem))
         # ========== /EXT module for this test =========
 
         self.vm.make_module(EXT)

--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -4,7 +4,7 @@ from spy.vm.b import B
 from spy.vm.object import spytype, Member, Annotated
 from spy.vm.sig import spy_builtin
 from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_I32, W_Void
-from spy.vm.opimpl import W_OpImpl, W_AbsVal
+from spy.vm.opimpl import W_OpImpl, W_Value
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM
 from spy.tests.support import CompilerTest, no_C, expect_errors, skip_backends
@@ -98,10 +98,10 @@ class TestOp(CompilerTest):
                 return W_MyClass(w_x)
 
             @staticmethod
-            def op_GETITEM(vm: 'SPyVM', wav_obj: W_AbsVal,
-                           wav_i: W_AbsVal) -> W_OpImpl:
-                assert isinstance(wav_obj, W_AbsVal)
-                assert isinstance(wav_i, W_AbsVal)
+            def op_GETITEM(vm: 'SPyVM', wav_obj: W_Value,
+                           wav_i: W_Value) -> W_OpImpl:
+                assert isinstance(wav_obj, W_Value)
+                assert isinstance(wav_i, W_Value)
                 # NOTE we are reversing the two!
                 return W_OpImpl.with_vals(EXT.w_sum, [wav_i, wav_obj])
             op_GETITEM.use_absval = True

--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -81,9 +81,6 @@ class TestOp(CompilerTest):
         self.compile_raises(src, "foo", errors)
 
     def test_Values(self):
-        if self.backend == 'doppler':
-            pytest.skip('FIXME')
-
         # ========== EXT module for this test ==========
         EXT = ModuleRegistry('ext', '<ext>')
 

--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -102,7 +102,7 @@ class TestOp(CompilerTest):
                            wv_i: W_Value) -> W_OpImpl:
                 assert isinstance(wv_obj, W_Value)
                 assert isinstance(wv_i, W_Value)
-                # NOTE we are reversing the two!
+                # NOTE we are reversing the two arguments
                 return W_OpImpl.with_values(EXT.w_sum, [wv_i, wv_obj])
 
         @EXT.builtin

--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -62,8 +62,8 @@ class TestOp(CompilerTest):
             def op_GETITEM(vm: 'SPyVM', w_listtype: W_Type,
                            w_itype: W_Type) -> W_OpImpl:
                 @spy_builtin(QN('ext::getitem'))
-                def getitem(vm: 'SPyVM', w_obj: W_MyClass) -> W_Void:
-                    return B.w_None
+                def getitem(vm: 'SPyVM', w_obj: W_MyClass) -> W_I32:
+                    return vm.wrap(42)
                 return W_OpImpl.simple(vm.wrap_func(getitem))
         # ========== /EXT module for this test =========
 

--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -103,7 +103,7 @@ class TestOp(CompilerTest):
                 assert isinstance(wv_obj, W_Value)
                 assert isinstance(wv_i, W_Value)
                 # NOTE we are reversing the two!
-                return W_OpImpl.with_vals(EXT.w_sum, [wv_i, wv_obj])
+                return W_OpImpl.with_values(EXT.w_sum, [wv_i, wv_obj])
 
         @EXT.builtin
         def sum(vm: 'SPyVM', w_i: W_I32, w_obj: W_MyClass) -> W_I32:

--- a/spy/tests/compiler/test_operator_attr.py
+++ b/spy/tests/compiler/test_operator_attr.py
@@ -71,7 +71,7 @@ class TestAttrOp(CompilerTest):
                                       w_attr: W_Str) -> W_Str:
                         attr = vm.unwrap_str(w_attr)
                         return vm.wrap(attr.upper() + '--42')  # type: ignore
-                return W_OpImpl(vm.wrap_func(fn))
+                return W_OpImpl.simple(vm.wrap_func(fn))
 
             @staticmethod
             def op_SETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str,
@@ -83,7 +83,7 @@ class TestAttrOp(CompilerTest):
                                w_attr: W_Str, w_val: W_I32) -> W_Void:
                         w_obj.x = vm.unwrap_i32(w_val)
                         return B.w_None
-                    return W_OpImpl(vm.wrap_func(fn))
+                    return W_OpImpl.simple(vm.wrap_func(fn))
                 else:
                     return W_OpImpl.NULL
         # ========== /EXT module for this test =========

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -35,7 +35,7 @@ class TestCallOp(CompilerTest):
                     y = vm.unwrap_i32(w_y)
                     res = w_obj.x + y
                     return vm.wrap(res) # type: ignore
-                return W_OpImpl(vm.wrap_func(call))
+                return W_OpImpl.simple(vm.wrap_func(call))
         # ========== /EXT module for this test =========
         self.vm.make_module(EXT)
         mod = self.compile("""
@@ -69,7 +69,7 @@ class TestCallOp(CompilerTest):
                 def new(vm: 'SPyVM', w_cls: W_Type,
                         w_x: W_I32, w_y: W_I32) -> W_Point:
                     return W_Point(w_x, w_y)
-                return W_OpImpl(vm.wrap_func(new))
+                return W_OpImpl.simple(vm.wrap_func(new))
         # ========== /EXT module for this test =========
         self.vm.make_module(EXT)
         mod = self.compile("""
@@ -139,7 +139,7 @@ class TestCallOp(CompilerTest):
                                w_arg: W_I32) -> W_I32:
                         y = vm.unwrap_i32(w_arg)
                         return vm.wrap(w_self.x + y)  # type: ignore
-                    return W_OpImpl(vm.wrap_func(fn))
+                    return W_OpImpl.simple(vm.wrap_func(fn))
 
                 elif meth == 'sub':
                     @spy_builtin(QN('ext::meth_sub'))
@@ -147,7 +147,7 @@ class TestCallOp(CompilerTest):
                                w_arg: W_I32) -> W_I32:
                         y = vm.unwrap_i32(w_arg)
                         return vm.wrap(w_self.x - y)  # type: ignore
-                    return W_OpImpl(vm.wrap_func(fn))
+                    return W_OpImpl.simple(vm.wrap_func(fn))
 
                 else:
                     return B.w_NotImplemented

--- a/spy/tests/support.py
+++ b/spy/tests/support.py
@@ -156,6 +156,7 @@ class CompilerTest:
             return interp_mod
         elif self.backend == 'doppler':
             self.vm.redshift()
+            #self.dump_module(modname)
             interp_mod = InterpModuleWrapper(self.vm, self.w_mod)
             return interp_mod
         elif self.backend == 'C':
@@ -171,6 +172,12 @@ class CompilerTest:
             return ExeWrapper(file_js)
         else:
             assert False, f'Unknown backend: {self.backend}'
+
+    def dump_module(self, modname: str) -> None:
+        from spy.__main__ import dump_spy_mod
+        print()
+        print()
+        dump_spy_mod(self.vm, modname)
 
     def compile_raises(self, src: str, funcname: str, ctx: Any,
                        *,

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -309,8 +309,7 @@ class ASTFrame:
         w_opimpl = self.t.opimpl[op]
         w_val = self.eval_expr(op.value)
         w_i = self.eval_expr(op.index)
-        w_res = self.vm.call(w_opimpl.w_func, [w_val, w_i])
-        return w_res
+        return w_opimpl.call(self.vm, [w_val, w_i])
 
     def eval_expr_GetAttr(self, op: ast.GetAttr) -> W_Object:
         # this is suboptimal, but good enough for now: ideally, we would like

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -309,7 +309,8 @@ class ASTFrame:
         w_opimpl = self.t.opimpl[op]
         w_val = self.eval_expr(op.value)
         w_i = self.eval_expr(op.index)
-        return w_opimpl.call(self.vm, [w_val, w_i])
+        args_w = w_opimpl.reorder([w_val, w_i])
+        return self.vm.call(w_opimpl.w_func, args_w)
 
     def eval_expr_GetAttr(self, op: ast.GetAttr) -> W_Object:
         # this is suboptimal, but good enough for now: ideally, we would like

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -66,7 +66,7 @@ class W_List(W_Object, metaclass=Meta_W_List):
     def meta_op_GETITEM(vm: 'SPyVM', w_type: W_Type,
                         w_vtype: W_Type) -> 'W_OpImpl':
         from spy.vm.opimpl import W_OpImpl
-        return W_OpImpl(vm.wrap_func(make_list_type))
+        return W_OpImpl.simple(vm.wrap_func(make_list_type))
 
 
 
@@ -126,7 +126,7 @@ def _make_W_List(w_T: W_Type) -> Type[W_List]:
                 i = vm.unwrap_i32(w_i)
                 # XXX bound check?
                 return w_list.items_w[i]
-            return W_OpImpl(vm.wrap_func(getitem))
+            return W_OpImpl.simple(vm.wrap_func(getitem))
 
         @staticmethod
         def op_SETITEM(vm: 'SPyVM', w_listtype: W_Type, w_itype: W_Type,
@@ -142,7 +142,7 @@ def _make_W_List(w_T: W_Type) -> Type[W_List]:
                 # XXX bound check?
                 w_list.items_w[i] = w_v
                 return B.w_None
-            return W_OpImpl(vm.wrap_func(setitem))
+            return W_OpImpl.simple(vm.wrap_func(setitem))
 
         @staticmethod
         def op_EQ(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
@@ -162,7 +162,7 @@ def _make_W_List(w_T: W_Type) -> Type[W_List]:
                 return B.w_True
 
             if w_ltype is w_rtype:
-                return W_OpImpl(vm.wrap_func(eq))
+                return W_OpImpl.simple(vm.wrap_func(eq))
             else:
                 return W_OpImpl.NULL
 

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -44,7 +44,7 @@ class W_Module(W_Object):
         def fn(vm: 'SPyVM', w_mod: W_Module, w_attr: W_Str) -> W_Dynamic:
             attr = vm.unwrap_str(w_attr)
             return w_mod.getattr(attr)
-        return W_OpImpl(vm.wrap_func(fn))
+        return W_OpImpl.simple(vm.wrap_func(fn))
 
 
     @staticmethod
@@ -56,7 +56,7 @@ class W_Module(W_Object):
             attr = vm.unwrap_str(w_attr)
             w_mod.setattr(attr, w_val)
             return B.w_None
-        return W_OpImpl(vm.wrap_func(fn))
+        return W_OpImpl.simple(vm.wrap_func(fn))
 
     # ==== public interp-level API ====
 

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -25,7 +25,7 @@ class W_JsRef(W_Object):
         @spy_builtin(QN(f'jsffi::getattr_{attr}'))
         def fn(vm: 'SPyVM', w_self: W_JsRef, w_attr: W_Str) -> W_JsRef:
             return js_getattr(vm, w_self, w_attr)
-        return W_OpImpl(vm.wrap_func(fn))
+        return W_OpImpl.simple(vm.wrap_func(fn))
 
     @staticmethod
     def op_SETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str,
@@ -37,7 +37,7 @@ class W_JsRef(W_Object):
         def fn(vm: 'SPyVM', w_self: W_JsRef, w_attr: W_Str,
                w_val: W_JsRef) -> None:
             js_setattr(vm, w_self, w_attr, w_val)
-        return W_OpImpl(vm.wrap_func(fn))
+        return W_OpImpl.simple(vm.wrap_func(fn))
 
     @staticmethod
     def op_CALL_METHOD(vm: 'SPyVM', w_type: W_Type, w_method: W_Str,
@@ -45,7 +45,7 @@ class W_JsRef(W_Object):
         argtypes_w = vm.unwrap(w_argtypes)
         n = len(argtypes_w)
         if n == 1:
-            return W_OpImpl(JSFFI.w_call_method_1)
+            return W_OpImpl.simple(JSFFI.w_call_method_1)
         else:
             raise Exception(
                 f"unsupported number of arguments for CALL_METHOD: {n}"

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -35,7 +35,7 @@ def GETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str) -> W_OpImpl:
         assert isinstance(w_func, W_Func)
         # XXX: ideally, we should be able to return directly an W_OpImpl from
         # applevel
-        return W_OpImpl(w_func)
+        return W_OpImpl.simple(w_func)
 
     return W_OpImpl.NULL
 
@@ -46,7 +46,7 @@ def SETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str,
     attr = vm.unwrap_str(w_attr)
     pyclass = w_type.pyclass
     if w_type is B.w_dynamic:
-        return W_OpImpl(OP.w_dynamic_setattr)
+        return W_OpImpl.simple(OP.w_dynamic_setattr)
     elif attr in pyclass.__spy_members__:
         return opimpl_member('set', vm, w_type, attr)
     elif pyclass.has_meth_overriden('op_SETATTR'):
@@ -58,7 +58,7 @@ def SETATTR(vm: 'SPyVM', w_type: W_Type, w_attr: W_Str,
         assert isinstance(w_setattr, W_Func)
         w_func = vm.call(w_setattr, [w_type, w_attr, w_vtype])
         assert isinstance(w_func, W_Func)
-        return W_OpImpl(w_func)
+        return W_OpImpl.simple(w_func)
 
     return W_OpImpl.NULL
 
@@ -80,7 +80,7 @@ def opimpl_member(kind: OpKind, vm: 'SPyVM', w_type: W_Type,
         def opimpl_get(vm: 'SPyVM', w_obj: W_Class, w_attr: W_Str) -> W_Value:
             return getattr(w_obj, field)
 
-        return W_OpImpl(vm.wrap_func(opimpl_get))
+        return W_OpImpl.simple(vm.wrap_func(opimpl_get))
 
     elif kind == 'set':
         @no_type_check
@@ -89,7 +89,7 @@ def opimpl_member(kind: OpKind, vm: 'SPyVM', w_type: W_Type,
                        w_val: W_Value) -> W_Void:
             setattr(w_obj, field, w_val)
 
-        return W_OpImpl(vm.wrap_func(opimpl_set))
+        return W_OpImpl.simple(vm.wrap_func(opimpl_set))
 
     else:
         assert False, f'Invalid OpKind: {kind}'

--- a/spy/vm/modules/operator/binop.py
+++ b/spy/vm/modules/operator/binop.py
@@ -105,23 +105,23 @@ def EQ(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
     if pyclass.has_meth_overriden('op_EQ'):
         return pyclass.op_EQ(vm, w_ltype, w_rtype)
     elif can_use_reference_eq(vm, w_ltype, w_rtype):
-        return W_OpImpl(OP.w_object_is)
+        return W_OpImpl.simple(OP.w_object_is)
     else:
         return MM.lookup('==', w_ltype, w_rtype)
 
 @OP.builtin(color='blue')
 def NE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
     if can_use_reference_eq(vm, w_ltype, w_rtype):
-        return W_OpImpl(OP.w_object_isnot)
+        return W_OpImpl.simple(OP.w_object_isnot)
     return MM.lookup('!=', w_ltype, w_rtype)
 
 @OP.builtin(color='blue')
 def UNIVERSAL_EQ(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
-    return W_OpImpl(OP.w_object_universal_eq)
+    return W_OpImpl.simple(OP.w_object_universal_eq)
 
 @OP.builtin(color='blue')
 def UNIVERSAL_NE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
-    return W_OpImpl(OP.w_object_universal_ne)
+    return W_OpImpl.simple(OP.w_object_universal_ne)
 
 @OP.builtin(color='blue')
 def LT(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:

--- a/spy/vm/modules/operator/itemop.py
+++ b/spy/vm/modules/operator/itemop.py
@@ -10,11 +10,20 @@ if TYPE_CHECKING:
 
 @OP.builtin(color='blue')
 def GETITEM(vm: 'SPyVM', wav_obj: W_AbsVal, wav_i: W_AbsVal) -> W_OpImpl:
+    from spy.vm.typechecker import opimpl_typecheck
+    w_opimpl = W_OpImpl.NULL
     pyclass = wav_obj.w_static_type.pyclass
     if pyclass.has_meth_overriden('op_GETITEM'):
-        return pyclass.op_GETITEM(vm, wav_obj, wav_i)
+        w_opimpl = pyclass.op_GETITEM(vm, wav_obj, wav_i)
 
-    return W_OpImpl.NULL
+    opimpl_typecheck(
+        w_opimpl,
+        [wav_obj, wav_i],
+        dispatch = 'single',
+        errmsg = 'cannot do `{0}`[...]'
+    )
+    return w_opimpl
+
 
 @OP.builtin(color='blue')
 def SETITEM(vm: 'SPyVM', w_type: W_Type, w_itype: W_Type,

--- a/spy/vm/modules/operator/itemop.py
+++ b/spy/vm/modules/operator/itemop.py
@@ -17,6 +17,7 @@ def GETITEM(vm: 'SPyVM', wav_obj: W_AbsVal, wav_i: W_AbsVal) -> W_OpImpl:
         w_opimpl = pyclass.op_GETITEM(vm, wav_obj, wav_i)
 
     typecheck_opimpl(
+        vm,
         w_opimpl,
         [wav_obj, wav_i],
         dispatch = 'single',

--- a/spy/vm/modules/operator/itemop.py
+++ b/spy/vm/modules/operator/itemop.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 from spy.vm.b import B
 from spy.vm.object import W_Type, W_Dynamic
-from spy.vm.opimpl import W_OpImpl, W_AbsVal
+from spy.vm.opimpl import W_OpImpl, W_Value
 
 from . import OP
 if TYPE_CHECKING:
@@ -9,17 +9,17 @@ if TYPE_CHECKING:
 
 
 @OP.builtin(color='blue')
-def GETITEM(vm: 'SPyVM', wav_obj: W_AbsVal, wav_i: W_AbsVal) -> W_OpImpl:
+def GETITEM(vm: 'SPyVM', wv_obj: W_Value, wv_i: W_Value) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opimpl
     w_opimpl = W_OpImpl.NULL
-    pyclass = wav_obj.w_static_type.pyclass
+    pyclass = wv_obj.w_static_type.pyclass
     if pyclass.has_meth_overriden('op_GETITEM'):
-        w_opimpl = pyclass.op_GETITEM(vm, wav_obj, wav_i)
+        w_opimpl = pyclass.op_GETITEM(vm, wv_obj, wv_i)
 
     typecheck_opimpl(
         vm,
         w_opimpl,
-        [wav_obj, wav_i],
+        [wv_obj, wv_i],
         dispatch = 'single',
         errmsg = 'cannot do `{0}`[...]'
     )

--- a/spy/vm/modules/operator/itemop.py
+++ b/spy/vm/modules/operator/itemop.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 from spy.vm.b import B
 from spy.vm.object import W_Type, W_Dynamic
-from spy.vm.opimpl import W_OpImpl
+from spy.vm.opimpl import W_OpImpl, W_AbsVal
 
 from . import OP
 if TYPE_CHECKING:
@@ -9,10 +9,10 @@ if TYPE_CHECKING:
 
 
 @OP.builtin(color='blue')
-def GETITEM(vm: 'SPyVM', w_type: W_Type, w_itype: W_Type) -> W_OpImpl:
-    pyclass = w_type.pyclass
+def GETITEM(vm: 'SPyVM', wav_obj: W_AbsVal, wav_i: W_AbsVal) -> W_OpImpl:
+    pyclass = wav_obj.w_static_type.pyclass
     if pyclass.has_meth_overriden('op_GETITEM'):
-        return pyclass.op_GETITEM(vm, w_type, w_itype)
+        return pyclass.op_GETITEM(vm, wav_obj, wav_i)
 
     return W_OpImpl.NULL
 

--- a/spy/vm/modules/operator/itemop.py
+++ b/spy/vm/modules/operator/itemop.py
@@ -10,13 +10,13 @@ if TYPE_CHECKING:
 
 @OP.builtin(color='blue')
 def GETITEM(vm: 'SPyVM', wav_obj: W_AbsVal, wav_i: W_AbsVal) -> W_OpImpl:
-    from spy.vm.typechecker import opimpl_typecheck
+    from spy.vm.typechecker import typecheck_opimpl
     w_opimpl = W_OpImpl.NULL
     pyclass = wav_obj.w_static_type.pyclass
     if pyclass.has_meth_overriden('op_GETITEM'):
         w_opimpl = pyclass.op_GETITEM(vm, wav_obj, wav_i)
 
-    opimpl_typecheck(
+    typecheck_opimpl(
         w_opimpl,
         [wav_obj, wav_i],
         dispatch = 'single',

--- a/spy/vm/modules/operator/multimethod.py
+++ b/spy/vm/modules/operator/multimethod.py
@@ -61,5 +61,5 @@ class MultiMethodTable:
         for key in keys:
             w_func = self.impls.get(key)
             if w_func:
-                return W_OpImpl(w_func)
-        return W_OpImpl(None)
+                return W_OpImpl.simple(w_func)
+        return W_OpImpl.NULL

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -381,7 +381,7 @@ def synthesize_meta_op_CALL(pyclass: Type[W_Object]) -> Any:
         qn = QN(modname='ext', attr='new') # XXX what modname should we use?
         # manually apply the @spy_builtin decorator to the spy_new function
         spyfunc = spy_builtin(qn)(spy_new)
-        return W_OpImpl(vm.wrap_func(spyfunc))
+        return W_OpImpl.simple(vm.wrap_func(spyfunc))
 
     return meta_op_CALL
 

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -1,27 +1,52 @@
-from typing import Annotated, Optional, ClassVar
+from typing import Annotated, Optional, ClassVar, no_type_check
 from spy import ast
-from spy.vm.object import Member, W_Type, W_Object, spytype
+from spy.fqn import QN
+from spy.vm.object import Member, W_Type, W_Object, spytype, W_Bool
 from spy.vm.function import W_Func
+from spy.vm.sig import spy_builtin
 
-@spytype('AbVal')
+@spytype('AbsVal')
 class W_AbsVal(W_Object):
-    """
-    Abstract Value.
-
-    XXX explain.
-    """
+    name: str
+    i: int
     w_static_type: Annotated[W_Type, Member('static_type')]
-    expr: ast.Expr
 
-    def __init__(self, w_type: W_Type, expr: ast.Expr) -> None:
-        self.w_type = w_type
-        self.expr = expr
+    def __init__(self, name: str, i: int, w_static_type: W_Type) -> None:
+        self.name = name
+        self.i = i
+        self.w_static_type = w_static_type
+
+    def __repr__(self):
+        return f'<W_AbsVal {self.name}{self.i}: {self.w_static_type.name}>'
+
+    @staticmethod
+    def op_EQ(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> 'W_OpImpl':
+        from spy.vm.b import B
+        assert w_ltype.pyclass is W_AbsVal
+
+        @no_type_check
+        @spy_builtin(QN('operator::absval_eq'))
+        def eq(vm: 'SPyVM', wav1: W_AbsVal, wav2: W_AbsVal) -> W_Bool:
+            # note that the name is NOT considered for equality, is purely for
+            # description
+            if (wav1.i == wav2.i and
+                wav1.w_static_type is wav2.w_static_type):
+                return B.w_True
+            else:
+                return B.w_False
+
+        if w_ltype is w_rtype:
+            return W_OpImpl.simple(vm.wrap_func(eq))
+        else:
+            return W_OpImpl.NULL
+
+
 
 @spytype('OpImpl')
 class W_OpImpl(W_Object):
     NULL: ClassVar['W_OpImpl']
     _w_func: Optional[W_Func]
-    _args_w: Optional[list[W_AbsVal]]
+    _args_wav: Optional[list[W_AbsVal]]
 
     def __init__(self, *args) -> None:
         raise NotImplementedError('Please use W_OpImpl.simple()')
@@ -30,7 +55,14 @@ class W_OpImpl(W_Object):
     def simple(cls, w_func: W_Func) -> 'W_OpImpl':
         w_opimpl = cls.__new__(cls)
         w_opimpl._w_func = w_func
-        w_opimpl._args_w = None
+        w_opimpl._args_wav = None
+        return w_opimpl
+
+    @classmethod
+    def with_vals(cls, w_func: W_Func, args_wav: list[W_AbsVal]) -> 'W_OpImpl':
+        w_opimpl = cls.__new__(cls)
+        w_opimpl._w_func = w_func
+        w_opimpl._args_wav = args_wav
         return w_opimpl
 
     def __repr__(self) -> str:
@@ -52,5 +84,9 @@ class W_OpImpl(W_Object):
     def w_restype(self) -> W_Type:
         return self.w_func.w_functype.w_restype
 
+    def call(self, vm: 'SPyVM', args_w: list[W_Object]) -> W_Object:
+        if self._args_wav is not None:
+            args_w = [args_w[wav.i] for wav in self._args_wav]
+        return vm.call(self._w_func, args_w)
 
 W_OpImpl.NULL = W_OpImpl.simple(None)

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -95,6 +95,9 @@ class W_OpImpl(W_Object):
     def is_null(self) -> bool:
         return self._w_func is None
 
+    def is_simple(self) -> bool:
+        return self._args_wv is None
+
     @property
     def w_func(self) -> W_Func:
         assert self._w_func is not None

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -1,6 +1,7 @@
 from typing import Annotated, Optional, ClassVar, no_type_check
 from spy import ast
 from spy.fqn import QN
+from spy.location import Loc
 from spy.vm.object import Member, W_Type, W_Object, spytype, W_Bool
 from spy.vm.function import W_Func
 from spy.vm.sig import spy_builtin
@@ -10,11 +11,14 @@ class W_AbsVal(W_Object):
     name: str
     i: int
     w_static_type: Annotated[W_Type, Member('static_type')]
+    loc: Optional[Loc]
 
-    def __init__(self, name: str, i: int, w_static_type: W_Type) -> None:
+    def __init__(self, name: str, i: int, w_static_type: W_Type,
+                 loc: Optional[Loc]) -> None:
         self.name = name
         self.i = i
         self.w_static_type = w_static_type
+        self.loc = loc
 
     def __repr__(self):
         return f'<W_AbsVal {self.name}{self.i}: {self.w_static_type.name}>'

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -6,8 +6,13 @@ from spy.vm.object import Member, W_Type, W_Object, spytype, W_Bool
 from spy.vm.function import W_Func
 from spy.vm.sig import spy_builtin
 
-@spytype('AbsVal')
-class W_AbsVal(W_Object):
+@spytype('Value')
+class W_Value(W_Object):
+    """
+    A Value represent an operand of an OPERATOR.
+
+    The naming convention is wv_one and manyvalues_wv.
+    """
     name: str
     i: int
     w_static_type: Annotated[W_Type, Member('static_type')]
@@ -21,20 +26,20 @@ class W_AbsVal(W_Object):
         self.loc = loc
 
     def __repr__(self):
-        return f'<W_AbsVal {self.name}{self.i}: {self.w_static_type.name}>'
+        return f'<W_Value {self.name}{self.i}: {self.w_static_type.name}>'
 
     @staticmethod
     def op_EQ(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> 'W_OpImpl':
         from spy.vm.b import B
-        assert w_ltype.pyclass is W_AbsVal
+        assert w_ltype.pyclass is W_Value
 
         @no_type_check
-        @spy_builtin(QN('operator::absval_eq'))
-        def eq(vm: 'SPyVM', wav1: W_AbsVal, wav2: W_AbsVal) -> W_Bool:
+        @spy_builtin(QN('operator::value_eq'))
+        def eq(vm: 'SPyVM', wv1: W_Value, wv2: W_Value) -> W_Bool:
             # note that the name is NOT considered for equality, is purely for
             # description
-            if (wav1.i == wav2.i and
-                wav1.w_static_type is wav2.w_static_type):
+            if (wv1.i == wv2.i and
+                wv1.w_static_type is wv2.w_static_type):
                 return B.w_True
             else:
                 return B.w_False
@@ -50,7 +55,7 @@ class W_AbsVal(W_Object):
 class W_OpImpl(W_Object):
     NULL: ClassVar['W_OpImpl']
     _w_func: Optional[W_Func]
-    _args_wav: Optional[list[W_AbsVal]]
+    _args_wv: Optional[list[W_Value]]
 
     def __init__(self, *args) -> None:
         raise NotImplementedError('Please use W_OpImpl.simple()')
@@ -59,14 +64,14 @@ class W_OpImpl(W_Object):
     def simple(cls, w_func: W_Func) -> 'W_OpImpl':
         w_opimpl = cls.__new__(cls)
         w_opimpl._w_func = w_func
-        w_opimpl._args_wav = None
+        w_opimpl._args_wv = None
         return w_opimpl
 
     @classmethod
-    def with_vals(cls, w_func: W_Func, args_wav: list[W_AbsVal]) -> 'W_OpImpl':
+    def with_vals(cls, w_func: W_Func, args_wv: list[W_Value]) -> 'W_OpImpl':
         w_opimpl = cls.__new__(cls)
         w_opimpl._w_func = w_func
-        w_opimpl._args_wav = args_wav
+        w_opimpl._args_wv = args_wv
         return w_opimpl
 
     def __repr__(self) -> str:
@@ -89,8 +94,8 @@ class W_OpImpl(W_Object):
         return self.w_func.w_functype.w_restype
 
     def call(self, vm: 'SPyVM', args_w: list[W_Object]) -> W_Object:
-        if self._args_wav is not None:
-            args_w = [args_w[wav.i] for wav in self._args_wav]
+        if self._args_wv is not None:
+            args_w = [args_w[wv.i] for wv in self._args_wv]
         return vm.call(self._w_func, args_w)
 
 W_OpImpl.NULL = W_OpImpl.simple(None)

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -68,7 +68,7 @@ class W_OpImpl(W_Object):
         return w_opimpl
 
     @classmethod
-    def with_vals(cls, w_func: W_Func, args_wv: list[W_Value]) -> 'W_OpImpl':
+    def with_values(cls, w_func: W_Func, args_wv: list[W_Value]) -> 'W_OpImpl':
         w_opimpl = cls.__new__(cls)
         w_opimpl._w_func = w_func
         w_opimpl._args_wv = args_wv

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -1,10 +1,12 @@
-from typing import Annotated, Optional, ClassVar, no_type_check
+from typing import Annotated, Optional, ClassVar, no_type_check, TypeVar
 from spy import ast
 from spy.fqn import QN
 from spy.location import Loc
 from spy.vm.object import Member, W_Type, W_Object, spytype, W_Bool
 from spy.vm.function import W_Func
 from spy.vm.sig import spy_builtin
+
+T = TypeVar('T')
 
 @spytype('Value')
 class W_Value(W_Object):
@@ -102,9 +104,15 @@ class W_OpImpl(W_Object):
     def w_restype(self) -> W_Type:
         return self.w_func.w_functype.w_restype
 
-    def call(self, vm: 'SPyVM', args_w: list[W_Object]) -> W_Object:
-        if self._args_wv is not None:
-            args_w = [args_w[wv.i] for wv in self._args_wv]
-        return vm.call(self._w_func, args_w)
+    def reorder(self, args: list[T]) -> list[T]:
+        """
+        If we have a complex W_OpImpl, we want to reorder the given args
+        depending on the order of _args_wv
+        """
+        if self._args_wv is None:
+            return args
+        else:
+            return [args[wv.i] for wv in self._args_wv]
+
 
 W_OpImpl.NULL = W_OpImpl.simple(None)

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -13,20 +13,24 @@ class W_Value(W_Object):
 
     The naming convention is wv_one and manyvalues_wv.
     """
-    name: str
+    prefix: str
     i: int
     w_static_type: Annotated[W_Type, Member('static_type')]
     loc: Optional[Loc]
 
-    def __init__(self, name: str, i: int, w_static_type: W_Type,
+    def __init__(self, prefix: str, i: int, w_static_type: W_Type,
                  loc: Optional[Loc]) -> None:
-        self.name = name
+        self.prefix = prefix
         self.i = i
         self.w_static_type = w_static_type
         self.loc = loc
 
+    @property
+    def name(self):
+        return f'{self.prefix}{self.i}'
+
     def __repr__(self):
-        return f'<W_Value {self.name}{self.i}: {self.w_static_type.name}>'
+        return f'<W_Value {self.name}: {self.w_static_type.name}>'
 
     @staticmethod
     def op_EQ(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> 'W_OpImpl':
@@ -36,7 +40,7 @@ class W_Value(W_Object):
         @no_type_check
         @spy_builtin(QN('operator::value_eq'))
         def eq(vm: 'SPyVM', wv1: W_Value, wv2: W_Value) -> W_Bool:
-            # note that the name is NOT considered for equality, is purely for
+            # note that the prefix is NOT considered for equality, is purely for
             # description
             if (wv1.i == wv2.i and
                 wv1.w_static_type is wv2.w_static_type):
@@ -77,9 +81,14 @@ class W_OpImpl(W_Object):
     def __repr__(self) -> str:
         if self._w_func is None:
             return f"<spy OpImpl NULL>"
-        else:
+        elif self._args_wv is None:
             qn = self._w_func.qn
             return f"<spy OpImpl {qn}>"
+        else:
+            qn = self._w_func.qn
+            argnames = [wv.name for wv in self._args_wv]
+            argnames = ', '.join(argnames)
+            return f"<spy OpImpl {qn}({argnames})>"
 
     def is_null(self) -> bool:
         return self._w_func is None

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -2,15 +2,36 @@ from typing import Annotated, Optional, ClassVar
 from spy import ast
 from spy.vm.object import Member, W_Type, W_Object, spytype
 from spy.vm.function import W_Func
-from spy.vm.list import W_List
+
+@spytype('AbVal')
+class W_AbsVal(W_Object):
+    """
+    Abstract Value.
+
+    XXX explain.
+    """
+    w_static_type: Annotated[W_Type, Member('static_type')]
+    expr: ast.Expr
+
+    def __init__(self, w_type: W_Type, expr: ast.Expr) -> None:
+        self.w_type = w_type
+        self.expr = expr
 
 @spytype('OpImpl')
 class W_OpImpl(W_Object):
     NULL: ClassVar['W_OpImpl']
     _w_func: Optional[W_Func]
+    _args_w: Optional[list[W_AbsVal]]
 
-    def __init__(self, w_func: Optional[W_Func]) -> None:
-        self._w_func = w_func
+    def __init__(self, *args) -> None:
+        raise NotImplementedError('Please use W_OpImpl.simple()')
+
+    @classmethod
+    def simple(cls, w_func: W_Func) -> 'W_OpImpl':
+        w_opimpl = cls.__new__(cls)
+        w_opimpl._w_func = w_func
+        w_opimpl._args_w = None
+        return w_opimpl
 
     def __repr__(self) -> str:
         if self._w_func is None:
@@ -32,4 +53,4 @@ class W_OpImpl(W_Object):
         return self.w_func.w_functype.w_restype
 
 
-W_OpImpl.NULL = W_OpImpl(None)
+W_OpImpl.NULL = W_OpImpl.simple(None)

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -75,7 +75,7 @@ class W_Str(W_Object):
             assert isinstance(w_i, W_I32)
             ptr_c = vm.ll.call('spy_str_getitem', w_s.ptr, w_i.value)
             return W_Str.from_ptr(vm, ptr_c)
-        return W_OpImpl(vm.wrap_func(str_getitem))
+        return W_OpImpl.simple(vm.wrap_func(str_getitem))
 
     @staticmethod
     def meta_op_CALL(vm: 'SPyVM', w_type: W_Type,
@@ -83,7 +83,7 @@ class W_Str(W_Object):
         from spy.vm.b import B
         argtypes_w = vm.unwrap(w_argtypes)
         if argtypes_w == [W_I32]:
-            return W_OpImpl(vm.wrap_func(int2str))
+            return W_OpImpl.simple(vm.wrap_func(int2str))
         else:
             return W_OpImpl.NULL
 

--- a/spy/vm/tuple.py
+++ b/spy/vm/tuple.py
@@ -30,7 +30,7 @@ class W_Tuple(W_Object):
     @staticmethod
     def op_GETITEM(vm: 'SPyVM', w_tupletype: W_Type,
                    w_itype: W_Type) -> W_OpImpl:
-        return W_OpImpl(vm.wrap_func(tuple_getitem))
+        return W_OpImpl.simple(vm.wrap_func(tuple_getitem))
 
 
 

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -6,7 +6,7 @@ from spy.irgen.symtable import Symbol, Color
 from spy.errors import (SPyTypeError, SPyNameError, maybe_plural)
 from spy.location import Loc
 from spy.vm.object import W_Object, W_Type
-from spy.vm.opimpl import W_OpImpl
+from spy.vm.opimpl import W_OpImpl, W_AbsVal
 from spy.vm.list import W_List
 from spy.vm.function import W_FuncType, W_ASTFunc, W_Func
 from spy.vm.b import B
@@ -402,6 +402,10 @@ class TypeChecker:
         differently, because they also take a VALUE (the attribute, as a
         string) instead of a TYPE.
         """
+        if w_OP.qn.attr == 'GETITEM':
+            return self.OP_dispatch_newstyle(w_OP, node, args,
+                                             dispatch=dispatch,
+                                             errmsg=errmsg)
         # step 1: determine the arguments to pass to OP()
         argtypes_w = []
         color: Color = 'blue'
@@ -419,6 +423,39 @@ class TypeChecker:
                               dispatch=dispatch, errmsg=errmsg)
         self.opimpl[node] = w_opimpl
         return color, w_opimpl.w_restype
+
+    def OP_dispatch_newstyle(self, w_OP: Any, node: ast.Node,
+                             args: list[ast.Expr],
+                             *,
+                             dispatch: DispatchKind,
+                             errmsg: str
+                             ) -> tuple[Color, W_Type]:
+        # step 1: determine the arguments to pass to OP()
+        args_wav: list[W_AbsVal] = []
+        color: Color = 'blue'
+        for i, arg in enumerate(args):
+            c1, w_argtype = self.check_expr(arg)
+            args_wav.append(self.vm.new_absval('v', i, w_argtype))
+            color = maybe_blue(color, c1)
+
+        # step 2: call OP() and get w_opimpl
+        assert w_OP.color == 'blue', f'{w_OP.qn} is not blue'
+        w_opimpl = self.vm.call_OP(w_OP, args_wav) # type: ignore
+
+        # step 3: check that we can call the returned w_opimpl
+        if w_opimpl._args_wav is None:
+            # XXX this is a temporary hack: in this case, what we want to do
+            # is to create "default" AbsVals and just pass them around. But we
+            # cannot because there are still operators using the old-style
+            # dispatch and they expect argtypes_w.
+            argtypes_w = [wav.w_static_type for wav in args_wav]
+        else:
+            argtypes_w = [wav.w_static_type for wav in w_opimpl._args_wav]
+        self.opimpl_typecheck(w_opimpl, node, args, argtypes_w,
+                              dispatch=dispatch, errmsg=errmsg)
+        self.opimpl[node] = w_opimpl
+        return color, w_opimpl.w_restype
+
 
     def opimpl_typecheck(self,
                          w_opimpl: W_OpImpl,

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -179,6 +179,12 @@ class TypeChecker:
             self.expr_types[expr] = color, w_type
             return color, w_type
 
+    def value_from_check_expr(self, expr: ast.Expr, prefix:
+                              str, i: int) -> tuple[Color, W_Value]:
+        color, w_type = self.check_expr(expr)
+        wv = W_Value(prefix, i, w_type, expr.loc)
+        return color, wv
+
     # ==== statements ====
 
     def check_stmt_Return(self, ret: ast.Return) -> None:
@@ -357,12 +363,10 @@ class TypeChecker:
     check_expr_GtE = check_expr_BinOp
 
     def check_expr_GetItem(self, expr: ast.GetItem) -> tuple[Color, W_Type]:
-        c1, w_valtype = self.check_expr(expr.value)
-        c2, w_itype = self.check_expr(expr.index)
+        c1, wv_obj = self.value_from_check_expr(expr.value, 'v', 0)
+        c2, wv_i = self.value_from_check_expr(expr.index, 'i', 1)
         color = maybe_blue(c1, c2)
-        wv_val = self.vm.new_absval('v', 0, w_valtype, expr.value.loc)
-        wv_i = self.vm.new_absval('i', 1, w_itype, expr.index.loc)
-        w_opimpl = self.vm.call_OP(OP.w_GETITEM, [wv_val, wv_i])
+        w_opimpl = self.vm.call_OP(OP.w_GETITEM, [wv_obj, wv_i])
         self.opimpl[expr] = w_opimpl
         return color, w_opimpl.w_restype
 

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -685,13 +685,13 @@ def typecheck_opimpl(
         vm: 'SPyVM',
         w_opimpl: W_OpImpl,
         #node: ast.Node,
-        args_wav: list[W_AbsVal],
+        orig_args_wav: list[W_AbsVal],
         *,
         dispatch: DispatchKind,
         errmsg: str,
 ) -> None:
     if w_opimpl.is_null():
-        typenames = [wav.w_static_type.name for wav in args_wav]
+        typenames = [wav.w_static_type.name for wav in orig_args_wav]
         errmsg = errmsg.format(*typenames)
         err = SPyTypeError(errmsg)
         if dispatch == 'single':
@@ -699,7 +699,7 @@ def typecheck_opimpl(
             # target doesn't support this operation: so we just report its
             # type and possibly its definition
             #assert args[0] is not None
-            wav_obj = args_wav[0]
+            wav_obj = orig_args_wav[0]
             t = wav_obj.w_static_type.name
             if wav_obj.loc:
                 err.add('error', f'this is `{t}`', wav_obj.loc)
@@ -721,6 +721,11 @@ def typecheck_opimpl(
         raise err
 
     w_functype = w_opimpl.w_func.w_functype
+    if w_opimpl._args_wav is None:
+        # for "simple" opimpls, we just pass the original wavs
+        args_wav = orig_args_wav
+    else:
+        args_wav = w_opimpl._args_wav
 
     typecheck_call(
         vm,

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -688,8 +688,8 @@ def typecheck_opimpl(
         raise err
 
     w_functype = w_opimpl.w_func.w_functype
-    if w_opimpl._args_wv is None:
-        # for "simple" opimpls, we just pass the original wvs
+    if w_opimpl.is_simple():
+        # for "simple" opimpls, we just pass the original values
         args_wv = orig_args_wv
     else:
         args_wv = w_opimpl._args_wv

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from types import FunctionType
 import fixedint
 from spy.fqn import QN, FQN
-from spy.location import Loc
 from spy import libspy
 from spy.doppler import redshift
 from spy.errors import SPyTypeError

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -15,7 +15,7 @@ from spy.vm.b import B
 from spy.vm.sig import SPyBuiltin
 from spy.vm.function import W_FuncType, W_Func, W_ASTFunc, W_BuiltinFunc
 from spy.vm.module import W_Module
-from spy.vm.opimpl import W_OpImpl, W_AbsVal
+from spy.vm.opimpl import W_OpImpl, W_Value
 from spy.vm.registry import ModuleRegistry
 from spy.vm.bluecache import BlueCache
 
@@ -300,8 +300,8 @@ class SPyVM:
         return self.unwrap(w_value) # type: ignore
 
     def new_absval(self, name: str, i: int, w_static_type: W_Type,
-                   loc: Loc) -> W_AbsVal:
-        return W_AbsVal(name, i, w_static_type, loc)
+                   loc: Loc) -> W_Value:
+        return W_Value(name, i, w_static_type, loc)
 
     def call(self, w_func: W_Func, args_w: list[W_Object]) -> W_Object:
         if w_func.color == 'blue':
@@ -369,10 +369,10 @@ class SPyVM:
         # FIXME: we need a more structured way of implementing operators
         # inside the vm, and possibly share the code with typechecker and
         # ASTFrame. See also vm.ne and vm.getitem
-        wav_obj = self.new_absval('obj', 0, self.dynamic_type(w_obj), None)
-        wav_i = self.new_absval('i', 1, self.dynamic_type(w_i), None)
+        wv_obj = self.new_absval('obj', 0, self.dynamic_type(w_obj), None)
+        wv_i = self.new_absval('i', 1, self.dynamic_type(w_i), None)
 
-        w_opimpl = self.call_OP(OPERATOR.w_GETITEM, [wav_obj, wav_i])
+        w_opimpl = self.call_OP(OPERATOR.w_GETITEM, [wv_obj, wv_i])
         if w_opimpl.is_null():
             # XXX see also eq and ne
             raise SPyTypeError("Cannot do []")

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -299,10 +299,6 @@ class SPyVM:
             raise Exception('Type mismatch')
         return self.unwrap(w_value) # type: ignore
 
-    def new_absval(self, name: str, i: int, w_static_type: W_Type,
-                   loc: Loc) -> W_Value:
-        return W_Value(name, i, w_static_type, loc)
-
     def call(self, w_func: W_Func, args_w: list[W_Object]) -> W_Object:
         if w_func.color == 'blue':
             # for blue functions, we memoize the result
@@ -369,8 +365,8 @@ class SPyVM:
         # FIXME: we need a more structured way of implementing operators
         # inside the vm, and possibly share the code with typechecker and
         # ASTFrame. See also vm.ne and vm.getitem
-        wv_obj = self.new_absval('obj', 0, self.dynamic_type(w_obj), None)
-        wv_i = self.new_absval('i', 1, self.dynamic_type(w_i), None)
+        wv_obj = W_Value('obj', 0, self.dynamic_type(w_obj), None)
+        wv_i = W_Value('i', 1, self.dynamic_type(w_i), None)
 
         w_opimpl = self.call_OP(OPERATOR.w_GETITEM, [wv_obj, wv_i])
         if w_opimpl.is_null():

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from types import FunctionType
 import fixedint
 from spy.fqn import QN, FQN
+from spy.location import Loc
 from spy import libspy
 from spy.doppler import redshift
 from spy.errors import SPyTypeError
@@ -298,8 +299,9 @@ class SPyVM:
             raise Exception('Type mismatch')
         return self.unwrap(w_value) # type: ignore
 
-    def new_absval(self, name: str, i: int, w_static_type: W_Type) -> W_AbsVal:
-        return W_AbsVal(name, i, w_static_type)
+    def new_absval(self, name: str, i: int, w_static_type: W_Type,
+                   loc: Loc) -> W_AbsVal:
+        return W_AbsVal(name, i, w_static_type, loc)
 
     def call(self, w_func: W_Func, args_w: list[W_Object]) -> W_Object:
         if w_func.color == 'blue':
@@ -367,8 +369,8 @@ class SPyVM:
         # FIXME: we need a more structured way of implementing operators
         # inside the vm, and possibly share the code with typechecker and
         # ASTFrame. See also vm.ne and vm.getitem
-        wav_obj = self.new_absval('obj', 0, self.dynamic_type(w_obj))
-        wav_i = self.new_absval('i', 1, self.dynamic_type(w_i))
+        wav_obj = self.new_absval('obj', 0, self.dynamic_type(w_obj), None)
+        wav_i = self.new_absval('i', 1, self.dynamic_type(w_i), None)
 
         w_opimpl = self.call_OP(OPERATOR.w_GETITEM, [wav_obj, wav_i])
         if w_opimpl.is_null():


### PR DESCRIPTION
This is a big refactoring in how OPERATORS, the vm and the typechecker play all together.

Old-style operators receive argument types, and return a function to be called on those arguments.

New-style operators receive abstract "Values", which also have a type but also represent a placeholder for the actual values which will be computed at runtime. They can decide to pass these Values in any order to the opimpl, but also discard them, or in the future to add type conversions, etc.

Contrarily to old-style, it's the job of new-style operators to raise a proper `SPyTypeError`.
This ensures that you get high-quality errors even at runtime (e.g. by calling `vm.getitem` or so). 

Compile-time type errors are no longer explicitly raised by the typechecker, but naturally come from redshifting blue OPERATOR calls.

So far, only `op.GETITEM` is new-style, more will follow