### PR TITLE
Add Build Guide for Linux and Docs Infrastructure 

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,23 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+python:
+  install:
+  - requirements: requirements-docs.txt

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,105 @@
+# Build Guide for Linux
+
+## Prerequisite
+
+- `python >= 3.10`
+- `zig >= 0.13.0`
+- `emscripten`
+- `gcc`
+- `git`
+
+## Install `emscripten`
+
+- Get the `emsdk` repository
+```
+git clone https://github.com/emscripten-core/emsdk.git
+```
+
+- Enter `emsdk` directory
+```
+cd emsdk
+```
+
+- Make the "latest" SDK "active" for the current user (writes .emscripten file)
+```
+./emsdk activate latest
+```
+
+- Download and install the latest SDK tools
+```
+./emsdk install latest
+```
+
+- Activate PATH and other environment variables in the current terminal
+```
+source ./emsdk_env.sh
+```
+
+## Install `spylang`
+
+- Get the `spylang` repository
+```
+git clone https://github.com/spylang/spy.git
+```
+
+- Enter `spy` directory
+```
+cd spy
+```
+
+- Make virtual environment for `spylang` project
+```
+python -m venv .venv --prompt spy
+```
+
+- Activate virtual environment
+```
+.venv/bin/activate
+```
+
+- Install `requirement.txt` for depedency
+```
+pip install -r requirements.txt
+```
+
+- Add `zig` compiler to PATH
+```
+ln -s $(realpath .venv/lib/python3.*/site-packages/ziglang/zig) .venv/bin/
+```
+
+- Build `libspy`
+```
+make -C spy/libspy
+```
+
+- Install `requirement.txt` for depedency
+```
+pip install -r requirements.txt
+```
+
+## Basic Commands
+
+- Execute script in interpreted mode
+```
+$ ./spy.sh --run examples/hello.spy 
+Hello world!
+```
+
+- Compile script to an executable
+```
+$ ./spy.sh -t native examples/hello.spy
+$ ./examples/hello
+Hello world!
+```
+
+- redshifting mode
+```
+$ ./spy.sh --redshift --no-pretty examples/hello.spy 
+def main() -> `builtins::void`:
+    `builtins::print_str`('Hello world!')
+```
+
+- Run tests
+```
+$ pytest
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,37 +3,45 @@
 ## Prerequisite
 
 - `python >= 3.10`
-- `zig >= 0.13.0`
 - `emscripten`
 - `gcc`
 - `git`
 
 ## Install `emscripten`
 
-- Get the `emsdk` repository
-```
-git clone https://github.com/emscripten-core/emsdk.git
-```
+=== "Linux"
+    - Get the `emsdk` repository
+    ```
+    git clone https://github.com/emscripten-core/emsdk.git
+    ```
 
-- Enter `emsdk` directory
-```
-cd emsdk
-```
+    - Enter `emsdk` directory
+    ```
+    cd emsdk
+    ```
 
-- Make the "latest" SDK "active" for the current user (writes .emscripten file)
-```
-./emsdk activate latest
-```
+    - Make the "latest" SDK "active" for the current user (writes .emscripten file)
+    ```
+    ./emsdk activate latest
+    ```
 
-- Download and install the latest SDK tools
-```
-./emsdk install latest
-```
+    - Download and install the latest SDK tools
+    ```
+    ./emsdk install latest
+    ```
 
-- Activate PATH and other environment variables in the current terminal
-```
-source ./emsdk_env.sh
-```
+    - Activate PATH and other environment variables in the current terminal
+    ```
+    source ./emsdk_env.sh
+    ```
+
+=== "MacOS"
+    - Install with `brew`
+    ```
+    $ brew install emscripten
+    ```
+???+ info
+    Or follow the recommended [installation process](https://emscripten.org/docs/getting_started/downloads.html#installation-instructions-using-the-emsdk-recommended).
 
 ## Install `spylang`
 
@@ -49,7 +57,7 @@ cd spy
 
 - Make virtual environment for `spylang` project
 ```
-python -m venv .venv --prompt spy
+python -m venv .venv
 ```
 
 - Activate virtual environment
@@ -62,19 +70,14 @@ python -m venv .venv --prompt spy
 pip install -r requirements.txt
 ```
 
-- Add `zig` compiler to PATH
+- Ensure that the `zig` is available on PATH
 ```
 ln -s $(realpath .venv/lib/python3.*/site-packages/ziglang/zig) .venv/bin/
 ```
 
-- Build `libspy`
+- Build native libraries for spy
 ```
 make -C spy/libspy
-```
-
-- Install `requirement.txt` for depedency
-```
-pip install -r requirements.txt
 ```
 
 ## Basic Commands

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,27 @@
+site_name: Spy Programming Language
+site_url: https://mydomain.org/mysite
+theme:
+  name: material
+  features:
+    - content.code.copy
+  palette:
+
+    # Palette toggle for automatic mode
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default 
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,3 +25,10 @@ theme:
       toggle:
         icon: material/brightness-4
         name: Switch to system preference
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Spy Programming Language
-site_url: https://mydomain.org/mysite
+site_url: https://gunungpw.github.io/
 theme:
   name: material
   features:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Spy Programming Language
-site_url: https://gunungpw.github.io/
+site_url: !ENV READTHEDOCS_CANONICAL_URL
 theme:
   name: material
   features:

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,2 @@
+mkdocs
+mkdocs-material


### PR DESCRIPTION
Add Build Guide according #70
Add Docs Infrastructure with `mkdocs`, `mkdocs-material`, and `readthedocs`

Preview
https://spy-docs.readthedocs.io/en/latest/