### PR TITLE
Make it possible to create new types inside closures

### DIFF
--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -104,6 +104,14 @@ class SPyBackend:
             for stmt in funcdef.body:
                 self.emit_stmt(stmt)
 
+    def emit_stmt_ClassDef(self, classdef: ast.ClassDef) -> None:
+        assert classdef.is_struct, 'IMPLEMENT ME'
+        name = classdef.name
+        self.wl(f'class {name}(struct):')
+        with self.out.indent():
+            for field in classdef.fields:
+                self.emit_stmt_VarDef(field)
+
     def emit_stmt_Pass(self, stmt: ast.Pass) -> None:
         self.wl('pass')
 

--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -87,17 +87,14 @@ class ModuleGen:
             err = SPyTypeError("the __INIT__ function must be @blue")
             err.add("error", "function defined here", funcdef.prototype_loc)
             raise err
+        # NOTE: executing the FuncDef automatically add the new w_func to the
+        # globals
         frame.exec_stmt_FuncDef(funcdef)
-        w_func = frame.load_local(funcdef.name)
-        assert isinstance(w_func, W_ASTFunc)
-        self.vm.add_global(w_func.fqn, w_func)
 
     def gen_ClassDef(self, frame: ASTFrame, classdef: ast.ClassDef) -> None:
+        # NOTE: executing the ClassDef automatically add the new w_type to the
+        # globals
         frame.exec_stmt_ClassDef(classdef)
-        w_class = frame.load_local(classdef.name)
-        assert isinstance(w_class, W_Type)
-        fqn = FQN([self.modname, classdef.name])
-        self.vm.add_global(fqn, w_class)
 
     def gen_GlobalVarDef(self, frame: ASTFrame, decl: ast.GlobalVarDef) -> None:
         vardef = decl.vardef

--- a/spy/tests/compiler/test_unsafe.py
+++ b/spy/tests/compiler/test_unsafe.py
@@ -166,6 +166,35 @@ class TestUnsafe(CompilerTest):
         """)
         assert mod.foo(2) == 3
 
+    def test_generic_struct(self):
+        mod = self.compile("""
+        from unsafe import gc_alloc, ptr
+
+        @blue
+        def make_Point(T):
+            class Point(struct):
+                x: T
+                y: T
+            return Point
+
+        Point_i32 = make_Point(i32)
+        Point_f64 = make_Point(f64)
+
+        def foo() -> i32:
+            p: ptr[Point_i32] = gc_alloc(Point_i32)(1)
+            p.x = 1
+            p.y = 2
+            return p.x + p.y
+
+        def bar() -> f64:
+            p: ptr[Point_f64] = gc_alloc(Point_f64)(1)
+            p.x = 1.1
+            p.y = 2.2
+            return p.x + p.y
+        """)
+        assert mod.foo() == 3
+        assert mod.bar() == 3.3
+
     @pytest.mark.xfail(reason='implement W_Dynamic.op_GETATTR')
     def test_ptr_NULL(self):
         mod = self.compile("""

--- a/spy/tests/compiler/test_unsafe.py
+++ b/spy/tests/compiler/test_unsafe.py
@@ -188,12 +188,12 @@ class TestUnsafe(CompilerTest):
 
         def bar() -> f64:
             p: ptr[Point_f64] = gc_alloc(Point_f64)(1)
-            p.x = 1.1
-            p.y = 2.2
+            p.x = 1.2
+            p.y = 3.4
             return p.x + p.y
         """)
         assert mod.foo() == 3
-        assert mod.bar() == 3.3
+        assert mod.bar() == 4.6
 
     @pytest.mark.xfail(reason='implement W_Dynamic.op_GETATTR')
     def test_ptr_NULL(self):

--- a/spy/tests/test_backend_spy.py
+++ b/spy/tests/test_backend_spy.py
@@ -200,6 +200,16 @@ class TestSPyBackend(CompilerTest):
         self.compile(src)
         self.assert_dump(expected)
 
+    def test_classdef(self):
+        src = """
+        def foo() -> void:
+            class Point(struct):
+                x: i32
+                y: i32
+        """
+        self.compile(src)
+        self.assert_dump(src)
+
     def test_zz_sanity_check(self):
         """
         This is a hack.

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -141,6 +141,7 @@ class ASTFrame:
         assert classdef.is_struct, 'only structs are supported for now'
         fqn = self.w_func.fqn.join(classdef.name)
         w_struct_type = make_struct_type(self.vm, fqn, d)
+        self.t.lazy_check_ClassDef(classdef, w_struct_type)
         self.store_local(classdef.name, w_struct_type)
 
     def exec_stmt_VarDef(self, vardef: ast.VarDef) -> None:

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -6,6 +6,7 @@ from spy.location import Loc
 from spy.errors import (SPyRuntimeAbort, SPyTypeError, SPyNameError,
                         SPyRuntimeError, maybe_plural)
 from spy.irgen.symtable import Symbol, Color
+from spy.fqn import FQN
 from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type
 from spy.vm.function import W_Func, W_FuncType, W_ASTFunc, Namespace
@@ -42,6 +43,22 @@ class ASTFrame:
 
     def __repr__(self) -> str:
         return f'<ASTFrame for {self.w_func.fqn}>'
+
+    @property
+    def is_module_body(self):
+        return self.w_func.fqn.is_module()
+
+    def get_unique_FQN_maybe(self, fqn: FQN) -> FQN:
+        """
+        Return an unique FQN to use for a type or function.
+
+        If we are executing a module body, we can assume that the FQN is
+        already unique and just return it, else we ask the VM to compute one.
+        """
+        if self.is_module_body:
+            return fqn
+        else:
+            return self.vm.get_unique_FQN(fqn)
 
     def store_local(self, name: str, w_value: W_Object) -> None:
         self._locals[name] = w_value
@@ -127,10 +144,12 @@ class ASTFrame:
         #
         # create the w_func
         fqn = self.w_func.fqn.join(funcdef.name)
+        fqn = self.get_unique_FQN_maybe(fqn)
         # XXX we should capture only the names actually used in the inner func
         closure = self.w_func.closure + (self._locals,)
         w_func = W_ASTFunc(w_functype, fqn, funcdef, closure)
         self.store_local(funcdef.name, w_func)
+        self.vm.add_global(fqn, w_func)
 
     def exec_stmt_ClassDef(self, classdef: ast.ClassDef) -> None:
         d = {}
@@ -140,9 +159,11 @@ class ASTFrame:
         #
         assert classdef.is_struct, 'only structs are supported for now'
         fqn = self.w_func.fqn.join(classdef.name)
+        fqn = self.get_unique_FQN_maybe(fqn)
         w_struct_type = make_struct_type(self.vm, fqn, d)
         self.t.lazy_check_ClassDef(classdef, w_struct_type)
         self.store_local(classdef.name, w_struct_type)
+        self.vm.add_global(fqn, w_struct_type)
 
     def exec_stmt_VarDef(self, vardef: ast.VarDef) -> None:
         w_type = self.eval_expr_type(vardef.type)

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -197,6 +197,18 @@ class TypeChecker:
         """
         self.declare_local(funcdef.name, w_type)
 
+    def check_stmt_ClassDef(self, classdef: ast.ClassDef) -> None:
+        """
+        See check_stmt_VarDef
+        """
+
+    def lazy_check_ClassDef(self, classdef: ast.ClassDef,
+                            w_type: W_Type) -> None:
+        """
+        See check_stmt_ClassDef and lazy_check_ClassDef
+        """
+        self.declare_local(classdef.name, w_type)
+
     def check_stmt_StmtExpr(self, stmt: ast.StmtExpr) -> None:
         pass
 

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -144,10 +144,11 @@ class SPyVM:
 
         # no FQN yet, we need to assign it one.
         if isinstance(w_val, W_ASTFunc):
-            # it's a closure, let's assign it an FQN and add to the globals
-            fqn = self.get_unique_FQN(w_val.fqn)
+            assert False, ("W_ASTFunc should be automatically be added to the "
+                           "globals by ASTFrame.exec_stmt_FuncDef")
         elif isinstance(w_val, W_BuiltinFunc):
-            # builtin functions should have an unique fqn already
+            # the fqn of builtin functions should be unique, else it's a fault
+            # of whoever declared it.
             fqn = w_val.fqn
             assert w_val.fqn not in self.globals_w
         elif isinstance(w_val, W_Type):


### PR DESCRIPTION
This PR makes it possible to write code like this:
```
@blue
def make_Point(T):
    class Point(struct):
        x: T
        y: T
    return Point
```

To do so, we had to teach the TypeChecker about `ClassDef`, and to refactor the way FQNs are computed for types.

In particular, we cannot compute the unique FQN lazily inside `vm.make_const`, because at that point it's too late: the FQN might have already been used e.g. to create the FQN of a pointer. The solution is to assign an unique FQN as soon as a new type is created.

For symmetry, we do the same also for `FuncDef`s. 