### PR TITLE
Refactor builtins

### DIFF
--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -1,9 +1,10 @@
+from typing import Annotated
 import pytest
-from spy.vm.primitive import W_I32, W_Void
+from spy.vm.primitive import W_I32, W_Dynamic, W_Void
 from spy.vm.b import B
-from spy.vm.object import Member, Annotated
+from spy.vm.object import Member
 from spy.vm.builtin import builtin_func, builtin_type
-from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str
+from spy.vm.w import W_Type, W_Object, W_Str
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM

--- a/spy/tests/compiler/test_operator_attr.py
+++ b/spy/tests/compiler/test_operator_attr.py
@@ -1,9 +1,10 @@
+from typing import Annotated
 import pytest
-from spy.vm.primitive import W_I32, W_Void
+from spy.vm.primitive import W_I32, W_Dynamic, W_Void
 from spy.vm.b import B
-from spy.vm.object import Member, Annotated
+from spy.vm.object import Member
 from spy.vm.builtin import builtin_func, builtin_type
-from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str
+from spy.vm.w import W_Type, W_Object, W_Str
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -1,9 +1,10 @@
+from typing import Annotated
 import pytest
-from spy.vm.primitive import W_I32, W_Void
+from spy.vm.primitive import W_I32, W_Dynamic, W_Void
 from spy.vm.b import B
-from spy.vm.object import Member, Annotated
+from spy.vm.object import Member
 from spy.vm.builtin import builtin_func, builtin_type
-from spy.vm.w import W_Type, W_Object, W_Dynamic, W_Str, W_List
+from spy.vm.w import W_Type, W_Object, W_Str, W_List
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM

--- a/spy/tests/vm/test_builtin.py
+++ b/spy/tests/vm/test_builtin.py
@@ -1,9 +1,9 @@
 import pytest
 from typing import Annotated
 from spy.vm.object import W_Object
-from spy.vm.primitive import W_I32
+from spy.vm.primitive import W_I32, W_Dynamic
 from spy.vm.vm import SPyVM
-from spy.vm.w import W_FuncType, W_BuiltinFunc, W_Dynamic, W_Str
+from spy.vm.w import W_FuncType, W_BuiltinFunc, W_Str
 from spy.vm.b import B
 from spy.fqn import FQN
 from spy.vm.builtin import builtin_func, functype_from_sig

--- a/spy/tests/vm/test_builtin.py
+++ b/spy/tests/vm/test_builtin.py
@@ -1,4 +1,6 @@
 import pytest
+from typing import Annotated
+from spy.vm.object import W_Object
 from spy.vm.primitive import W_I32
 from spy.vm.vm import SPyVM
 from spy.vm.w import W_FuncType, W_BuiltinFunc, W_Dynamic, W_Str
@@ -40,12 +42,16 @@ class TestBuiltin:
             def w_foo(w_x: W_I32) -> W_I32:  # type: ignore
                 pass
 
-        with pytest.raises(ValueError, match="Invalid param: 'x: int'"):
+        with pytest.raises(
+                ValueError,
+                match="Invalid @builtin_func annotation: <class 'int'>"):
             @builtin_func('mymod')
             def w_foo(vm: 'SPyVM', x: int) -> W_I32:  # type: ignore
                 pass
 
-        with pytest.raises(ValueError, match="Invalid return type"):
+        with pytest.raises(
+                ValueError,
+                match="Invalid @builtin_func annotation: <class 'int'>"):
             @builtin_func('mymod')
             def w_foo(vm: 'SPyVM') -> int:  # type: ignore
                 pass

--- a/spy/tests/vm/test_builtin.py
+++ b/spy/tests/vm/test_builtin.py
@@ -16,6 +16,13 @@ class TestBuiltin:
         w_functype = functype_from_sig(foo, 'red')
         assert w_functype == W_FuncType.parse('def(x: i32) -> str')
 
+    def test_annotated_type(self):
+        W_MyType = Annotated[W_Object, B.w_i32]
+        def foo(vm: 'SPyVM', w_x: W_MyType) -> None:
+            pass
+        w_functype = functype_from_sig(foo, 'red')
+        assert w_functype == W_FuncType.parse('def(x: i32) -> void')
+
     def test_builtin_func(self):
         vm = SPyVM()
 

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -197,7 +197,6 @@ class TestVM:
     def test_call_function_TypeError(self):
         vm = SPyVM()
         w_abs = B.w_abs
-        #import pdb;pdb.set_trace()
         w_x = vm.wrap('hello')
         msg = 'Invalid cast. Expected `i32`, got `str`'
         with pytest.raises(SPyTypeError, match=msg):

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -71,8 +71,7 @@ class TestVM:
         class W_B(W_A):
             pass
         #
-        w_None = W_Void._w_singleton
-        assert W_Object._w.w_base is w_None
+        assert W_Object._w.w_base is B.w_None
         assert W_A._w.w_base is W_Object._w
         assert W_B._w.w_base is W_A._w
 

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -1,6 +1,5 @@
 import fixedint
 import pytest
-from spy.vm.builtin import builtin_type
 from spy.vm.primitive import W_I32, W_Bool, W_Void
 from spy.vm.vm import SPyVM
 from spy.vm.b import B
@@ -10,6 +9,7 @@ from spy.vm.object import W_Object, W_Type
 from spy.vm.str import W_Str
 from spy.vm.function import W_BuiltinFunc
 from spy.vm.module import W_Module
+from spy.vm.builtin import builtin_type
 from spy.tests.support import expect_errors
 
 class TestVM:
@@ -198,6 +198,7 @@ class TestVM:
     def test_call_function_TypeError(self):
         vm = SPyVM()
         w_abs = B.w_abs
+        #import pdb;pdb.set_trace()
         w_x = vm.wrap('hello')
         msg = 'Invalid cast. Expected `i32`, got `str`'
         with pytest.raises(SPyTypeError, match=msg):

--- a/spy/vm/b.py
+++ b/spy/vm/b.py
@@ -15,28 +15,12 @@ This strange setup is needed to avoid circular imports, since B.* is needed
 all over the place and we need to import it very early.
 """
 
-from spy.vm.primitive import W_F64, W_I32, W_Bool, W_NotImplementedType, W_Void
 from spy.vm.registry import ModuleRegistry
 from spy.vm.object import (W_Object, W_Type, w_DynamicType)
-from spy.vm.str import W_Str
-from spy.vm.list import W_List
-from spy.vm.tuple import W_Tuple
-
 
 BUILTINS = ModuleRegistry('builtins')
 B = BUILTINS
 
 B.add('object', W_Object._w)
 B.add('type', W_Type._w)
-B.add('void', W_Void._w)
 B.add('dynamic', w_DynamicType)
-B.add('i32', W_I32._w)
-B.add('f64', W_F64._w)
-B.add('bool', W_Bool._w)
-B.add('str', W_Str._w)
-B.add('list', W_List._w)
-B.add('tuple', W_Tuple._w)
-B.add('None', W_Void._w_singleton)
-B.add('True', W_Bool._w_singleton_True)
-B.add('False', W_Bool._w_singleton_False)
-B.add('NotImplemented', W_NotImplementedType._w_singleton)

--- a/spy/vm/b.py
+++ b/spy/vm/b.py
@@ -1,12 +1,11 @@
 """
 First half of the `builtins` module.
 
-This contains the definition of the BUILTINS registry, and registers the
-"basic" builtins, i.e., all the primitive types and constants which are used
-everywhere.
+This contains the empty definition of the BUILTINS registry. Additionally, it
+also contains an alias B, because it's shorter to type than BUILTINS
 
-Additionally, it also contains an alias B, because it's shorter to type than
-BUILTINS
+Many of the fundamental types are registered using @B.builtin_type and @B.add
+inside vm/object.py, vm/primitive.py, etc.
 
 The rest of the builtins are registered in vm/modules/builtins.py, which is
 the proper place where to put modules.
@@ -16,11 +15,6 @@ all over the place and we need to import it very early.
 """
 
 from spy.vm.registry import ModuleRegistry
-from spy.vm.object import (W_Object, W_Type, w_DynamicType)
 
 BUILTINS = ModuleRegistry('builtins')
 B = BUILTINS
-
-B.add('object', W_Object._w)
-B.add('type', W_Type._w)
-B.add('dynamic', w_DynamicType)

--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -7,12 +7,11 @@ vm/modules/builtins.py.
 """
 
 import inspect
-import typing
 from typing import TYPE_CHECKING, Any, Callable, Type, Optional
 from spy.fqn import FQN, QUALIFIERS
 from spy.ast import Color
 from spy.vm.primitive import W_Void
-from spy.vm.object import W_Object, W_Type, W_Dynamic, _get_member_maybe, make_metaclass, w_DynamicType
+from spy.vm.object import W_Object, W_Type, W_Dynamic, make_metaclass, w_DynamicType
 from spy.vm.function import FuncParam, W_FuncType, W_BuiltinFunc
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -132,14 +131,5 @@ def builtin_type(namespace: FQN|str,
         W_MetaClass = make_metaclass(fqn, pyclass)
         pyclass.type_fqn = fqn
         pyclass._w = W_MetaClass(fqn, pyclass)
-        # setup __spy_members__
-        pyclass.__spy_members__ = {}
-        for field, t in pyclass.__annotations__.items():
-            member = _get_member_maybe(t)
-            if member is not None:
-                member.field = field
-                member.w_type = typing.get_args(t)[0]._w
-                pyclass.__spy_members__[member.name] = member
-
         return pyclass
     return decorator

--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -10,7 +10,6 @@ import inspect
 from typing import TYPE_CHECKING, Any, Callable, Type, Optional
 from spy.fqn import FQN, QUALIFIERS
 from spy.ast import Color
-from spy.vm.primitive import W_Void
 from spy.vm.object import W_Object, W_Type, W_Dynamic, make_metaclass, w_DynamicType
 from spy.vm.function import FuncParam, W_FuncType, W_BuiltinFunc
 if TYPE_CHECKING:
@@ -39,9 +38,7 @@ def to_spy_FuncParam(p: Any) -> FuncParam:
 
 
 def functype_from_sig(fn: Callable, color: Color) -> W_FuncType:
-    # we cannot import spy.vm.b due to circular imports, fake it
-    B_w_Void = W_Void._w
-    B_w_dynamic = w_DynamicType
+    from spy.vm.b import B
 
     sig = inspect.signature(fn)
     params = list(sig.parameters.values())
@@ -56,9 +53,9 @@ def functype_from_sig(fn: Callable, color: Color) -> W_FuncType:
     func_params = [to_spy_FuncParam(p) for p in params[1:]]
     ret = sig.return_annotation
     if ret is None:
-        w_restype = B_w_Void
+        w_restype = B.w_void
     elif ret is W_Dynamic:
-        w_restype = B_w_dynamic
+        w_restype = B.w_dynamic
     elif is_W_class(ret):
         w_restype = ret._w
     else:

--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -11,7 +11,7 @@ from typing import (TYPE_CHECKING, Any, Callable, Type, Optional, get_origin,
                     Annotated)
 from spy.fqn import FQN, QUALIFIERS
 from spy.ast import Color
-from spy.vm.object import W_Object, W_Type, W_Dynamic, make_metaclass
+from spy.vm.object import W_Object, W_Type, make_metaclass
 from spy.vm.function import FuncParam, W_FuncType, W_BuiltinFunc
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -38,8 +38,6 @@ def to_spy_type(ann: Any, *, allow_None=False) -> W_Type:
     from spy.vm.b import B
     if allow_None and ann is None:
         return B.w_void
-    elif ann is W_Dynamic:
-        return B.w_dynamic
     elif is_W_class(ann):
         return ann._w
     elif w_t := get_spy_type_annotation(ann):

--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -26,7 +26,7 @@ def get_spy_type_annotation(ann: Any) -> Optional[W_Type]:
                 return x
     return None
 
-def to_spy_type(ann: Any, *, allow_None=False) -> W_Type:
+def to_spy_type(ann: Any, *, allow_None: bool = False) -> W_Type:
     """
     Convert an interp-level annotation into a spy type.
     Examples:

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Any, Optional, Callable, Sequence
 from spy import ast
 from spy.ast import Color
 from spy.fqn import FQN, NSPart
-#from spy.vm.primitive import W_Void
 from spy.vm.object import W_Object, W_Type
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -230,10 +230,8 @@ class W_BuiltinFunc(W_Func):
         return f"<spy function '{self.fqn}' (builtin)>"
 
     def spy_call(self, vm: 'SPyVM', args_w: Sequence[W_Object]) -> W_Object:
-        # we cannot import B due to circular imports, let's fake it
-        from spy.vm.primitive import W_Void #XXX
-        B_w_Void = W_Void._w
+        from spy.vm.b import B
         w_res = self._pyfunc(vm, *args_w)
-        if w_res is None and self.w_functype.w_restype is B_w_Void:
+        if w_res is None and self.w_functype.w_restype is B.w_void:
             return vm.wrap(None)
         return w_res

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, Optional, Callable, Sequence
 from spy import ast
 from spy.ast import Color
 from spy.fqn import FQN, NSPart
-from spy.vm.primitive import W_Void
+#from spy.vm.primitive import W_Void
 from spy.vm.object import W_Object, W_Type
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -231,6 +231,7 @@ class W_BuiltinFunc(W_Func):
 
     def spy_call(self, vm: 'SPyVM', args_w: Sequence[W_Object]) -> W_Object:
         # we cannot import B due to circular imports, let's fake it
+        from spy.vm.primitive import W_Void #XXX
         B_w_Void = W_Void._w
         w_res = self._pyfunc(vm, *args_w)
         if w_res is None and self.w_functype.w_restype is B_w_Void:

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -40,7 +40,7 @@ class Meta_W_List(type):
 
 T = TypeVar('T', bound='W_Object')
 
-@builtin_type('builtins', 'list')
+@B.builtin_type('list')
 class W_List(W_Object, Generic[T], metaclass=Meta_W_List):
     """
     The 'list' type.
@@ -180,7 +180,3 @@ def _make_W_List(w_T: W_Type) -> Type[W_List]:
 
     W_MyList.__name__ = W_MyList.__qualname__
     return W_MyList
-
-
-
-B.add('list', W_List._w)

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -1,5 +1,6 @@
 from typing import (TYPE_CHECKING, Any, no_type_check, Optional, Type, ClassVar,
                     TypeVar, Generic)
+from spy.vm.b import B
 from spy.vm.primitive import W_I32, W_Bool, W_Void
 from spy.vm.object import (W_Object, W_Type, W_Dynamic)
 from spy.vm.builtin import builtin_func, builtin_type
@@ -179,3 +180,7 @@ def _make_W_List(w_T: W_Type) -> Type[W_List]:
 
     W_MyList.__name__ = W_MyList.__qualname__
     return W_MyList
+
+
+
+B.add('list', W_List._w)

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -1,5 +1,5 @@
-from typing import (TYPE_CHECKING, Any, no_type_check, Optional, Type, ClassVar,
-                    TypeVar, Generic)
+from typing import (TYPE_CHECKING, Any, Optional, Type, ClassVar,
+                    TypeVar, Generic, Annotated)
 from spy.vm.b import B
 from spy.vm.primitive import W_I32, W_Bool, W_Dynamic, W_Void
 from spy.vm.object import (W_Object, W_Type)
@@ -109,11 +109,11 @@ def _make_W_List(w_T: W_Type) -> Type[W_List]:
     """
     from spy.vm.opimpl import W_OpImpl
 
-    T = w_T.pyclass
+    T = Annotated[W_Object, w_T]
 
     @builtin_type('builtins', 'list', [w_T.fqn])
     class W_MyList(W_List):
-        __qualname__ = f'W_List[{T.__name__}]' # e.g. W_List[W_I32]
+        __qualname__ = f'W_List[{w_T.pyclass.__name__}]' # e.g. W_List[W_I32]
         items_w: list[W_Object]
 
         def __init__(self, items_w: list[W_Object]) -> None:
@@ -130,7 +130,6 @@ def _make_W_List(w_T: W_Type) -> Type[W_List]:
         @staticmethod
         def op_GETITEM(vm: 'SPyVM', wop_obj: 'W_OpArg',
                        wop_i: 'W_OpArg') -> W_OpImpl:
-            @no_type_check
             @builtin_func(W_MyList.type_fqn)
             def w_getitem(vm: 'SPyVM', w_list: W_MyList, w_i: W_I32) -> T:
                 i = vm.unwrap_i32(w_i)
@@ -143,11 +142,9 @@ def _make_W_List(w_T: W_Type) -> Type[W_List]:
                        wop_v: 'W_OpArg') -> W_OpImpl:
             from spy.vm.b import B
 
-            @no_type_check
             @builtin_func(W_MyList.type_fqn)
             def w_setitem(vm: 'SPyVM', w_list: W_MyList, w_i: W_I32,
                           w_v: T) -> W_Void:
-                assert isinstance(w_v, T)
                 i = vm.unwrap_i32(w_i)
                 # XXX bound check?
                 w_list.items_w[i] = w_v
@@ -161,7 +158,6 @@ def _make_W_List(w_T: W_Type) -> Type[W_List]:
             w_rtype = wop_r.w_static_type
             assert w_ltype.pyclass is W_MyList
 
-            @no_type_check
             @builtin_func(W_MyList.type_fqn)
             def w_eq(vm: 'SPyVM', w_l1: W_MyList, w_l2: W_MyList) -> W_Bool:
                 items1_w = w_l1.items_w

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -1,8 +1,8 @@
 from typing import (TYPE_CHECKING, Any, no_type_check, Optional, Type, ClassVar,
                     TypeVar, Generic)
 from spy.vm.b import B
-from spy.vm.primitive import W_I32, W_Bool, W_Void
-from spy.vm.object import (W_Object, W_Type, W_Dynamic)
+from spy.vm.primitive import W_I32, W_Bool, W_Dynamic, W_Void
+from spy.vm.object import (W_Object, W_Type)
 from spy.vm.builtin import builtin_func, builtin_type
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -1,8 +1,8 @@
 from typing import TYPE_CHECKING, Optional, Iterable
 from spy.fqn import FQN
-from spy.vm.primitive import W_Void
+from spy.vm.primitive import W_Dynamic, W_Void
 from spy.vm.b import B
-from spy.vm.object import W_Object, W_Type, W_Dynamic
+from spy.vm.object import W_Object, W_Type
 from spy.vm.str import W_Str
 from spy.vm.function import W_ASTFunc
 from spy.vm.builtin import builtin_func

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -5,7 +5,7 @@ from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type, W_Dynamic
 from spy.vm.str import W_Str
 from spy.vm.function import W_ASTFunc
-from spy.vm.builtin import builtin_func, builtin_type
+from spy.vm.builtin import builtin_func
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 
 if TYPE_CHECKING:
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 
-@builtin_type('builtins', 'module')
+@B.builtin_type('module')
 class W_Module(W_Object):
     vm: 'SPyVM'
     name: str

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -5,8 +5,8 @@ The first half is in vm/b.py. See its docstring for more details.
 """
 
 from typing import TYPE_CHECKING, Any
-from spy.vm.primitive import W_F64, W_I32, W_Bool, W_Void
-from spy.vm.object import (W_Dynamic, W_Object,
+from spy.vm.primitive import W_F64, W_I32, W_Bool, W_Dynamic, W_Void
+from spy.vm.object import (W_Object,
                            W_Type)
 from spy.vm.str import W_Str
 from spy.vm.b import BUILTINS, B

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -1,10 +1,10 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 import struct
-from spy.vm.primitive import W_F64, W_I32, W_Void
+from spy.vm.primitive import W_F64, W_I32, W_Dynamic, W_Void
 from spy.vm.b import B
-from spy.vm.object import Member, Annotated
+from spy.vm.object import Member
 from spy.vm.w import (W_Func, W_Type, W_Object, W_Str,
-                      W_Dynamic, W_List, W_FuncType)
+                      W_List, W_FuncType)
 from spy.vm.list import W_List
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.builtin import builtin_func, builtin_type

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Literal, no_type_check
-from spy.vm.primitive import W_Void
+from spy.vm.primitive import W_Dynamic, W_Void
 from spy.vm.b import B
-from spy.vm.object import W_Object, W_Type, W_Dynamic
+from spy.vm.object import W_Object, W_Type
 from spy.vm.module import W_Module
 from spy.vm.str import W_Str
 from spy.vm.function import W_Func

--- a/spy/vm/modules/operator/binop.py
+++ b/spy/vm/modules/operator/binop.py
@@ -1,7 +1,8 @@
 from typing import TYPE_CHECKING
 from spy.vm.b import B
-from spy.vm.object import W_Dynamic, W_Type
+from spy.vm.object import W_Type
 from spy.vm.opimpl import W_OpImpl, W_OpArg
+from spy.vm.primitive import W_Dynamic
 from . import OP
 from .multimethod import MultiMethodTable
 if TYPE_CHECKING:

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 from spy.vm.b import B
-from spy.vm.object import W_Object, W_Type, W_Dynamic
+from spy.vm.object import W_Object, W_Type
+from spy.vm.primitive import W_Dynamic
 from spy.vm.str import W_Str
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.list import W_List

--- a/spy/vm/modules/operator/itemop.py
+++ b/spy/vm/modules/operator/itemop.py
@@ -1,7 +1,8 @@
 from typing import TYPE_CHECKING
 from spy.vm.b import B
-from spy.vm.object import W_Type, W_Dynamic
+from spy.vm.object import W_Type
 from spy.vm.opimpl import W_OpImpl, W_OpArg
+from spy.vm.primitive import W_Dynamic
 
 from . import OP
 if TYPE_CHECKING:

--- a/spy/vm/modules/operator/opimpl_dynamic.py
+++ b/spy/vm/modules/operator/opimpl_dynamic.py
@@ -1,7 +1,8 @@
 from typing import TYPE_CHECKING, Any
 from spy.errors import SPyTypeError
 from spy.vm.b import B
-from spy.vm.object import W_Dynamic, W_Type
+from spy.vm.object import W_Type
+from spy.vm.primitive import W_Dynamic
 from spy.vm.str import W_Str
 from spy.vm.function import W_Func
 from spy.vm.opimpl import W_OpImpl, W_OpArg

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -5,10 +5,10 @@ SPy `types` module.
 from typing import TYPE_CHECKING, Annotated
 from spy.fqn import FQN
 from spy.vm.builtin import builtin_type
-from spy.vm.primitive import W_Void
+from spy.vm.primitive import W_Dynamic, W_Void
 from spy.vm.module import W_Module
 from spy.vm.b import B
-from spy.vm.object import W_Type, W_Object, W_Dynamic, Member
+from spy.vm.object import W_Type, W_Object, Member
 from spy.vm.str import W_Str
 from spy.vm.function import W_Func
 from spy.vm.opimpl import W_OpImpl

--- a/spy/vm/modules/unsafe/mem.py
+++ b/spy/vm/modules/unsafe/mem.py
@@ -1,8 +1,8 @@
 from typing import TYPE_CHECKING, no_type_check
 import fixedint
 from spy.vm.b import B
-from spy.vm.primitive import W_I32
-from spy.vm.w import W_Func, W_Type, W_Dynamic, W_Object
+from spy.vm.primitive import W_I32, W_Dynamic
+from spy.vm.w import W_Func, W_Type, W_Object
 from spy.vm.builtin import builtin_func
 from . import UNSAFE
 from .ptr import W_Ptr, w_make_ptr_type, is_ptr_type

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -2,10 +2,10 @@ from typing import TYPE_CHECKING, ClassVar, Optional, no_type_check
 import fixedint
 from spy.errors import SPyPanicError
 from spy.fqn import FQN
-from spy.vm.primitive import W_I32, W_Void, W_Bool
+from spy.vm.primitive import W_I32, W_Dynamic, W_Void, W_Bool
 from spy.vm.b import B
 from spy.vm.builtin import builtin_type
-from spy.vm.w import W_Object, W_Type, W_Str, W_Dynamic, W_Func
+from spy.vm.w import W_Object, W_Type, W_Str, W_Func
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.builtin import builtin_func
 from . import UNSAFE

--- a/spy/vm/modules/unsafe/struct.py
+++ b/spy/vm/modules/unsafe/struct.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, no_type_check, Optional, Type, ClassVar
+from typing import TYPE_CHECKING, Any, Optional, Type, ClassVar
 from dataclasses import dataclass
 import fixedint
 from spy.fqn import FQN

--- a/spy/vm/modules/unsafe/struct.py
+++ b/spy/vm/modules/unsafe/struct.py
@@ -56,8 +56,6 @@ class W_Struct(W_Object):
 
 
 def make_struct_type(vm: 'SPyVM', fqn: FQN, fields: FIELDS_T) -> W_Type:
-    size, layout = calc_layout(fields)
-
     class W_MyStruct(W_Struct):
         pass
 

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -236,9 +236,9 @@ class W_Type(W_Object):
     # Union[W_Type, W_Void] means "either a W_Type or B.w_None"
     @property
     def w_base(self) -> Union['W_Type', 'W_Void']:
-        from spy.vm.primitive import W_Void
+        from spy.vm.b import B
         if self is W_Object._w or self is w_DynamicType:
-            return W_Void._w_singleton  # this is B.w_None
+            return B.w_None
         basecls = self.pyclass.__base__
         assert issubclass(basecls, W_Object)
         assert isinstance(basecls._w, W_Type)

--- a/spy/vm/primitive.py
+++ b/spy/vm/primitive.py
@@ -2,14 +2,10 @@ from typing import ClassVar, TYPE_CHECKING
 import fixedint
 from spy.vm.object import W_Object
 from spy.vm.b import B
-
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
-# NOTE: we apply @builtin_type later, at the end of the file, to avoid circular
-# imports
-
-
+@B.builtin_type('void')
 class W_Void(W_Object):
     """
     Equivalent of Python's NoneType.
@@ -33,7 +29,7 @@ class W_Void(W_Object):
 
 W_Void._w_singleton = W_Void.__new__(W_Void)
 
-
+@B.builtin_type('i32')
 class W_I32(W_Object):
     value: fixedint.Int32
 
@@ -48,6 +44,7 @@ class W_I32(W_Object):
         return self.value
 
 
+@B.builtin_type('f64')
 class W_F64(W_Object):
     value: float
 
@@ -62,6 +59,7 @@ class W_F64(W_Object):
         return self.value
 
 
+@B.builtin_type('bool')
 class W_Bool(W_Object):
     value: bool
     #
@@ -95,6 +93,7 @@ W_Bool._w_singleton_True = W_Bool._make_singleton(True)
 W_Bool._w_singleton_False = W_Bool._make_singleton(False)
 
 
+@B.builtin_type('NotImplementedType') # XXX it should go to types?
 class W_NotImplementedType(W_Object):
     _w_singleton: ClassVar['W_NotImplementedType']
 
@@ -108,20 +107,9 @@ W_NotImplementedType._w_singleton = (
 )
 
 
-# manually apply @builtin_type to all the classes above. This is done here
-# to avoid circular imports between object.py, builtin.py and primitive.py
-from spy.vm.builtin import builtin_type
-builtin_type('builtins', 'void')(W_Void)
-builtin_type('builtins', 'i32')(W_I32)
-builtin_type('builtins', 'f64')(W_F64)
-builtin_type('builtins', 'bool')(W_Bool)
-builtin_type('builtins', 'NotImplementedType')(W_NotImplementedType)
 
-B.add('i32', W_I32._w)
-B.add('f64', W_F64._w)
-B.add('bool', W_Bool._w)
+
 B.add('NotImplemented', W_NotImplementedType._w_singleton)
-B.add('void', W_Void._w)
 B.add('None', W_Void._w_singleton)
 B.add('True', W_Bool._w_singleton_True)
 B.add('False', W_Bool._w_singleton_False)

--- a/spy/vm/primitive.py
+++ b/spy/vm/primitive.py
@@ -13,9 +13,6 @@ class W_Void(W_Object):
     This is a singleton: there should be only one instance of this class,
     which is w_None.
     """
-
-    _w_singleton: ClassVar['W_Void']
-
     def __init__(self) -> None:
         # this is just a sanity check: we don't want people to be able to
         # create additional instances of W_Void
@@ -27,7 +24,8 @@ class W_Void(W_Object):
     def spy_unwrap(self, vm: 'SPyVM') -> None:
         return None
 
-W_Void._w_singleton = W_Void.__new__(W_Void)
+B.add('None', W_Void.__new__(W_Void))
+
 
 @B.builtin_type('i32')
 class W_I32(W_Object):
@@ -62,9 +60,6 @@ class W_F64(W_Object):
 @B.builtin_type('bool')
 class W_Bool(W_Object):
     value: bool
-    #
-    _w_singleton_True: ClassVar['W_Bool']
-    _w_singleton_False: ClassVar['W_Bool']
 
     def __init__(self, value: bool) -> None:
         # this is just a sanity check: we don't want people to be able to
@@ -85,31 +80,20 @@ class W_Bool(W_Object):
 
     def not_(self, vm: 'SPyVM') -> 'W_Bool':
         if self.value:
-            return W_Bool._w_singleton_False
+            return B.w_False
         else:
-            return W_Bool._w_singleton_True
+            return B.w_True
 
-W_Bool._w_singleton_True = W_Bool._make_singleton(True)
-W_Bool._w_singleton_False = W_Bool._make_singleton(False)
+B.add('True', W_Bool._make_singleton(True))
+B.add('False', W_Bool._make_singleton(False))
 
 
 @B.builtin_type('NotImplementedType') # XXX it should go to types?
 class W_NotImplementedType(W_Object):
-    _w_singleton: ClassVar['W_NotImplementedType']
 
     def __init__(self) -> None:
         # this is just a sanity check: we don't want people to be able to
         # create additional instances
         raise Exception("You cannot instantiate W_NotImplementedType")
 
-W_NotImplementedType._w_singleton = (
-    W_NotImplementedType.__new__(W_NotImplementedType)
-)
-
-
-
-
-B.add('NotImplemented', W_NotImplementedType._w_singleton)
-B.add('None', W_Void._w_singleton)
-B.add('True', W_Bool._w_singleton_True)
-B.add('False', W_Bool._w_singleton_False)
+B.add('NotImplemented', W_NotImplementedType.__new__(W_NotImplementedType))

--- a/spy/vm/primitive.py
+++ b/spy/vm/primitive.py
@@ -1,6 +1,7 @@
 from typing import ClassVar, TYPE_CHECKING
 import fixedint
 from spy.vm.object import W_Object
+from spy.vm.b import B
 
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -115,3 +116,12 @@ builtin_type('builtins', 'i32')(W_I32)
 builtin_type('builtins', 'f64')(W_F64)
 builtin_type('builtins', 'bool')(W_Bool)
 builtin_type('builtins', 'NotImplementedType')(W_NotImplementedType)
+
+B.add('i32', W_I32._w)
+B.add('f64', W_F64._w)
+B.add('bool', W_Bool._w)
+B.add('NotImplemented', W_NotImplementedType._w_singleton)
+B.add('void', W_Void._w)
+B.add('None', W_Void._w_singleton)
+B.add('True', W_Bool._w_singleton_True)
+B.add('False', W_Bool._w_singleton_False)

--- a/spy/vm/registry.py
+++ b/spy/vm/registry.py
@@ -3,9 +3,11 @@ from types import FunctionType
 from dataclasses import dataclass
 from spy.ast import Color
 from spy.fqn import FQN, QUALIFIERS
-from spy.vm.function import W_FuncType, W_BuiltinFunc
-from spy.vm.builtin import builtin_func, builtin_type
-from spy.vm.object import W_Object
+#from spy.vm.builtin import builtin_func, builtin_type
+
+if TYPE_CHECKING:
+    from spy.vm.object import W_Object
+    from spy.vm.function import W_BuiltinFunc
 
 class ModuleRegistry:
     """
@@ -14,7 +16,7 @@ class ModuleRegistry:
     At startup, the `vm` will create a W_Module out of it.
     """
     fqn: FQN
-    content: list[tuple[FQN, W_Object]]
+    content: list[tuple[FQN, 'W_Object']]
 
     def __init__(self, modname: str) -> None:
         self.fqn = FQN(modname)
@@ -38,7 +40,7 @@ class ModuleRegistry:
             but well...)
             """
 
-    def add(self, attr: str, w_obj: W_Object) -> None:
+    def add(self, attr: str, w_obj: 'W_Object') -> None:
         fqn = self.fqn.join(attr)
         setattr(self, f'w_{attr}', w_obj)
         self.content.append((fqn, w_obj))
@@ -52,16 +54,17 @@ class ModuleRegistry:
 
         In practice:
             @MOD.spytype('Foo')
-            class W_Foo(W_Object):
+            class W_Foo('W_Object'):
                 ...
 
         is equivalent to:
             @spytype('Foo')
-            class W_Foo(W_Object):
+            class W_Foo('W_Object'):
                 ...
             MOD.add('Foo', W_Foo._w)
         """
-        def decorator(pyclass: Type[W_Object]) -> Type[W_Object]:
+        from spy.vm.builtin import builtin_type
+        def decorator(pyclass: Type['W_Object']) -> Type['W_Object']:
             W_class = builtin_type(self.fqn, typename, qualifiers)(pyclass)
             self.add(typename, W_class._w)
             return W_class
@@ -89,6 +92,7 @@ class ModuleRegistry:
         'qualifiers' is allowed only if you also explicitly specify
         'funcname'.
         """
+        from spy.vm.builtin import builtin_func
         if isinstance(pyfunc_or_funcname, FunctionType):
             pyfunc = pyfunc_or_funcname
             funcname = None
@@ -102,7 +106,7 @@ class ModuleRegistry:
             funcname = None
             assert qualifiers is None
 
-        def decorator(pyfunc: Callable) -> W_BuiltinFunc:
+        def decorator(pyfunc: Callable) -> 'W_BuiltinFunc':
             namespace = self.fqn
             # apply the @builtin_func decorator to pyfunc
             w_func = builtin_func(

--- a/spy/vm/registry.py
+++ b/spy/vm/registry.py
@@ -3,7 +3,6 @@ from types import FunctionType
 from dataclasses import dataclass
 from spy.ast import Color
 from spy.fqn import FQN, QUALIFIERS
-#from spy.vm.builtin import builtin_func, builtin_type
 
 if TYPE_CHECKING:
     from spy.vm.object import W_Object

--- a/spy/vm/registry.py
+++ b/spy/vm/registry.py
@@ -23,7 +23,7 @@ class ModuleRegistry:
         self.content = []
 
     def __repr__(self) -> str:
-        return f"<ModuleRegistry '{self.modname}'>"
+        return f"<ModuleRegistry '{self.fqn}'>"
 
     if TYPE_CHECKING:
         def __getattr__(self, attr: str) -> Any:
@@ -42,7 +42,9 @@ class ModuleRegistry:
 
     def add(self, attr: str, w_obj: 'W_Object') -> None:
         fqn = self.fqn.join(attr)
-        setattr(self, f'w_{attr}', w_obj)
+        attr = f'w_{attr}'
+        assert not hasattr(self, attr)
+        setattr(self, attr, w_obj)
         self.content.append((fqn, w_obj))
 
     def builtin_type(self,

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -26,7 +26,7 @@ def ll_spy_Str_new(ll: LLWasmInstance, s: str) -> int:
 
 
 
-@builtin_type('builtins', 'str')
+@B.builtin_type('str')
 class W_Str(W_Object):
     """
     An unicode string, internally represented as UTF-8.
@@ -97,5 +97,3 @@ class W_Str(W_Object):
 def w_int2str(vm: 'SPyVM', w_i: W_I32) -> W_Str:
     i = vm.unwrap_i32(w_i)
     return vm.wrap(str(i))  # type: ignore
-
-B.add('str', W_Str._w)

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Any
 from spy.llwasm import LLWasmInstance
+from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type, W_Dynamic
 from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.opimpl import W_OpImpl, W_OpArg
@@ -96,3 +97,5 @@ class W_Str(W_Object):
 def w_int2str(vm: 'SPyVM', w_i: W_I32) -> W_Str:
     i = vm.unwrap_i32(w_i)
     return vm.wrap(str(i))  # type: ignore
+
+B.add('str', W_Str._w)

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING, Any
 from spy.llwasm import LLWasmInstance
 from spy.vm.b import B
-from spy.vm.object import W_Object, W_Type, W_Dynamic
+from spy.vm.object import W_Object, W_Type
 from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.list import W_List
-from spy.vm.primitive import W_I32
+from spy.vm.primitive import W_I32, W_Dynamic
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 

--- a/spy/vm/tuple.py
+++ b/spy/vm/tuple.py
@@ -7,7 +7,7 @@ from spy.vm.opimpl import W_OpImpl, W_OpArg
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
-@builtin_type('builtins', 'tuple')
+@B.builtin_type('tuple')
 class W_Tuple(W_Object):
     """
     This is not the "real" tuple type that we will have in SPy.
@@ -39,6 +39,3 @@ def w_tuple_getitem(vm: 'SPyVM', w_tup: W_Tuple, w_i: W_I32) -> W_Dynamic:
     i = vm.unwrap_i32(w_i)
     # XXX bound check?
     return w_tup.items_w[i]
-
-
-B.add('tuple', W_Tuple._w)

--- a/spy/vm/tuple.py
+++ b/spy/vm/tuple.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any, no_type_check, Optional
 from spy.vm.b import B
-from spy.vm.primitive import W_I32, W_Bool, W_Void
-from spy.vm.object import (W_Object, W_Type, W_Dynamic)
+from spy.vm.primitive import W_I32, W_Bool, W_Dynamic, W_Void
+from spy.vm.object import (W_Object, W_Type)
 from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 if TYPE_CHECKING:

--- a/spy/vm/tuple.py
+++ b/spy/vm/tuple.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING, Any, no_type_check, Optional
+from spy.vm.b import B
 from spy.vm.primitive import W_I32, W_Bool, W_Void
 from spy.vm.object import (W_Object, W_Type, W_Dynamic)
 from spy.vm.builtin import builtin_func, builtin_type
@@ -38,3 +39,6 @@ def w_tuple_getitem(vm: 'SPyVM', w_tup: W_Tuple, w_i: W_I32) -> W_Dynamic:
     i = vm.unwrap_i32(w_i)
     # XXX bound check?
     return w_tup.items_w[i]
+
+
+B.add('tuple', W_Tuple._w)

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -9,8 +9,8 @@ from spy.location import Loc
 from spy import libspy
 from spy.doppler import redshift
 from spy.errors import SPyTypeError
-from spy.vm.object import W_Object, W_Type, W_Dynamic
-from spy.vm.primitive import W_F64, W_I32, W_Bool
+from spy.vm.object import W_Object, W_Type
+from spy.vm.primitive import W_F64, W_I32, W_Bool, W_Dynamic
 from spy.vm.str import W_Str
 from spy.vm.b import B
 from spy.vm.function import W_FuncType, W_Func, W_ASTFunc, W_BuiltinFunc

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -26,6 +26,7 @@ from spy.vm.modules.unsafe import UNSAFE
 from spy.vm.modules.rawbuffer import RAW_BUFFER
 from spy.vm.modules.jsffi import JSFFI
 
+
 class SPyVM:
     """
     A Virtual Machine to execute SPy code.

--- a/spy/vm/w.py
+++ b/spy/vm/w.py
@@ -2,11 +2,11 @@
 This is just to make it easier to import all the various W_* classes
 """
 
-from spy.vm.primitive import W_F64, W_I32, W_Bool, W_Void
+from spy.vm.primitive import W_F64, W_I32, W_Bool, W_Dynamic, W_Void
 from spy.vm.function import W_Func, W_FuncType, W_ASTFunc, W_BuiltinFunc
 from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.module import W_Module
-from spy.vm.object import (W_Object, W_Type, W_Dynamic)
+from spy.vm.object import (W_Object, W_Type)
 from spy.vm.str import W_Str
 from spy.vm.list import W_List
 from spy.vm.opimpl import W_OpImpl


### PR DESCRIPTION
This PR is big, but most of the diff is just "moving things around".
The long term goals are to reduce circular dependencies between modules imports, and preprare the ground for killing `._w`.

Highlights:
  - it is now possible to use `Annotated[W_Object, w_my_type]` for `@builtin_func` signatures. This gives a cleaner implementation of `W_Dynamic` and removes the need to lot of `@no_type_check` in generic functions such as in `ptr.py`
  - `vm.b` now contains an empty `B` registry, which is populated by `objects.py`, `primitives.py`, etc. This removes a lot of circular dependencies
  - kill `W_Void._w_singleton` and similar singletons for bools, notimplemented, etc.: they now live directly on `B`.
  - `W_Dynamic` has been moved to `primitive.py`
  - the handling of `__spy_members__` is now done by `W_Type.__init__`, instead of `@builtin_type`

