### PR TITLE
Support for *args in builtin functions

### DIFF
--- a/spy/backend/c/context.py
+++ b/spy/backend/c/context.py
@@ -57,6 +57,7 @@ class Context:
     """
     vm: SPyVM
     out_types_decl: TextBuilder
+    out_ptrs_def: TextBuilder
     out_types_def: TextBuilder
     _d: dict[W_Type, C_Type]
 
@@ -64,6 +65,7 @@ class Context:
         self.vm = vm
         # set by CModuleWriter.emit_module
         self.out_types_decl = None # type: ignore
+        self.out_ptrs_def = None   # type: ignore
         self.out_types_def = None  # type: ignore
         self._d = {}
         self._d[B.w_void] = C_Type('void')

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -4,11 +4,10 @@ from spy.vm.primitive import W_I32, W_Dynamic, W_Void
 from spy.vm.b import B
 from spy.vm.object import Member
 from spy.vm.builtin import builtin_func, builtin_type
-from spy.vm.w import W_Type, W_Object, W_Str, W_List
+from spy.vm.w import W_Type, W_Object, W_Str
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM
-from spy.vm.list import W_List, W_OpArgList
 from spy.tests.support import CompilerTest, no_C
 
 @no_C
@@ -51,7 +50,7 @@ class TestCallOp(CompilerTest):
 
             @staticmethod
             def op_CALL(vm: 'SPyVM', wop_obj: W_OpArg,
-                        w_opargs: W_OpArgList) -> W_OpImpl:
+                        *args_wop: W_OpArg) -> W_OpImpl:
                 @builtin_func('ext')
                 def w_call(vm: 'SPyVM', w_obj: W_Adder, w_y: W_I32) -> W_I32:
                     y = vm.unwrap_i32(w_y)
@@ -85,8 +84,8 @@ class TestCallOp(CompilerTest):
                 self.w_y = w_y
 
             @staticmethod
-            def meta_op_CALL(vm: 'SPyVM', w_type: W_Type,
-                             w_argtypes: W_Dynamic) -> W_OpImpl:
+            def meta_op_CALL(vm: 'SPyVM', wop_obj: W_OpArg,
+                             *args_wop: W_OpArg) -> W_OpImpl:
                 @builtin_func('ext')
                 def w_new(vm: 'SPyVM', w_cls: W_Type,
                         w_x: W_I32, w_y: W_I32) -> W_Point:
@@ -153,7 +152,7 @@ class TestCallOp(CompilerTest):
             @staticmethod
             def op_CALL_METHOD(vm: 'SPyVM', wop_obj: W_OpArg,
                                wop_method: W_OpArg,
-                               w_opargs: W_OpArgList) -> W_OpImpl:
+                               *args_wop: W_OpArg) -> W_OpImpl:
                 meth = wop_method.blue_unwrap_str(vm)
                 if meth == 'add':
                     @builtin_func('ext', 'add')
@@ -161,7 +160,7 @@ class TestCallOp(CompilerTest):
                              w_arg: W_I32) -> W_I32:
                         y = vm.unwrap_i32(w_arg)
                         return vm.wrap(w_self.x + y)  # type: ignore
-                    return W_OpImpl(w_fn, [wop_obj] + w_opargs.items_w)
+                    return W_OpImpl(w_fn, [wop_obj] + list(args_wop))
 
                 elif meth == 'sub':
                     @builtin_func('ext', 'sub')
@@ -169,7 +168,7 @@ class TestCallOp(CompilerTest):
                              w_arg: W_I32) -> W_I32:
                         y = vm.unwrap_i32(w_arg)
                         return vm.wrap(w_self.x - y)  # type: ignore
-                    return W_OpImpl(w_fn, [wop_obj] + w_opargs.items_w)
+                    return W_OpImpl(w_fn, [wop_obj] + list(args_wop))
                 else:
                     return W_OpImpl.NULL
         # ========== /EXT module for this test =========

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -23,7 +23,7 @@ class TestCallOp(CompilerTest):
             tot = 0
             for w_x in args_w:
                 tot += vm.unwrap_i32(w_x)
-            return vm.wrap(tot)
+            return vm.wrap(tot)  # type: ignore
         # ========== /EXT module for this test =========
         self.vm.make_module(EXT)
         mod = self.compile("""

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -15,6 +15,26 @@ from spy.tests.support import CompilerTest, no_C
 class TestCallOp(CompilerTest):
     SKIP_SPY_BACKEND_SANITY_CHECK = True
 
+    def test_call_varargs(self):
+        # ========== EXT module for this test ==========
+        EXT = ModuleRegistry('ext')
+
+        @EXT.builtin_func
+        def w_sum(vm: 'SPyVM', *args_w: W_I32) -> W_I32:
+            tot = 0
+            for w_x in args_w:
+                tot += vm.unwrap_i32(w_x)
+            return vm.wrap(tot)
+        # ========== /EXT module for this test =========
+        self.vm.make_module(EXT)
+        mod = self.compile("""
+        from ext import sum
+
+        def foo(x: i32) -> i32:
+            return sum(x, 1, 2, 3)
+        """)
+        assert mod.foo(10) == 16
+
     def test_call_instance(self):
         # ========== EXT module for this test ==========
         EXT = ModuleRegistry('ext')

--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -12,7 +12,7 @@ from typing import (TYPE_CHECKING, Any, Callable, Type, Optional, get_origin,
 from spy.fqn import FQN, QUALIFIERS
 from spy.ast import Color
 from spy.vm.object import W_Object, W_Type, make_metaclass
-from spy.vm.function import FuncParam, W_FuncType, W_BuiltinFunc
+from spy.vm.function import FuncParam, FuncParamKind, W_FuncType, W_BuiltinFunc
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
@@ -51,6 +51,7 @@ def to_spy_FuncParam(p: Any) -> FuncParam:
         name = p.name
     #
     w_type = to_spy_type(p.annotation)
+    kind: FuncParamKind
     if p.kind == p.POSITIONAL_OR_KEYWORD:
         kind = 'simple'
     elif p.kind == p.VAR_POSITIONAL:

--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -51,7 +51,13 @@ def to_spy_FuncParam(p: Any) -> FuncParam:
         name = p.name
     #
     w_type = to_spy_type(p.annotation)
-    return FuncParam(name, w_type)
+    if p.kind == p.POSITIONAL_OR_KEYWORD:
+        kind = 'simple'
+    elif p.kind == p.VAR_POSITIONAL:
+        kind = 'varargs'
+    else:
+        assert False
+    return FuncParam(name, w_type, kind)
 
 
 def functype_from_sig(fn: Callable, color: Color) -> W_FuncType:

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -120,7 +120,7 @@ class W_FuncType(W_Type):
 
     @property
     def is_varargs(self) -> bool:
-        return self.params and self.params[-1].kind == 'varargs'
+        return bool(self.params) and self.params[-1].kind == 'varargs'
 
 
 
@@ -172,7 +172,7 @@ class W_Func(W_Object):
         assert isinstance(w_functype, W_FuncType)
         return W_OpImpl(
             W_DirectCall(w_functype),
-            args_wop,
+            list(args_wop),
         )
 
 

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -14,7 +14,7 @@ Namespace = dict[str, Optional[W_Object]]
 
 FuncParamKind = Literal['simple', 'varargs']
 
-@dataclass
+@dataclass(frozen=True, eq=True)
 class FuncParam:
     name: str
     w_type: W_Type

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -7,7 +7,6 @@ from spy.vm.object import W_Object, W_Type
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
     from spy.vm.opimpl import W_OpImpl, W_OpArg
-    from spy.vm.list import W_OpArgList
 
 # dictionary which contains local vars in an ASTFrame. The type is defined
 # here because it's also used by W_ASTFunc.closure.
@@ -151,7 +150,7 @@ class W_Func(W_Object):
 
     @staticmethod
     def op_CALL(vm: 'SPyVM', wop_func: 'W_OpArg',
-                w_opargs: 'W_OpArgList') -> 'W_OpImpl':
+                *args_wop: 'W_OpArg') -> 'W_OpImpl':
         """
         This is a bit of a hack.
 
@@ -173,7 +172,7 @@ class W_Func(W_Object):
         assert isinstance(w_functype, W_FuncType)
         return W_OpImpl(
             W_DirectCall(w_functype),
-            w_opargs.items_w           # type: ignore
+            args_wop,
         )
 
 

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -166,12 +166,15 @@ class W_List(W_BaseList, Generic[T]):
 # prebuilt list types
 # ===================
 
-# this is mainly needed to make the type `list[OpArg]` available, since it's
-# used a bit everywhere
+# This it is no longer used in the current state, but the code is kept around
+# in case it's needed in the future.
+#
+# The following commented-out code makes an interp-level type W_OpArgList
+# which corresponds to the interp-level type `list[OpArg]`.
 
-w_oparglist_type = _make_list_type(OP.w_OpArg)
-PREBUILT_LIST_TYPES[OP.w_OpArg] = w_oparglist_type
+## w_oparglist_type = _make_list_type(OP.w_OpArg)
+## PREBUILT_LIST_TYPES[OP.w_OpArg] = w_oparglist_type
 
-W_OpArgList = Annotated[W_List[W_OpArg], w_oparglist_type]
-def make_oparg_list(args_wop: list[W_OpArg]) -> W_OpArgList:
-   return W_List(w_oparglist_type, args_wop)  # type: ignore
+## W_OpArgList = Annotated[W_List[W_OpArg], w_oparglist_type]
+## def make_oparg_list(args_wop: list[W_OpArg]) -> W_OpArgList:
+##    return W_List(w_oparglist_type, args_wop)  # type: ignore

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING, Annotated
 import struct
-from spy.vm.list import W_OpArgList
 from spy.vm.primitive import W_F64, W_I32, W_Dynamic, W_Void
 from spy.vm.b import B
 from spy.vm.object import Member
@@ -30,8 +29,7 @@ class W_JsRef(W_Object):
 
     @staticmethod
     def op_CALL_METHOD(vm: 'SPyVM', wop_obj: W_OpArg, wop_method: W_OpArg,
-                       w_opargs: W_OpArgList) -> W_OpImpl:
-        args_wop = w_opargs.items_w
+                       *args_wop: W_OpArg) -> W_OpImpl:
         n = len(args_wop)
         if n == 1:
             return W_OpImpl(JSFFI.w_js_call_method_1)

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -19,7 +19,7 @@ def w_CALL(vm: 'SPyVM', wop_obj: W_OpArg, *args_wop: W_OpArg) -> W_OpImpl:
     w_type = wop_obj.w_static_type
     pyclass = w_type.pyclass
     if w_type is B.w_dynamic:
-        # XXX fixme
+        #w_opimpl = W_OpImpl(OP.w_dynamic_call)  # see _dynamic_call_opimpl
         w_opimpl = _dynamic_call_opimpl(args_wop)
     elif pyclass.has_meth_overriden('op_CALL'):
         w_opimpl = pyclass.op_CALL(vm, wop_obj, *args_wop)
@@ -38,20 +38,13 @@ def _dynamic_call_opimpl(args_wop: list[W_OpArg]) -> W_OpImpl:
     """
     This is a hack, and it's half wrong.
 
-    We are trying to CALL something of type dynamic, so we don't know anything
-    about it. Ideally, we would like a setup like this:
+    Ideally, we would like to do this in w_CALL above:
+        if w_type is B.w_dynamic:
+            w_opimpl = W_OpImpl(OP.w_dynamic_call)
 
-    in opimpl_dynamic.py:
-        def dynamic_call(vm, w_obj: W_Dynamic, args_w: list[W_Dynamic])
-
-    here:
-        return W_OpImpl(OP.w_dynamic_call)
-
-    but this doesn't work because we don't have any support for calling
-    opimpls with a variable number of arguments.
-
-    MERGE BLOCKER check whether we can kill this hack in this branch
-
+    But in order for it to work, we need more goodies, like the ability of
+    comparing two W_FuncType by equality (because e.g. for test_unsafe they
+    end up in the bluecache).
 
     The temporary workaround is to pretend that this is a direct call: for
     this, we fabricate a fake w_functype which takes the right number of

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -53,6 +53,9 @@ def _dynamic_call_opimpl(args_wop: list[W_OpArg]) -> W_OpImpl:
     but this doesn't work because we don't have any support for calling
     opimpls with a variable number of arguments.
 
+    MERGE BLOCKER check whether we can kill this hack in this branch
+
+
     The temporary workaround is to pretend that this is a direct call: for
     this, we fabricate a fake w_functype which takes the right number of
     arguments, to ensure that we pass the typechecking.
@@ -64,7 +67,7 @@ def _dynamic_call_opimpl(args_wop: list[W_OpArg]) -> W_OpImpl:
     """
     N  = len(args_wop)
     w_functype = W_FuncType(
-        params = [FuncParam(f'v{i}', B.w_dynamic) for i in range(N)],
+        params = [FuncParam(f'v{i}', B.w_dynamic, 'simple') for i in range(N)],
         w_restype = B.w_dynamic
     )
     return W_OpImpl(

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -20,7 +20,7 @@ def w_CALL(vm: 'SPyVM', wop_obj: W_OpArg, *args_wop: W_OpArg) -> W_OpImpl:
     pyclass = w_type.pyclass
     if w_type is B.w_dynamic:
         #w_opimpl = W_OpImpl(OP.w_dynamic_call)  # see _dynamic_call_opimpl
-        w_opimpl = _dynamic_call_opimpl(args_wop)
+        w_opimpl = _dynamic_call_opimpl(list(args_wop))
     elif pyclass.has_meth_overriden('op_CALL'):
         w_opimpl = pyclass.op_CALL(vm, wop_obj, *args_wop)
 

--- a/spy/vm/modules/operator/opimpl_dynamic.py
+++ b/spy/vm/modules/operator/opimpl_dynamic.py
@@ -67,3 +67,16 @@ def w_dynamic_getattr(vm: 'SPyVM', w_obj: W_Dynamic,
     wop_attr = W_OpArg.from_w_obj(vm, w_attr, 'a', 1)
     w_opimpl = vm.call_OP(OP.w_GETATTR, [wop_obj, wop_attr])
     return w_opimpl.call(vm, [w_obj, w_attr])
+
+
+# NOT USED, but will be soon (hopefully)
+@OP.builtin_func
+def w_dynamic_call(vm: 'SPyVM', w_obj: W_Dynamic,
+                   *args_w: W_Dynamic) -> W_Dynamic:
+    all_args_w = (w_obj,) + args_w
+    all_args_wop = [
+        W_OpArg.from_w_obj(vm, w_x, 'v', i)
+        for i, w_x in enumerate(all_args_w)
+    ]
+    w_opimpl = vm.call_OP(OP.w_CALL, all_args_wop)
+    return w_opimpl.call(vm, all_args_w)

--- a/spy/vm/modules/operator/opimpl_dynamic.py
+++ b/spy/vm/modules/operator/opimpl_dynamic.py
@@ -73,7 +73,7 @@ def w_dynamic_getattr(vm: 'SPyVM', w_obj: W_Dynamic,
 @OP.builtin_func
 def w_dynamic_call(vm: 'SPyVM', w_obj: W_Dynamic,
                    *args_w: W_Dynamic) -> W_Dynamic:
-    all_args_w = (w_obj,) + args_w
+    all_args_w = [w_obj] + list(args_w)
     all_args_wop = [
         W_OpArg.from_w_obj(vm, w_x, 'v', i)
         for i, w_x in enumerate(all_args_w)

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -53,7 +53,6 @@ if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
     from spy.vm.primitive import W_Void, W_Dynamic
     from spy.vm.opimpl import W_OpImpl, W_OpArg
-    from spy.vm.list import W_OpArgList
 
 # Basic setup of the object model: <object> and <type>
 # =====================================================
@@ -171,12 +170,12 @@ class W_Object:
 
     @staticmethod
     def op_CALL(vm: 'SPyVM', wop_obj: 'W_OpArg',
-                w_opargs: 'W_OpArgList') -> 'W_OpImpl':
+                *args_wop: 'W_OpArg') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
     @staticmethod
     def op_CALL_METHOD(vm: 'SPyVM', wop_obj: 'W_OpArg', wop_method: 'W_OpArg',
-                       w_opargs: 'W_OpArgList') -> 'W_OpImpl':
+                       *args_wop: 'W_OpArg') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
     @staticmethod
@@ -361,7 +360,7 @@ def synthesize_meta_op_CALL(fqn: FQN, pyclass: Type[W_Object]) -> Any:
     w_spy_new = pyclass.w_spy_new
 
     def meta_op_CALL(vm: 'SPyVM', wop_obj: W_OpArg,
-                     w_opargs: 'W_Dynamic') -> W_OpImpl:
+                     *args_wop: W_OpArg) -> W_OpImpl:
         fix_annotations(w_spy_new, {pyclass.__name__: pyclass})
         # manually apply the @builtin_func decorator to the spy_new function
         w_spyfunc = builtin_func(fqn, '__new__')(w_spy_new)

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING, Any
 from spy.llwasm import LLWasmInstance
 from spy.vm.b import B
-from spy.vm.list import W_OpArgList
 from spy.vm.object import W_Object, W_Type
 from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.opimpl import W_OpImpl, W_OpArg
@@ -82,9 +81,8 @@ class W_Str(W_Object):
 
     @staticmethod
     def meta_op_CALL(vm: 'SPyVM', wop_obj: W_OpArg,
-                     w_opargs: W_OpArgList) -> W_OpImpl:
+                     *args_wop: W_OpArg) -> W_OpImpl:
         from spy.vm.b import B
-        args_wop: list[W_OpArg] = w_opargs.items_w  # type: ignore
         if len(args_wop) == 1 and args_wop[0].w_static_type is B.w_i32:
             wop_i = args_wop[0]
             return W_OpImpl(w_int2str, [wop_i])

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -7,7 +7,6 @@ from spy.location import Loc
 from spy.vm.modules.operator.convop import CONVERT_maybe
 from spy.vm.object import W_Object, W_Type
 from spy.vm.opimpl import W_OpImpl, W_OpArg
-from spy.vm.list import W_List, make_oparg_list
 from spy.vm.function import W_ASTFunc, W_Func
 from spy.vm.b import B
 from spy.vm.modules.operator import OP, OP_from_token
@@ -381,9 +380,7 @@ class TypeChecker:
             ['f'] + ['v']*n,
             [call.func] + call.args
         )
-        wop_func = args_wop[0]
-        w_opargs = make_oparg_list(args_wop[1:])
-        w_opimpl = self.vm.call_OP(OP.w_CALL, [wop_func, w_opargs])
+        w_opimpl = self.vm.call_OP(OP.w_CALL, args_wop)
         self.opimpl[call] = w_opimpl
         w_functype = w_opimpl.w_functype
         return w_functype.color, w_functype.w_restype
@@ -394,13 +391,7 @@ class TypeChecker:
             ['t', 'm'] + ['v']*n,
             [op.target, op.method] + op.args  # type: ignore
         )
-        wop_obj = args_wop[0]
-        wop_method = args_wop[1]
-        w_opargs = make_oparg_list(args_wop[2:])
-        w_opimpl = self.vm.call_OP(
-            OP.w_CALL_METHOD,
-            [wop_obj, wop_method, w_opargs]
-        )
+        w_opimpl = self.vm.call_OP(OP.w_CALL_METHOD, args_wop)
         self.opimpl[op] = w_opimpl
         w_functype = w_opimpl.w_functype
         return w_functype.color, w_functype.w_restype

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -497,7 +497,13 @@ def typecheck_opimpl(
     w_functype = w_opimpl.w_functype
     got_nargs = len(args_wop)
     exp_nargs = len(w_functype.params)
-    if got_nargs != exp_nargs:
+
+    if w_functype.is_varargs:
+        argcount_ok = got_nargs >= exp_nargs
+    else:
+        argcount_ok = got_nargs == exp_nargs
+
+    if not argcount_ok:
         _call_error_wrong_argcount(
             got_nargs,
             exp_nargs,

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -311,7 +311,7 @@ class SPyVM:
             # for red functions, we just call them
             return self._call_func(w_func, args_w)
 
-    def call_OP(self, w_OP: W_Func, args_wop: Sequence[W_Object]) -> W_OpImpl:
+    def call_OP(self, w_OP: W_Func, args_wop: Sequence[W_OpArg]) -> W_OpImpl:
         """
         Like vm.call, but ensures that the result is a W_OpImpl.
 

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -338,9 +338,17 @@ class SPyVM:
     def _call_func(self, w_func: W_Func,
                    args_w: Sequence[W_Object]) -> W_Object:
         w_functype = w_func.w_functype
-        assert w_functype.arity == len(args_w)
-        for param, w_arg in zip(w_functype.params, args_w):
+        n = w_functype.arity
+        if w_functype.is_varargs:
+            assert len(args_w) >= n
+        else:
+            assert len(args_w) == n
+        for param, w_arg in zip(w_functype.params[:n], args_w[:n]):
             self.typecheck(w_arg, param.w_type)
+        if w_functype.is_varargs:
+            param = w_functype.params[-1]
+            for w_arg in args_w[n:]:
+                self.typecheck(w_arg, param.w_type)
         return w_func.spy_call(self, args_w)
 
     def eq(self, w_a: W_Dynamic, w_b: W_Dynamic) -> W_Bool:


### PR DESCRIPTION
This PR makes it possible to write stuff like this:
```
        @EXT.builtin_func
        def w_sum(vm: 'SPyVM', *args_w: W_I32) -> W_I32:
            ...
```

and then we use this functionality to make the signatures of op_CALL and op_CALL_METHOD more regular, and kill `W_OpArgList`:
```
    @staticmethod
    def op_CALL(vm: 'SPyVM', wop_obj: 'W_OpArg',
                *args_wop: 'W_OpArg') -> 'W_OpImpl':
        ...

    @staticmethod
    def op_CALL_METHOD(vm: 'SPyVM', wop_obj: 'W_OpArg', wop_method: 'W_OpArg',
                       *args_wop: 'W_OpArg') -> 'W_OpImpl':
        ...
```

