### PR TITLE
Make op.CALL and op.CALL_METHOD new-style

### DIFF
--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -415,15 +415,6 @@ class CFuncWriter:
         # I think we need a more general way so that OPERATORs can have more
         # control on which arguments are passed to opimpls.
 
-        if call.func.fqn == FQN.parse("builtins::int2str"):
-            # special case: remove the first param (this is the 'str' type)
-            arg0 = call.args[0]
-            assert (isinstance(arg0, ast.FQNConst) and
-                    arg0.fqn == FQN.parse("builtins::str"))
-            c_name = call.func.fqn.c_name
-            c_arg = self.fmt_expr(call.args[1])
-            return C.Call(c_name, [c_arg])
-
         if str(call.func.fqn).startswith("jsffi::getattr_"):
             assert isinstance(call.args[1], ast.Constant)
             c_name = "jsffi_getattr"

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -173,7 +173,14 @@ class FuncDoppler:
 
     def _call_opimpl(self, op, w_opimpl, orig_args):
         func = self.make_const(op.loc, w_opimpl._w_func)
-        new_args = w_opimpl.reorder(orig_args)
+
+        new_args = []
+        for wv_arg, conv in zip(w_opimpl._args_wv, w_opimpl._converters):
+            arg = orig_args[wv_arg.i]
+            if conv is not None:
+                arg = conv.redshift(self.vm, arg)
+            new_args.append(arg)
+
         return ast.Call(op.loc, func, new_args)
 
     def shift_expr_Constant(self, const: ast.Constant) -> ast.Expr:

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -138,7 +138,7 @@ class FuncDoppler:
         v_attr = ast.Constant(node.loc, value=node.attr)
         v_value = self.shift_expr(node.value)
         w_opimpl = self.t.opimpl[node]
-        call = self._call_opimpl(node, w_opimpl, [v_target, v_attr, v_value])
+        call = self.shift_opimpl(node, w_opimpl, [v_target, v_attr, v_value])
         return [ast.StmtExpr(node.loc, call)]
 
     def shift_stmt_StmtExpr(self, stmt: ast.StmtExpr) -> list[ast.Stmt]:
@@ -171,7 +171,7 @@ class FuncDoppler:
 
     # ==== expressions ====
 
-    def _call_opimpl(self, op, w_opimpl, orig_args):
+    def shift_opimpl(self, op, w_opimpl, orig_args):
         func = self.make_const(op.loc, w_opimpl._w_func)
         real_args = w_opimpl.redshift_args(self.vm, orig_args)
         return ast.Call(op.loc, func, real_args)
@@ -190,7 +190,7 @@ class FuncDoppler:
         l = self.shift_expr(binop.left)
         r = self.shift_expr(binop.right)
         w_opimpl = self.t.opimpl[binop]
-        return self._call_opimpl(binop, w_opimpl, [l, r])
+        return self.shift_opimpl(binop, w_opimpl, [l, r])
 
     shift_expr_Add = shift_expr_BinOp
     shift_expr_Sub = shift_expr_BinOp
@@ -207,19 +207,19 @@ class FuncDoppler:
         v = self.shift_expr(op.value)
         i = self.shift_expr(op.index)
         w_opimpl = self.t.opimpl[op]
-        return self._call_opimpl(op, w_opimpl, [v, i])
+        return self.shift_opimpl(op, w_opimpl, [v, i])
 
     def shift_expr_GetAttr(self, op: ast.GetAttr) -> ast.Expr:
         v = self.shift_expr(op.value)
         v_attr = ast.Constant(op.loc, value=op.attr)
         w_opimpl = self.t.opimpl[op]
-        return self._call_opimpl(op, w_opimpl, [v, v_attr])
+        return self.shift_opimpl(op, w_opimpl, [v, v_attr])
 
     def shift_expr_Call(self, call: ast.Call) -> ast.Expr:
         if call in self.t.opimpl:
             w_opimpl = self.t.opimpl[call]
             # XXX we should shift all the args?
-            return self._call_opimpl(call, w_opimpl, [call.func] + call.args)
+            return self.shift_opimpl(call, w_opimpl, [call.func] + call.args)
 
         newfunc = self.shift_expr(call.func)
         # sanity check: the redshift MUST have produced a const. If it
@@ -256,4 +256,4 @@ class FuncDoppler:
         v_target = self.shift_expr(op.target)
         v_method = ast.Constant(op.loc, value=op.method)
         newargs_v = [self.shift_expr(arg) for arg in op.args]
-        return self._call_opimpl(op, w_opimpl, [v_target, v_method] + newargs_v)
+        return self.shift_opimpl(op, w_opimpl, [v_target, v_method] + newargs_v)

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -173,15 +173,8 @@ class FuncDoppler:
 
     def _call_opimpl(self, op, w_opimpl, orig_args):
         func = self.make_const(op.loc, w_opimpl._w_func)
-
-        new_args = []
-        for wv_arg, conv in zip(w_opimpl._args_wv, w_opimpl._converters):
-            arg = orig_args[wv_arg.i]
-            if conv is not None:
-                arg = conv.redshift(self.vm, arg)
-            new_args.append(arg)
-
-        return ast.Call(op.loc, func, new_args)
+        real_args = w_opimpl.redshift_args(self.vm, orig_args)
+        return ast.Call(op.loc, func, real_args)
 
     def shift_expr_Constant(self, const: ast.Constant) -> ast.Expr:
         return const

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -218,6 +218,7 @@ class FuncDoppler:
     def shift_expr_Call(self, call: ast.Call) -> ast.Expr:
         if call in self.t.opimpl:
             w_opimpl = self.t.opimpl[call]
+            # XXX we should shift all the args?
             return self._call_opimpl(call, w_opimpl, [call.func] + call.args)
 
         newfunc = self.shift_expr(call.func)
@@ -252,9 +253,7 @@ class FuncDoppler:
     def shift_expr_CallMethod(self, op: ast.CallMethod) -> ast.Expr:
         assert op in self.t.opimpl
         w_opimpl = self.t.opimpl[op]
-        v_func = self.make_const(op.loc, w_opimpl._w_func)
         v_target = self.shift_expr(op.target)
         v_method = ast.Constant(op.loc, value=op.method)
-        newargs_v = [v_target, v_method] + \
-            [self.shift_expr(arg) for arg in op.args]
-        return ast.Call(op.loc, v_func, newargs_v)
+        newargs_v = [self.shift_expr(arg) for arg in op.args]
+        return self._call_opimpl(op, w_opimpl, [v_target, v_method] + newargs_v)

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -220,7 +220,6 @@ class FuncDoppler:
         newargs = [self.shift_expr(arg) for arg in call.args]
         if call in self.t.opimpl:
             w_opimpl = self.t.opimpl[call]
-            # XXX we should shift all the args?
             return self.shift_opimpl(call, w_opimpl, [newfunc] + newargs)
         else:
             # sanity check: the redshift MUST have produced a const. If it

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -218,15 +218,13 @@ class FuncDoppler:
     def shift_expr_Call(self, call: ast.Call) -> ast.Expr:
         if call in self.t.opimpl:
             w_opimpl = self.t.opimpl[call]
-            newfunc = self.make_const(call.loc, w_opimpl._w_func)
-            extra_args = [self.shift_expr(call.func)]
-        else:
-            newfunc = self.shift_expr(call.func)
-            # sanity check: the redshift MUST have produced a const. If it
-            # didn't, the C backend won't be able to compile the call.
-            assert isinstance(newfunc, (ast.FQNConst, ast.Constant))
-            extra_args = []
+            return self._call_opimpl(call, w_opimpl, [call.func] + call.args)
 
+        newfunc = self.shift_expr(call.func)
+        # sanity check: the redshift MUST have produced a const. If it
+        # didn't, the C backend won't be able to compile the call.
+        assert isinstance(newfunc, (ast.FQNConst, ast.Constant))
+        extra_args = []
         newargs = extra_args + [self.shift_expr(arg) for arg in call.args]
         newop = ast.Call(call.loc, newfunc, newargs)
         return self.specialize_print_maybe(newop)

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -299,7 +299,7 @@ class TestBasic(CompilerTest):
         errors = expect_errors(
             'cannot call objects of type `i32`',
             ('this is `i32`', 'x'),
-            ('`x` defined here', 'x: i32 = 0'),
+#            ('`x` defined here', 'x: i32 = 0'), # would be nice to re-enable
         )
         self.compile_raises(src, "foo", errors)
 

--- a/spy/tests/compiler/test_jsffi.py
+++ b/spy/tests/compiler/test_jsffi.py
@@ -30,7 +30,6 @@ class TestJsFFI(CompilerTest):
         out = exe.run()
         assert out == 'hello from console.log\n42\n'
 
-    @pytest.mark.skip(reason="missing type conversions")
     def test_setattr(self):
         exe = self.compile(
         """

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -135,22 +135,25 @@ class TestCallOp(CompilerTest):
                 meth = wv_method.blue_unwrap_str(vm)
                 if meth == 'add':
                     @spy_builtin(QN('ext::meth_add'))
-                    def fn(vm: 'SPyVM', w_self: W_Calc, w_method: W_Str,
-                               w_arg: W_I32) -> W_I32:
+                    def fn(vm: 'SPyVM', w_self: W_Calc, w_arg: W_I32) -> W_I32:
                         y = vm.unwrap_i32(w_arg)
                         return vm.wrap(w_self.x + y)  # type: ignore
-                    return W_OpImpl.simple(vm.wrap_func(fn))
+                    return W_OpImpl.with_values(
+                        vm.wrap_func(fn),
+                        [wv_obj] + w_values.items_w
+                    )
 
                 elif meth == 'sub':
                     @spy_builtin(QN('ext::meth_sub'))
-                    def fn(vm: 'SPyVM', w_self: W_Calc, w_method: W_Str,
-                               w_arg: W_I32) -> W_I32:
+                    def fn(vm: 'SPyVM', w_self: W_Calc, w_arg: W_I32) -> W_I32:
                         y = vm.unwrap_i32(w_arg)
                         return vm.wrap(w_self.x - y)  # type: ignore
-                    return W_OpImpl.simple(vm.wrap_func(fn))
-
+                    return W_OpImpl.with_values(
+                        vm.wrap_func(fn),
+                        [wv_obj] + w_values.items_w
+                    )
                 else:
-                    return B.w_NotImplemented
+                    return W_OpImpl.NULL
         # ========== /EXT module for this test =========
 
         self.vm.make_module(EXT)

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -4,9 +4,10 @@ from spy.vm.b import B
 from spy.vm.object import spytype, Member, Annotated
 from spy.vm.sig import spy_builtin
 from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_I32, W_Void
-from spy.vm.opimpl import W_OpImpl
+from spy.vm.opimpl import W_OpImpl, W_Value
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM
+from spy.vm.list import W_List
 from spy.tests.support import CompilerTest, no_C
 
 @no_C
@@ -129,10 +130,9 @@ class TestCallOp(CompilerTest):
                 return W_Calc(vm.unwrap_i32(w_x))
 
             @staticmethod
-            def op_CALL_METHOD(vm: 'SPyVM', w_type: W_Type, w_method: W_Str,
-                               w_argtypes: W_Dynamic) -> W_OpImpl:
-
-                meth = vm.unwrap_str(w_method)
+            def op_CALL_METHOD(vm: 'SPyVM', wv_obj: W_Value, wv_method: W_Str,
+                               w_values: W_List[W_Value]) -> W_OpImpl:
+                meth = wv_method.blue_unwrap_str(vm)
                 if meth == 'add':
                     @spy_builtin(QN('ext::meth_add'))
                     def fn(vm: 'SPyVM', w_self: W_Calc, w_method: W_Str,

--- a/spy/tests/support.py
+++ b/spy/tests/support.py
@@ -166,6 +166,7 @@ class CompilerTest:
             return WasmModuleWrapper(self.vm, modname, file_wasm)
         elif self.backend == 'emscripten':
             self.vm.redshift()
+            #self.dump_module(modname)
             compiler = Compiler(self.vm, modname, self.builddir)
             file_js = compiler.cbuild(opt_level=self.OPT_LEVEL,
                                       toolchain_type = 'emscripten')
@@ -177,7 +178,7 @@ class CompilerTest:
         from spy.__main__ import dump_spy_mod
         print()
         print()
-        dump_spy_mod(self.vm, modname)
+        dump_spy_mod(self.vm, modname, pretty=True)
 
     def compile_raises(self, src: str, funcname: str, ctx: Any,
                        *,

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -260,10 +260,7 @@ class ASTFrame:
         w_opimpl = self.t.opimpl[call]
         w_target = self.eval_expr(call.func)
         args_w = [self.eval_expr(arg) for arg in call.args]
-        # kill this when we migrate op.CALL to new-tyle
-        w_res = self.vm.call(w_opimpl._w_func, [w_target] + args_w)
-        # this is the correct one
-        # w_res = w_opimpl.call(self.vm, [w_target] + args_w)
+        w_res = w_opimpl.call(self.vm, [w_target] + args_w)
         return w_res
 
     def _eval_call_func(self, call: ast.Call, color: Color,

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -300,10 +300,8 @@ class ASTFrame:
         w_opimpl = self.t.opimpl[op]
         w_target = self.eval_expr(op.target)
         w_method = self.vm.wrap(op.method)
-        arg_w = [self.eval_expr(arg) for arg in op.args]
-        w_res = self.vm.call(w_opimpl._w_func,
-                                      [w_target, w_method] + arg_w)
-        return w_res
+        args_w = [self.eval_expr(arg) for arg in op.args]
+        return w_opimpl.call(self.vm, [w_target, w_method] + args_w)
 
     def eval_expr_GetItem(self, op: ast.GetItem) -> W_Object:
         w_opimpl = self.t.opimpl[op]

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -5,6 +5,7 @@ from spy.vm.b import B
 from spy.vm.object import spytype, Member, Annotated
 from spy.vm.w import (W_Func, W_Type, W_Object, W_I32, W_F64, W_Void, W_Str,
                       W_Dynamic, W_List, W_FuncType)
+from spy.vm.list import W_List
 from spy.vm.opimpl import W_OpImpl, W_Value
 from spy.vm.sig import spy_builtin
 from spy.vm.registry import ModuleRegistry
@@ -39,10 +40,10 @@ class W_JsRef(W_Object):
         return W_OpImpl.simple(vm.wrap_func(fn))
 
     @staticmethod
-    def op_CALL_METHOD(vm: 'SPyVM', w_type: W_Type, w_method: W_Str,
-                       w_argtypes: W_Dynamic) -> W_OpImpl:
-        argtypes_w = vm.unwrap(w_argtypes)
-        n = len(argtypes_w)
+    def op_CALL_METHOD(vm: 'SPyVM', wv_obj: W_Value, wv_method: W_Value,
+                       w_values: W_List[W_Value]) -> W_OpImpl:
+        args_wv = w_values.items_w
+        n = len(args_wv)
         if n == 1:
             return W_OpImpl.simple(JSFFI.w_call_method_1)
         else:

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -2,21 +2,37 @@ from typing import TYPE_CHECKING
 from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type, W_Dynamic
 from spy.vm.str import W_Str
-from spy.vm.opimpl import W_OpImpl
+from spy.vm.opimpl import W_OpImpl, W_Value
+from spy.vm.list import W_List
 
 from . import OP
 from .binop import MM
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
+W_List.make_prebuilt(W_Value)
+
 @OP.builtin(color='blue')
-def CALL(vm: 'SPyVM', w_type: W_Type, w_argtypes: W_Object) -> W_OpImpl:
+def CALL(vm: 'SPyVM', wv_obj: W_Value, w_values: W_List[W_Value]) -> W_OpImpl:
+    from spy.vm.typechecker import typecheck_opimpl
+    w_opimpl = W_OpImpl.NULL
+    w_type = wv_obj.w_static_type
     pyclass = w_type.pyclass
     if w_type is B.w_dynamic:
         raise NotImplementedError("implement me")
     elif pyclass.has_meth_overriden('op_CALL'):
-        return pyclass.op_CALL(vm, w_type, w_argtypes)
-    return W_OpImpl.NULL
+        w_opimpl = pyclass.op_CALL(vm, w_type, w_values)
+
+    # turn the app-level W_List[W_Value] into an interp-level list[W_Value]
+    args_wv = w_values.items_w
+    typecheck_opimpl(
+        vm,
+        w_opimpl,
+        [wv_obj] + args_wv,
+        dispatch = 'single',
+        errmsg = 'cannot call objects of type `{0}`'
+    )
+    return w_opimpl
 
 @OP.builtin(color='blue')
 def CALL_METHOD(vm: 'SPyVM', w_type: W_Type, w_method: W_Str,

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -21,7 +21,7 @@ def CALL(vm: 'SPyVM', wv_obj: W_Value, w_values: W_List[W_Value]) -> W_OpImpl:
     if w_type is B.w_dynamic:
         raise NotImplementedError("implement me")
     elif pyclass.has_meth_overriden('op_CALL'):
-        w_opimpl = pyclass.op_CALL(vm, w_type, w_values)
+        w_opimpl = pyclass.op_CALL(vm, wv_obj, w_values)
 
     # turn the app-level W_List[W_Value] into an interp-level list[W_Value]
     args_wv = w_values.items_w
@@ -35,9 +35,22 @@ def CALL(vm: 'SPyVM', wv_obj: W_Value, w_values: W_List[W_Value]) -> W_OpImpl:
     return w_opimpl
 
 @OP.builtin(color='blue')
-def CALL_METHOD(vm: 'SPyVM', w_type: W_Type, w_method: W_Str,
-                w_argtypes: W_Object) -> W_OpImpl:
+def CALL_METHOD(vm: 'SPyVM', wv_obj: W_Value, wv_method: W_Value,
+                w_values: W_List[W_Value]) -> W_OpImpl:
+    from spy.vm.typechecker import typecheck_opimpl
+    w_opimpl = W_OpImpl.NULL
+    w_type = wv_obj.w_static_type
     pyclass = w_type.pyclass
     if pyclass.has_meth_overriden('op_CALL_METHOD'):
-        return pyclass.op_CALL_METHOD(vm, w_type, w_method, w_argtypes)
-    return W_OpImpl.NULL
+        w_opimpl = pyclass.op_CALL_METHOD(vm, wv_obj, wv_method, w_values)
+
+    # turn the app-level W_List[W_Value] into an interp-level list[W_Value]
+    args_wv = w_values.items_w
+    typecheck_opimpl(
+        vm,
+        w_opimpl,
+        [wv_obj, wv_method] + args_wv,
+        dispatch = 'single',
+        errmsg = 'cannot call methods on type `{0}`'
+    )
+    return w_opimpl

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -163,7 +163,7 @@ class W_Object:
 
     @staticmethod
     def op_CALL(vm: 'SPyVM', w_type: 'W_Type',
-                w_argtypes: 'W_Dynamic') -> 'W_OpImpl':
+                w_argvalues: 'W_Dynamic') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
     @staticmethod
@@ -370,13 +370,13 @@ def synthesize_meta_op_CALL(pyclass: Type[W_Object]) -> Any:
     W_Foo. Once we have done that, we can manually apply @spy_builtin and
     finally vm.wrap() it.
     """
-    from spy.vm.opimpl import W_OpImpl
+    from spy.vm.opimpl import W_OpImpl, W_Value
     from spy.vm.sig import spy_builtin
     assert hasattr(pyclass, 'spy_new')
     spy_new = pyclass.spy_new
 
-    def meta_op_CALL(vm: 'SPyVM', w_type: W_Type,
-                     w_argtypes: W_Dynamic) -> W_OpImpl:
+    def meta_op_CALL(vm: 'SPyVM', wv_obj: W_Value,
+                     w_argvalues: W_Dynamic) -> W_OpImpl:
         fix_annotations(spy_new, {pyclass.__name__: pyclass})
         qn = QN(modname='ext', attr='new') # XXX what modname should we use?
         # manually apply the @spy_builtin decorator to the spy_new function

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -162,13 +162,13 @@ class W_Object:
         raise NotImplementedError('this should never be called')
 
     @staticmethod
-    def op_CALL(vm: 'SPyVM', w_type: 'W_Type',
-                w_argvalues: 'W_Dynamic') -> 'W_OpImpl':
+    def op_CALL(vm: 'SPyVM', wv_obj: 'W_Value',
+                w_values: 'W_Dynamic') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
     @staticmethod
-    def op_CALL_METHOD(vm: 'SPyVM', w_type: 'W_Type', w_method: 'W_Str',
-                       w_argtypes: 'W_Dynamic') -> 'W_OpImpl':
+    def op_CALL_METHOD(vm: 'SPyVM', wv_obj: 'W_Value', wv_method: 'W_Value',
+                       w_values: 'W_Dynamic') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
 
@@ -376,7 +376,7 @@ def synthesize_meta_op_CALL(pyclass: Type[W_Object]) -> Any:
     spy_new = pyclass.spy_new
 
     def meta_op_CALL(vm: 'SPyVM', wv_obj: W_Value,
-                     w_argvalues: W_Dynamic) -> W_OpImpl:
+                     w_values: W_Dynamic) -> W_OpImpl:
         fix_annotations(spy_new, {pyclass.__name__: pyclass})
         qn = QN(modname='ext', attr='new') # XXX what modname should we use?
         # manually apply the @spy_builtin decorator to the spy_new function

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -202,4 +202,15 @@ class W_OpImpl(W_Object):
             real_args_w.append(w_arg)
         return vm.call(self._w_func, real_args_w)
 
+    def redshift_args(self, vm: 'SPyVM',
+                      orig_args: list[ast.Expr]) -> list[ast.Expr]:
+        real_args = []
+        for wv_arg, conv in zip(self._args_wv, self._converters):
+            arg = orig_args[wv_arg.i]
+            if conv is not None:
+                arg = conv.redshift(vm, arg)
+            real_args.append(arg)
+        return real_args
+
+
 W_OpImpl.NULL = W_OpImpl.simple(None)

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -717,16 +717,10 @@ def convert_type_maybe(
     elif w_got is B.w_i32 and w_exp is B.w_f64:
         return NumericConv(w_type=w_exp, w_fromtype=w_got)
     elif w_exp is JSFFI.w_JsRef and w_got in (B.w_str, B.w_i32):
-        XXX
-        self.expr_conv[expr] = JsRefConv(w_type=JSFFI.w_JsRef,
-                                         w_fromtype=w_got)
-        return None
+        return JsRefConv(w_type=JSFFI.w_JsRef, w_fromtype=w_got)
     elif w_exp is JSFFI.w_JsRef and isinstance(w_got, W_FuncType):
-        XXX
         assert w_got == W_FuncType.parse('def() -> void')
-        self.expr_conv[expr] = JsRefConv(w_type=JSFFI.w_JsRef,
-                                         w_fromtype=w_got)
-        return None
+        return JsRefConv(w_type=JSFFI.w_JsRef, w_fromtype=w_got)
 
     # mismatched types
     err = SPyTypeError('mismatched types')

--- a/spy/vm/typeconverter.py
+++ b/spy/vm/typeconverter.py
@@ -25,6 +25,8 @@ class TypeConverter:
         """
         raise NotImplementedError
 
+    def redshift(self, vm: 'SPyVM', expr: ast.Expr) -> ast.Expr:
+        return expr
 
 class DynamicCast(TypeConverter):
     """

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -317,11 +317,6 @@ class SPyVM:
 
         Mostly useful to call OPERATORs.
         """
-        # XXX operator::CALL is still old-style, so skip the sanity check
-        if w_func.qn != QN('operator::CALL') and w_func.qn != QN('operator::CALL_METHOD'):
-            # sanity check
-            for wv_arg in args_wv:
-                assert isinstance(wv_arg, W_Value)
         w_opimpl = self.call(w_func, args_wv)
         # XXX maybe this should be a TypeError instead? What happens if we
         # don't return an OpImpl from an user-defined OPERATOR?


### PR DESCRIPTION
These are the last two operators that needed to be turned into new-style.

Other highlights:
  - thanks to W_Values, we can now remove the first unused arg from int2str. This lets us to kill a special case in the C backend
  - type conversions now works again, both in interp and doppler mode: this lets us to unskip a JSFFI test
  - we can finally kill `TypeChecker.opimpl_typecheck`, which is completely superseded by the new `typecheck_opimpl` (which will be probably moved inside `W_OpImpl` eventually)