### PR TITLE
Automatic declare forward references to types

### DIFF
--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -11,6 +11,7 @@ from spy.vm.module import W_Module
 from spy.vm.object import W_Type
 from spy.vm.function import W_FuncType, W_ASTFunc
 from spy.vm.astframe import ASTFrame
+from spy.vm.modules.types import W_ForwardRef
 
 
 class ModuleGen:
@@ -48,6 +49,15 @@ class ModuleGen:
         w_INIT = W_ASTFunc(w_functype, fqn, modinit_funcdef, closure)
         frame = ASTFrame(self.vm, w_INIT)
         #
+
+        # automatically predeclare types as ForwardRef
+        # XXX: should we maybe predeclare also functions and variables?
+        for decl in self.mod.decls:
+            if isinstance(decl, ast.GlobalClassDef):
+                type_fqn = fqn.join(decl.classdef.name)
+                w_fw = W_ForwardRef(type_fqn)
+                self.vm.add_global(type_fqn, w_fw)
+
         for decl in self.mod.decls:
             if isinstance(decl, ast.Import):
                 pass

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -230,13 +230,12 @@ class TestVM:
     def test_forwardref_become(self):
         vm = SPyVM()
         w_fw = W_ForwardRef(FQN('test::hello'))
-        w_x = vm.wrap(42)
-        w_fw.become(w_x)
-        assert isinstance(w_fw, W_I32)
-        assert w_fw.value == 42
-        assert not hasattr(w_fw, 'fqn')
-        assert vm.eq(w_fw, w_x) is B.w_True
-        assert w_fw is not w_x
+        w_HelloType = W_Type(FQN('test::hello'), W_Object)
+        w_fw.become(w_HelloType)
+        assert isinstance(w_fw, W_Type)
+        assert w_fw.fqn == FQN('test::hello')
+        assert w_fw.pyclass is W_Object
+        assert w_fw is not w_HelloType
 
     def test_add_global(self):
         vm = SPyVM()
@@ -249,10 +248,10 @@ class TestVM:
 
     def test_add_global_forwardref(self):
         vm = SPyVM()
-        fqn = FQN('builtins::x')
+        fqn = FQN('builtins::hello')
         w_fw = W_ForwardRef(fqn)
-        w_x = vm.wrap(42)
+        w_HelloType = W_Type(fqn, W_Object)
         vm.add_global(fqn, w_fw)
-        vm.add_global(fqn, w_x)
+        vm.add_global(fqn, w_HelloType)
         assert vm.lookup_global(fqn) is w_fw
-        assert vm.unwrap(w_fw) == 42
+        assert isinstance(w_fw, W_Type)

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -56,16 +56,16 @@ class W_TypeDef(W_Type):
 
 
 @TYPES.builtin_type('ForwardRef')
-class W_ForwardRef(W_Object):
+class W_ForwardRef(W_Type):
     """
-    A ForwardRef represent a value which has been declared but not defined
+    A ForwardRef represent a type which has been declared but not defined
     yet.
-    It can `become()` a different value while preserving identity, so that
+    It can `become()` an actual type while preserving identity, so that
     existing references to the forward ref are automatically updated.
 
-    It is primarily used to predeclare types and functions in a module, so
-    they can be referenced in advance before their actual definition. Consider
-    the following example:
+    It is primarily used to predeclare types in a module, so they can be
+    referenced in advance before their actual definition. Consider the
+    following example:
 
         def foo(p: Point) -> void:
             pass
@@ -75,28 +75,27 @@ class W_ForwardRef(W_Object):
 
     When executing the module, there are implicit statements, shown below:
 
-        foo = ForwardRef('test::foo')
         Point = ForwardRef('test::Point')
 
         def foo(p: Point) -> void:
             pass
-        `test::foo`.become(foo)
 
         # here foo's signature is 'def(x: ForwardRef(`test::Point`))'
 
         class Point:
             ...
-        # `test::Point`.become(Point)
+        `test::Point`.become(Point)
         # now, foo's signature is 'def(x: Point)'.
     """
     fqn: FQN
 
     def __init__(self, fqn: FQN) -> None:
-        self.fqn = fqn
+        super().__init__(fqn, pyclass=W_Object)
 
     def __repr__(self) -> str:
         return f"<ForwardRef '{self.fqn}'>"
 
-    def become(self, w_val: W_Object) -> None:
-        self.__class__ = w_val.__class__
-        self.__dict__ = w_val.__dict__
+    def become(self, w_T: W_Type) -> None:
+        assert self.fqn == w_T.fqn
+        self.__class__ = w_T.__class__
+        self.__dict__ = w_T.__dict__


### PR DESCRIPTION
This is a big departure from Python semantics, but it's required to write types having fields which directly or indirectly reference themselves. Moreover, it makes writing type-annotated code much easier.
TL;DR, we can now do this:
```
def foo(x: MyType) -> void:
    ...

class MyType:
    ...
```

i.e., use `MyType` *before* its definition has been executed.
This is done by introducing the concept of `ForwardRef`, which is a special object which can `become()` a new object.

With these new tools, we could finally make `test_struct_with_ptr_to_itself` working, as in:
```
        class Node(struct):
            val: i32
            next: ptr[Node]
```