### PR TITLE
Rename @spytype into @builtin_type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ tmp/
 tmp_*
 all.sh
 comp.sh
+basic.sh
 
 examples/jsffi/demo.c
 examples/jsffi/demo.mjs

--- a/spy/compiler.py
+++ b/spy/compiler.py
@@ -6,7 +6,7 @@ from spy.cbuild import get_toolchain
 from spy.vm.vm import SPyVM
 from spy.vm.module import W_Module
 from spy.vm.function import W_ASTFunc
-from spy.vm.object import W_I32
+from spy.vm.primitive import W_I32
 from spy.util import highlight_C_maybe
 
 DUMP_WASM = False

--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -2,7 +2,7 @@ import pytest
 from spy.fqn import QN
 from spy.vm.primitive import W_I32, W_Void
 from spy.vm.b import B
-from spy.vm.object import spytype, Member, Annotated
+from spy.vm.object import builtin_type, Member, Annotated
 from spy.vm.builtin import builtin_func
 from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str
 from spy.vm.opimpl import W_OpImpl, W_OpArg

--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -2,8 +2,8 @@ import pytest
 from spy.fqn import QN
 from spy.vm.primitive import W_I32, W_Void
 from spy.vm.b import B
-from spy.vm.object import builtin_type, Member, Annotated
-from spy.vm.builtin import builtin_func
+from spy.vm.object import Member, Annotated
+from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.registry import ModuleRegistry

--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -1,9 +1,10 @@
 import pytest
 from spy.fqn import QN
+from spy.vm.primitive import W_Void
 from spy.vm.b import B
 from spy.vm.object import spytype, Member, Annotated
 from spy.vm.builtin import builtin_func
-from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_I32, W_Void
+from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_I32
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM

--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -1,10 +1,10 @@
 import pytest
 from spy.fqn import QN
-from spy.vm.primitive import W_Void
+from spy.vm.primitive import W_I32, W_Void
 from spy.vm.b import B
 from spy.vm.object import spytype, Member, Annotated
 from spy.vm.builtin import builtin_func
-from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_I32
+from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM

--- a/spy/tests/compiler/test_operator_attr.py
+++ b/spy/tests/compiler/test_operator_attr.py
@@ -2,7 +2,7 @@ import pytest
 from spy.fqn import QN
 from spy.vm.primitive import W_I32, W_Void
 from spy.vm.b import B
-from spy.vm.object import spytype, Member, Annotated
+from spy.vm.object import builtin_type, Member, Annotated
 from spy.vm.builtin import builtin_func
 from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str
 from spy.vm.opimpl import W_OpImpl, W_OpArg

--- a/spy/tests/compiler/test_operator_attr.py
+++ b/spy/tests/compiler/test_operator_attr.py
@@ -2,8 +2,8 @@ import pytest
 from spy.fqn import QN
 from spy.vm.primitive import W_I32, W_Void
 from spy.vm.b import B
-from spy.vm.object import builtin_type, Member, Annotated
-from spy.vm.builtin import builtin_func
+from spy.vm.object import Member, Annotated
+from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.registry import ModuleRegistry

--- a/spy/tests/compiler/test_operator_attr.py
+++ b/spy/tests/compiler/test_operator_attr.py
@@ -1,9 +1,10 @@
 import pytest
 from spy.fqn import QN
+from spy.vm.primitive import W_Void
 from spy.vm.b import B
 from spy.vm.object import spytype, Member, Annotated
 from spy.vm.builtin import builtin_func
-from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_I32, W_Void
+from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_I32
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM

--- a/spy/tests/compiler/test_operator_attr.py
+++ b/spy/tests/compiler/test_operator_attr.py
@@ -1,10 +1,10 @@
 import pytest
 from spy.fqn import QN
-from spy.vm.primitive import W_Void
+from spy.vm.primitive import W_I32, W_Void
 from spy.vm.b import B
 from spy.vm.object import spytype, Member, Annotated
 from spy.vm.builtin import builtin_func
-from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_I32
+from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -1,10 +1,10 @@
 import pytest
 from spy.fqn import QN
-from spy.vm.primitive import W_Void
+from spy.vm.primitive import W_I32, W_Void
 from spy.vm.b import B
 from spy.vm.object import spytype, Member, Annotated
 from spy.vm.builtin import builtin_func
-from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_I32, W_List
+from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_List
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -2,7 +2,7 @@ import pytest
 from spy.fqn import QN
 from spy.vm.primitive import W_I32, W_Void
 from spy.vm.b import B
-from spy.vm.object import spytype, Member, Annotated
+from spy.vm.object import builtin_type, Member, Annotated
 from spy.vm.builtin import builtin_func
 from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_List
 from spy.vm.opimpl import W_OpImpl, W_OpArg

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -2,8 +2,8 @@ import pytest
 from spy.fqn import QN
 from spy.vm.primitive import W_I32, W_Void
 from spy.vm.b import B
-from spy.vm.object import builtin_type, Member, Annotated
-from spy.vm.builtin import builtin_func
+from spy.vm.object import Member, Annotated
+from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_List
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.registry import ModuleRegistry

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -1,9 +1,10 @@
 import pytest
 from spy.fqn import QN
+from spy.vm.primitive import W_Void
 from spy.vm.b import B
 from spy.vm.object import spytype, Member, Annotated
 from spy.vm.builtin import builtin_func
-from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_I32, W_Void, W_List
+from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_I32, W_List
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM

--- a/spy/tests/vm/test_builtin.py
+++ b/spy/tests/vm/test_builtin.py
@@ -1,6 +1,7 @@
 import pytest
+from spy.vm.primitive import W_I32
 from spy.vm.vm import SPyVM
-from spy.vm.w import W_FuncType, W_I32, W_BuiltinFunc, W_Dynamic, W_Str
+from spy.vm.w import W_FuncType, W_BuiltinFunc, W_Dynamic, W_Str
 from spy.vm.b import B
 from spy.fqn import QN
 from spy.vm.builtin import builtin_func, functype_from_sig

--- a/spy/tests/vm/test_function.py
+++ b/spy/tests/vm/test_function.py
@@ -1,7 +1,8 @@
 import pytest
+from spy.vm.primitive import W_I32
 from spy.vm.vm import SPyVM
 from spy.vm.b import B
-from spy.vm.w import W_FuncType, W_I32
+from spy.vm.w import W_FuncType
 
 class TestFunction:
 

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -1,11 +1,12 @@
 import fixedint
 import pytest
+from spy.vm.builtin import builtin_type
 from spy.vm.primitive import W_I32, W_Bool, W_Void
 from spy.vm.vm import SPyVM
 from spy.vm.b import B
 from spy.fqn import QN, FQN
 from spy.errors import SPyTypeError
-from spy.vm.object import W_Object, W_Type, builtin_type
+from spy.vm.object import W_Object, W_Type
 from spy.vm.str import W_Str
 from spy.vm.function import W_BuiltinFunc
 from spy.vm.module import W_Module

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -1,11 +1,11 @@
 import fixedint
 import pytest
-from spy.vm.primitive import W_Void
+from spy.vm.primitive import W_I32, W_Bool, W_Void
 from spy.vm.vm import SPyVM
 from spy.vm.b import B
 from spy.fqn import QN, FQN
 from spy.errors import SPyTypeError
-from spy.vm.object import W_Object, W_Type, spytype, W_I32, W_Bool
+from spy.vm.object import W_Object, W_Type, spytype
 from spy.vm.str import W_Str
 from spy.vm.function import W_BuiltinFunc
 from spy.vm.module import W_Module

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -5,7 +5,7 @@ from spy.vm.vm import SPyVM
 from spy.vm.b import B
 from spy.fqn import QN, FQN
 from spy.errors import SPyTypeError
-from spy.vm.object import W_Object, W_Type, spytype
+from spy.vm.object import W_Object, W_Type, builtin_type
 from spy.vm.str import W_Str
 from spy.vm.function import W_BuiltinFunc
 from spy.vm.module import W_Module
@@ -53,7 +53,7 @@ class TestVM:
         assert repr(B.w_dynamic) == "<spy type 'dynamic'>"
 
     def test_spytype_decorator(self):
-        @spytype('foo')
+        @builtin_type('foo')
         class W_Foo(W_Object):
             pass
         #
@@ -62,11 +62,11 @@ class TestVM:
         assert W_Foo._w.pyclass is W_Foo
 
     def test_w_base(self):
-        @spytype('A')
+        @builtin_type('A')
         class W_A(W_Object):
             pass
         #
-        @spytype('B')
+        @builtin_type('B')
         class W_B(W_A):
             pass
         #
@@ -76,11 +76,11 @@ class TestVM:
         assert W_B._w.w_base is W_A._w
 
     def test_issubclass(self):
-        @spytype('A')
+        @builtin_type('A')
         class W_A(W_Object):
             pass
         #
-        @spytype('B')
+        @builtin_type('B')
         class W_B(W_A):
             pass
         #
@@ -96,15 +96,15 @@ class TestVM:
         assert not vm.issubclass(w_a, w_b)
 
     def test_union_type(self):
-        @spytype('A')
+        @builtin_type('A')
         class W_A(W_Object):
             pass
         #
-        @spytype('B')
+        @builtin_type('B')
         class W_B(W_A):
             pass
         #
-        @spytype('C')
+        @builtin_type('C')
         class W_C(W_A):
             pass
         vm = SPyVM()

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -1,10 +1,11 @@
 import fixedint
 import pytest
+from spy.vm.primitive import W_Void
 from spy.vm.vm import SPyVM
 from spy.vm.b import B
 from spy.fqn import QN, FQN
 from spy.errors import SPyTypeError
-from spy.vm.object import W_Object, W_Type, spytype, W_Void, W_I32, W_Bool
+from spy.vm.object import W_Object, W_Type, spytype, W_I32, W_Bool
 from spy.vm.str import W_Str
 from spy.vm.function import W_BuiltinFunc
 from spy.vm.module import W_Module

--- a/spy/vm/b.py
+++ b/spy/vm/b.py
@@ -15,8 +15,9 @@ This strange setup is needed to avoid circular imports, since B.* is needed
 all over the place and we need to import it very early.
 """
 
+from spy.vm.primitive import W_Void
 from spy.vm.registry import ModuleRegistry
-from spy.vm.object import (W_Object, W_Type, w_DynamicType, W_Void, W_I32,
+from spy.vm.object import (W_Object, W_Type, w_DynamicType, W_I32,
                            W_F64, W_Bool, W_NotImplementedType)
 from spy.vm.str import W_Str
 from spy.vm.list import W_List

--- a/spy/vm/b.py
+++ b/spy/vm/b.py
@@ -15,10 +15,9 @@ This strange setup is needed to avoid circular imports, since B.* is needed
 all over the place and we need to import it very early.
 """
 
-from spy.vm.primitive import W_Void
+from spy.vm.primitive import W_F64, W_I32, W_Bool, W_NotImplementedType, W_Void
 from spy.vm.registry import ModuleRegistry
-from spy.vm.object import (W_Object, W_Type, w_DynamicType, W_I32,
-                           W_F64, W_Bool, W_NotImplementedType)
+from spy.vm.object import (W_Object, W_Type, w_DynamicType)
 from spy.vm.str import W_Str
 from spy.vm.list import W_List
 from spy.vm.tuple import W_Tuple

--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -10,7 +10,8 @@ import inspect
 from typing import TYPE_CHECKING, Any, Callable
 from spy.fqn import QN
 from spy.ast import Color
-from spy.vm.object import W_Object, W_Type, W_Dynamic, w_DynamicType, W_Void
+from spy.vm.primitive import W_Void
+from spy.vm.object import W_Object, W_Type, W_Dynamic, w_DynamicType
 from spy.vm.function import FuncParam, W_FuncType, W_BuiltinFunc
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM

--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -7,11 +7,12 @@ vm/modules/builtins.py.
 """
 
 import inspect
-from typing import TYPE_CHECKING, Any, Callable
+import typing
+from typing import TYPE_CHECKING, Any, Callable, Type
 from spy.fqn import QN
 from spy.ast import Color
 from spy.vm.primitive import W_Void
-from spy.vm.object import W_Object, W_Type, W_Dynamic, w_DynamicType
+from spy.vm.object import W_Object, W_Type, W_Dynamic, _get_member_maybe, make_metaclass, w_DynamicType
 from spy.vm.function import FuncParam, W_FuncType, W_BuiltinFunc
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -88,4 +89,28 @@ def builtin_func(qn: QN, color: Color = 'red') -> Callable:
         assert fn.__name__.startswith('w_')
         w_functype = functype_from_sig(fn, color)
         return W_BuiltinFunc(w_functype, qn, fn)
+    return decorator
+
+
+def builtin_type(name: str) -> Any:
+    """
+    Class decorator to simplify the creation of SPy types.
+
+    Given a W_* class, it automatically creates the corresponding instance of
+    W_Type and attaches it to the W_* class.
+    """
+    def decorator(pyclass: Type[W_Object]) -> Type[W_Object]:
+        W_MetaClass = make_metaclass(name, pyclass)
+
+        pyclass._w = W_MetaClass(name, pyclass)
+        # setup __spy_members__
+        pyclass.__spy_members__ = {}
+        for field, t in pyclass.__annotations__.items():
+            member = _get_member_maybe(t)
+            if member is not None:
+                member.field = field
+                member.w_type = typing.get_args(t)[0]._w
+                pyclass.__spy_members__[member.name] = member
+
+        return pyclass
     return decorator

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -3,7 +3,8 @@ from typing import TYPE_CHECKING, Any, Optional, Callable, Sequence
 from spy import ast
 from spy.ast import Color
 from spy.fqn import QN
-from spy.vm.object import W_Object, W_Type, W_Void
+from spy.vm.primitive import W_Void
+from spy.vm.object import W_Object, W_Type
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
     from spy.vm.list import W_List

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -2,8 +2,8 @@ from typing import (TYPE_CHECKING, Any, no_type_check, Optional, Type, ClassVar,
                     TypeVar, Generic)
 from spy.fqn import QN
 from spy.vm.primitive import W_I32, W_Bool, W_Void
-from spy.vm.object import (W_Object, builtin_type, W_Type, W_Dynamic)
-from spy.vm.builtin import builtin_func
+from spy.vm.object import (W_Object, W_Type, W_Dynamic)
+from spy.vm.builtin import builtin_func, builtin_type
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
     from spy.vm.opimpl import W_OpImpl, W_OpArg

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -2,7 +2,7 @@ from typing import (TYPE_CHECKING, Any, no_type_check, Optional, Type, ClassVar,
                     TypeVar, Generic)
 from spy.fqn import QN
 from spy.vm.primitive import W_I32, W_Bool, W_Void
-from spy.vm.object import (W_Object, spytype, W_Type, W_Dynamic)
+from spy.vm.object import (W_Object, builtin_type, W_Type, W_Dynamic)
 from spy.vm.builtin import builtin_func
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -40,7 +40,7 @@ class Meta_W_List(type):
 
 T = TypeVar('T', bound='W_Object')
 
-@spytype('list')
+@builtin_type('list')
 class W_List(W_Object, Generic[T], metaclass=Meta_W_List):
     """
     The 'list' type.
@@ -110,7 +110,7 @@ def _make_W_List(w_T: W_Type) -> Type[W_List]:
     app_name = f'list[{w_T.name}]'        # e.g. list[i32]
     interp_name = f'W_List[{T.__name__}]' # e.g. W_List[W_I32]
 
-    @spytype(app_name)
+    @builtin_type(app_name)
     class W_MyList(W_List):
         items_w: list[W_Object]
 

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -1,8 +1,8 @@
 from typing import (TYPE_CHECKING, Any, no_type_check, Optional, Type, ClassVar,
                     TypeVar, Generic)
 from spy.fqn import QN
-from spy.vm.primitive import W_Void
-from spy.vm.object import (W_Object, spytype, W_Type, W_Dynamic, W_I32, W_Bool)
+from spy.vm.primitive import W_I32, W_Bool, W_Void
+from spy.vm.object import (W_Object, spytype, W_Type, W_Dynamic)
 from spy.vm.builtin import builtin_func
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -1,8 +1,8 @@
 from typing import (TYPE_CHECKING, Any, no_type_check, Optional, Type, ClassVar,
                     TypeVar, Generic)
 from spy.fqn import QN
-from spy.vm.object import (W_Object, spytype, W_Type, W_Dynamic, W_I32, W_Void,
-                           W_Bool)
+from spy.vm.primitive import W_Void
+from spy.vm.object import (W_Object, spytype, W_Type, W_Dynamic, W_I32, W_Bool)
 from spy.vm.builtin import builtin_func
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Optional, Iterable
 from spy.fqn import QN, FQN
 from spy.vm.primitive import W_Void
 from spy.vm.b import B
-from spy.vm.object import W_Object, spytype, W_Type, W_Dynamic
+from spy.vm.object import W_Object, builtin_type, W_Type, W_Dynamic
 from spy.vm.str import W_Str
 from spy.vm.function import W_ASTFunc
 from spy.vm.builtin import builtin_func
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 
-@spytype('module')
+@builtin_type('module')
 class W_Module(W_Object):
     vm: 'SPyVM'
     name: str

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -1,7 +1,8 @@
 from typing import TYPE_CHECKING, Optional, Iterable
 from spy.fqn import QN, FQN
+from spy.vm.primitive import W_Void
 from spy.vm.b import B
-from spy.vm.object import W_Object, spytype, W_Type, W_Dynamic, W_Void
+from spy.vm.object import W_Object, spytype, W_Type, W_Dynamic
 from spy.vm.str import W_Str
 from spy.vm.function import W_ASTFunc
 from spy.vm.builtin import builtin_func

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -2,10 +2,10 @@ from typing import TYPE_CHECKING, Optional, Iterable
 from spy.fqn import QN, FQN
 from spy.vm.primitive import W_Void
 from spy.vm.b import B
-from spy.vm.object import W_Object, builtin_type, W_Type, W_Dynamic
+from spy.vm.object import W_Object, W_Type, W_Dynamic
 from spy.vm.str import W_Str
 from spy.vm.function import W_ASTFunc
-from spy.vm.builtin import builtin_func
+from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 
 if TYPE_CHECKING:

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -5,7 +5,8 @@ The first half is in vm/b.py. See its docstring for more details.
 """
 
 from typing import TYPE_CHECKING, Any
-from spy.vm.object import (W_I32, W_F64, W_Bool, W_Dynamic, W_Void, W_Object,
+from spy.vm.primitive import W_Void
+from spy.vm.object import (W_I32, W_F64, W_Bool, W_Dynamic, W_Object,
                            W_Type)
 from spy.vm.str import W_Str
 from spy.vm.b import BUILTINS, B

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -5,8 +5,8 @@ The first half is in vm/b.py. See its docstring for more details.
 """
 
 from typing import TYPE_CHECKING, Any
-from spy.vm.primitive import W_Void
-from spy.vm.object import (W_I32, W_F64, W_Bool, W_Dynamic, W_Object,
+from spy.vm.primitive import W_F64, W_I32, W_Bool, W_Void
+from spy.vm.object import (W_Dynamic, W_Object,
                            W_Type)
 from spy.vm.str import W_Str
 from spy.vm.b import BUILTINS, B

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -1,9 +1,10 @@
 from typing import TYPE_CHECKING
 import struct
 from spy.fqn import QN
+from spy.vm.primitive import W_Void
 from spy.vm.b import B
 from spy.vm.object import spytype, Member, Annotated
-from spy.vm.w import (W_Func, W_Type, W_Object, W_I32, W_F64, W_Void, W_Str,
+from spy.vm.w import (W_Func, W_Type, W_Object, W_I32, W_F64, W_Str,
                       W_Dynamic, W_List, W_FuncType)
 from spy.vm.list import W_List
 from spy.vm.opimpl import W_OpImpl, W_OpArg

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -1,10 +1,10 @@
 from typing import TYPE_CHECKING
 import struct
 from spy.fqn import QN
-from spy.vm.primitive import W_Void
+from spy.vm.primitive import W_F64, W_I32, W_Void
 from spy.vm.b import B
 from spy.vm.object import spytype, Member, Annotated
-from spy.vm.w import (W_Func, W_Type, W_Object, W_I32, W_F64, W_Str,
+from spy.vm.w import (W_Func, W_Type, W_Object, W_Str,
                       W_Dynamic, W_List, W_FuncType)
 from spy.vm.list import W_List
 from spy.vm.opimpl import W_OpImpl, W_OpArg

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -3,7 +3,7 @@ import struct
 from spy.fqn import QN
 from spy.vm.primitive import W_F64, W_I32, W_Void
 from spy.vm.b import B
-from spy.vm.object import spytype, Member, Annotated
+from spy.vm.object import builtin_type, Member, Annotated
 from spy.vm.w import (W_Func, W_Type, W_Object, W_Str,
                       W_Dynamic, W_List, W_FuncType)
 from spy.vm.list import W_List

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -3,12 +3,12 @@ import struct
 from spy.fqn import QN
 from spy.vm.primitive import W_F64, W_I32, W_Void
 from spy.vm.b import B
-from spy.vm.object import builtin_type, Member, Annotated
+from spy.vm.object import Member, Annotated
 from spy.vm.w import (W_Func, W_Type, W_Object, W_Str,
                       W_Dynamic, W_List, W_FuncType)
 from spy.vm.list import W_List
 from spy.vm.opimpl import W_OpImpl, W_OpArg
-from spy.vm.builtin import builtin_func
+from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.registry import ModuleRegistry
 from spy.vm.modules.types import W_TypeDef
 

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -1,7 +1,8 @@
 from typing import TYPE_CHECKING, Literal, no_type_check
 from spy.fqn import QN
+from spy.vm.primitive import W_Void
 from spy.vm.b import B
-from spy.vm.object import W_Object, W_Type, W_Dynamic, W_Void
+from spy.vm.object import W_Object, W_Type, W_Dynamic
 from spy.vm.module import W_Module
 from spy.vm.str import W_Str
 from spy.vm.function import W_Func

--- a/spy/vm/modules/operator/opimpl_f64.py
+++ b/spy/vm/modules/operator/opimpl_f64.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Any
 from spy.vm.b import B
-from spy.vm.object import W_Object, W_Type, W_F64, W_Bool
+from spy.vm.object import W_Object, W_Type
+from spy.vm.primitive import W_F64, W_Bool
 from . import OP
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM

--- a/spy/vm/modules/operator/opimpl_i32.py
+++ b/spy/vm/modules/operator/opimpl_i32.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Any
 from spy.vm.b import B
-from spy.vm.object import W_Object, W_Type, W_I32, W_Bool
+from spy.vm.object import W_Object, W_Type
+from spy.vm.primitive import W_I32, W_Bool
 from . import OP
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM

--- a/spy/vm/modules/operator/opimpl_object.py
+++ b/spy/vm/modules/operator/opimpl_object.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Any
 from spy.vm.b import B
-from spy.vm.object import W_Object, W_Bool
+from spy.vm.object import W_Object
+from spy.vm.primitive import W_Bool
 from . import OP
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM

--- a/spy/vm/modules/operator/opimpl_str.py
+++ b/spy/vm/modules/operator/opimpl_str.py
@@ -1,7 +1,8 @@
 from typing import TYPE_CHECKING
 from spy.vm.b import B
+from spy.vm.primitive import W_I32
 from spy.vm.str import W_Str
-from spy.vm.object import W_I32, W_Bool
+from spy.vm.primitive import W_Bool
 from . import OP
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM

--- a/spy/vm/modules/rawbuffer.py
+++ b/spy/vm/modules/rawbuffer.py
@@ -4,9 +4,10 @@ SPy `rawbuffer` module.
 
 from typing import TYPE_CHECKING
 import struct
+from spy.vm.primitive import W_Void
 from spy.vm.b import B
 from spy.vm.object import spytype
-from spy.vm.w import W_Func, W_Type, W_Object, W_I32, W_F64, W_Void, W_Str
+from spy.vm.w import W_Func, W_Type, W_Object, W_I32, W_F64, W_Str
 from spy.vm.registry import ModuleRegistry
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM

--- a/spy/vm/modules/rawbuffer.py
+++ b/spy/vm/modules/rawbuffer.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import struct
 from spy.vm.primitive import W_F64, W_I32, W_Void
 from spy.vm.b import B
-from spy.vm.object import spytype
+from spy.vm.object import builtin_type
 from spy.vm.w import W_Func, W_Type, W_Object, W_Str
 from spy.vm.registry import ModuleRegistry
 if TYPE_CHECKING:

--- a/spy/vm/modules/rawbuffer.py
+++ b/spy/vm/modules/rawbuffer.py
@@ -4,10 +4,10 @@ SPy `rawbuffer` module.
 
 from typing import TYPE_CHECKING
 import struct
-from spy.vm.primitive import W_Void
+from spy.vm.primitive import W_F64, W_I32, W_Void
 from spy.vm.b import B
 from spy.vm.object import spytype
-from spy.vm.w import W_Func, W_Type, W_Object, W_I32, W_F64, W_Str
+from spy.vm.w import W_Func, W_Type, W_Object, W_Str
 from spy.vm.registry import ModuleRegistry
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM

--- a/spy/vm/modules/rawbuffer.py
+++ b/spy/vm/modules/rawbuffer.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import struct
 from spy.vm.primitive import W_F64, W_I32, W_Void
 from spy.vm.b import B
-from spy.vm.object import builtin_type
+from spy.vm.builtin import builtin_type
 from spy.vm.w import W_Func, W_Type, W_Object, W_Str
 from spy.vm.registry import ModuleRegistry
 if TYPE_CHECKING:

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Annotated
 from spy.vm.primitive import W_Void
 from spy.vm.module import W_Module
 from spy.vm.b import B
-from spy.vm.object import W_Type, W_Object, spytype, W_Dynamic, Member
+from spy.vm.object import W_Type, W_Object, builtin_type, W_Dynamic, Member
 from spy.vm.str import W_Str
 from spy.vm.function import W_Func
 from spy.vm.opimpl import W_OpImpl

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -3,10 +3,11 @@ SPy `types` module.
 """
 
 from typing import TYPE_CHECKING, Annotated
+from spy.vm.builtin import builtin_type
 from spy.vm.primitive import W_Void
 from spy.vm.module import W_Module
 from spy.vm.b import B
-from spy.vm.object import W_Type, W_Object, builtin_type, W_Dynamic, Member
+from spy.vm.object import W_Type, W_Object, W_Dynamic, Member
 from spy.vm.str import W_Str
 from spy.vm.function import W_Func
 from spy.vm.opimpl import W_OpImpl

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -3,9 +3,10 @@ SPy `types` module.
 """
 
 from typing import TYPE_CHECKING, Annotated
+from spy.vm.primitive import W_Void
 from spy.vm.module import W_Module
 from spy.vm.b import B
-from spy.vm.object import W_Type, W_Object, spytype, W_Dynamic, W_Void, Member
+from spy.vm.object import W_Type, W_Object, spytype, W_Dynamic, Member
 from spy.vm.str import W_Str
 from spy.vm.function import W_Func
 from spy.vm.opimpl import W_OpImpl

--- a/spy/vm/modules/unsafe/__init__.py
+++ b/spy/vm/modules/unsafe/__init__.py
@@ -1,8 +1,9 @@
 from typing import TYPE_CHECKING
 import fixedint
+from spy.vm.primitive import W_Void
 from spy.vm.b import B
 from spy.vm.object import spytype
-from spy.vm.w import W_Object, W_I32, W_Type, W_Void
+from spy.vm.w import W_Object, W_I32, W_Type
 from spy.vm.registry import ModuleRegistry
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 if TYPE_CHECKING:

--- a/spy/vm/modules/unsafe/__init__.py
+++ b/spy/vm/modules/unsafe/__init__.py
@@ -1,9 +1,9 @@
 from typing import TYPE_CHECKING
 import fixedint
-from spy.vm.primitive import W_Void
+from spy.vm.primitive import W_I32, W_Void
 from spy.vm.b import B
 from spy.vm.object import spytype
-from spy.vm.w import W_Object, W_I32, W_Type
+from spy.vm.w import W_Object, W_Type
 from spy.vm.registry import ModuleRegistry
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 if TYPE_CHECKING:

--- a/spy/vm/modules/unsafe/__init__.py
+++ b/spy/vm/modules/unsafe/__init__.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 import fixedint
 from spy.vm.primitive import W_I32, W_Void
 from spy.vm.b import B
-from spy.vm.object import builtin_type
+from spy.vm.builtin import builtin_type
 from spy.vm.w import W_Object, W_Type
 from spy.vm.registry import ModuleRegistry
 from spy.vm.opimpl import W_OpImpl, W_OpArg

--- a/spy/vm/modules/unsafe/__init__.py
+++ b/spy/vm/modules/unsafe/__init__.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 import fixedint
 from spy.vm.primitive import W_I32, W_Void
 from spy.vm.b import B
-from spy.vm.object import spytype
+from spy.vm.object import builtin_type
 from spy.vm.w import W_Object, W_Type
 from spy.vm.registry import ModuleRegistry
 from spy.vm.opimpl import W_OpImpl, W_OpArg

--- a/spy/vm/modules/unsafe/mem.py
+++ b/spy/vm/modules/unsafe/mem.py
@@ -2,7 +2,8 @@ from typing import TYPE_CHECKING, no_type_check
 import fixedint
 from spy.fqn import QN
 from spy.vm.b import B
-from spy.vm.w import W_I32, W_Func, W_Type, W_Dynamic, W_Object
+from spy.vm.primitive import W_I32
+from spy.vm.w import W_Func, W_Type, W_Dynamic, W_Object
 from spy.vm.builtin import builtin_func
 from . import UNSAFE
 from .ptr import W_Ptr, w_make_ptr_type, hack_hack_fix_typename

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -2,10 +2,10 @@ from typing import TYPE_CHECKING, ClassVar, Optional, no_type_check
 import fixedint
 from spy.errors import SPyPanicError
 from spy.fqn import QN
-from spy.vm.primitive import W_Void
+from spy.vm.primitive import W_I32, W_Void
 from spy.vm.b import B
 from spy.vm.object import spytype
-from spy.vm.w import W_Object, W_I32, W_Type, W_Str, W_Dynamic, W_Func
+from spy.vm.w import W_Object, W_Type, W_Str, W_Dynamic, W_Func
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.builtin import builtin_func
 from . import UNSAFE

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -2,9 +2,10 @@ from typing import TYPE_CHECKING, ClassVar, Optional, no_type_check
 import fixedint
 from spy.errors import SPyPanicError
 from spy.fqn import QN
+from spy.vm.primitive import W_Void
 from spy.vm.b import B
 from spy.vm.object import spytype
-from spy.vm.w import W_Object, W_I32, W_Type, W_Void, W_Str, W_Dynamic, W_Func
+from spy.vm.w import W_Object, W_I32, W_Type, W_Str, W_Dynamic, W_Func
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.builtin import builtin_func
 from . import UNSAFE

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -4,7 +4,7 @@ from spy.errors import SPyPanicError
 from spy.fqn import QN
 from spy.vm.primitive import W_I32, W_Void
 from spy.vm.b import B
-from spy.vm.object import builtin_type
+from spy.vm.builtin import builtin_type
 from spy.vm.w import W_Object, W_Type, W_Str, W_Dynamic, W_Func
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.builtin import builtin_func

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -4,7 +4,7 @@ from spy.errors import SPyPanicError
 from spy.fqn import QN
 from spy.vm.primitive import W_I32, W_Void
 from spy.vm.b import B
-from spy.vm.object import spytype
+from spy.vm.object import builtin_type
 from spy.vm.w import W_Object, W_Type, W_Str, W_Dynamic, W_Func
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.builtin import builtin_func
@@ -59,7 +59,7 @@ def w_make_ptr_type(vm: 'SPyVM', w_T: W_Type) -> W_Object:
     interp_name = f'W_Ptr[{T.__name__}]'  # e.g. W_Ptr[W_I32]
     ITEMSIZE = sizeof(w_T)
 
-    @spytype(app_name)
+    @builtin_type(app_name)
     class W_MyPtr(W_Ptr):
         w_itemtype: ClassVar[W_Type] = w_T
 

--- a/spy/vm/modules/unsafe/struct.py
+++ b/spy/vm/modules/unsafe/struct.py
@@ -1,8 +1,9 @@
 from typing import TYPE_CHECKING, Any, no_type_check, Optional, Type, ClassVar
 from dataclasses import dataclass
 import fixedint
+from spy.vm.primitive import W_Void
 from spy.vm.b import B
-from spy.vm.object import W_Object, W_Type, W_I32, W_Void
+from spy.vm.object import W_Object, W_Type, W_I32
 from spy.vm.builtin import builtin_func
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from . import UNSAFE

--- a/spy/vm/modules/unsafe/struct.py
+++ b/spy/vm/modules/unsafe/struct.py
@@ -1,9 +1,9 @@
 from typing import TYPE_CHECKING, Any, no_type_check, Optional, Type, ClassVar
 from dataclasses import dataclass
 import fixedint
-from spy.vm.primitive import W_Void
+from spy.vm.primitive import W_I32, W_Void
 from spy.vm.b import B
-from spy.vm.object import W_Object, W_Type, W_I32
+from spy.vm.object import W_Object, W_Type
 from spy.vm.builtin import builtin_func
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from . import UNSAFE

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -49,8 +49,10 @@ import typing
 from typing import (TYPE_CHECKING, ClassVar, Type, Any, Annotated, Optional,
                     Union)
 from spy.fqn import QN
+
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
+    from spy.vm.primitive import W_Void
     from spy.vm.str import W_Str
     from spy.vm.list import W_List
     from spy.vm.opimpl import W_OpImpl, W_OpArg
@@ -192,6 +194,7 @@ class W_Type(W_Object):
     # Union[W_Type, W_Void] means "either a W_Type or B.w_None"
     @property
     def w_base(self) -> Union['W_Type', 'W_Void']:
+        from spy.vm.primitive import W_Void
         if self is W_Object._w or self is w_DynamicType:
             return W_Void._w_singleton  # this is B.w_None
         basecls = self.pyclass.__base__
@@ -413,29 +416,6 @@ def spytype(name: str) -> Any:
         return pyclass
     return decorator
 
-@spytype('void')
-class W_Void(W_Object):
-    """
-    Equivalent of Python's NoneType.
-
-    This is a singleton: there should be only one instance of this class,
-    which is w_None.
-    """
-
-    _w_singleton: ClassVar['W_Void']
-
-    def __init__(self) -> None:
-        # this is just a sanity check: we don't want people to be able to
-        # create additional instances of W_Void
-        raise Exception("You cannot instantiate W_Void")
-
-    def __repr__(self) -> str:
-        return '<spy None>'
-
-    def spy_unwrap(self, vm: 'SPyVM') -> None:
-        return None
-
-W_Void._w_singleton = W_Void.__new__(W_Void)
 
 
 @spytype('i32')

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -44,7 +44,6 @@ For simple cases, SPy app-level types are instances of W_Type, which is
 basically a thin wrapper around the correspindig interp-level W_* class.
 """
 
-import fixedint
 import typing
 from typing import (TYPE_CHECKING, ClassVar, Type, Any, Annotated, Optional,
                     Union)
@@ -415,83 +414,3 @@ def spytype(name: str) -> Any:
 
         return pyclass
     return decorator
-
-
-
-@spytype('i32')
-class W_I32(W_Object):
-    value: fixedint.Int32
-
-    def __init__(self, value: int | fixedint.Int32) -> None:
-        assert type(value) in (int, fixedint.Int32)
-        self.value = fixedint.Int32(value)
-
-    def __repr__(self) -> str:
-        return f'W_I32({self.value})'
-
-    def spy_unwrap(self, vm: 'SPyVM') -> fixedint.Int32:
-        return self.value
-
-
-@spytype('f64')
-class W_F64(W_Object):
-    value: float
-
-    def __init__(self, value: float) -> None:
-        assert type(value) is float
-        self.value = value
-
-    def __repr__(self) -> str:
-        return f'W_F64({self.value})'
-
-    def spy_unwrap(self, vm: 'SPyVM') -> float:
-        return self.value
-
-
-@spytype('bool')
-class W_Bool(W_Object):
-    value: bool
-    #
-    _w_singleton_True: ClassVar['W_Bool']
-    _w_singleton_False: ClassVar['W_Bool']
-
-    def __init__(self, value: bool) -> None:
-        # this is just a sanity check: we don't want people to be able to
-        # create additional instances of W_Bool
-        raise Exception("You cannot instantiate W_Bool. Use vm.wrap().")
-
-    @staticmethod
-    def _make_singleton(value: bool) -> 'W_Bool':
-        w_obj = W_Bool.__new__(W_Bool)
-        w_obj.value = value
-        return w_obj
-
-    def __repr__(self) -> str:
-        return f'W_Bool({self.value})'
-
-    def spy_unwrap(self, vm: 'SPyVM') -> bool:
-        return self.value
-
-    def not_(self, vm: 'SPyVM') -> 'W_Bool':
-        if self.value:
-            return W_Bool._w_singleton_False
-        else:
-            return W_Bool._w_singleton_True
-
-W_Bool._w_singleton_True = W_Bool._make_singleton(True)
-W_Bool._w_singleton_False = W_Bool._make_singleton(False)
-
-
-@spytype('NotImplementedType')
-class W_NotImplementedType(W_Object):
-    _w_singleton: ClassVar['W_NotImplementedType']
-
-    def __init__(self) -> None:
-        # this is just a sanity check: we don't want people to be able to
-        # create additional instances
-        raise Exception("You cannot instantiate W_NotImplementedType")
-
-
-W_NotImplementedType._w_singleton = (
-    W_NotImplementedType.__new__(W_NotImplementedType)
-)

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -44,7 +44,6 @@ For simple cases, SPy app-level types are instances of W_Type, which is
 basically a thin wrapper around the correspindig interp-level W_* class.
 """
 
-import typing
 from typing import (TYPE_CHECKING, ClassVar, Type, Any, Annotated, Optional,
                     Union)
 from spy.fqn import QN
@@ -392,25 +391,3 @@ def synthesize_meta_op_CALL(pyclass: Type[W_Object]) -> Any:
 
     return meta_op_CALL
 
-def builtin_type(name: str) -> Any:
-    """
-    Class decorator to simplify the creation of SPy types.
-
-    Given a W_* class, it automatically creates the corresponding instance of
-    W_Type and attaches it to the W_* class.
-    """
-    def decorator(pyclass: Type[W_Object]) -> Type[W_Object]:
-        W_MetaClass = make_metaclass(name, pyclass)
-
-        pyclass._w = W_MetaClass(name, pyclass)
-        # setup __spy_members__
-        pyclass.__spy_members__ = {}
-        for field, t in pyclass.__annotations__.items():
-            member = _get_member_maybe(t)
-            if member is not None:
-                member.field = field
-                member.w_type = typing.get_args(t)[0]._w
-                pyclass.__spy_members__[member.name] = member
-
-        return pyclass
-    return decorator

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -392,7 +392,7 @@ def synthesize_meta_op_CALL(pyclass: Type[W_Object]) -> Any:
 
     return meta_op_CALL
 
-def spytype(name: str) -> Any:
+def builtin_type(name: str) -> Any:
     """
     Class decorator to simplify the creation of SPy types.
 

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -31,9 +31,10 @@ from spy.fqn import QN
 from spy.location import Loc
 from spy.irgen.symtable import Symbol
 from spy.errors import SPyTypeError
-from spy.vm.object import Member, W_Type, W_Object, spytype, W_Bool
+from spy.vm.object import Member, W_Type, W_Object, spytype
 from spy.vm.function import W_Func, W_FuncType, W_DirectCall
 from spy.vm.builtin import builtin_func
+from spy.vm.primitive import W_Bool
 
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -31,7 +31,7 @@ from spy.fqn import QN
 from spy.location import Loc
 from spy.irgen.symtable import Symbol
 from spy.errors import SPyTypeError
-from spy.vm.object import Member, W_Type, W_Object, spytype
+from spy.vm.object import Member, W_Type, W_Object, builtin_type
 from spy.vm.function import W_Func, W_FuncType, W_DirectCall
 from spy.vm.builtin import builtin_func
 from spy.vm.primitive import W_Bool
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
 
 T = TypeVar('T')
 
-@spytype('OpArg')
+@builtin_type('OpArg')
 class W_OpArg(W_Object):
     """
     Class which represents the operands passed to OPERATORs.
@@ -184,7 +184,7 @@ def w_oparg_eq(vm: 'SPyVM', wop1: W_OpArg, wop2: W_OpArg) -> W_Bool:
 
 
 
-@spytype('OpImpl')
+@builtin_type('OpImpl')
 class W_OpImpl(W_Object):
     NULL: ClassVar['W_OpImpl']
     _w_func: Optional[W_Func]

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -31,9 +31,9 @@ from spy.fqn import QN
 from spy.location import Loc
 from spy.irgen.symtable import Symbol
 from spy.errors import SPyTypeError
-from spy.vm.object import Member, W_Type, W_Object, builtin_type
+from spy.vm.object import Member, W_Type, W_Object
 from spy.vm.function import W_Func, W_FuncType, W_DirectCall
-from spy.vm.builtin import builtin_func
+from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.primitive import W_Bool
 
 if TYPE_CHECKING:

--- a/spy/vm/primitive.py
+++ b/spy/vm/primitive.py
@@ -1,12 +1,12 @@
 from typing import ClassVar, TYPE_CHECKING
 import fixedint
-from spy.vm.object import W_Object, spytype
+from spy.vm.object import W_Object, builtin_type
 
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
 
-@spytype('void')
+@builtin_type('void')
 class W_Void(W_Object):
     """
     Equivalent of Python's NoneType.
@@ -31,7 +31,7 @@ class W_Void(W_Object):
 W_Void._w_singleton = W_Void.__new__(W_Void)
 
 
-@spytype('i32')
+@builtin_type('i32')
 class W_I32(W_Object):
     value: fixedint.Int32
 
@@ -46,7 +46,7 @@ class W_I32(W_Object):
         return self.value
 
 
-@spytype('f64')
+@builtin_type('f64')
 class W_F64(W_Object):
     value: float
 
@@ -61,7 +61,7 @@ class W_F64(W_Object):
         return self.value
 
 
-@spytype('bool')
+@builtin_type('bool')
 class W_Bool(W_Object):
     value: bool
     #
@@ -95,7 +95,7 @@ W_Bool._w_singleton_True = W_Bool._make_singleton(True)
 W_Bool._w_singleton_False = W_Bool._make_singleton(False)
 
 
-@spytype('NotImplementedType')
+@builtin_type('NotImplementedType')
 class W_NotImplementedType(W_Object):
     _w_singleton: ClassVar['W_NotImplementedType']
 

--- a/spy/vm/primitive.py
+++ b/spy/vm/primitive.py
@@ -1,11 +1,9 @@
 from typing import ClassVar, TYPE_CHECKING
+import fixedint
 from spy.vm.object import W_Object, spytype
 
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
-
-
-
 
 
 @spytype('void')
@@ -31,3 +29,81 @@ class W_Void(W_Object):
         return None
 
 W_Void._w_singleton = W_Void.__new__(W_Void)
+
+
+@spytype('i32')
+class W_I32(W_Object):
+    value: fixedint.Int32
+
+    def __init__(self, value: int | fixedint.Int32) -> None:
+        assert type(value) in (int, fixedint.Int32)
+        self.value = fixedint.Int32(value)
+
+    def __repr__(self) -> str:
+        return f'W_I32({self.value})'
+
+    def spy_unwrap(self, vm: 'SPyVM') -> fixedint.Int32:
+        return self.value
+
+
+@spytype('f64')
+class W_F64(W_Object):
+    value: float
+
+    def __init__(self, value: float) -> None:
+        assert type(value) is float
+        self.value = value
+
+    def __repr__(self) -> str:
+        return f'W_F64({self.value})'
+
+    def spy_unwrap(self, vm: 'SPyVM') -> float:
+        return self.value
+
+
+@spytype('bool')
+class W_Bool(W_Object):
+    value: bool
+    #
+    _w_singleton_True: ClassVar['W_Bool']
+    _w_singleton_False: ClassVar['W_Bool']
+
+    def __init__(self, value: bool) -> None:
+        # this is just a sanity check: we don't want people to be able to
+        # create additional instances of W_Bool
+        raise Exception("You cannot instantiate W_Bool. Use vm.wrap().")
+
+    @staticmethod
+    def _make_singleton(value: bool) -> 'W_Bool':
+        w_obj = W_Bool.__new__(W_Bool)
+        w_obj.value = value
+        return w_obj
+
+    def __repr__(self) -> str:
+        return f'W_Bool({self.value})'
+
+    def spy_unwrap(self, vm: 'SPyVM') -> bool:
+        return self.value
+
+    def not_(self, vm: 'SPyVM') -> 'W_Bool':
+        if self.value:
+            return W_Bool._w_singleton_False
+        else:
+            return W_Bool._w_singleton_True
+
+W_Bool._w_singleton_True = W_Bool._make_singleton(True)
+W_Bool._w_singleton_False = W_Bool._make_singleton(False)
+
+
+@spytype('NotImplementedType')
+class W_NotImplementedType(W_Object):
+    _w_singleton: ClassVar['W_NotImplementedType']
+
+    def __init__(self) -> None:
+        # this is just a sanity check: we don't want people to be able to
+        # create additional instances
+        raise Exception("You cannot instantiate W_NotImplementedType")
+
+W_NotImplementedType._w_singleton = (
+    W_NotImplementedType.__new__(W_NotImplementedType)
+)

--- a/spy/vm/primitive.py
+++ b/spy/vm/primitive.py
@@ -1,0 +1,33 @@
+from typing import ClassVar, TYPE_CHECKING
+from spy.vm.object import W_Object, spytype
+
+if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
+
+
+
+
+
+@spytype('void')
+class W_Void(W_Object):
+    """
+    Equivalent of Python's NoneType.
+
+    This is a singleton: there should be only one instance of this class,
+    which is w_None.
+    """
+
+    _w_singleton: ClassVar['W_Void']
+
+    def __init__(self) -> None:
+        # this is just a sanity check: we don't want people to be able to
+        # create additional instances of W_Void
+        raise Exception("You cannot instantiate W_Void")
+
+    def __repr__(self) -> str:
+        return '<spy None>'
+
+    def spy_unwrap(self, vm: 'SPyVM') -> None:
+        return None
+
+W_Void._w_singleton = W_Void.__new__(W_Void)

--- a/spy/vm/primitive.py
+++ b/spy/vm/primitive.py
@@ -1,12 +1,14 @@
 from typing import ClassVar, TYPE_CHECKING
 import fixedint
-from spy.vm.object import W_Object, builtin_type
+from spy.vm.object import W_Object
 
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
+# NOTE: we apply @builtin_type later, at the end of the file, to avoid circular
+# imports
 
-@builtin_type('void')
+
 class W_Void(W_Object):
     """
     Equivalent of Python's NoneType.
@@ -31,7 +33,6 @@ class W_Void(W_Object):
 W_Void._w_singleton = W_Void.__new__(W_Void)
 
 
-@builtin_type('i32')
 class W_I32(W_Object):
     value: fixedint.Int32
 
@@ -46,7 +47,6 @@ class W_I32(W_Object):
         return self.value
 
 
-@builtin_type('f64')
 class W_F64(W_Object):
     value: float
 
@@ -61,7 +61,6 @@ class W_F64(W_Object):
         return self.value
 
 
-@builtin_type('bool')
 class W_Bool(W_Object):
     value: bool
     #
@@ -95,7 +94,6 @@ W_Bool._w_singleton_True = W_Bool._make_singleton(True)
 W_Bool._w_singleton_False = W_Bool._make_singleton(False)
 
 
-@builtin_type('NotImplementedType')
 class W_NotImplementedType(W_Object):
     _w_singleton: ClassVar['W_NotImplementedType']
 
@@ -107,3 +105,13 @@ class W_NotImplementedType(W_Object):
 W_NotImplementedType._w_singleton = (
     W_NotImplementedType.__new__(W_NotImplementedType)
 )
+
+
+# manually apply @builtin_type to all the classes above. This is done here
+# to avoid circular imports between object.py, builtin.py and primitive.py
+from spy.vm.builtin import builtin_type
+builtin_type('void')(W_Void)
+builtin_type('i32')(W_I32)
+builtin_type('f64')(W_F64)
+builtin_type('bool')(W_Bool)
+builtin_type('NotImplementedType')(W_NotImplementedType)

--- a/spy/vm/registry.py
+++ b/spy/vm/registry.py
@@ -4,7 +4,7 @@ from spy.ast import Color
 from spy.fqn import QN
 from spy.vm.function import W_FuncType, W_BuiltinFunc
 from spy.vm.builtin import builtin_func
-from spy.vm.object import W_Object, spytype
+from spy.vm.object import W_Object, builtin_type
 
 class ModuleRegistry:
     """
@@ -58,7 +58,7 @@ class ModuleRegistry:
             MOD.add('Foo', W_Foo._w)
         """
         def decorator(pyclass: Type[W_Object]) -> Type[W_Object]:
-            W_class = spytype(name)(pyclass)
+            W_class = builtin_type(name)(pyclass)
             self.add(name, W_class._w)
             return W_class
         return decorator

--- a/spy/vm/registry.py
+++ b/spy/vm/registry.py
@@ -3,8 +3,8 @@ from dataclasses import dataclass
 from spy.ast import Color
 from spy.fqn import QN
 from spy.vm.function import W_FuncType, W_BuiltinFunc
-from spy.vm.builtin import builtin_func
-from spy.vm.object import W_Object, builtin_type
+from spy.vm.builtin import builtin_func, builtin_type
+from spy.vm.object import W_Object
 
 class ModuleRegistry:
     """

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -1,10 +1,11 @@
 from typing import TYPE_CHECKING, Any
 from spy.llwasm import LLWasmInstance
 from spy.fqn import QN
-from spy.vm.object import W_Object, W_Type, W_Dynamic, spytype, W_I32
+from spy.vm.object import W_Object, W_Type, W_Dynamic, spytype
 from spy.vm.builtin import builtin_func
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.list import W_List
+from spy.vm.primitive import W_I32
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -1,8 +1,8 @@
 from typing import TYPE_CHECKING, Any
 from spy.llwasm import LLWasmInstance
 from spy.fqn import QN
-from spy.vm.object import W_Object, W_Type, W_Dynamic, builtin_type
-from spy.vm.builtin import builtin_func
+from spy.vm.object import W_Object, W_Type, W_Dynamic
+from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.list import W_List
 from spy.vm.primitive import W_I32

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any
 from spy.llwasm import LLWasmInstance
 from spy.fqn import QN
-from spy.vm.object import W_Object, W_Type, W_Dynamic, spytype
+from spy.vm.object import W_Object, W_Type, W_Dynamic, builtin_type
 from spy.vm.builtin import builtin_func
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.list import W_List
@@ -26,7 +26,7 @@ def ll_spy_Str_new(ll: LLWasmInstance, s: str) -> int:
 
 
 
-@spytype('str')
+@builtin_type('str')
 class W_Str(W_Object):
     """
     An unicode string, internally represented as UTF-8.

--- a/spy/vm/tuple.py
+++ b/spy/vm/tuple.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any, no_type_check, Optional
 from spy.fqn import QN
-from spy.vm.object import (W_Object, spytype, W_Type, W_Dynamic, W_I32, W_Void,
-                           W_Bool)
+from spy.vm.primitive import W_Void
+from spy.vm.object import (W_Object, spytype, W_Type, W_Dynamic, W_I32, W_Bool)
 from spy.vm.builtin import builtin_func
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 if TYPE_CHECKING:

--- a/spy/vm/tuple.py
+++ b/spy/vm/tuple.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any, no_type_check, Optional
 from spy.fqn import QN
-from spy.vm.primitive import W_Void
-from spy.vm.object import (W_Object, spytype, W_Type, W_Dynamic, W_I32, W_Bool)
+from spy.vm.primitive import W_I32, W_Bool, W_Void
+from spy.vm.object import (W_Object, spytype, W_Type, W_Dynamic)
 from spy.vm.builtin import builtin_func
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 if TYPE_CHECKING:

--- a/spy/vm/tuple.py
+++ b/spy/vm/tuple.py
@@ -1,13 +1,13 @@
 from typing import TYPE_CHECKING, Any, no_type_check, Optional
 from spy.fqn import QN
 from spy.vm.primitive import W_I32, W_Bool, W_Void
-from spy.vm.object import (W_Object, spytype, W_Type, W_Dynamic)
+from spy.vm.object import (W_Object, builtin_type, W_Type, W_Dynamic)
 from spy.vm.builtin import builtin_func
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
-@spytype('tuple')
+@builtin_type('tuple')
 class W_Tuple(W_Object):
     """
     This is not the "real" tuple type that we will have in SPy.

--- a/spy/vm/tuple.py
+++ b/spy/vm/tuple.py
@@ -1,8 +1,8 @@
 from typing import TYPE_CHECKING, Any, no_type_check, Optional
 from spy.fqn import QN
 from spy.vm.primitive import W_I32, W_Bool, W_Void
-from spy.vm.object import (W_Object, builtin_type, W_Type, W_Dynamic)
-from spy.vm.builtin import builtin_func
+from spy.vm.object import (W_Object, W_Type, W_Dynamic)
+from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -9,7 +9,8 @@ from spy.location import Loc
 from spy import libspy
 from spy.doppler import redshift
 from spy.errors import SPyTypeError
-from spy.vm.object import W_Object, W_Type, W_I32, W_F64, W_Bool, W_Dynamic
+from spy.vm.object import W_Object, W_Type, W_Dynamic
+from spy.vm.primitive import W_F64, W_I32, W_Bool
 from spy.vm.str import W_Str
 from spy.vm.b import B
 from spy.vm.function import W_FuncType, W_Func, W_ASTFunc, W_BuiltinFunc

--- a/spy/vm/w.py
+++ b/spy/vm/w.py
@@ -4,9 +4,9 @@ This is just to make it easier to import all the various W_* classes
 
 from spy.vm.primitive import W_F64, W_I32, W_Bool, W_Void
 from spy.vm.function import W_Func, W_FuncType, W_ASTFunc, W_BuiltinFunc
-from spy.vm.builtin import builtin_func
+from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.module import W_Module
-from spy.vm.object import (W_Object, W_Type, W_Dynamic, builtin_type)
+from spy.vm.object import (W_Object, W_Type, W_Dynamic)
 from spy.vm.str import W_Str
 from spy.vm.list import W_List
 from spy.vm.opimpl import W_OpImpl

--- a/spy/vm/w.py
+++ b/spy/vm/w.py
@@ -2,11 +2,11 @@
 This is just to make it easier to import all the various W_* classes
 """
 
-from spy.vm.primitive import W_Void
+from spy.vm.primitive import W_F64, W_I32, W_Bool, W_Void
 from spy.vm.function import W_Func, W_FuncType, W_ASTFunc, W_BuiltinFunc
 from spy.vm.builtin import builtin_func
 from spy.vm.module import W_Module
-from spy.vm.object import (W_Bool, W_F64, W_I32, W_Object, W_Type, W_Dynamic, spytype)
+from spy.vm.object import (W_Object, W_Type, W_Dynamic, spytype)
 from spy.vm.str import W_Str
 from spy.vm.list import W_List
 from spy.vm.opimpl import W_OpImpl

--- a/spy/vm/w.py
+++ b/spy/vm/w.py
@@ -2,11 +2,11 @@
 This is just to make it easier to import all the various W_* classes
 """
 
+from spy.vm.primitive import W_Void
 from spy.vm.function import W_Func, W_FuncType, W_ASTFunc, W_BuiltinFunc
 from spy.vm.builtin import builtin_func
 from spy.vm.module import W_Module
-from spy.vm.object import (W_Bool, W_F64, W_I32, W_Object, W_Type, W_Void,
-                           W_Dynamic, spytype)
+from spy.vm.object import (W_Bool, W_F64, W_I32, W_Object, W_Type, W_Dynamic, spytype)
 from spy.vm.str import W_Str
 from spy.vm.list import W_List
 from spy.vm.opimpl import W_OpImpl

--- a/spy/vm/w.py
+++ b/spy/vm/w.py
@@ -6,7 +6,7 @@ from spy.vm.primitive import W_F64, W_I32, W_Bool, W_Void
 from spy.vm.function import W_Func, W_FuncType, W_ASTFunc, W_BuiltinFunc
 from spy.vm.builtin import builtin_func
 from spy.vm.module import W_Module
-from spy.vm.object import (W_Object, W_Type, W_Dynamic, spytype)
+from spy.vm.object import (W_Object, W_Type, W_Dynamic, builtin_type)
 from spy.vm.str import W_Str
 from spy.vm.list import W_List
 from spy.vm.opimpl import W_OpImpl


### PR DESCRIPTION
For consistency with @builtin_func.
Moreover, move `W_Void`, `W_I32`, `W_F64`, `W_Bool` and `W_NotImplementedType` into `primitive.py`.