### PR TITLE
Improve performance of the SPy interpreter by 20x

### DIFF
--- a/examples/vector.spy
+++ b/examples/vector.spy
@@ -2,67 +2,103 @@
 
 from unsafe import gc_alloc, ptr
 
-@blue
-def play_with_vector(T):
+class Vector(struct):
+    capacity: i32
+    length: i32
+    items: ptr[i32]
 
-    class Vector(struct):
-        capacity: i32
-        length: i32
-        items: ptr[i32]
 
-    def vector_new(capacity: i32) -> ptr[Vector]:
-        v: ptr[Vector] = gc_alloc(Vector)(1)
-        v.capacity = capacity
-        v.length = 0
-        v.items = gc_alloc(i32)(capacity)
-        return v
+# available operations:
+#     arr: ptr[i32] = gc_alloc(i32)(5)  # allocates an array of 5 i32
+#     arr[0]     # read item 0 of the array
+#     arr[0] = x # write item 0
+#     v = gc_alloc(Vector)(1)   # allocate a new Vector
+#     v.capacity  # read the field "capacity" of the Vector "v"
 
-    def vector_append(v: ptr[Vector], item: i32) -> void:
-        if v.length >= v.capacity:
-            new_capacity = v.capacity * 2
-            new_items: ptr[i32] = gc_alloc(i32)(new_capacity)
-            i = 0
-            while i < v.length:
-                new_items[i] = v.items[i]
-                i = i+1
-            v.items = new_items
-            v.capacity = new_capacity
-        v.items[v.length] = item
-        v.length = v.length+1
+def vector_new(capacity: i32) -> ptr[Vector]:
+    v: ptr[Vector] = gc_alloc(Vector)(1)
+    v.capacity = capacity
+    v.length = 0
+    v.items = gc_alloc(i32)(capacity)
+    return v
 
-    def vector_get(v: ptr[Vector], index: i32) -> i32:
-        if index < 0:
-            print("Index out of bounds")
-        if index >= v.length:
-            print("Index out of bounds")
-        return v.items[index]
-
-    def vector_set(v: ptr[Vector], index: i32, item: i32) -> void:
-        if index < 0:
-            print("Index out of bounds")
-
-        if index >= v.length:
-            print("Index out of bounds")
-        v.items[index] = item
-
-    def vector_len(v: ptr[Vector]) -> i32:
-        return v.length
-
-    def vector_print(v: ptr[Vector]) -> void:
+def vector_append(v: ptr[Vector], item: i32) -> void:
+    if v.length >= v.capacity:
+        new_capacity = v.capacity * 2
+        new_items: ptr[i32] = gc_alloc(i32)(new_capacity)
         i = 0
         while i < v.length:
-            print(v.items[i])
+            new_items[i] = v.items[i]
             i = i+1
+        v.items = new_items
+        v.capacity = new_capacity
+    v.items[v.length] = item
+    v.length = v.length+1
 
-    def play(n: i32) -> void:
-        v = vector_new(n)
-        i = 0
-        while i < n:
-            vector_append(v, i*i)
-            i = i+1
-        vector_print(v)
+def vector_get(v: ptr[Vector], index: i32) -> i32:
+    if index < 0:
+        print("Index out of bounds")
+    if index >= v.length:
+        print("Index out of bounds")
+    return v.items[index]
 
-    return play
+def vector_set(v: ptr[Vector], index: i32, item: i32) -> void:
+    if index < 0:
+        print("Index out of bounds")
+
+    if index >= v.length:
+        print("Index out of bounds")
+    v.items[index] = item
+
+def vector_len(v: ptr[Vector]) -> i32:
+    return v.length
+
+def vector_print(v: ptr[Vector]) -> void:
+    i = 0
+    while i < v.length:
+        print(v.items[i])
+        i = i+1
+
+def test_vector() -> void:
+    v = vector_new(2)
+    if vector_len(v) != 0:
+        print("Test failed: Initial length should be 0")
+
+    vector_append(v, 10)
+    if vector_len(v) != 1:
+        print("Test failed: Length should be 1 after one append")
+    if vector_get(v, 0) != 10:
+        print("Test failed: First item should be 10")
+
+    vector_append(v, 20)
+    if vector_len(v) != 2:
+        print("Test failed: Length should be 2 after two appends")
+    if vector_get(v, 1) != 20:
+        print("Test failed: Second item should be 20")
+
+    vector_append(v, 30)
+    if vector_len(v) != 3:
+        print("Test failed: Length should be 3 after three appends")
+    if vector_get(v, 2) != 30:
+        print("Test failed: Third item should be 30")
+
+    vector_set(v, 1, 25)
+    if vector_get(v, 1) != 25:
+        print("Test failed: Second item should be 25 after set")
+
+    #vector_get(v, 5) # PANIC
+
+    print("All tests completed")
+
+
+def test_squares(n: i32) -> void:
+    v = vector_new(n)
+    i = 0
+    while i < n:
+        vector_append(v, i*i)
+        i = i+1
+    vector_print(v)
 
 def main() -> void:
-    play_with_vector(i32)(10)
+    #test_vector()
+    test_squares(100)

--- a/spy/__main__.py
+++ b/spy/__main__.py
@@ -1,5 +1,7 @@
+import sys
 from typing import Annotated, Any, no_type_check
 from pathlib import Path
+import time
 import typer
 import py.path
 from spy.magic_py_parse import magic_py_parse
@@ -51,10 +53,11 @@ def main(filename: Path,
              names=['--toolchain', '-t']
          ) = "zig",
          pretty: boolopt("prettify redshifted modules") = True,
+         timeit: boolopt("print execution time") = False,
          ) -> None:
     try:
         do_main(filename, run, pyparse, parse, redshift, cwrite, g, O,
-                release_mode, toolchain, pretty)
+                release_mode, toolchain, pretty, timeit)
     except SPyError as e:
         print(e.format(use_colors=True))
         #import pdb;pdb.xpm()
@@ -66,7 +69,8 @@ def do_main(filename: Path, run: bool, pyparse: bool, parse: bool,
             opt_level: int,
             release_mode: bool,
             toolchain: ToolchainType,
-            pretty: bool) -> None:
+            pretty: bool,
+            timeit: bool) -> None:
     if pyparse:
         do_pyparse(str(filename))
         return
@@ -91,8 +95,13 @@ def do_main(filename: Path, run: bool, pyparse: bool, parse: bool,
             return
         vm.typecheck(w_main, w_main_functype)
         assert isinstance(w_main, W_Func)
+        a = time.time()
         w_res = vm.call(w_main, [])
+        b = time.time()
+        if timeit:
+            print(f'main(): {b - a:.3f} seconds', file=sys.stderr)
         assert w_res is B.w_None
+
         return
 
     vm.redshift()

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -70,11 +70,16 @@ class CModuleWriter:
         #    define SPY_LINE(SPY, C) SPY "{self.spyfile}"
         #endif
 
-        // global declarations and definitions
         """)
         self.out_warnings = self.out.make_nested_builder()
+        self.out.wl()
+        self.out.wl('// forward type declarations')
         self.out_types_decl = self.out.make_nested_builder()
+        self.out.wl()
+        self.out.wl('// type definitions')
         self.out_types_def = self.out.make_nested_builder()
+        self.out.wl()
+        self.out.wl('// constants and functions')
         self.out_globals = self.out.make_nested_builder()
         self.out.wl()
 

--- a/spy/location.py
+++ b/spy/location.py
@@ -1,4 +1,4 @@
-import inspect
+import sys
 import dataclasses
 from dataclasses import dataclass
 
@@ -22,12 +22,15 @@ class Loc:
         By default, level=-1 means "caller's frame".
         level=-2 is "caller of the caller", etc.
         """
+        # don't use inspect.stack(), it's horribly slow. Better to get
+        # the frames directly. Using inspect.stack() makes the SPy
+        # interpreter ~20x slower
         assert level < 0
-        f = inspect.stack()[-level]
+        f = sys._getframe(-level)
         return cls(
-            filename = f.filename,
-            line_start = f.lineno,
-            line_end = f.lineno,
+            filename = f.f_code.co_filename,
+            line_start = f.f_lineno,
+            line_end = f.f_lineno,
             col_start = 0,
             col_end = -1 # whole line
         )


### PR DESCRIPTION
commit 0683517 introduced `Location.here`, which helps to include interp-level functions into diagnostics.

However, it turns out that using `inspect.stack()` is unbearably slow.
`Location.here()` is called continuously, every time we create a `W_OpArg` from interp-level code.

By using directly `sys._getframe` we can speedup `examples/vector.spy` by 20x 😱