### PR TITLE
Fix test_struct_with_ptr_to_itself[C]

### DIFF
--- a/spy/backend/c/context.py
+++ b/spy/backend/c/context.py
@@ -105,9 +105,18 @@ class Context:
         c_ptrtype = C_Type(fqn.c_name)
         w_itemtype = w_ptrtype.w_itemtype
         c_itemtype = self.w2c(w_itemtype)
-        self.out_types_decl.wl(f'typedef struct {c_ptrtype} {c_ptrtype};')
-        self.out_types_def.wl(f"SPY_DEFINE_PTR_TYPE({c_ptrtype}, {c_itemtype})")
-        self.out_types_def.wl(f"#define {c_ptrtype}$NULL (({c_ptrtype}){{0}})")
+        self.out_types_decl.wb(f"""
+        typedef struct {c_ptrtype} {{
+            {c_itemtype} *p;
+        #ifdef SPY_DEBUG
+            size_t length;
+        #endif
+        }} {c_ptrtype};
+        """)
+        self.out_ptrs_def.wb(f"""
+        SPY_PTR_FUNCTIONS({c_ptrtype}, {c_itemtype});
+        #define {c_ptrtype}$NULL (({c_ptrtype}){{0}})
+        """)
         self._d[w_ptrtype] = c_ptrtype
         return c_ptrtype
 

--- a/spy/backend/c/context.py
+++ b/spy/backend/c/context.py
@@ -115,6 +115,8 @@ class Context:
         fqn = self.vm.reverse_lookup_global(w_st)
         assert fqn is not None
         c_struct_type = C_Type(fqn.c_name)
+        # forward declaration
+        self._d[w_st] = c_struct_type
         self.out_types_decl.wl(f'typedef struct {c_struct_type} {c_struct_type};')
 
         # XXX this is VERY wrong: it assumes that the standard C layout
@@ -135,6 +137,4 @@ class Context:
         out.wl("};")
         out.wl("")
         self.out_types_def.attach_nested_builder(out)
-
-        self._d[w_st] = c_struct_type
         return c_struct_type

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -80,12 +80,16 @@ class CModuleWriter:
         self.out.wl('// type definitions')
         self.out_types_def = self.out.make_nested_builder()
         self.out.wl()
+        self.out.wl('// unsafe::ptr accessors')
+        self.out_ptrs_def = self.out.make_nested_builder()
+        self.out.wl()
         self.out.wl('// constants and functions')
         self.out_globals = self.out.make_nested_builder()
         self.out.wl()
 
         # this is a bit of a hack, but too bad
         self.ctx.out_types_decl = self.out_types_decl
+        self.ctx.out_ptrs_def = self.out_ptrs_def
         self.ctx.out_types_def = self.out_types_def
 
         self.out.wb("""

--- a/spy/tests/compiler/test_unsafe.py
+++ b/spy/tests/compiler/test_unsafe.py
@@ -282,5 +282,7 @@ class TestUnsafe(CompilerTest):
         """)
         ptr = mod.alloc_list(1, 2, 3)
         mod.print_list(ptr)
+        if self.backend == 'C':
+            mod.ll.call('spy_flush')
         out, err = capfd.readouterr()
         assert out.splitlines() == ['1', '2', '3']

--- a/spy/tests/compiler/test_unsafe.py
+++ b/spy/tests/compiler/test_unsafe.py
@@ -264,7 +264,7 @@ class TestUnsafe(CompilerTest):
             next: ptr[Node]
 
         def new_node(val: i32) -> ptr[Node]:
-            n = gc_alloc(Node)(1)
+            n: ptr[Node] = gc_alloc(Node)(1)
             n.val = val
             n.next = ptr[Node].NULL
             return n


### PR DESCRIPTION
This test was still broken, even after #101.

To fix it, we need to make sure that the C compiler sees all ptr struct definitions before emitting the accessor functions