### PR TITLE
Introduce W_ListType

### DIFF
--- a/spy/tests/compiler/test_list.py
+++ b/spy/tests/compiler/test_list.py
@@ -101,4 +101,4 @@ class TestList(CompilerTest):
         """)
         w_foo = mod.foo.w_func
         w_l = self.vm.call(w_foo, [])
-        assert repr(w_l) == 'W_List[W_I32]([W_I32(1), W_I32(2)])'
+        assert repr(w_l) == "W_List('i32', [W_I32(1), W_I32(2)])"

--- a/spy/tests/compiler/test_list.py
+++ b/spy/tests/compiler/test_list.py
@@ -4,6 +4,7 @@ import pytest
 from spy.fqn import FQN
 from spy.vm.b import B
 from spy.vm.object import W_Type
+from spy.vm.opimpl import W_OpArg
 from spy.vm.list import W_List
 from spy.tests.support import CompilerTest, no_C
 
@@ -33,9 +34,9 @@ class TestList(CompilerTest):
             return list[T]
         """)
         w_make_list = mod.make_list.w_func
-        w_list_type = self.vm.call(w_make_list, [B.w_type])
+        w_list_type = self.vm.call(w_make_list, [W_OpArg._w])
         assert isinstance(w_list_type, W_Type)
-        assert w_list_type.pyclass is W_List[W_Type]
+        assert w_list_type.pyclass is W_List[W_OpArg]
         #
         w_list_f64a = self.vm.call(w_make_list, [B.w_f64])
         w_list_f64b = self.vm.call(w_make_list, [B.w_f64])

--- a/spy/tests/compiler/test_list.py
+++ b/spy/tests/compiler/test_list.py
@@ -5,7 +5,7 @@ from spy.fqn import FQN
 from spy.vm.b import B
 from spy.vm.object import W_Type
 from spy.vm.opimpl import W_OpArg
-from spy.vm.list import W_List
+from spy.vm.list import W_List, W_ListType
 from spy.tests.support import CompilerTest, no_C
 
 # Eventually we want to remove the @no_C, but for now the C backend
@@ -22,9 +22,8 @@ class TestList(CompilerTest):
         """)
         w_foo = mod.foo.w_func
         w_list_i32 = self.vm.call(w_foo, [])
-        assert isinstance(w_list_i32, W_Type)
+        assert isinstance(w_list_i32, W_ListType)
         assert w_list_i32.fqn == FQN('builtins::list[i32]')
-        assert w_list_i32.pyclass.__name__ == 'W_List[W_I32]'
 
     def test_generalize_literal(self):
         mod = self.compile(

--- a/spy/tests/compiler/test_list.py
+++ b/spy/tests/compiler/test_list.py
@@ -26,22 +26,6 @@ class TestList(CompilerTest):
         assert w_list_i32.fqn == FQN('builtins::list[i32]')
         assert w_list_i32.pyclass.__name__ == 'W_List[W_I32]'
 
-    def test_cached_generic(self):
-        mod = self.compile(
-        """
-        @blue
-        def make_list(T: type):
-            return list[T]
-        """)
-        w_make_list = mod.make_list.w_func
-        w_list_type = self.vm.call(w_make_list, [W_OpArg._w])
-        assert isinstance(w_list_type, W_Type)
-        assert w_list_type.pyclass is W_List[W_OpArg]
-        #
-        w_list_f64a = self.vm.call(w_make_list, [B.w_f64])
-        w_list_f64b = self.vm.call(w_make_list, [B.w_f64])
-        assert w_list_f64a is w_list_f64b
-
     def test_generalize_literal(self):
         mod = self.compile(
         """

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -5,7 +5,7 @@ from spy.vm.b import B
 from spy.vm.object import Member
 from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.w import W_Type, W_Object, W_Str, W_List
-from spy.vm.opimpl import W_OpImpl, W_OpArg
+from spy.vm.opimpl import W_OpImpl, W_OpArg, W_OpArgList
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM
 from spy.vm.list import W_List
@@ -31,7 +31,7 @@ class TestCallOp(CompilerTest):
 
             @staticmethod
             def op_CALL(vm: 'SPyVM', wop_obj: W_OpArg,
-                        w_opargs: W_List[W_OpArg]) -> W_OpImpl:
+                        w_opargs: W_OpArgList) -> W_OpImpl:
                 @builtin_func('ext')
                 def w_call(vm: 'SPyVM', w_obj: W_Adder, w_y: W_I32) -> W_I32:
                     y = vm.unwrap_i32(w_y)
@@ -133,7 +133,7 @@ class TestCallOp(CompilerTest):
             @staticmethod
             def op_CALL_METHOD(vm: 'SPyVM', wop_obj: W_OpArg,
                                wop_method: W_OpArg,
-                               w_opargs: W_List[W_OpArg]) -> W_OpImpl:
+                               w_opargs: W_OpArgList) -> W_OpImpl:
                 meth = wop_method.blue_unwrap_str(vm)
                 if meth == 'add':
                     @builtin_func('ext', 'add')

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -5,10 +5,10 @@ from spy.vm.b import B
 from spy.vm.object import Member
 from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.w import W_Type, W_Object, W_Str, W_List
-from spy.vm.opimpl import W_OpImpl, W_OpArg, W_OpArgList
+from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM
-from spy.vm.list import W_List
+from spy.vm.list import W_List, W_OpArgList
 from spy.tests.support import CompilerTest, no_C
 
 @no_C

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -10,7 +10,7 @@ from spy.fqn import FQN
 from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type
 from spy.vm.function import W_Func, W_FuncType, W_ASTFunc, Namespace
-from spy.vm.list import W_List
+from spy.vm.list import W_List, W_ListType
 from spy.vm.tuple import W_Tuple
 from spy.vm.modules.unsafe.struct import W_StructType
 from spy.vm.typechecker import TypeChecker
@@ -347,8 +347,8 @@ class ASTFrame:
 
     def eval_expr_List(self, op: ast.List) -> W_Object:
         color, w_listtype = self.t.check_expr(op)
+        assert isinstance(w_listtype, W_ListType)
         items_w = [self.eval_expr(item) for item in op.items]
-        assert w_listtype.pyclass is W_List
         return W_List(w_listtype, items_w)
 
     def eval_expr_Tuple(self, op: ast.Tuple) -> W_Object:

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -348,8 +348,8 @@ class ASTFrame:
     def eval_expr_List(self, op: ast.List) -> W_Object:
         color, w_listtype = self.t.check_expr(op)
         items_w = [self.eval_expr(item) for item in op.items]
-        assert issubclass(w_listtype.pyclass, W_List)
-        return w_listtype.pyclass(items_w) # type: ignore
+        assert w_listtype.pyclass is W_List
+        return W_List(w_listtype, items_w)
 
     def eval_expr_Tuple(self, op: ast.Tuple) -> W_Object:
         color, w_tupletype = self.t.check_expr(op)

--- a/spy/vm/b.py
+++ b/spy/vm/b.py
@@ -12,9 +12,15 @@ the proper place where to put modules.
 
 This strange setup is needed to avoid circular imports, since B.* is needed
 all over the place and we need to import it very early.
+
+Morever, it also contains the empty definition of the OPERATOR module, since
+we also need it very early.
 """
 
 from spy.vm.registry import ModuleRegistry
 
 BUILTINS = ModuleRegistry('builtins')
 B = BUILTINS
+
+OPERATOR = ModuleRegistry('operator')
+OP = OPERATOR

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -6,7 +6,8 @@ from spy.fqn import FQN, NSPart
 from spy.vm.object import W_Object, W_Type
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
-    from spy.vm.opimpl import W_OpImpl, W_OpArg, W_OpArgList
+    from spy.vm.opimpl import W_OpImpl, W_OpArg
+    from spy.vm.list import W_OpArgList
 
 # dictionary which contains local vars in an ASTFrame. The type is defined
 # here because it's also used by W_ASTFunc.closure.

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -6,8 +6,7 @@ from spy.fqn import FQN, NSPart
 from spy.vm.object import W_Object, W_Type
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
-    from spy.vm.list import W_List
-    from spy.vm.opimpl import W_OpImpl, W_OpArg
+    from spy.vm.opimpl import W_OpImpl, W_OpArg, W_OpArgList
 
 # dictionary which contains local vars in an ASTFrame. The type is defined
 # here because it's also used by W_ASTFunc.closure.
@@ -134,7 +133,7 @@ class W_Func(W_Object):
 
     @staticmethod
     def op_CALL(vm: 'SPyVM', wop_func: 'W_OpArg',
-                w_opargs: 'W_List[W_OpArg]') -> 'W_OpImpl':
+                w_opargs: 'W_OpArgList') -> 'W_OpImpl':
         """
         This is a bit of a hack.
 

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -191,11 +191,17 @@ def _make_W_List(w_T: W_Type) -> Type[W_List]:
     class W_MyList(W_List):
         __qualname__ = f'W_List[{w_T.pyclass.__name__}]' # e.g. W_List[W_I32]
 
-
-
     W_MyList.__name__ = W_MyList.__qualname__
     w_listtype = W_ListType(fqn, w_T, pyclass=W_MyList)
     W_MyList._w = w_listtype
     W_MyList.type_fqn = fqn
-
     return W_MyList
+
+
+### temporary
+from spy.vm.opimpl import W_OpArg
+w_oparglist_type = make_prebuilt(W_OpArg)
+W_OpArgList = Annotated[W_List, w_oparglist_type]
+
+def make_oparg_list(args_wop: list[W_OpArg]) -> W_OpArgList:
+   return w_oparglist_type.pyclass(w_oparglist_type, args_wop)  # type: ignore

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -109,6 +109,21 @@ class W_List(W_BaseList):
             return w_list.items_w[i]
         return W_OpImpl(w_getitem)
 
+    @staticmethod
+    def op_SETITEM(vm: 'SPyVM', wop_list: 'W_OpArg', wop_i: 'W_OpArg',
+                   wop_v: 'W_OpArg') -> 'W_OpImpl':
+        from spy.vm.opimpl import W_OpImpl
+        w_listtype = W_List._get_listtype(wop_list)
+        w_T = w_listtype.w_itemtype
+        LIST = Annotated[W_List, w_listtype]
+        T = Annotated[W_Object, w_T]
+
+        @builtin_func(w_listtype.fqn)
+        def w_setitem(vm: 'SPyVM', w_list: LIST, w_i: W_I32, w_v: T) -> None:
+            i = vm.unwrap_i32(w_i)
+            # XXX bound check?
+            w_list.items_w[i] = w_v
+        return W_OpImpl(w_setitem)
 
 
 @builtin_func('__spy__', color='blue')
@@ -153,19 +168,6 @@ def _make_W_List(w_T: W_Type) -> Type[W_List]:
     class W_MyList(W_List):
         __qualname__ = f'W_List[{w_T.pyclass.__name__}]' # e.g. W_List[W_I32]
 
-        @staticmethod
-        def op_SETITEM(vm: 'SPyVM', wop_obj: 'W_OpArg', wop_i: 'W_OpArg',
-                       wop_v: 'W_OpArg') -> W_OpImpl:
-            from spy.vm.b import B
-
-            @builtin_func(W_MyList.type_fqn)
-            def w_setitem(vm: 'SPyVM', w_list: W_MyList, w_i: W_I32,
-                          w_v: T) -> W_Void:
-                i = vm.unwrap_i32(w_i)
-                # XXX bound check?
-                w_list.items_w[i] = w_v
-                return B.w_None
-            return W_OpImpl(w_setitem)
 
         @staticmethod
         def op_EQ(vm: 'SPyVM', wop_l: 'W_OpArg', wop_r: 'W_OpArg') -> W_OpImpl:

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -23,7 +23,7 @@ class W_ListType(W_Type):
 
 
 # PREBUILT list types are instantiated the end of the file
-PREBUILT_LIST_TYPES = {}
+PREBUILT_LIST_TYPES: dict[W_Type, W_ListType] = {}
 
 @builtin_func('__spy__', color='blue')
 def w_make_list_type(vm: 'SPyVM', w_list: W_Object, w_T: W_Type) -> W_ListType:
@@ -172,7 +172,6 @@ class W_List(W_BaseList, Generic[T]):
 w_oparglist_type = _make_list_type(OP.w_OpArg)
 PREBUILT_LIST_TYPES[OP.w_OpArg] = w_oparglist_type
 
-W_OpArgList = Annotated[W_List, w_oparglist_type]
-
+W_OpArgList = Annotated[W_List[W_OpArg], w_oparglist_type]
 def make_oparg_list(args_wop: list[W_OpArg]) -> W_OpArgList:
-   return w_oparglist_type.pyclass(w_oparglist_type, args_wop)  # type: ignore
+   return W_List(w_oparglist_type, args_wop)  # type: ignore

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -3,11 +3,12 @@ from typing import (TYPE_CHECKING, Any, Optional, Type, ClassVar,
 from spy.fqn import FQN
 from spy.vm.b import B
 from spy.vm.primitive import W_I32, W_Bool, W_Dynamic, W_Void
-from spy.vm.object import (W_Object, W_Type)
+from spy.vm.object import W_Object, W_Type
+from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.builtin import builtin_func, builtin_type
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
-    from spy.vm.opimpl import W_OpImpl, W_OpArg
+
 
 
 CACHE = {}
@@ -57,8 +58,8 @@ class W_BaseList(W_Object):
         raise Exception("You cannot instantiate W_BaseList, use W_List")
 
     @staticmethod
-    def meta_op_GETITEM(vm: 'SPyVM', wop_obj: 'W_OpArg',
-                        wop_i: 'W_OpArg') -> 'W_OpImpl':
+    def meta_op_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg,
+                        wop_i: W_OpArg) -> W_OpImpl:
         from spy.vm.opimpl import W_OpImpl
         return W_OpImpl(w_make_list_type)
 
@@ -85,7 +86,7 @@ class W_List(W_BaseList):
         return [vm.unwrap(w_item) for w_item in self.items_w]
 
     @staticmethod
-    def _get_listtype(wop_list: 'W_OpArg') -> W_ListType:
+    def _get_listtype(wop_list: W_OpArg) -> W_ListType:
         w_listtype = wop_list.w_static_type
         if isinstance(w_listtype, W_ListType):
             return w_listtype
@@ -95,8 +96,7 @@ class W_List(W_BaseList):
             assert False, 'FIXME: raise a nice error'
 
     @staticmethod
-    def op_GETITEM(vm: 'SPyVM', wop_list: 'W_OpArg',
-                   wop_i: 'W_OpArg') -> 'W_OpImpl':
+    def op_GETITEM(vm: 'SPyVM', wop_list: W_OpArg, wop_i: W_OpArg) -> W_OpImpl:
         from spy.vm.opimpl import W_OpImpl
         w_listtype = W_List._get_listtype(wop_list)
         w_T = w_listtype.w_itemtype
@@ -111,8 +111,8 @@ class W_List(W_BaseList):
         return W_OpImpl(w_getitem)
 
     @staticmethod
-    def op_SETITEM(vm: 'SPyVM', wop_list: 'W_OpArg', wop_i: 'W_OpArg',
-                   wop_v: 'W_OpArg') -> 'W_OpImpl':
+    def op_SETITEM(vm: 'SPyVM', wop_list: W_OpArg, wop_i: W_OpArg,
+                   wop_v: W_OpArg) -> W_OpImpl:
         from spy.vm.opimpl import W_OpImpl
         w_listtype = W_List._get_listtype(wop_list)
         w_T = w_listtype.w_itemtype
@@ -127,7 +127,7 @@ class W_List(W_BaseList):
         return W_OpImpl(w_setitem)
 
     @staticmethod
-    def op_EQ(vm: 'SPyVM', wop_l: 'W_OpArg', wop_r: 'W_OpArg') -> 'W_OpImpl':
+    def op_EQ(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
         from spy.vm.opimpl import W_OpImpl
         w_ltype = wop_l.w_static_type
         w_rtype = wop_r.w_static_type
@@ -199,7 +199,6 @@ def _make_W_List(w_T: W_Type) -> Type[W_List]:
 
 
 ### temporary
-from spy.vm.opimpl import W_OpArg
 w_oparglist_type = make_prebuilt(W_OpArg)
 W_OpArgList = Annotated[W_List, w_oparglist_type]
 

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -34,6 +34,8 @@ class Meta_W_List(type):
 
     def make_prebuilt(self, itemcls: Type[W_Object]) -> None:
         assert issubclass(itemcls, W_Object)
+        if itemcls.__name__ != 'W_OpArg':
+            import pdb;pdb.set_trace()
         if itemcls not in self.CACHE:
             W_MyList = _make_W_List(itemcls._w)
             self.CACHE[itemcls] = W_MyList

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -75,7 +75,8 @@ class W_List(W_BaseList):
 
     def __repr__(self) -> str:
         cls = self.__class__.__name__
-        return f'{cls}({self.items_w})'
+        T = self.w_listtype.w_itemtype.fqn.human_name
+        return f"{cls}('{T}', {self.items_w})"
 
     def spy_get_w_type(self, vm: 'SPyVM') -> W_Type:
         return self.w_listtype

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -50,8 +50,6 @@ def make_prebuilt(itemcls: Type[W_Object]) -> W_Type:
         CACHE[itemcls] = w_listtype
     return CACHE[itemcls]
 
-
-
 @B.builtin_type('list')
 class W_BaseList(W_Object):
     """
@@ -81,15 +79,17 @@ class W_BaseList(W_Object):
         return W_OpImpl(w_make_list_type)
 
 
-class W_List(W_BaseList):
+T = TypeVar('T', bound='W_Object')
+
+class W_List(W_BaseList, Generic[T]):
     w_listtype: W_ListType
-    items_w: list[W_Object]
+    items_w: list[T]
 
     def __init__(self, w_listtype: W_ListType, items_w: list[W_Object]) -> None:
         assert isinstance(w_listtype, W_ListType)
         self.w_listtype = w_listtype
         # XXX typecheck?
-        self.items_w = items_w
+        self.items_w = items_w  # type: ignore
 
     def __repr__(self) -> str:
         cls = self.__class__.__name__

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -3,10 +3,8 @@ import struct
 from spy.vm.primitive import W_F64, W_I32, W_Dynamic, W_Void
 from spy.vm.b import B
 from spy.vm.object import Member
-from spy.vm.w import (W_Func, W_Type, W_Object, W_Str,
-                      W_List, W_FuncType)
-from spy.vm.list import W_List
-from spy.vm.opimpl import W_OpImpl, W_OpArg
+from spy.vm.w import W_Func, W_Type, W_Object, W_Str, W_FuncType
+from spy.vm.opimpl import W_OpImpl, W_OpArg, W_OpArgList
 from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.registry import ModuleRegistry
 from spy.vm.modules.types import W_TypeDef
@@ -31,7 +29,7 @@ class W_JsRef(W_Object):
 
     @staticmethod
     def op_CALL_METHOD(vm: 'SPyVM', wop_obj: W_OpArg, wop_method: W_OpArg,
-                       w_opargs: W_List[W_OpArg]) -> W_OpImpl:
+                       w_opargs: W_OpArgList) -> W_OpImpl:
         args_wop = w_opargs.items_w
         n = len(args_wop)
         if n == 1:

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -1,10 +1,11 @@
 from typing import TYPE_CHECKING, Annotated
 import struct
+from spy.vm.list import W_OpArgList
 from spy.vm.primitive import W_F64, W_I32, W_Dynamic, W_Void
 from spy.vm.b import B
 from spy.vm.object import Member
 from spy.vm.w import W_Func, W_Type, W_Object, W_Str, W_FuncType
-from spy.vm.opimpl import W_OpImpl, W_OpArg, W_OpArgList
+from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.registry import ModuleRegistry
 from spy.vm.modules.types import W_TypeDef

--- a/spy/vm/modules/operator/__init__.py
+++ b/spy/vm/modules/operator/__init__.py
@@ -34,13 +34,13 @@ The exception is the type `dynamic`:
     a + b
 
 In this case, the dispatch will be done on the dynamic type of the operands.
+
+Note that for bootstrap reason, the OPERATOR module is defined in vm/b.py, and
+re-exported here.
 """
 
 from spy.vm.function import W_Func
-from spy.vm.registry import ModuleRegistry
-
-OPERATOR = ModuleRegistry('operator')
-OP = OPERATOR
+from spy.vm.b import OPERATOR, OP
 
 # the folloing imports register all the various objects on OP
 from . import opimpl_i32     # side effects

--- a/spy/vm/modules/operator/__init__.py
+++ b/spy/vm/modules/operator/__init__.py
@@ -39,31 +39,7 @@ In this case, the dispatch will be done on the dynamic type of the operands.
 from spy.vm.function import W_Func
 from spy.vm.registry import ModuleRegistry
 
-class OperatorRegistry(ModuleRegistry):
-    """
-    Like ModuleRegistry, but adds a from_token method.
-    """
-
-    _from_token: dict[str, W_Func] = {}
-    def from_token(self, token: str) -> W_Func:
-        """
-        Return the generic operator corresponding to the given token.
-
-        E.g., OPS.from_token('+') returns OPS.w_ADD.
-        """
-        return self._from_token[token]
-
-    def to_token(self, w_OP: W_Func) -> str:
-        """
-        Inverse of from_token
-        """
-        for token, w_obj in self._from_token.items():
-            if w_obj is w_OP:
-                return token
-        raise KeyError(w_OP)
-
-
-OPERATOR = OperatorRegistry('operator')
+OPERATOR = ModuleRegistry('operator')
 OP = OPERATOR
 
 # the folloing imports register all the various objects on OP
@@ -77,8 +53,8 @@ from . import attrop         # side effects
 from . import itemop         # side effects
 from . import callop         # side effects
 
-# fill the _from_token dict
-OP._from_token.update({
+
+_from_token: dict[str, W_Func] = {
     '+': OP.w_ADD,
     '-': OP.w_SUB,
     '*': OP.w_MUL,
@@ -92,4 +68,12 @@ OP._from_token.update({
     '[]': OP.w_GETITEM,
     '<universal_eq>': OP.w_UNIVERSAL_EQ,
     '<universal_ne>': OP.w_UNIVERSAL_NE,
-})
+}
+
+def OP_from_token(token: str) -> W_Func:
+    """
+    Return the generic operator corresponding to the given token.
+
+    E.g., OPS.from_token('+') returns OPS.w_ADD.
+    """
+    return _from_token[token]

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -3,8 +3,8 @@ from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type
 from spy.vm.primitive import W_Dynamic
 from spy.vm.str import W_Str
-from spy.vm.opimpl import W_OpImpl, W_OpArg, W_OpArgList
-from spy.vm.list import W_List
+from spy.vm.opimpl import W_OpImpl, W_OpArg
+from spy.vm.list import W_List, W_OpArgList
 from spy.vm.function import W_DirectCall, W_FuncType, FuncParam
 
 from . import OP

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -3,7 +3,7 @@ from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type
 from spy.vm.primitive import W_Dynamic
 from spy.vm.str import W_Str
-from spy.vm.opimpl import W_OpImpl, W_OpArg
+from spy.vm.opimpl import W_OpImpl, W_OpArg, W_OpArgList
 from spy.vm.list import W_List
 from spy.vm.function import W_DirectCall, W_FuncType, FuncParam
 
@@ -12,11 +12,10 @@ from .binop import MM
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
-W_List.make_prebuilt(W_OpArg)
 
 @OP.builtin_func(color='blue')
 def w_CALL(vm: 'SPyVM', wop_obj: W_OpArg,
-           w_opargs: W_List[W_OpArg]) -> W_OpImpl:
+           w_opargs: W_OpArgList) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opimpl
     w_opimpl = W_OpImpl.NULL
     w_type = wop_obj.w_static_type
@@ -26,7 +25,7 @@ def w_CALL(vm: 'SPyVM', wop_obj: W_OpArg,
     elif pyclass.has_meth_overriden('op_CALL'):
         w_opimpl = pyclass.op_CALL(vm, wop_obj, w_opargs)
 
-    # turn the app-level W_List[W_OpArg] into an interp-level list[W_OpArg]
+    # turn the app-level W_OpArgList into an interp-level list[W_OpArg]
     args_wop = w_opargs.items_w
     typecheck_opimpl(
         vm,
@@ -76,7 +75,7 @@ def _dynamic_call_opimpl(args_wop: list[W_OpArg]) -> W_OpImpl:
 
 @OP.builtin_func(color='blue')
 def w_CALL_METHOD(vm: 'SPyVM', wop_obj: W_OpArg, wop_method: W_OpArg,
-                  w_opargs: W_List[W_OpArg]) -> W_OpImpl:
+                  w_opargs: W_OpArgList) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opimpl
     w_opimpl = W_OpImpl.NULL
     w_type = wop_obj.w_static_type
@@ -84,7 +83,7 @@ def w_CALL_METHOD(vm: 'SPyVM', wop_obj: W_OpArg, wop_method: W_OpArg,
     if pyclass.has_meth_overriden('op_CALL_METHOD'):
         w_opimpl = pyclass.op_CALL_METHOD(vm, wop_obj, wop_method, w_opargs)
 
-    # turn the app-level W_List[W_OpArg] into an interp-level list[W_OpArg]
+    # turn the app-level W_OpArgList into an interp-level list[W_OpArg]
     args_wop = w_opargs.items_w
     typecheck_opimpl(
         vm,

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -43,7 +43,7 @@ class W_BasePtr(W_Object):
     """
 
     def __init__(self) -> None:
-        raise Exception("You cannot instantiate W_Ptr, use W_PtrValue")
+        raise Exception("You cannot instantiate W_BasePtr, use W_Ptr")
 
     @staticmethod
     def meta_op_GETITEM(vm: 'SPyVM', wop_p: W_OpArg, wop_T: W_OpArg)-> W_OpImpl:
@@ -78,7 +78,6 @@ class W_Ptr(W_BasePtr):
 
     def spy_get_w_type(self, vm: 'SPyVM') -> W_Type:
         return self.w_ptrtype
-
 
     def spy_unwrap(self, vm: 'SPyVM') -> 'W_BasePtr':
         return self

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -52,7 +52,8 @@ from spy.vm.b import B
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
     from spy.vm.primitive import W_Void, W_Dynamic
-    from spy.vm.opimpl import W_OpImpl, W_OpArg, W_OpArgList
+    from spy.vm.opimpl import W_OpImpl, W_OpArg
+    from spy.vm.list import W_OpArgList
 
 # Basic setup of the object model: <object> and <type>
 # =====================================================

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -52,9 +52,7 @@ from spy.vm.b import B
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
     from spy.vm.primitive import W_Void, W_Dynamic
-    from spy.vm.str import W_Str
-    from spy.vm.list import W_List
-    from spy.vm.opimpl import W_OpImpl, W_OpArg
+    from spy.vm.opimpl import W_OpImpl, W_OpArg, W_OpArgList
 
 # Basic setup of the object model: <object> and <type>
 # =====================================================
@@ -174,12 +172,12 @@ class W_Object:
 
     @staticmethod
     def op_CALL(vm: 'SPyVM', wop_obj: 'W_OpArg',
-                w_opargs: 'W_List[W_OpArg]') -> 'W_OpImpl':
+                w_opargs: 'W_OpArgList') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
     @staticmethod
     def op_CALL_METHOD(vm: 'SPyVM', wop_obj: 'W_OpArg', wop_method: 'W_OpArg',
-                       w_opargs: 'W_List[W_OpArg]') -> 'W_OpImpl':
+                       w_opargs: 'W_OpArgList') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
 

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -34,7 +34,6 @@ from spy.vm.object import Member, W_Type, W_Object
 from spy.vm.function import W_Func, W_FuncType, W_DirectCall
 from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.primitive import W_Bool
-from spy.vm.list import W_List
 
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -291,12 +291,3 @@ class W_OpImpl(W_Object):
 
 
 W_OpImpl.NULL = W_OpImpl(None)  # type: ignore
-
-
-# XXX temporary
-from spy.vm.list import W_List, make_prebuilt
-w_oparglist_type = make_prebuilt(W_OpArg)
-W_OpArgList = Annotated[W_List, w_oparglist_type]
-
-def make_oparg_list(args_wop: list[W_OpArg]) -> W_OpArgList:
-    return w_oparglist_type.pyclass(w_oparglist_type, args_wop)  # type: ignore

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -297,7 +297,7 @@ W_OpImpl.NULL = W_OpImpl(None)  # type: ignore
 # XXX temporary
 from spy.vm.list import W_List, make_prebuilt
 w_oparglist_type = make_prebuilt(W_OpArg)
-W_OpArgList = Annotated[W_List[W_OpArg], w_oparglist_type]
+W_OpArgList = Annotated[W_List, w_oparglist_type]
 
 def make_oparg_list(args_wop: list[W_OpArg]) -> W_OpArgList:
     return w_oparglist_type.pyclass(args_wop)  # type: ignore

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -30,6 +30,7 @@ from spy import ast
 from spy.location import Loc
 from spy.irgen.symtable import Symbol
 from spy.errors import SPyTypeError
+from spy.vm.b import OPERATOR
 from spy.vm.object import Member, W_Type, W_Object
 from spy.vm.function import W_Func, W_FuncType, W_DirectCall
 from spy.vm.builtin import builtin_func, builtin_type
@@ -41,7 +42,7 @@ if TYPE_CHECKING:
 
 T = TypeVar('T')
 
-@builtin_type('operator', 'OpArg')
+@OPERATOR.builtin_type('OpArg')
 class W_OpArg(W_Object):
     """
     Class which represents the operands passed to OPERATORs.
@@ -183,7 +184,7 @@ def w_oparg_eq(vm: 'SPyVM', wop1: W_OpArg, wop2: W_OpArg) -> W_Bool:
 
 
 
-@builtin_type('operator', 'OpImpl')
+@OPERATOR.builtin_type('OpImpl')
 class W_OpImpl(W_Object):
     NULL: ClassVar['W_OpImpl']
     _w_func: Optional[W_Func]

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -300,4 +300,4 @@ w_oparglist_type = make_prebuilt(W_OpArg)
 W_OpArgList = Annotated[W_List, w_oparglist_type]
 
 def make_oparg_list(args_wop: list[W_OpArg]) -> W_OpArgList:
-    return w_oparglist_type.pyclass(args_wop)  # type: ignore
+    return w_oparglist_type.pyclass(w_oparglist_type, args_wop)  # type: ignore

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -34,6 +34,7 @@ from spy.vm.object import Member, W_Type, W_Object
 from spy.vm.function import W_Func, W_FuncType, W_DirectCall
 from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.primitive import W_Bool
+from spy.vm.list import W_List
 
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -291,3 +292,12 @@ class W_OpImpl(W_Object):
 
 
 W_OpImpl.NULL = W_OpImpl(None)  # type: ignore
+
+
+# XXX temporary
+from spy.vm.list import W_List, make_prebuilt
+w_oparglist_type = make_prebuilt(W_OpArg)
+W_OpArgList = Annotated[W_List[W_OpArg], w_oparglist_type]
+
+def make_oparg_list(args_wop: list[W_OpArg]) -> W_OpArgList:
+    return w_oparglist_type.pyclass(args_wop)  # type: ignore

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -1,9 +1,10 @@
 from typing import TYPE_CHECKING, Any
 from spy.llwasm import LLWasmInstance
 from spy.vm.b import B
+from spy.vm.list import W_OpArgList
 from spy.vm.object import W_Object, W_Type
 from spy.vm.builtin import builtin_func, builtin_type
-from spy.vm.opimpl import W_OpImpl, W_OpArg, W_OpArgList
+from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.primitive import W_I32, W_Dynamic
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -3,13 +3,11 @@ from spy.llwasm import LLWasmInstance
 from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type
 from spy.vm.builtin import builtin_func, builtin_type
-from spy.vm.opimpl import W_OpImpl, W_OpArg
-from spy.vm.list import W_List
+from spy.vm.opimpl import W_OpImpl, W_OpArg, W_OpArgList
 from spy.vm.primitive import W_I32, W_Dynamic
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
-W_List.make_prebuilt(W_OpArg)
 
 def ll_spy_Str_new(ll: LLWasmInstance, s: str) -> int:
     """
@@ -83,7 +81,7 @@ class W_Str(W_Object):
 
     @staticmethod
     def meta_op_CALL(vm: 'SPyVM', wop_obj: W_OpArg,
-                     w_opargs: W_List[W_OpArg]) -> W_OpImpl:
+                     w_opargs: W_OpArgList) -> W_OpImpl:
         from spy.vm.b import B
         args_wop: list[W_OpArg] = w_opargs.items_w  # type: ignore
         if len(args_wop) == 1 and args_wop[0].w_static_type is B.w_i32:

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -5,7 +5,7 @@ from spy.irgen.symtable import Symbol, Color
 from spy.errors import (SPyTypeError, SPyNameError, maybe_plural)
 from spy.location import Loc
 from spy.vm.object import W_Object, W_Type
-from spy.vm.opimpl import W_OpImpl, W_OpArg
+from spy.vm.opimpl import W_OpImpl, W_OpArg, make_oparg_list
 from spy.vm.list import W_List
 from spy.vm.function import W_FuncType, W_ASTFunc, W_Func
 from spy.vm.b import B
@@ -17,8 +17,6 @@ from spy.vm.modules.types import W_TypeDef
 from spy.util import magic_dispatch
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
-
-W_List.make_prebuilt(W_OpArg) # make it possible to use W_List[W_OpArg]
 
 # DispatchKind is a property of an OPERATOR and can be:
 #
@@ -386,7 +384,7 @@ class TypeChecker:
             [call.func] + call.args
         )
         wop_func = args_wop[0]
-        w_opargs = W_List[W_OpArg](args_wop[1:]) # type: ignore
+        w_opargs = make_oparg_list(args_wop[1:])
         w_opimpl = self.vm.call_OP(OP.w_CALL, [wop_func, w_opargs])
         self.opimpl[call] = w_opimpl
         w_functype = w_opimpl.w_functype
@@ -400,7 +398,7 @@ class TypeChecker:
         )
         wop_obj = args_wop[0]
         wop_method = args_wop[1]
-        w_opargs = W_List[W_OpArg](args_wop[2:])
+        w_opargs = make_oparg_list(args_wop[2:])
         w_opimpl = self.vm.call_OP(
             OP.w_CALL_METHOD,
             [wop_obj, wop_method, w_opargs]

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -9,7 +9,7 @@ from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.list import W_List, make_oparg_list
 from spy.vm.function import W_FuncType, W_ASTFunc, W_Func
 from spy.vm.b import B
-from spy.vm.modules.operator import OP
+from spy.vm.modules.operator import OP, OP_from_token
 from spy.vm.modules.jsffi import JSFFI
 from spy.vm.typeconverter import (TypeConverter, DynamicCast, NumericConv,
                                   JsRefConv)
@@ -321,7 +321,7 @@ class TypeChecker:
         return 'blue', w_type
 
     def check_expr_BinOp(self, binop: ast.BinOp) -> tuple[Color, W_Type]:
-        w_OP = OP.from_token(binop.op) # e.g., w_ADD, w_MUL, etc.
+        w_OP = OP_from_token(binop.op) # e.g., w_ADD, w_MUL, etc.
         colors, args_wop = self.check_many_exprs(
             ['l', 'r'],
             [binop.left, binop.right],

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -18,8 +18,7 @@ from spy.util import magic_dispatch
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
-W_List.make_prebuilt(W_Type) # make it possible to use W_List[W_Type]
-W_List.make_prebuilt(W_OpArg)
+W_List.make_prebuilt(W_OpArg) # make it possible to use W_List[W_OpArg]
 
 # DispatchKind is a property of an OPERATOR and can be:
 #

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -5,8 +5,8 @@ from spy.irgen.symtable import Symbol, Color
 from spy.errors import (SPyTypeError, SPyNameError, maybe_plural)
 from spy.location import Loc
 from spy.vm.object import W_Object, W_Type
-from spy.vm.opimpl import W_OpImpl, W_OpArg, make_oparg_list
-from spy.vm.list import W_List
+from spy.vm.opimpl import W_OpImpl, W_OpArg
+from spy.vm.list import W_List, make_oparg_list
 from spy.vm.function import W_FuncType, W_ASTFunc, W_Func
 from spy.vm.b import B
 from spy.vm.modules.operator import OP


### PR DESCRIPTION
This does something very similar to PR #96 , but for `list`.

By doing so, we are able to use a single `W_List` class for every specialized list, and avoid the creation of dynamic `W_MyList` subclasses.

We also greatly simplify the way we handle prebuilt list types