### PR TITLE
Make (F)QNs arbitrarily nestable

### DIFF
--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -105,7 +105,7 @@ class CModuleWriter:
 
         # XXX: this is probably broken in case we are compiling together
         # multiple modules with a 'main' function, but it's ok for now
-        fqn_main = FQN.make_global(self.w_mod.name, 'main')
+        fqn_main = FQN.make_global([self.w_mod.name, 'main'])
         if fqn_main in self.ctx.vm.globals_w:
             self.out.wb(f"""
                 int main(void) {{

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -105,7 +105,7 @@ class CModuleWriter:
 
         # XXX: this is probably broken in case we are compiling together
         # multiple modules with a 'main' function, but it's ok for now
-        fqn_main = FQN.make(modname=self.w_mod.name, attr='main', suffix="")
+        fqn_main = FQN.make_global(self.w_mod.name, 'main')
         if fqn_main in self.ctx.vm.globals_w:
             self.out.wb(f"""
                 int main(void) {{

--- a/spy/backend/c/wrapper.py
+++ b/spy/backend/c/wrapper.py
@@ -28,7 +28,7 @@ class WasmModuleWrapper:
         return f"<WasmModuleWrapper '{self.ll.llmod.f}'>"
 
     def __getattr__(self, attr: str) -> Any:
-        fqn = FQN.make_global(modname=self.modname, attr=attr)
+        fqn = FQN.make_global([self.modname, attr])
         wasm_obj = self.ll.get_export(fqn.c_name)
         if isinstance(wasm_obj, wasmtime.Func):
             return self.read_function(fqn)

--- a/spy/backend/interp.py
+++ b/spy/backend/interp.py
@@ -27,7 +27,7 @@ class InterpModuleWrapper:
         self.w_mod = w_mod
 
     def __dir__(self) -> list[str]:
-        return [fqn.attr for fqn in self.w_mod.keys()]
+        return [fqn.symbol_name for fqn in self.w_mod.keys()]
 
     def __getattr__(self, attr: str) -> Any:
         w_obj = self.w_mod.getattr(attr)

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -35,7 +35,7 @@ class SPyBackend:
     def dump_w_func(self, fqn: FQN, w_func: W_ASTFunc) -> None:
         if fqn.suffix == '':
             # this is a global function, we can just use its name
-            name = fqn.attr
+            name = fqn.symbol_name
         else:
             name = self.fmt_fqn(fqn)
         w_functype = w_func.w_functype
@@ -66,9 +66,9 @@ class SPyBackend:
 
     def fmt_fqn(self, fqn: FQN) -> str:
         if self.fqn_format == 'no':
-            return fqn.attr # don't show the namespace
+            return fqn.symbol_name # don't show the namespace
         elif self.fqn_format == 'short' and fqn.modname == 'builtins':
-            return fqn.attr # don't show builtins::
+            return fqn.symbol_name # don't show builtins::
         else:
             return f'`{fqn}`'
 

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -132,6 +132,10 @@ class QN:
         return str(self.parts[0])
 
     @property
+    def symbol_name(self) -> str:
+        return str(self.parts[-1])
+
+    @property
     def parent(self) -> 'QN':
         return QN(self.parts[:-1])
 
@@ -185,6 +189,10 @@ class FQN:
     @property
     def modname(self) -> str:
         return self.qn.modname
+
+    @property
+    def symbol_name(self) -> str:
+        return self.qn.symbol_name
 
     def __repr__(self) -> str:
         return f"FQN({self.fullname!r})"

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -122,7 +122,7 @@ class FQN:
                          "Please use vm.get_FQN()")
 
     @classmethod
-    def make(cls, x: QN | str | list[str], suffix: str) -> 'FQN':
+    def make(cls, x: QN | str | list[str], *, suffix: str) -> 'FQN':
         obj = cls.__new__(cls)
         if isinstance(x, QN):
             obj.qn = x
@@ -132,11 +132,11 @@ class FQN:
         return obj
 
     @classmethod
-    def make_global(cls, modname: str, attr: str) -> 'FQN':
+    def make_global(cls, x: QN | str | list[str]) -> 'FQN':
         """
         Return the FQN corresponding to a global name.
         """
-        return cls.make([modname, attr], suffix="")
+        return cls.make(x, suffix="")
 
     @classmethod
     def parse(cls, s: str) -> 'FQN':

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -62,7 +62,7 @@ class NSPart:
     qualifiers: list['NSPart']
 
     @classmethod
-    def parse(cls, s: str) -> 'Optional[NSPart]':
+    def parse(cls, s: str) -> 'NSPart':
         m = _NSPART.fullmatch(s)
         if not m:
             raise ValueError(f'Invalid NSPart: {s}')
@@ -113,9 +113,9 @@ class QN:
         elif len(x) == 0:
             self.parts = []
         elif isinstance(x[0], NSPart):
-            self.parts = x
+            self.parts = x  # type: ignore
         else:
-            self.parts = [NSPart.parse(part) for part in x]
+            self.parts = [NSPart.parse(part) for part in x]  # type: ignore
 
     @staticmethod
     def parse(s: str) -> list[NSPart]:

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -173,18 +173,30 @@ class FQN:
             result in the same C name.  This is not ideal but we will solve it
             only if it becomes an actual issue in practice.
 
-          - for separating modname and attr, we use a '$'. Strictly speaking,
+          - for separating parts, we use a '$'. Strictly speaking,
             using a '$' in C identifiers is not supported by the standard, but
             in reality it is supported by GCC, clang and MSVC. Again, we will
             think of a different approach if it becomes an actual issue.
 
+          - if a part has qualifiers, we use '__' to separate the name from the
+            qualifiers, and '_' to separate each qualifier. Same as above w.r.t.
+            safety.
+
+          - if the FQN has a suffix, we append it with a '$'.
+
         So e.g., the following FQN:
-            a.b.c::foo
+            mod::dict<i32, f64>::foo#0
 
         Becomes:
-            spy_a_b_c$foo
+            spy_mod$dict__i32_f64$foo$0
         """
-        parts = [str(part) for part in self.qn.parts]
+        def fmt_part(part: NSPart) -> str:
+            s = part.name
+            if part.qualifiers:
+                s += '__' + '_'.join(part.qualifiers)
+            return s
+
+        parts = [fmt_part(part) for part in self.qn.parts]
         parts = [part.replace('.', '_') for part in parts]
         cn = 'spy_' + '$'.join(parts)
         if self.suffix != '':

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -13,8 +13,22 @@ Examples:
 A NSPart must be a valid Python identifier, but it can also contain dots.
 NSParts have 0 or more "qualifiers", expressed in angular brackets.
 
-The first part of a QN is the module name, which usually corresponds to a single
-.spy file.
+Various subparts of a QN have different names:
+
+  - the first part is the "module name", which usually corresponds to a single
+    .spy file
+
+  - the parts up to the last one are the "namespace"
+
+  - the last part is the "symbol name"
+
+E.g., for "builtins::list<i32>::append":
+  - module name: "builtins"
+
+  - namespace: "builtins::list<i32>"
+
+  - symbol name: "append"
+
 
 In case of closures and generics, you can have multiple objects with the same
 QN. To uniquely identify an object inside a live VM, we use a Fully Qualified
@@ -24,13 +38,14 @@ at all.
 
 The following example explains the difference between QNs and FQNs:
 
-@blue def make_fn(T):
+@blue
+def make_fn(T):
     def fn(x: T) -> T:
         # QN is 'test::fn' return ...
     return fn
 
-fn_i32 = make_fn(i32)  # QN is 'test::fn', FQN is 'test::fn#1' fn_f64 =
-make_fn(f64)  # QN is 'test::fn', FQN is 'test::fn#2'
+fn_i32 = make_fn(i32)  # QN is 'test::make_fn::fn', FQN is 'test::make_fn::fn#1'
+fn_f64 = make_fn(f64)  # QN is 'test::make_fn::fn', FQN is 'test::make_fn::fn#2'
 
 See also SPyVM.get_FQN().
 """

--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -97,7 +97,7 @@ class ModuleGen:
         frame.exec_stmt_ClassDef(classdef)
         w_class = frame.load_local(classdef.name)
         assert isinstance(w_class, W_Type)
-        qn = QN(modname=self.modname, attr=classdef.name)
+        qn = QN([self.modname, classdef.name])
         fqn = self.vm.get_FQN(qn, is_global=True)
         self.vm.add_global(fqn, None, w_class)
 

--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -104,8 +104,8 @@ class ModuleGen:
     def gen_GlobalVarDef(self, frame: ASTFrame, decl: ast.GlobalVarDef) -> None:
         vardef = decl.vardef
         assign = decl.assign
-        fqn = self.vm.get_FQN(QN(modname=self.modname, attr=vardef.name),
-                              is_global=True)
+        qn = QN([self.modname, vardef.name])
+        fqn = self.vm.get_FQN(qn, is_global=True)
         if isinstance(vardef.type, ast.Auto):
             # type inference
             w_val = frame.eval_expr(assign.value)

--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -39,9 +39,10 @@ class ModuleGen:
         self.w_mod = W_Module(self.vm, self.modname, str(self.file_spy))
         self.vm.register_module(self.w_mod)
         #
-        # Synthesize and execute the fake '@module' function to populate the mod
+        # Synthesize and execute a function where to evaluate module-level
+        # declarations.
         w_functype = W_FuncType.parse('def() -> void')
-        qn = QN(modname=self.modname, attr='@module')
+        qn = QN(self.modname)
         modinit_funcdef = self.make_modinit()
         closure = ()
         w_INIT = W_ASTFunc(w_functype, qn, modinit_funcdef, closure)

--- a/spy/irgen/scope.py
+++ b/spy/irgen/scope.py
@@ -121,7 +121,7 @@ class ScopeAnalyzer:
 
         if fqn is None and self.scope is self.mod_scope:
             # this is a module-level global. Let's give it a FQN
-            fqn = FQN.make_global(modname=self.mod_scope.name, attr=name)
+            fqn = FQN.make_global([self.mod_scope.name, name])
 
         sym = Symbol(name, color, loc=loc, type_loc=type_loc, fqn=fqn, level=0)
         self.scope.add(sym)

--- a/spy/irgen/scope.py
+++ b/spy/irgen/scope.py
@@ -149,8 +149,9 @@ class ScopeAnalyzer:
                     loc=imp.loc)
         else:
             # attribute not found
+            attr = str(imp.fqn.qn.parts[-1])
             err.add('error',
-                    f'attribute `{imp.fqn.attr}` does not exist ' +
+                    f'attribute `{attr}` does not exist ' +
                     f'in module `{imp.fqn.modname}`',
                     loc=imp.loc_asname)
         raise err

--- a/spy/irgen/scope.py
+++ b/spy/irgen/scope.py
@@ -149,7 +149,7 @@ class ScopeAnalyzer:
                     loc=imp.loc)
         else:
             # attribute not found
-            attr = str(imp.fqn.qn.parts[-1])
+            attr = str(imp.fqn.symbol_name)
             err.add('error',
                     f'attribute `{attr}` does not exist ' +
                     f'in module `{imp.fqn.modname}`',

--- a/spy/irgen/symtable.py
+++ b/spy/irgen/symtable.py
@@ -59,7 +59,8 @@ class SymTable:
                   col_end=0)
         builtins_mod = vm.modules_w['builtins']
         for fqn, w_obj in builtins_mod.items_w():
-            sym = Symbol(fqn.attr, 'blue', loc=loc, type_loc=loc,
+            sym_name = str(fqn.qn.parts[-1])
+            sym = Symbol(sym_name, 'blue', loc=loc, type_loc=loc,
                          level=0, fqn=fqn)
             scope.add(sym)
         return scope

--- a/spy/irgen/symtable.py
+++ b/spy/irgen/symtable.py
@@ -59,8 +59,7 @@ class SymTable:
                   col_end=0)
         builtins_mod = vm.modules_w['builtins']
         for fqn, w_obj in builtins_mod.items_w():
-            sym_name = str(fqn.qn.parts[-1])
-            sym = Symbol(sym_name, 'blue', loc=loc, type_loc=loc,
+            sym = Symbol(fqn.symbol_name, 'blue', loc=loc, type_loc=loc,
                          level=0, fqn=fqn)
             scope.add(sym)
         return scope

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -222,7 +222,7 @@ class Parser:
         res = []
         for py_alias in py_imp.names:
             assert py_imp.module is not None
-            fqn = FQN.make_global(py_imp.module, py_alias.name)
+            fqn = FQN.make_global([py_imp.module, py_alias.name])
             asname = py_alias.asname or py_alias.name
             res.append(spy.ast.Import(
                 loc = py_imp.loc,

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -222,7 +222,7 @@ class Parser:
         res = []
         for py_alias in py_imp.names:
             assert py_imp.module is not None
-            fqn = FQN.make(modname=py_imp.module, attr=py_alias.name, suffix="")
+            fqn = FQN.make_global(py_imp.module, py_alias.name)
             asname = py_alias.asname or py_alias.name
             res.append(spy.ast.Import(
                 loc = py_imp.loc,
@@ -235,7 +235,7 @@ class Parser:
     def from_py_Import(self, py_imp: py_ast.Import) -> list[spy.ast.Import]:
         res = []
         for py_alias in py_imp.names:
-            fqn = FQN.make_global(modname=py_alias.name, attr="")
+            fqn = FQN.make([py_alias.name], suffix="")
             asname = py_alias.asname or py_alias.name
             res.append(spy.ast.Import(
                 loc = py_imp.loc,

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -615,7 +615,7 @@ class TestBasic(CompilerTest):
         """)
         vm = self.vm
         assert mod.x == 7
-        fqn = FQN.make_global("test", "x")
+        fqn = FQN.make_global(["test", "x"])
         w_xtype = self.vm.globals_types[fqn]
         assert w_xtype is B.w_i32
 

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -133,9 +133,9 @@ class TestDoppler:
         """)
         self.assert_dump("""
         def foo() -> i32:
-            return `test::fn#0`(21)
+            return `test::make_fn::fn#0`(21)
 
-        def `test::fn#0`(x: i32) -> i32:
+        def `test::make_fn::fn#0`(x: i32) -> i32:
             return x * 2
         """)
 

--- a/spy/tests/test_fqn.py
+++ b/spy/tests/test_fqn.py
@@ -70,3 +70,7 @@ def test_FQN_parse():
     fqn = FQN.parse("aaa::bbb#0")
     assert fqn.qn == QN("aaa::bbb")
     assert fqn.suffix == "0"
+
+def test_qualifiers_c_name():
+    a = FQN.make("a::b<x, y>::c", suffix="0")
+    assert a.c_name == "spy_a$b__x_y$c$0"

--- a/spy/tests/test_fqn.py
+++ b/spy/tests/test_fqn.py
@@ -40,6 +40,11 @@ def test_qualifiers():
         NSPart("c", [])
     ]
 
+def test_QN_nested():
+    a = QN("aaa::bbb")
+    b = a.nested("ccc")
+    assert b.fullname == "aaa::bbb::ccc"
+
 def test_FQN():
     a = FQN.make("aaa::bbb", suffix="0")
     assert a.fullname == "aaa::bbb#0"

--- a/spy/tests/test_fqn.py
+++ b/spy/tests/test_fqn.py
@@ -36,9 +36,13 @@ def test_qualifiers():
     assert a.modname == "a"
     assert a.parts == [
         NSPart("a", []),
-        NSPart("b", ["x", "y"]),
+        NSPart("b", [NSPart("x", []), NSPart("y", [])]),
         NSPart("c", [])
     ]
+
+def test_nested_qualifiers():
+    a = QN("foo::list<Ptr<Point>>")
+    assert a.fullname == "foo::list<Ptr<Point>>"
 
 def test_QN_nested():
     a = QN("aaa::bbb")
@@ -79,3 +83,7 @@ def test_FQN_parse():
 def test_qualifiers_c_name():
     a = FQN.make("a::b<x, y>::c", suffix="0")
     assert a.c_name == "spy_a$b__x_y$c$0"
+
+def test_nested_qualifiers_c_name():
+    a = FQN.make("a::list<Ptr<x, y>>::c", suffix="0")
+    assert a.c_name == "spy_a$list__Ptr__x_y$c$0"

--- a/spy/tests/test_fqn.py
+++ b/spy/tests/test_fqn.py
@@ -1,31 +1,23 @@
 import pytest
-from spy.fqn import QN, FQN
+from spy.fqn import NSPart, QN, FQN
 
 def test_QN_init_fullname():
     a = QN("a.b.c::xxx")
     assert a.fullname == "a.b.c::xxx"
     assert a.modname == "a.b.c"
-    assert a.attr == "xxx"
+    assert a.parts == [
+        NSPart("a.b.c", []),
+        NSPart("xxx", [])
+    ]
 
 def test_QN_init_parts():
-    a = QN(modname="a.b.c", attr="xxx")
+    a = QN(['a.b.c', 'xxx'])
     assert a.fullname == "a.b.c::xxx"
     assert a.modname == "a.b.c"
-    assert a.attr == "xxx"
 
-def test_QN_wrong_init():
-    with pytest.raises(AssertionError):
-        QN("aaa")
-    with pytest.raises(AssertionError):
-        QN("aaa::bbb::ccc")
-    with pytest.raises(AssertionError):
-        QN("aaa::bbb", modname="aaa")
-    with pytest.raises(AssertionError):
-        QN("aaa::bbb", attr="bbb")
-    with pytest.raises(AssertionError):
-        QN()
-    with pytest.raises(AssertionError):
-        QN(modname="aaa")
+def test_many_QNs():
+    assert str(QN("aaa")) == "aaa"
+    assert str(QN("aaa::bbb::ccc")) == "aaa::bbb::ccc"
 
 def test_QN_str_repr():
     a = QN("aaa::bbb")
@@ -38,38 +30,43 @@ def test_QN_hash_eq():
     assert a == b
     assert hash(a) == hash(b)
 
+def test_qualifiers():
+    a = QN("a::b<x, y>::c")
+    assert a.fullname == "a::b<x, y>::c"
+    assert a.modname == "a"
+    assert a.parts == [
+        NSPart("a", []),
+        NSPart("b", ["x", "y"]),
+        NSPart("c", [])
+    ]
+
 def test_FQN():
-    a = FQN.make("aaa", "bbb", suffix="0")
-    assert a.modname == "aaa"
-    assert a.attr == "bbb"
-    assert a.suffix == "0"
+    a = FQN.make("aaa::bbb", suffix="0")
     assert a.fullname == "aaa::bbb#0"
 
 def test_FQN_str():
-    a = FQN.make("aaa", "bbb", suffix='0')
+    a = FQN.make("aaa::bbb", suffix='0')
     assert str(a) == "aaa::bbb#0"
     assert a.c_name == "spy_aaa$bbb$0"
-    b = FQN.make("aaa", "bbb", suffix='')
+    b = FQN.make("aaa::bbb", suffix='')
     assert str(b) == "aaa::bbb"
     assert b.c_name == "spy_aaa$bbb"
 
 def test_FQN_hash_eq():
-    a = FQN.make("aaa", "bbb", suffix="0")
-    b = FQN.make("aaa", "bbb", suffix="0")
+    a = FQN.make("aaa::bbb", suffix="0")
+    b = FQN.make("aaa::bbb", suffix="0")
     assert a == b
     assert hash(a) == hash(b)
 
 def test_FQN_c_name_dotted():
-    a = FQN.make("a.b.c", "xxx", suffix="0")
+    a = FQN.make("a.b.c::xxx", suffix="0")
     assert a.c_name == "spy_a_b_c$xxx$0"
 
 def test_FQN_parse():
     fqn = FQN.parse("aaa::bbb")
-    assert fqn.modname == "aaa"
-    assert fqn.attr == "bbb"
+    assert fqn.qn == QN("aaa::bbb")
     assert fqn.suffix == ""
     #
     fqn = FQN.parse("aaa::bbb#0")
-    assert fqn.modname == "aaa"
-    assert fqn.attr == "bbb"
+    assert fqn.qn == QN("aaa::bbb")
     assert fqn.suffix == "0"

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -749,10 +749,10 @@ class TestParser:
         Module(
             filename='{tmpdir}/test.spy',
             decls=[
-                Import(fqn=FQN('aaa::'), asname='aaa'),
-                Import(fqn=FQN('bbb::'), asname='BBB'),
-                Import(fqn=FQN('ccc::'), asname='ccc'),
-                Import(fqn=FQN('ddd::'), asname='DDD'),
+                Import(fqn=FQN('aaa'), asname='aaa'),
+                Import(fqn=FQN('bbb'), asname='BBB'),
+                Import(fqn=FQN('ccc'), asname='ccc'),
+                Import(fqn=FQN('ddd'), asname='DDD'),
             ],
         )
         """

--- a/spy/tests/vm/test_module.py
+++ b/spy/tests/vm/test_module.py
@@ -11,8 +11,8 @@ class TestModule:
         w_mod = W_Module(vm, 'mymod', 'mymod.spy')
         vm.register_module(w_mod)
         #
-        fqn_a = FQN.make('mymod', 'a', '')
-        fqn_b = FQN.make('mymod', 'b', '')
+        fqn_a = FQN.parse('mymod::a')
+        fqn_b = FQN.parse('mymod::b')
         w_a = vm.wrap(10)
         w_b = vm.wrap(20)
         vm.add_global(fqn_a, B.w_i32, w_a)

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -127,8 +127,7 @@ class ASTFrame:
         self.t.lazy_check_FuncDef(funcdef, w_functype)
         #
         # create the w_func
-        modname = self.w_func.qn.modname # the module of the "outer" function
-        qn = QN(modname=modname, attr=funcdef.name)
+        qn = self.w_func.qn.nested(funcdef.name)
         # XXX we should capture only the names actually used in the inner func
         closure = self.w_func.closure + (self._locals,)
         w_func = W_ASTFunc(w_functype, qn, funcdef, closure)

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -177,8 +177,6 @@ class W_ASTFunc(W_Func):
                  ) -> None:
         self.w_functype = w_functype
         self.qn = qn
-        if str(qn) == 'test::None':
-            import pdb;pdb.set_trace()
         self.funcdef = funcdef
         self.closure = closure
         self.locals_types_w = locals_types_w

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -154,7 +154,7 @@ class W_DirectCall(W_Func):
     """
     See W_Func.op_CALL.
     """
-    qn = QN(modname='<direct-call>', attr='')
+    qn = QN("builtins::__direct_call__")
 
     def __init__(self, w_functype: W_FuncType) -> None:
         self.w_functype = w_functype
@@ -177,6 +177,8 @@ class W_ASTFunc(W_Func):
                  ) -> None:
         self.w_functype = w_functype
         self.qn = qn
+        if str(qn) == 'test::None':
+            import pdb;pdb.set_trace()
         self.funcdef = funcdef
         self.closure = closure
         self.locals_types_w = locals_types_w

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -159,11 +159,10 @@ def _make_W_List(w_T: W_Type) -> Type[W_List]:
             w_rtype = wop_r.w_static_type
             assert w_ltype.pyclass is W_MyList
 
-            # the final '#' in the QN means that it's a non-unique
-            # builtin. See also FuncDoppler.make_const. This is a temporary
-            # hack that we should fix eventually.
+            # XXX: we use use proper nested QNs. See also the comment in
+            # vm.make_fqn_const
             @no_type_check
-            @spy_builtin(QN('operator::list_eq#'))
+            @spy_builtin(QN('operator::list_eq'))
             def eq(vm: 'SPyVM', w_l1: W_MyList, w_l2: W_MyList) -> W_Bool:
                 items1_w = w_l1.items_w
                 items2_w = w_l2.items_w

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -62,7 +62,7 @@ class W_Module(W_Object):
     # ==== public interp-level API ====
 
     def getattr_maybe(self, attr: str) -> Optional[W_Object]:
-        fqn = FQN.make_global(modname=self.name, attr=attr)
+        fqn = FQN.make_global([self.name, attr])
         return self.vm.lookup_global(fqn)
 
     def getattr(self, attr: str) -> W_Object:
@@ -78,7 +78,7 @@ class W_Module(W_Object):
 
     def setattr(self, attr: str, w_value: W_Object) -> None:
         # XXX we should raise an exception if the attr doesn't exist
-        fqn = FQN.make_global(modname=self.name, attr=attr)
+        fqn = FQN.make_global([self.name, attr])
         self.vm.store_global(fqn, w_value)
 
     def keys(self) -> Iterable[FQN]:

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -92,12 +92,12 @@ def opimpl_member(kind: OpKind, vm: 'SPyVM', w_type: W_Type,
     W_OpArg = member.w_type.pyclass
     field = member.field # the interp-level name of the attr (e.g, 'w_x')
 
-    # XXX QNs are slightly wrong because they uses the type name as the
+    # XXX FIXME QNs are slightly wrong because they uses the type name as the
     # modname. We need to rethink how QNs are computed
 
     if kind == 'get':
         @no_type_check
-        @spy_builtin(QN(modname=w_type.name, attr=f"__get_{attr}__"))
+        @spy_builtin(QN([w_type.name, f"__get_{attr}__"]))
         def opimpl_get(vm: 'SPyVM', w_obj: W_Class, w_attr: W_Str) -> W_OpArg:
             return getattr(w_obj, field)
 
@@ -105,7 +105,7 @@ def opimpl_member(kind: OpKind, vm: 'SPyVM', w_type: W_Type,
 
     elif kind == 'set':
         @no_type_check
-        @spy_builtin(QN(modname=w_type.name, attr=f"__set_{attr}__"))
+        @spy_builtin(QN([w_type.name, f"__set_{attr}__"]))
         def opimpl_set(vm: 'SPyVM', w_obj: W_Class, w_attr: W_Str,
                        w_val: W_OpArg) -> W_Void:
             setattr(w_obj, field, w_val)

--- a/spy/vm/modules/unsafe/mem.py
+++ b/spy/vm/modules/unsafe/mem.py
@@ -5,7 +5,7 @@ from spy.vm.b import B
 from spy.vm.w import W_I32, W_Func, W_Type, W_Dynamic, W_Object
 from spy.vm.sig import spy_builtin
 from . import UNSAFE
-from .ptr import W_Ptr, make_ptr_type
+from .ptr import W_Ptr, make_ptr_type, hack_hack_fix_typename
 from .misc import sizeof
 
 if TYPE_CHECKING:
@@ -35,6 +35,7 @@ def gc_alloc(vm: 'SPyVM', w_T: W_Type) -> W_Dynamic:
 def mem_read(vm: 'SPyVM', w_T: W_Type) -> W_Dynamic:
     T = w_T.pyclass
     t = w_T.name
+    t = hack_hack_fix_typename(t)
 
     @no_type_check
     @spy_builtin(QN(f'unsafe::mem_read_{t}'))

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -12,6 +12,11 @@ from .misc import sizeof
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
+def hack_hack_fix_typename(t: str) -> str:
+    # XXX hack hack hack, it will be fixed when types have a QN and we can
+    # properly nest QN qualifiers. In the meantime, we just use W_Type.name, but
+    # we  make sure it doesn't contain any square brackets.
+    return t.replace('[', '_').replace(']', '')
 
 @UNSAFE.spytype('ptr')
 class W_Ptr(W_Object):
@@ -173,6 +178,9 @@ def getfield(vm: 'SPyVM', w_T: W_Type) -> W_Dynamic:
 
     # unsafe::getfield_prim_i32
     # unsafe::getfield_ref_Point
+
+    t = hack_hack_fix_typename(t)
+
     @no_type_check
     @spy_builtin(QN(f'unsafe::getfield_{by}_{t}'))
     def getfield_T(vm: 'SPyVM', w_ptr: W_Ptr, w_attr: W_Str,

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -383,7 +383,7 @@ def synthesize_meta_op_CALL(pyclass: Type[W_Object]) -> Any:
     def meta_op_CALL(vm: 'SPyVM', wop_obj: W_OpArg,
                      w_opargs: W_Dynamic) -> W_OpImpl:
         fix_annotations(spy_new, {pyclass.__name__: pyclass})
-        qn = QN(modname='ext', attr='new') # XXX what modname should we use?
+        qn = QN('ext::new') # XXX what modname should we use?
         # manually apply the @spy_builtin decorator to the spy_new function
         spyfunc = spy_builtin(qn)(spy_new)
         return W_OpImpl(vm.wrap_func(spyfunc))

--- a/spy/vm/registry.py
+++ b/spy/vm/registry.py
@@ -12,12 +12,12 @@ class ModuleRegistry:
 
     At startup, the `vm` will create a W_Module out of it.
     """
-    modname: str
+    qn: QN
     filepath: str
     content: list[tuple[QN, W_Object]]
 
     def __init__(self, modname: str, filepath: str) -> None:
-        self.modname = modname
+        self.qn = QN(modname)
         self.filepath = filepath
         self.content = []
 
@@ -40,7 +40,7 @@ class ModuleRegistry:
             """
 
     def add(self, attr: str, w_obj: W_Object) -> None:
-        qn = QN(modname=self.modname, attr=attr)
+        qn = self.qn.nested(attr)
         setattr(self, f'w_{attr}', w_obj)
         self.content.append((qn, w_obj))
 
@@ -81,7 +81,7 @@ class ModuleRegistry:
         """
         def decorator(pyfunc: Callable) -> SPyBuiltin:
             attr = pyfunc.__name__
-            qn = QN(modname=self.modname, attr=attr)
+            qn = self.qn.nested(attr)
             # apply the @spy_builtin decorator to pyfunc
             spyfunc = spy_builtin(qn, color=color)(pyfunc)
             w_func = spyfunc._w

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -101,7 +101,7 @@ class SPyVM:
         self.modules_w[w_mod.name] = w_mod
 
     def make_module(self, reg: ModuleRegistry) -> None:
-        w_mod = W_Module(self, reg.modname, reg.filepath)
+        w_mod = W_Module(self, reg.qn.modname, reg.filepath)
         self.register_module(w_mod)
         for qn, w_obj in reg.content:
             fqn = self.get_FQN(qn, is_global=True)
@@ -120,12 +120,12 @@ class SPyVM:
         an unique suffix, we just increment a numeric counter.
         """
         if is_global:
-            fqn = FQN.make_global(modname=qn.modname, attr=qn.attr)
+            fqn = FQN.make(qn, suffix="")
         else:
             # XXX this is potentially quadratic if we create tons of
             # conflicting FQNs, but for now we don't care
             for n in itertools.count():
-                fqn = FQN.make(modname=qn.modname, attr=qn.attr, suffix=str(n))
+                fqn = FQN.make(qn, suffix=str(n))
                 if fqn not in self.unique_fqns:
                     break
         assert fqn not in self.unique_fqns

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -199,7 +199,8 @@ class SPyVM:
         elif isinstance(w_val, W_Type):
             # this is terribly wrong: types should carry their own QN, as
             # functions do
-            qn = QN(modname='__fake_mod__', attr=w_val.name)
+            name = w_val.name.replace('[', '__').replace(']', '__')
+            qn = QN(['__fake_mod__', name])
             fqn = self.get_FQN(qn, is_global=False)
         else:
             assert False, 'implement me'

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -190,13 +190,10 @@ class SPyVM:
             # probably we want to introduce at least
             # "modname::type::attr", or maybe even
             # "modname::namespace1::namespace2::...::attr".
-            have_suffix = w_val.qn.attr.endswith('#')
-            if have_suffix:
-                qn2 = QN(
-                    modname=w_val.qn.modname,
-                    attr=w_val.qn.attr[:-1]
-                )
-                fqn = self.get_FQN(qn2, is_global=False)
+            #
+            # XXX temporary hack for list_eq, we should kill it eventually
+            if w_val.qn.fullname == 'operator::list_eq':
+                fqn = self.get_FQN(w_val.qn, is_global=False)
             else:
                 fqn = self.get_FQN(w_val.qn, is_global=True)
         elif isinstance(w_val, W_Type):


### PR DESCRIPTION
Until now, a QN was only `modname::attr`.
This PR generalizes it, to be able to have `arbitrarily::nested::namespaces`, and also `names<with, qualifiers>`.
