### PR TITLE
Make Loc non-optional everywhere

### DIFF
--- a/spy/errors.py
+++ b/spy/errors.py
@@ -19,7 +19,7 @@ def maybe_plural(n: int, singular: str, plural: Optional[str] = None) -> str:
 class Annotation:
     level: Level
     message: str
-    loc: Optional[Loc]
+    loc: Loc
 
     def get_src(self) -> str:
         """
@@ -68,16 +68,18 @@ class ErrorFormatter:
         line = ann.loc.line_start
         col = ann.loc.col_start + 1  # Loc columns are 0-based but we want 1-based
         srcline = linecache.getline(filename, line).rstrip('\n')
-        carets = self.make_carets(ann.loc, ann.message)
+        carets = self.make_carets(srcline, ann.loc, ann.message)
         carets = self.color.set(ann.level, carets)
         self.w(f'   --> {filename}:{line}:{col}')
         self.w(f'{line:>3} | {srcline}')
         self.w(f'    | {carets}')
         self.w('')
 
-    def make_carets(self, loc: Loc, message: str) -> str:
+    def make_carets(self, srcline: str, loc: Loc, message: str) -> str:
         a = loc.col_start
         b = loc.col_end
+        if b < 0:
+            b = len(srcline) + b + 1
         n = b-a
         line = ' ' * a + '^' * n
         return line + ' ' + message

--- a/spy/errors.py
+++ b/spy/errors.py
@@ -26,8 +26,6 @@ class Annotation:
         Return the piece of source code pointed by the annotation.
         """
         loc = self.loc
-        if loc is None:
-            return ''
         filename = loc.filename
         assert loc.line_start == loc.line_end, 'multi-line not supported'
         line = loc.line_start
@@ -62,8 +60,6 @@ class ErrorFormatter:
         self.w(f'{prefix}: {message}')
 
     def emit_annotation(self, ann: Annotation) -> None:
-        if ann.loc is None:
-            return
         filename = ann.loc.filename
         line = ann.loc.line_start
         col = ann.loc.col_start + 1  # Loc columns are 0-based but we want 1-based

--- a/spy/location.py
+++ b/spy/location.py
@@ -14,8 +14,16 @@ class Loc:
     col_end: int
 
     @classmethod
-    def here(cls) -> 'Loc':
-        f = inspect.stack()[1] # caller's frame
+    def here(cls, level: int = -1) -> 'Loc':
+        """
+        Return a Loc corresponding to the interp-level code on the call
+        stack.
+
+        By default, level=-1 means "caller's frame".
+        level=-2 is "caller of the caller", etc.
+        """
+        assert level < 0
+        f = inspect.stack()[-level]
         return cls(
             filename = f.filename,
             line_start = f.lineno,

--- a/spy/location.py
+++ b/spy/location.py
@@ -1,6 +1,6 @@
+import inspect
 import dataclasses
 from dataclasses import dataclass
-import linecache
 
 @dataclass
 class Loc:
@@ -12,6 +12,17 @@ class Loc:
     line_end: int
     col_start: int
     col_end: int
+
+    @classmethod
+    def here(cls) -> 'Loc':
+        f = inspect.stack()[1] # caller's frame
+        return cls(
+            filename = f.filename,
+            line_start = f.lineno,
+            line_end = f.lineno,
+            col_start = 0,
+            col_end = -1 # whole line
+        )
 
     @classmethod
     def fake(cls) -> 'Loc':

--- a/spy/tests/test_loc.py
+++ b/spy/tests/test_loc.py
@@ -1,0 +1,13 @@
+from spy.location import Loc
+from spy.errors import Annotation
+
+def myfunc() -> Loc:
+    loc = Loc.here()
+    return loc
+
+def test_Loc_here():
+    loc = myfunc()
+    ann = Annotation("error", "hello", loc)
+    src = ann.get_src()
+    exp = '    loc = Loc.here()'
+    assert src == exp

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -8,6 +8,7 @@ from spy.vm.object import W_Object, W_Type, spytype, W_Void, W_I32, W_Bool
 from spy.vm.str import W_Str
 from spy.vm.function import W_BuiltinFunc
 from spy.vm.module import W_Module
+from spy.tests.support import expect_errors
 
 class TestVM:
 
@@ -231,3 +232,14 @@ class TestVM:
         assert vm.is_False(vm.eq(B.w_i32, B.w_str))
         assert vm.is_True(vm.ne(B.w_i32, B.w_str))
         assert vm.is_False(vm.ne(B.w_i32, B.w_i32))
+
+    def test_error_loc(self):
+        vm = SPyVM()
+        w_a = vm.wrap(1)
+        w_b = vm.wrap('x')
+        errors = expect_errors(
+            "cannot do `i32`[...]",
+            ("this is `i32`", "            vm.getitem(w_a, w_b) # hello")
+        )
+        with errors:
+            vm.getitem(w_a, w_b) # hello

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -65,7 +65,7 @@ class W_OpArg(W_Object):
     prefix: str
     i: Optional[int]
     w_static_type: Annotated[W_Type, Member('static_type')]
-    loc: Optional[Loc]
+    loc: Loc
     sym: Optional[Symbol]
     _w_blueval: Optional[W_Object]
 
@@ -73,7 +73,7 @@ class W_OpArg(W_Object):
                  prefix: str,
                  i: Optional[int],
                  w_static_type: W_Type,
-                 loc: Optional[Loc],
+                 loc: Loc,
                  *,
                  sym: Optional[Symbol] = None,
                  w_blueval: Optional[W_Object] = None,
@@ -90,13 +90,13 @@ class W_OpArg(W_Object):
     @classmethod
     def const(cls, vm: 'SPyVM', w_obj: W_Object, prefix: str) -> 'W_OpArg':
         w_type = vm.dynamic_type(w_obj)
-        return cls(prefix, None, w_type, None, w_blueval=w_obj)
+        return cls(prefix, None, w_type, Loc.here(-2), w_blueval=w_obj)
 
     @classmethod
     def from_w_obj(cls, vm: 'SPyVM', w_obj: W_Object,
                    prefix: str, i: int) -> 'W_OpArg':
         w_type = vm.dynamic_type(w_obj)
-        return W_OpArg(prefix, i, w_type, None, w_blueval=w_obj)
+        return W_OpArg(prefix, i, w_type, Loc.here(-2), w_blueval=w_obj)
 
     @property
     def name(self) -> str:

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from types import FunctionType
 import fixedint
 from spy.fqn import QN, FQN
+from spy.location import Loc
 from spy import libspy
 from spy.doppler import redshift
 from spy.errors import SPyTypeError
@@ -390,16 +391,16 @@ class SPyVM:
         return w_func.spy_call(self, args_w)
 
     def eq(self, w_a: W_Dynamic, w_b: W_Dynamic) -> W_Bool:
-        wop_a = W_OpArg('a', 0, self.dynamic_type(w_a), None)
-        wop_b = W_OpArg('b', 1, self.dynamic_type(w_b), None)
+        wop_a = W_OpArg('a', 0, self.dynamic_type(w_a), Loc.here(-2))
+        wop_b = W_OpArg('b', 1, self.dynamic_type(w_b), Loc.here(-2))
         w_opimpl = self.call_OP(OPERATOR.w_EQ, [wop_a, wop_b])
         w_res = w_opimpl.call(self, [w_a, w_b])
         assert isinstance(w_res, W_Bool)
         return w_res
 
     def ne(self, w_a: W_Dynamic, w_b: W_Dynamic) -> W_Bool:
-        wop_a = W_OpArg('a', 0, self.dynamic_type(w_a), None)
-        wop_b = W_OpArg('b', 1, self.dynamic_type(w_b), None)
+        wop_a = W_OpArg('a', 0, self.dynamic_type(w_a), Loc.here(-2))
+        wop_b = W_OpArg('b', 1, self.dynamic_type(w_b), Loc.here(-2))
         w_opimpl = self.call_OP(OPERATOR.w_NE, [wop_a, wop_b])
         w_res = w_opimpl.call(self, [w_a, w_b])
         assert isinstance(w_res, W_Bool)
@@ -409,8 +410,8 @@ class SPyVM:
         # FIXME: we need a more structured way of implementing operators
         # inside the vm, and possibly share the code with typechecker and
         # ASTFrame. See also vm.ne and vm.getitem
-        wop_obj = W_OpArg('obj', 0, self.dynamic_type(w_obj), None)
-        wop_i = W_OpArg('i', 1, self.dynamic_type(w_i), None)
+        wop_obj = W_OpArg('obj', 0, self.dynamic_type(w_obj), Loc.here(-2))
+        wop_i = W_OpArg('i', 1, self.dynamic_type(w_i), Loc.here(-2))
         w_opimpl = self.call_OP(OPERATOR.w_GETITEM, [wop_obj, wop_i])
         return w_opimpl.call(self, [w_obj, w_i])
 
@@ -460,8 +461,8 @@ class SPyVM:
         if isinstance(w_a, W_OpArg) and isinstance(w_b, W_OpArg):
             return oparg_eq(self, w_a, w_b)
 
-        wop_a = W_OpArg('a', 0, self.dynamic_type(w_a), None)
-        wop_b = W_OpArg('b', 1, self.dynamic_type(w_b), None)
+        wop_a = W_OpArg('a', 0, self.dynamic_type(w_a), Loc.here(-2))
+        wop_b = W_OpArg('b', 1, self.dynamic_type(w_b), Loc.here(-2))
         try:
             w_opimpl = self.call_OP(OPERATOR.w_EQ, [wop_a, wop_b])
         except SPyTypeError:


### PR DESCRIPTION
`W_OpArg` used to have an optional Loc, because sometimes they are generated from interp-level code which doesn't have a direct origin in the source code.

However, this is annoying because it forces to add `Optional[Loc]` and "if loc is not None" a bit everywhere.
The solution is to always provide a Loc, possibly pointing to interp-level code.

This finally fixes mypy.