### PR TITLE
Make op.ADD and all other binops new-style

### DIFF
--- a/spy/__main__.py
+++ b/spy/__main__.py
@@ -20,7 +20,6 @@ def opt(T: type, help: str, names: tuple[str, ...]=()) -> Any:
 def boolopt(help: str, names: tuple[str, ...]=()) -> Any:
     return opt(bool, help, names)
 
-
 def do_pyparse(filename: str) -> None:
     import ast as py_ast
     with open(filename) as f:
@@ -28,9 +27,9 @@ def do_pyparse(filename: str) -> None:
     mod = magic_py_parse(src)
     mod.pp()
 
-def dump_spy_mod(vm: SPyVM, modname: str) -> None:
-    b = SPyBackend(vm, fqn_format='short')
-    #b = SPyBackend(vm, fqn_format='full')
+def dump_spy_mod(vm: SPyVM, modname: str, pretty: bool) -> None:
+    fqn_format = 'short' if pretty else 'full'
+    b = SPyBackend(vm, fqn_format=fqn_format)
     print(b.dump_mod(modname))
 
 @no_type_check
@@ -48,9 +47,11 @@ def main(filename: Path,
              "which compiler to use",
              names=['--toolchain', '-t']
          ) = "zig",
+         pretty: boolopt("prettify redshifted modules") = True,
          ) -> None:
     try:
-        do_main(filename, run, pyparse, parse, redshift, cwrite, g, O, toolchain)
+        do_main(filename, run, pyparse, parse, redshift, cwrite, g, O,
+                toolchain, pretty)
     except SPyError as e:
         print(e.format(use_colors=True))
 
@@ -59,7 +60,8 @@ def do_main(filename: Path, run: bool, pyparse: bool, parse: bool,
             cwrite: bool,
             debug_symbols: bool,
             opt_level: int,
-            toolchain: ToolchainType) -> None:
+            toolchain: ToolchainType,
+            pretty: bool) -> None:
     if pyparse:
         do_pyparse(str(filename))
         return
@@ -90,7 +92,7 @@ def do_main(filename: Path, run: bool, pyparse: bool, parse: bool,
 
     vm.redshift()
     if redshift:
-        dump_spy_mod(vm, modname)
+        dump_spy_mod(vm, modname, pretty)
         return
 
     compiler = Compiler(vm, modname, py.path.local(builddir))

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -223,7 +223,8 @@ class SPyBackend:
         return None
 
     def fmt_expr_Call(self, call: ast.Call) -> str:
-        if opclass := self.get_binop_maybe(call.func):
+        opclass = self.get_binop_maybe(call.func)
+        if self.fqn_format == 'short' and opclass:
             # special case
             assert len(call.args) == 2
             binop = opclass(call.loc, call.args[0], call.args[1])

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -138,9 +138,7 @@ class FuncDoppler:
         v_attr = ast.Constant(node.loc, value=node.attr)
         v_value = self.shift_expr(node.value)
         w_opimpl = self.t.opimpl[node]
-        # XXX this is wrong but there is no failing test
-        func = self.make_const(node.loc, w_opimpl.w_func)
-        call = ast.Call(node.loc, func, [v_target, v_attr, v_value])
+        call = self._call_opimpl(node, w_opimpl, [v_target, v_attr, v_value])
         return [ast.StmtExpr(node.loc, call)]
 
     def shift_stmt_StmtExpr(self, stmt: ast.StmtExpr) -> list[ast.Stmt]:
@@ -215,9 +213,7 @@ class FuncDoppler:
         v = self.shift_expr(op.value)
         v_attr = ast.Constant(op.loc, value=op.attr)
         w_opimpl = self.t.opimpl[op]
-        # XXX this is wrong but there is no failing test
-        func = self.make_const(op.loc, w_opimpl.w_func)
-        return ast.Call(op.loc, func, [v, v_attr])
+        return self._call_opimpl(op, w_opimpl, [v, v_attr])
 
     def shift_expr_Call(self, call: ast.Call) -> ast.Expr:
         if call in self.t.opimpl:

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -138,6 +138,7 @@ class FuncDoppler:
         v_attr = ast.Constant(node.loc, value=node.attr)
         v_value = self.shift_expr(node.value)
         w_opimpl = self.t.opimpl[node]
+        # XXX this is wrong but there is no failing test
         func = self.make_const(node.loc, w_opimpl.w_func)
         call = ast.Call(node.loc, func, [v_target, v_attr, v_value])
         return [ast.StmtExpr(node.loc, call)]
@@ -172,6 +173,11 @@ class FuncDoppler:
 
     # ==== expressions ====
 
+    def _call_opimpl(self, op, w_opimpl, orig_args):
+        func = self.make_const(op.loc, w_opimpl._w_func)
+        new_args = w_opimpl.reorder(orig_args)
+        return ast.Call(op.loc, func, new_args)
+
     def shift_expr_Constant(self, const: ast.Constant) -> ast.Expr:
         return const
 
@@ -186,8 +192,7 @@ class FuncDoppler:
         l = self.shift_expr(binop.left)
         r = self.shift_expr(binop.right)
         w_opimpl = self.t.opimpl[binop]
-        func = self.make_const(binop.loc, w_opimpl.w_func)
-        return ast.Call(binop.loc, func, [l, r])
+        return self._call_opimpl(binop, w_opimpl, [l, r])
 
     shift_expr_Add = shift_expr_BinOp
     shift_expr_Sub = shift_expr_BinOp
@@ -204,21 +209,20 @@ class FuncDoppler:
         v = self.shift_expr(op.value)
         i = self.shift_expr(op.index)
         w_opimpl = self.t.opimpl[op]
-        func = self.make_const(op.loc, w_opimpl.w_func)
-        args = w_opimpl.reorder([v, i])
-        return ast.Call(op.loc, func, args)
+        return self._call_opimpl(op, w_opimpl, [v, i])
 
     def shift_expr_GetAttr(self, op: ast.GetAttr) -> ast.Expr:
         v = self.shift_expr(op.value)
         v_attr = ast.Constant(op.loc, value=op.attr)
         w_opimpl = self.t.opimpl[op]
+        # XXX this is wrong but there is no failing test
         func = self.make_const(op.loc, w_opimpl.w_func)
         return ast.Call(op.loc, func, [v, v_attr])
 
     def shift_expr_Call(self, call: ast.Call) -> ast.Expr:
         if call in self.t.opimpl:
             w_opimpl = self.t.opimpl[call]
-            newfunc = self.make_const(call.loc, w_opimpl.w_func)
+            newfunc = self.make_const(call.loc, w_opimpl._w_func)
             extra_args = [self.shift_expr(call.func)]
         else:
             newfunc = self.shift_expr(call.func)
@@ -254,7 +258,7 @@ class FuncDoppler:
     def shift_expr_CallMethod(self, op: ast.CallMethod) -> ast.Expr:
         assert op in self.t.opimpl
         w_opimpl = self.t.opimpl[op]
-        v_func = self.make_const(op.loc, w_opimpl.w_func)
+        v_func = self.make_const(op.loc, w_opimpl._w_func)
         v_target = self.shift_expr(op.target)
         v_method = ast.Constant(op.loc, value=op.method)
         newargs_v = [v_target, v_method] + \

--- a/spy/errors.py
+++ b/spy/errors.py
@@ -18,13 +18,15 @@ def maybe_plural(n: int, singular: str, plural: Optional[str] = None) -> str:
 class Annotation:
     level: Level
     message: str
-    loc: Loc
+    loc: Optional[Loc]
 
     def get_src(self) -> str:
         """
         Return the piece of source code pointed by the annotation.
         """
         loc = self.loc
+        if loc is None:
+            return ''
         filename = loc.filename
         assert loc.line_start == loc.line_end, 'multi-line not supported'
         line = loc.line_start
@@ -59,6 +61,8 @@ class ErrorFormatter:
         self.w(f'{prefix}: {message}')
 
     def emit_annotation(self, ann: Annotation) -> None:
+        if ann.loc is None:
+            return
         filename = ann.loc.filename
         line = ann.loc.line_start
         col = ann.loc.col_start + 1  # Loc columns are 0-based but we want 1-based

--- a/spy/tests/compiler/test_operator_attr.py
+++ b/spy/tests/compiler/test_operator_attr.py
@@ -97,13 +97,11 @@ class TestAttrOp(CompilerTest):
             obj = MyClass()
             return obj.hello
 
-        @blue
-        def get_x():
+        def get_x() -> i32:
             obj = MyClass()
             return obj.x
 
-        @blue
-        def set_get_x():
+        def set_get_x() -> i32:
             obj = MyClass()
             obj.x = 123
             return obj.x

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -234,7 +234,7 @@ class ASTFrame:
         assert w_opimpl, 'bug in the typechecker'
         w_l = self.eval_expr(binop.left)
         w_r = self.eval_expr(binop.right)
-        w_res = self.vm.call(w_opimpl.w_func, [w_l, w_r])
+        w_res = w_opimpl.call(self.vm, [w_l, w_r])
         return w_res
 
     eval_expr_Add = eval_expr_BinOp

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -171,14 +171,14 @@ class ASTFrame:
         w_target = self.eval_expr(node.target)
         w_attr = self.vm.wrap(node.attr)
         w_value = self.eval_expr(node.value)
-        self.vm.call(w_opimpl.w_func, [w_target, w_attr, w_value])
+        w_opimpl.call(self.vm, [w_target, w_attr, w_value])
 
     def exec_stmt_SetItem(self, node: ast.SetItem) -> None:
         w_opimpl = self.t.opimpl[node]
         w_target = self.eval_expr(node.target)
         w_index = self.eval_expr(node.index)
         w_value = self.eval_expr(node.value)
-        self.vm.call(w_opimpl.w_func, [w_target, w_index, w_value])
+        w_opimpl.call(self.vm, [w_target, w_index, w_value])
 
     def exec_stmt_StmtExpr(self, stmt: ast.StmtExpr) -> None:
         self.eval_expr(stmt.value)
@@ -260,7 +260,10 @@ class ASTFrame:
         w_opimpl = self.t.opimpl[call]
         w_target = self.eval_expr(call.func)
         args_w = [self.eval_expr(arg) for arg in call.args]
-        w_res = self.vm.call(w_opimpl.w_func, [w_target] + args_w)
+        # kill this when we migrate op.CALL to new-tyle
+        w_res = self.vm.call(w_opimpl._w_func, [w_target] + args_w)
+        # this is the correct one
+        # w_res = w_opimpl.call(self.vm, [w_target] + args_w)
         return w_res
 
     def _eval_call_func(self, call: ast.Call, color: Color,
@@ -301,7 +304,7 @@ class ASTFrame:
         w_target = self.eval_expr(op.target)
         w_method = self.vm.wrap(op.method)
         arg_w = [self.eval_expr(arg) for arg in op.args]
-        w_res = self.vm.call(w_opimpl.w_func,
+        w_res = self.vm.call(w_opimpl._w_func,
                                       [w_target, w_method] + arg_w)
         return w_res
 
@@ -309,8 +312,7 @@ class ASTFrame:
         w_opimpl = self.t.opimpl[op]
         w_val = self.eval_expr(op.value)
         w_i = self.eval_expr(op.index)
-        args_w = w_opimpl.reorder([w_val, w_i])
-        return self.vm.call(w_opimpl.w_func, args_w)
+        return w_opimpl.call(self.vm, [w_val, w_i])
 
     def eval_expr_GetAttr(self, op: ast.GetAttr) -> W_Object:
         # this is suboptimal, but good enough for now: ideally, we would like
@@ -321,7 +323,7 @@ class ASTFrame:
         w_opimpl = self.t.opimpl[op]
         w_val = self.eval_expr(op.value)
         w_attr = self.vm.wrap(op.attr)
-        w_res = self.vm.call(w_opimpl.w_func, [w_val, w_attr])
+        w_res = w_opimpl.call(self.vm, [w_val, w_attr])
         return w_res
 
     def eval_expr_List(self, op: ast.List) -> W_Object:

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -145,8 +145,10 @@ def _make_W_List(w_T: W_Type) -> Type[W_List]:
             return W_OpImpl.simple(vm.wrap_func(setitem))
 
         @staticmethod
-        def op_EQ(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
+        def op_EQ(vm: 'SPyVM', wv_l: 'W_Value', wv_r: 'W_Value') -> W_OpImpl:
             from spy.vm.b import B
+            w_ltype = wv_l.w_static_type
+            w_rtype = wv_r.w_static_type
             assert w_ltype.pyclass is W_MyList
 
             @no_type_check

--- a/spy/vm/modules/operator/__init__.py
+++ b/spy/vm/modules/operator/__init__.py
@@ -90,4 +90,6 @@ OP._from_token.update({
     '>':  OP.w_GT,
     '>=': OP.w_GE,
     '[]': OP.w_GETITEM,
+    '<universal_eq>': OP.w_UNIVERSAL_EQ,
+    '<universal_ne>': OP.w_UNIVERSAL_NE,
 })

--- a/spy/vm/modules/operator/binop.py
+++ b/spy/vm/modules/operator/binop.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 from spy.vm.b import B
 from spy.vm.object import W_Dynamic, W_Type
-from spy.vm.opimpl import W_OpImpl
+from spy.vm.opimpl import W_OpImpl, W_Value
 from . import OP
 from .multimethod import MultiMethodTable
 if TYPE_CHECKING:
@@ -75,22 +75,22 @@ MM.register_partial('>=', 'dynamic', OP.w_dynamic_ge)
 
 
 @OP.builtin(color='blue')
-def ADD(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
-    return MM.lookup('+', w_ltype, w_rtype)
+def ADD(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> W_OpImpl:
+    return MM.lookup(vm, '+', wv_l, wv_r)
 
 @OP.builtin(color='blue')
-def SUB(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
-    return MM.lookup('-', w_ltype, w_rtype)
+def SUB(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> W_OpImpl:
+    return MM.lookup(vm, '-', wv_l, wv_r)
 
 @OP.builtin(color='blue')
-def MUL(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
-    return MM.lookup('*', w_ltype, w_rtype)
+def MUL(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> W_OpImpl:
+    return MM.lookup(vm, '*', wv_l, wv_r)
 
 @OP.builtin(color='blue')
-def DIV(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
-    return MM.lookup('/', w_ltype, w_rtype)
+def DIV(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> W_OpImpl:
+    return MM.lookup(vm, '/', wv_l, wv_r)
 
-def can_use_reference_eq(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> bool:
+def can_use_reference_eq(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> bool:
     """
     We can use 'is' to implement 'eq' if:
       1. the two types have a common ancestor
@@ -100,41 +100,41 @@ def can_use_reference_eq(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> bool:
     return w_common is not B.w_object and w_common.is_reference_type(vm)
 
 @OP.builtin(color='blue')
-def EQ(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
+def EQ(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> W_OpImpl:
     pyclass = w_ltype.pyclass
     if pyclass.has_meth_overriden('op_EQ'):
         return pyclass.op_EQ(vm, w_ltype, w_rtype)
     elif can_use_reference_eq(vm, w_ltype, w_rtype):
         return W_OpImpl.simple(OP.w_object_is)
     else:
-        return MM.lookup('==', w_ltype, w_rtype)
+        return MM.lookup(vm, '==', wv_l, wv_r)
 
 @OP.builtin(color='blue')
-def NE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
+def NE(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> W_OpImpl:
     if can_use_reference_eq(vm, w_ltype, w_rtype):
         return W_OpImpl.simple(OP.w_object_isnot)
-    return MM.lookup('!=', w_ltype, w_rtype)
+    return MM.lookup(vm, '!=', wv_l, wv_r)
 
 @OP.builtin(color='blue')
-def UNIVERSAL_EQ(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
+def UNIVERSAL_EQ(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> W_OpImpl:
     return W_OpImpl.simple(OP.w_object_universal_eq)
 
 @OP.builtin(color='blue')
-def UNIVERSAL_NE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
+def UNIVERSAL_NE(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> W_OpImpl:
     return W_OpImpl.simple(OP.w_object_universal_ne)
 
 @OP.builtin(color='blue')
-def LT(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
-    return MM.lookup('<', w_ltype, w_rtype)
+def LT(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> W_OpImpl:
+    return MM.lookup(vm, '<', wv_l, wv_r)
 
 @OP.builtin(color='blue')
-def LE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
-    return MM.lookup('<=', w_ltype, w_rtype)
+def LE(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> W_OpImpl:
+    return MM.lookup(vm, '<=', wv_l, wv_r)
 
 @OP.builtin(color='blue')
-def GT(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
-    return MM.lookup('>', w_ltype, w_rtype)
+def GT(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> W_OpImpl:
+    return MM.lookup(vm, '>', wv_l, wv_r)
 
 @OP.builtin(color='blue')
-def GE(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> W_OpImpl:
-    return MM.lookup('>=', w_ltype, w_rtype)
+def GE(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> W_OpImpl:
+    return MM.lookup(vm, '>=', wv_l, wv_r)

--- a/spy/vm/modules/operator/binop.py
+++ b/spy/vm/modules/operator/binop.py
@@ -90,7 +90,7 @@ def MUL(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> W_OpImpl:
 def DIV(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> W_OpImpl:
     return MM.lookup(vm, '/', wv_l, wv_r)
 
-def can_use_reference_eq(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> bool:
+def can_use_reference_eq(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> bool:
     """
     We can use 'is' to implement 'eq' if:
       1. the two types have a common ancestor
@@ -101,9 +101,10 @@ def can_use_reference_eq(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> bool:
 
 @OP.builtin(color='blue')
 def EQ(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> W_OpImpl:
-    pyclass = w_ltype.pyclass
-    if pyclass.has_meth_overriden('op_EQ'):
-        return pyclass.op_EQ(vm, w_ltype, w_rtype)
+    w_ltype = wv_l.w_static_type
+    w_rtype = wv_r.w_static_type
+    if w_ltype.pyclass.has_meth_overriden('op_EQ'):
+        return w_ltype.pyclass.op_EQ(vm, wv_l, wv_r)
     elif can_use_reference_eq(vm, w_ltype, w_rtype):
         return W_OpImpl.simple(OP.w_object_is)
     else:
@@ -111,6 +112,8 @@ def EQ(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> W_OpImpl:
 
 @OP.builtin(color='blue')
 def NE(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> W_OpImpl:
+    w_ltype = wv_l.w_static_type
+    w_rtype = wv_r.w_static_type
     if can_use_reference_eq(vm, w_ltype, w_rtype):
         return W_OpImpl.simple(OP.w_object_isnot)
     return MM.lookup(vm, '!=', wv_l, wv_r)

--- a/spy/vm/modules/operator/binop.py
+++ b/spy/vm/modules/operator/binop.py
@@ -101,10 +101,15 @@ def can_use_reference_eq(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> bool:
 
 @OP.builtin(color='blue')
 def EQ(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> W_OpImpl:
+    from spy.vm.typechecker import typecheck_opimpl
     w_ltype = wv_l.w_static_type
     w_rtype = wv_r.w_static_type
     if w_ltype.pyclass.has_meth_overriden('op_EQ'):
-        return w_ltype.pyclass.op_EQ(vm, wv_l, wv_r)
+        w_opimpl = w_ltype.pyclass.op_EQ(vm, wv_l, wv_r)
+        typecheck_opimpl(vm, w_opimpl, [wv_l, wv_r],
+                         dispatch='multi',
+                         errmsg='cannot do `{0}` == `{1}`')
+        return w_opimpl
     elif can_use_reference_eq(vm, w_ltype, w_rtype):
         return W_OpImpl.simple(OP.w_object_is)
     else:

--- a/spy/vm/modules/operator/binop.py
+++ b/spy/vm/modules/operator/binop.py
@@ -111,16 +111,28 @@ def EQ(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> W_OpImpl:
                          errmsg='cannot do `{0}` == `{1}`')
         return w_opimpl
     elif can_use_reference_eq(vm, w_ltype, w_rtype):
-        return W_OpImpl.simple(OP.w_object_is)
+        w_opimpl = W_OpImpl.simple(OP.w_object_is)
+        typecheck_opimpl(vm, w_opimpl, [wv_l, wv_r],
+                         dispatch='multi',
+                         errmsg='cannot do `{0}` == `{1}`')
+        return w_opimpl
     else:
         return MM.lookup(vm, '==', wv_l, wv_r)
 
 @OP.builtin(color='blue')
 def NE(vm: 'SPyVM', wv_l: W_Value, wv_r: W_Value) -> W_OpImpl:
+    from spy.vm.typechecker import typecheck_opimpl
     w_ltype = wv_l.w_static_type
     w_rtype = wv_r.w_static_type
     if can_use_reference_eq(vm, w_ltype, w_rtype):
-        return W_OpImpl.simple(OP.w_object_isnot)
+        # XXX this is silly: currently we NEED to call typecheck_opimpl else
+        # we cannot .call() it later. We need a better API to avoid this
+        # pitfall
+        w_opimpl = W_OpImpl.simple(OP.w_object_isnot)
+        typecheck_opimpl(vm, w_opimpl, [wv_l, wv_r],
+                         dispatch='multi',
+                         errmsg='cannot do `{0}` != `{1}`')
+        return w_opimpl
     return MM.lookup(vm, '!=', wv_l, wv_r)
 
 @OP.builtin(color='blue')

--- a/spy/vm/modules/operator/opimpl_dynamic.py
+++ b/spy/vm/modules/operator/opimpl_dynamic.py
@@ -65,5 +65,4 @@ def dynamic_setattr(vm: 'SPyVM', w_obj: W_Dynamic, w_attr: W_Str,
     wv_attr = W_Value.from_w_obj(vm, w_attr, 'a', 1)
     wv_v = W_Value.from_w_obj(vm, w_value, 'v', 2)
     w_opimpl = vm.call_OP(OP.w_SETATTR, [wv_obj, wv_attr, wv_v])
-    args_w = w_opimpl.reorder([w_obj, w_attr, w_value])
-    return vm.call(w_opimpl.w_func, args_w)
+    return w_opimpl.call(vm, [w_obj, w_attr, w_value])

--- a/spy/vm/modules/operator/opimpl_dynamic.py
+++ b/spy/vm/modules/operator/opimpl_dynamic.py
@@ -12,16 +12,18 @@ if TYPE_CHECKING:
 def _dynamic_op(vm: 'SPyVM', w_op: W_Func,
                 w_a: W_Dynamic, w_b: W_Dynamic,
                 ) -> W_Dynamic:
-    w_ltype = vm.dynamic_type(w_a)
-    w_rtype = vm.dynamic_type(w_b)
-    w_opimpl = vm.call_OP(w_op, [w_ltype, w_rtype])
-    if w_opimpl.is_null():
-        token = OP.to_token(w_op)
-        l = w_ltype.name
-        r = w_rtype.name
-        raise SPyTypeError(f'cannot do `{l}` {token} `{r}`')
-    return vm.call(w_opimpl.w_func, [w_a, w_b])
+    from spy.vm.typechecker import typecheck_opimpl
+    # this looks suspiciously like vm.eq & co., we should unify them
+    token = OP.to_token(w_op)
+    errmsg = 'cannot do `{0}` %s `{1}`' % token
 
+    wv_a = W_Value.from_w_obj(vm, w_a, 'a', 0)
+    wv_b = W_Value.from_w_obj(vm, w_b, 'b', 1)
+    w_opimpl = vm.call_OP(w_op, [wv_a, wv_b])
+    typecheck_opimpl(vm, w_opimpl, [wv_a, wv_b],
+                     dispatch='multi',
+                     errmsg=errmsg)
+    return w_opimpl.call(vm, [w_a, w_b])
 
 @OP.builtin
 def dynamic_add(vm: 'SPyVM', w_a: W_Dynamic, w_b: W_Dynamic) -> W_Dynamic:

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -138,7 +138,7 @@ class W_Object:
         return True
 
     @staticmethod
-    def op_EQ(vm: 'SPyVM', w_tself: 'W_Type', w_tother: 'W_Type') -> 'W_OpImpl':
+    def op_EQ(vm: 'SPyVM', wv_a: 'W_Value', wv_b: 'W_Value') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
     @staticmethod

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -91,29 +91,33 @@ class W_Value(W_Object):
         return vm.unwrap_str(self._w_blueval)
 
     @staticmethod
-    def op_EQ(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> 'W_OpImpl':
-        from spy.vm.b import B
+    def op_EQ(vm: 'SPyVM', wv_l: 'W_Value', wv_r: 'W_Value') -> 'W_OpImpl':
+        w_ltype = wv_l.w_static_type
+        w_rtype = wv_r.w_static_type
         assert w_ltype.pyclass is W_Value
 
-        @no_type_check
-        @spy_builtin(QN('operator::value_eq'))
-        def eq(vm: 'SPyVM', wv1: W_Value, wv2: W_Value) -> W_Bool:
-            # note that the prefix is NOT considered for equality, is purely for
-            # description
-            if wv1.i != wv2.i:
-                return B.w_False
-            if wv1.w_static_type is not wv2.w_static_type:
-                return B.w_False
-            if (wv1.is_blue() and
-                wv2.is_blue() and
-                vm.is_False(vm.eq(wv1._w_blueval, wv2._w_blueval))):
-                return B.w_False
-            return B.w_True
-
         if w_ltype is w_rtype:
-            return W_OpImpl.simple(vm.wrap_func(eq))
+            return W_OpImpl.simple(vm.wrap_func(value_eq))
         else:
             return W_OpImpl.NULL
+
+
+@no_type_check
+@spy_builtin(QN('operator::value_eq'))
+def value_eq(vm: 'SPyVM', wv1: W_Value, wv2: W_Value) -> W_Bool:
+    from spy.vm.b import B
+    # note that the prefix is NOT considered for equality, is purely for
+    # description
+    if wv1.i != wv2.i:
+        return B.w_False
+    if wv1.w_static_type is not wv2.w_static_type:
+        return B.w_False
+    if (wv1.is_blue() and
+        wv2.is_blue() and
+        vm.is_False(vm.eq(wv1._w_blueval, wv2._w_blueval))):
+        return B.w_False
+    return B.w_True
+
 
 
 

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -4,7 +4,7 @@ from spy import ast
 from spy.fqn import QN
 from spy.location import Loc
 from spy.vm.object import Member, W_Type, W_Object, spytype, W_Bool
-from spy.vm.function import W_Func
+from spy.vm.function import W_Func, W_FuncType
 from spy.vm.sig import spy_builtin
 
 if TYPE_CHECKING:
@@ -170,13 +170,12 @@ class W_OpImpl(W_Object):
         return self._args_wv is None
 
     @property
-    def w_func(self) -> W_Func:
-        assert self._w_func is not None
-        return self._w_func
+    def w_functype(self) -> W_FuncType:
+        return self._w_func.w_functype
 
     @property
     def w_restype(self) -> W_Type:
-        return self.w_func.w_functype.w_restype
+        return self._w_func.w_functype.w_restype
 
     def set_args_wv(self, args_wv):
         assert self._args_wv is None
@@ -201,6 +200,6 @@ class W_OpImpl(W_Object):
             if conv is not None:
                 w_arg = conv.convert(vm, w_arg)
             real_args_w.append(w_arg)
-        return vm.call(self.w_func, real_args_w)
+        return vm.call(self._w_func, real_args_w)
 
 W_OpImpl.NULL = W_OpImpl.simple(None)

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -740,7 +740,7 @@ def convert_type_maybe(
     got = w_got.name
     exp = w_exp.name
     err.add('error', f'expected `{exp}`, got `{got}`', loc=wv_x.loc)
-    return err
+    raise err
 
 
 def _call_error_wrong_argcount(

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -440,7 +440,7 @@ class TypeChecker:
                         err.add('error', f'this is `{t}`', arg.loc)
             raise err
 
-        w_functype = w_opimpl.w_func.w_functype
+        w_functype = w_opimpl.w_functype
 
         self.call_typecheck(
             w_functype,
@@ -503,7 +503,7 @@ class TypeChecker:
         self.opimpl[call] = w_opimpl
         # XXX I'm not sure that the color is correct here. We need to think
         # more.
-        w_functype = w_opimpl.w_func.w_functype
+        w_functype = w_opimpl.w_functype
         return w_functype.color, w_functype.w_restype
 
     def call_typecheck(self,
@@ -589,7 +589,7 @@ class TypeChecker:
         self.opimpl[op] = w_opimpl
         # XXX I'm not sure that the color is correct here. We need to think
         # more.
-        w_functype = w_opimpl.w_func.w_functype
+        w_functype = w_opimpl.w_functype
         return w_functype.color, w_functype.w_restype
 
     def check_expr_List(self, listop: ast.List) -> tuple[Color, W_Type]:
@@ -682,7 +682,7 @@ def typecheck_call(
     call_loc = None
     def_loc = None
 
-    w_functype = w_opimpl.w_func.w_functype
+    w_functype = w_opimpl.w_functype
 
     got_nargs = len(args_wv)
     exp_nargs = len(w_functype.params)

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -331,17 +331,11 @@ class SPyVM:
         return w_func.spy_call(self, args_w)
 
     def eq(self, w_a: W_Dynamic, w_b: W_Dynamic) -> W_Bool:
-        # FIXME: we need a more structured way of implementing operators
-        # inside the vm, and possibly share the code with typechecker and
-        # ASTFrame. See also vm.ne and vm.getitem
-        w_ta = self.dynamic_type(w_a)
-        w_tb = self.dynamic_type(w_b)
-        w_opimpl = self.call_OP(OPERATOR.w_EQ, [w_ta, w_tb])
-        if w_opimpl.is_null():
-            # XXX: the logic to produce a good error message should be in a
-            # single place
-            raise SPyTypeError("Cannot do ==")
-        w_res = self.call(w_opimpl.w_func, [w_a, w_b])
+        wv_a = W_Value('a', 0, self.dynamic_type(w_a), None)
+        wv_b = W_Value('b', 1, self.dynamic_type(w_b), None)
+        w_opimpl = self.call_OP(OPERATOR.w_EQ, [wv_a, wv_b])
+        assert not w_opimpl.is_null()
+        w_res = self.call(w_opimpl.w_func, [w_a, w_b]) # XXX we should reorder?
         assert isinstance(w_res, W_Bool)
         return w_res
 
@@ -349,6 +343,7 @@ class SPyVM:
         # FIXME: we need a more structured way of implementing operators
         # inside the vm, and possibly share the code with typechecker and
         # ASTFrame. See also vm.ne and vm.getitem
+        XXX
         w_ta = self.dynamic_type(w_a)
         w_tb = self.dynamic_type(w_b)
         w_opimpl = self.call_OP(OPERATOR.w_NE, [w_ta, w_tb])

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -359,12 +359,8 @@ class SPyVM:
         # ASTFrame. See also vm.ne and vm.getitem
         wv_obj = W_Value('obj', 0, self.dynamic_type(w_obj), None)
         wv_i = W_Value('i', 1, self.dynamic_type(w_i), None)
-
         w_opimpl = self.call_OP(OPERATOR.w_GETITEM, [wv_obj, wv_i])
-        if w_opimpl.is_null():
-            # XXX see also eq and ne
-            raise SPyTypeError("Cannot do []")
-        return self.call(w_opimpl.w_func, [w_obj, w_i])
+        return w_opimpl.call(self, [w_obj, w_i])
 
     def universal_eq(self, w_a: W_Dynamic, w_b: W_Dynamic) -> W_Bool:
         """
@@ -424,7 +420,7 @@ class SPyVM:
             assert w_ta is not w_tb, f'EQ missing on type `{w_ta.name}`'
             return B.w_False
 
-        w_res = self.call(w_opimpl.w_func, [w_a, w_b]) # XXX is this correct?
+        w_res = w_opimpl.call(self, [w_a, w_b])
         assert isinstance(w_res, W_Bool)
         return w_res
 

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -340,23 +340,16 @@ class SPyVM:
         wv_b = W_Value('b', 1, self.dynamic_type(w_b), None)
         w_opimpl = self.call_OP(OPERATOR.w_EQ, [wv_a, wv_b])
         assert not w_opimpl.is_null()
-        w_res = self.call(w_opimpl.w_func, [w_a, w_b]) # XXX we should reorder?
+        w_res = w_opimpl.call(self, [w_a, w_b])
         assert isinstance(w_res, W_Bool)
         return w_res
 
     def ne(self, w_a: W_Dynamic, w_b: W_Dynamic) -> W_Bool:
-        # FIXME: we need a more structured way of implementing operators
-        # inside the vm, and possibly share the code with typechecker and
-        # ASTFrame. See also vm.ne and vm.getitem
-        XXX
-        w_ta = self.dynamic_type(w_a)
-        w_tb = self.dynamic_type(w_b)
-        w_opimpl = self.call_OP(OPERATOR.w_NE, [w_ta, w_tb])
-        if w_opimpl.is_null():
-            # XXX: the logic to produce a good error message should be in a
-            # single place
-            raise SPyTypeError("Cannot do !=")
-        w_res = self.call(w_opimpl.w_func, [w_a, w_b])
+        wv_a = W_Value('a', 0, self.dynamic_type(w_a), None)
+        wv_b = W_Value('b', 1, self.dynamic_type(w_b), None)
+        w_opimpl = self.call_OP(OPERATOR.w_NE, [wv_a, wv_b])
+        assert not w_opimpl.is_null()
+        w_res = w_opimpl.call(self, [w_a, w_b])
         assert isinstance(w_res, W_Bool)
         return w_res
 


### PR DESCRIPTION
This is another big refactoring.

All the binops are now migrated to be new-style operators, taking W_Value instead of W_Type as inputs.
This required a big of refactorings here and there, mostly around op.EQ and op.UNIVERSAL_EQ, which need special care to avoid infinite recursion.

Moreover, we made W_OpImpl.w_func private, to ensure that everybody to the actual execution by doing w_opimpl.call: this ensures that arguments are correctly reordered.

The only exceptions are op.CALL and CALL_METHOD, which are still using the old mechanism and will be refactored soon.