### PR TITLE
Simplify W_OpImpl, introduce W_FuncAdapter, sanitize calling convention

### DIFF
--- a/spy/__main__.py
+++ b/spy/__main__.py
@@ -96,7 +96,7 @@ def do_main(filename: Path, run: bool, pyparse: bool, parse: bool,
         vm.typecheck(w_main, w_main_functype)
         assert isinstance(w_main, W_Func)
         a = time.time()
-        w_res = vm.call(w_main, [])
+        w_res = vm.fast_call(w_main, [])
         b = time.time()
         if timeit:
             print(f'main(): {b - a:.3f} seconds', file=sys.stderr)

--- a/spy/backend/interp.py
+++ b/spy/backend/interp.py
@@ -53,7 +53,7 @@ class InterpFuncWrapper:
         # *args contains python-level objs. We want to wrap them into args_w
         # *and to call the func, and unwrap the result
         args_w = [self.vm.wrap(arg) for arg in args]
-        w_res = self.vm.call(self.w_func, args_w)
+        w_res = self.vm.fast_call(self.w_func, args_w)
         if unwrap:
             return self.vm.unwrap(w_res)
         else:

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -187,7 +187,7 @@ class FuncDoppler:
         return ast.Call(op.loc, func, real_args)
 
     def _shift_adapter_args(self, w_adapter: W_FuncAdapter,
-                            orig_args: list[ast.Expr]):
+                            orig_args: list[ast.Expr]) -> list[ast.Expr]:
         real_args = []
         for spec in w_adapter.args:
             if isinstance(spec, ArgSpec.Arg):
@@ -251,6 +251,7 @@ class FuncDoppler:
         newfunc = self.shift_expr(call.func)
         newargs = [self.shift_expr(arg) for arg in call.args]
         w_opimpl = self.t.opimpl[call]
+        assert isinstance(w_opimpl, W_FuncAdapter)
         if w_opimpl.is_direct_call():
             # sanity check: the redshift MUST have produced a const. If it
             # didn't, the C backend won't be able to compile the call.

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -202,9 +202,7 @@ class FuncDoppler:
                         args = [arg]
                     )
             elif isinstance(spec, ArgSpec.Const):
-                # XXX: we use op.loc, but ideally we should add
-                # ArgSpec.Const.loc and use that
-                arg = make_const(vm, op.loc, spec.w_const)
+                arg = make_const(self.vm, spec.loc, spec.w_const)
             else:
                 assert False
             real_args.append(arg)

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -175,9 +175,19 @@ class FQN:
     @property
     def human_name(self) -> str:
         """
-        Like fullname, but doesn't show 'builtins::'
+        Like fullname, but doesn't show 'builtins::',
+        and special-case 'def[...]'
         """
-        return self._fullname(human=True)
+        is_def = (len(self.parts) == 2 and
+                  self.modname == 'builtins' and
+                  self.parts[1].name == 'def')
+        if is_def:
+            quals = [fqn.human_name for fqn in self.parts[1].qualifiers]
+            p = ', '.join(quals[:-1])
+            r = quals[-1]
+            return f'def({p}) -> {r}'
+        else:
+            return self._fullname(human=True)
 
     @property
     def modname(self) -> str:

--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -75,7 +75,7 @@ class ModuleGen:
         if w_init is not None:
             assert isinstance(w_init, W_ASTFunc)
             assert w_init.color == "blue"
-            self.vm.call(w_init, [self.w_mod])
+            self.vm.fast_call(w_init, [self.w_mod])
         #
         return self.w_mod
 

--- a/spy/tests/compiler/test_00_bluemod.py
+++ b/spy/tests/compiler/test_00_bluemod.py
@@ -55,7 +55,7 @@ class TestBlueMod:
         """)
         w_mod = mod.w_mod
         w_foo = w_mod.getattr('foo')
-        w_res = self.vm.call(w_foo, [])
+        w_res = self.vm.fast_call(w_foo, [])
         assert w_res is B.w_i32
 
     def test_make_function(self):
@@ -68,11 +68,11 @@ class TestBlueMod:
         """)
         w_mod = mod.w_mod
         w_foo = w_mod.getattr('foo')
-        w_bar = self.vm.call(w_foo, [])
+        w_bar = self.vm.fast_call(w_foo, [])
         assert isinstance(w_bar, W_ASTFunc)
         assert w_bar.w_functype == W_FuncType.parse('def(x: i32) -> i32')
         w_42 = self.vm.wrap(42)
-        assert self.vm.call(w_bar, [w_42]) is w_42
+        assert self.vm.fast_call(w_bar, [w_42]) is w_42
 
     def test_closure(self):
         mod = self.import_("""
@@ -84,8 +84,8 @@ class TestBlueMod:
         """)
         w_mod = mod.w_mod
         w_make_adder = w_mod.getattr('make_adder')
-        w_add5 = self.vm.call(w_make_adder, [self.vm.wrap(5)])
+        w_add5 = self.vm.fast_call(w_make_adder, [self.vm.wrap(5)])
         assert isinstance(w_add5, W_ASTFunc)
-        w_42 = self.vm.call(w_add5, [self.vm.wrap(37)])
+        w_42 = self.vm.fast_call(w_add5, [self.vm.wrap(37)])
         res = self.vm.unwrap(w_42)
         assert res == 42

--- a/spy/tests/compiler/test_list.py
+++ b/spy/tests/compiler/test_list.py
@@ -21,7 +21,7 @@ class TestList(CompilerTest):
             return list[i32]
         """)
         w_foo = mod.foo.w_func
-        w_list_i32 = self.vm.call(w_foo, [])
+        w_list_i32 = self.vm.fast_call(w_foo, [])
         assert isinstance(w_list_i32, W_ListType)
         assert w_list_i32.fqn == FQN('builtins::list[i32]')
 
@@ -100,5 +100,5 @@ class TestList(CompilerTest):
             return [1, 2]
         """)
         w_foo = mod.foo.w_func
-        w_l = self.vm.call(w_foo, [])
+        w_l = self.vm.fast_call(w_foo, [])
         assert repr(w_l) == "W_List('i32', [W_I32(1), W_I32(2)])"

--- a/spy/tests/compiler/test_unsafe.py
+++ b/spy/tests/compiler/test_unsafe.py
@@ -12,7 +12,7 @@ class TestUnsafe(CompilerTest):
 
     @only_interp
     def test_ptrtype_repr(self):
-        w_ptrtype = self.vm.call(UNSAFE.w_make_ptr_type, [B.w_i32])
+        w_ptrtype = self.vm.fast_call(UNSAFE.w_make_ptr_type, [B.w_i32])
         assert repr(w_ptrtype) == "<spy type 'unsafe::ptr[i32]'>"
 
     @only_interp

--- a/spy/tests/test_fqn.py
+++ b/spy/tests/test_fqn.py
@@ -83,3 +83,10 @@ def test_qualifiers_c_name():
 def test_nested_qualifiers_c_name():
     a = FQN("a::list[Ptr[x, y]]::c#0")
     assert a.c_name == "spy_a$list__Ptr__x_y$c$0"
+
+def test_FQN_human_name():
+    assert FQN("a::b").human_name == "a::b"
+    assert FQN("builtins::i32").human_name == "i32"
+    func = FQN("builtins").join('def', ['builtins::i32', 'builtins::f64',
+                                        'builtins::str'])
+    assert func.human_name == 'def(i32, f64) -> str'

--- a/spy/tests/vm/test_builtin.py
+++ b/spy/tests/vm/test_builtin.py
@@ -33,7 +33,7 @@ class TestBuiltin:
 
         assert isinstance(w_foo, W_BuiltinFunc)
         assert w_foo.fqn == FQN('mymod::foo')
-        w_y = vm.call(w_foo, [vm.wrap(10)])
+        w_y = vm.fast_call(w_foo, [vm.wrap(10)])
         assert vm.unwrap_i32(w_y) == 20
 
     def test_builtin_func_errors(self):
@@ -77,7 +77,7 @@ class TestBuiltin:
             pass
         assert w_foo.w_functype.signature == 'def() -> void'
         assert isinstance(w_foo, W_BuiltinFunc)
-        w_res = vm.call(w_foo, [])
+        w_res = vm.fast_call(w_foo, [])
         assert w_res is B.w_None
 
     def test_blue(self):
@@ -89,6 +89,6 @@ class TestBuiltin:
             return vm.wrap(x*2)  # type: ignore
 
         assert w_foo.w_functype.signature == '@blue def(x: i32) -> i32'
-        w_x = vm.call(w_foo, [vm.wrap(21)])
-        w_y = vm.call(w_foo, [vm.wrap(21)])
+        w_x = vm.fast_call(w_foo, [vm.wrap(21)])
+        w_y = vm.fast_call(w_foo, [vm.wrap(21)])
         assert w_x is w_y

--- a/spy/tests/vm/test_func_adapter.py
+++ b/spy/tests/vm/test_func_adapter.py
@@ -28,3 +28,15 @@ def test_shuffle_args():
     )
     w_s = vm.call(w_adapter, [vm.wrap(3), vm.wrap('ab ')])
     assert vm.unwrap_str(w_s) == 'ab ab ab '
+
+def test_const():
+    vm = SPyVM()
+    w_functype = W_FuncType.parse('def(n: i32) -> str')
+    w_s = vm.wrap('ab ')
+    w_adapter = W_FuncAdapter(
+        w_functype,
+        w_repeat,
+        [ArgSpec.Const(w_s), ArgSpec.Arg(0)]
+    )
+    w_s = vm.call(w_adapter, [vm.wrap(3)])
+    assert vm.unwrap_str(w_s) == 'ab ab ab '

--- a/spy/tests/vm/test_func_adapter.py
+++ b/spy/tests/vm/test_func_adapter.py
@@ -31,6 +31,9 @@ def test_shuffle_args():
     w_s = vm.call(w_adapter, [vm.wrap(3), vm.wrap('ab ')])
     assert vm.unwrap_str(w_s) == 'ab ab ab '
     #
+    r = '<spy adapter `def(n: i32, s: str) -> str` for `test::repeat`>'
+    assert repr(w_adapter) == r
+    #
     expected = textwrap.dedent("""
     def(n: i32, s: str) -> str:
         return `test::repeat`(s, n)

--- a/spy/tests/vm/test_func_adapter.py
+++ b/spy/tests/vm/test_func_adapter.py
@@ -1,4 +1,5 @@
 import pytest
+import textwrap
 from spy.vm.vm import SPyVM
 from spy.vm.function import W_FuncType
 from spy.vm.func_adapter import W_FuncAdapter, ArgSpec
@@ -29,6 +30,12 @@ def test_shuffle_args():
     )
     w_s = vm.call(w_adapter, [vm.wrap(3), vm.wrap('ab ')])
     assert vm.unwrap_str(w_s) == 'ab ab ab '
+    #
+    expected = textwrap.dedent("""
+    def(n: i32, s: str) -> str:
+        return `test::repeat`(s, n)
+    """).strip()
+    assert w_adapter.render() == expected
 
 def test_const():
     vm = SPyVM()
@@ -41,6 +48,11 @@ def test_const():
     )
     w_s = vm.call(w_adapter, [vm.wrap(3)])
     assert vm.unwrap_str(w_s) == 'ab ab ab '
+    expected = textwrap.dedent("""
+    def(n: i32) -> str:
+        return `test::repeat`(W_Str('ab '), n)
+    """).strip()
+    assert w_adapter.render() == expected
 
 def test_converter():
     vm = SPyVM()
@@ -52,3 +64,9 @@ def test_converter():
     )
     w_s = vm.call(w_adapter, [vm.wrap(3.5), vm.wrap('ab ')])
     assert vm.unwrap_str(w_s) == 'ab ab ab '
+    #
+    expected = textwrap.dedent("""
+    def(x: f64, s: str) -> str:
+        return `test::repeat`(s, `operator::f64_to_i32`(x))
+    """).strip()
+    assert w_adapter.render() == expected

--- a/spy/tests/vm/test_func_adapter.py
+++ b/spy/tests/vm/test_func_adapter.py
@@ -1,0 +1,30 @@
+import pytest
+from spy.vm.vm import SPyVM
+from spy.vm.function import W_FuncType
+from spy.vm.func_adapter import W_FuncAdapter, ArgSpec
+from spy.vm.primitive import W_I32
+from spy.vm.str import W_Str
+from spy.vm.builtin import builtin_func
+
+
+@builtin_func('test')
+def w_repeat(vm: 'SPyVM', w_s: W_Str, w_n: W_I32) -> W_Str:
+    s = vm.unwrap_str(w_s)
+    n = vm.unwrap_i32(w_n)
+    return vm.wrap(s * int(n))  # type: ignore
+
+def test_repeat():
+    vm = SPyVM()
+    w_s = vm.call(w_repeat, [vm.wrap('ab '), vm.wrap(3)])
+    assert vm.unwrap_str(w_s) == 'ab ab ab '
+
+def test_shuffle_args():
+    vm = SPyVM()
+    w_functype = W_FuncType.parse('def(n: i32, s: str) -> str')
+    w_adapter = W_FuncAdapter(
+        w_functype,
+        w_repeat,
+        [ArgSpec.Arg(1), ArgSpec.Arg(0)]
+    )
+    w_s = vm.call(w_adapter, [vm.wrap(3), vm.wrap('ab ')])
+    assert vm.unwrap_str(w_s) == 'ab ab ab '

--- a/spy/tests/vm/test_func_adapter.py
+++ b/spy/tests/vm/test_func_adapter.py
@@ -5,6 +5,7 @@ from spy.vm.func_adapter import W_FuncAdapter, ArgSpec
 from spy.vm.primitive import W_I32
 from spy.vm.str import W_Str
 from spy.vm.builtin import builtin_func
+from spy.vm.b import OP
 
 
 @builtin_func('test')
@@ -39,4 +40,15 @@ def test_const():
         [ArgSpec.Const(w_s), ArgSpec.Arg(0)]
     )
     w_s = vm.call(w_adapter, [vm.wrap(3)])
+    assert vm.unwrap_str(w_s) == 'ab ab ab '
+
+def test_converter():
+    vm = SPyVM()
+    w_functype = W_FuncType.parse('def(x: f64, s: str) -> str')
+    w_adapter = W_FuncAdapter(
+        w_functype,
+        w_repeat,
+        [ArgSpec.Arg(1), ArgSpec.Arg(0, OP.w_f64_to_i32)]
+    )
+    w_s = vm.call(w_adapter, [vm.wrap(3.5), vm.wrap('ab ')])
     assert vm.unwrap_str(w_s) == 'ab ab ab '

--- a/spy/tests/vm/test_func_adapter.py
+++ b/spy/tests/vm/test_func_adapter.py
@@ -1,5 +1,6 @@
 import pytest
 import textwrap
+from spy.location import Loc
 from spy.vm.vm import SPyVM
 from spy.vm.function import W_FuncType
 from spy.vm.func_adapter import W_FuncAdapter, ArgSpec
@@ -17,7 +18,7 @@ def w_repeat(vm: 'SPyVM', w_s: W_Str, w_n: W_I32) -> W_Str:
 
 def test_repeat():
     vm = SPyVM()
-    w_s = vm.call(w_repeat, [vm.wrap('ab '), vm.wrap(3)])
+    w_s = vm.fast_call(w_repeat, [vm.wrap('ab '), vm.wrap(3)])
     assert vm.unwrap_str(w_s) == 'ab ab ab '
 
 def test_shuffle_args():
@@ -28,7 +29,7 @@ def test_shuffle_args():
         w_repeat,
         [ArgSpec.Arg(1), ArgSpec.Arg(0)]
     )
-    w_s = vm.call(w_adapter, [vm.wrap(3), vm.wrap('ab ')])
+    w_s = vm.fast_call(w_adapter, [vm.wrap(3), vm.wrap('ab ')])
     assert vm.unwrap_str(w_s) == 'ab ab ab '
     #
     r = '<spy adapter `def(n: i32, s: str) -> str` for `test::repeat`>'
@@ -47,9 +48,9 @@ def test_const():
     w_adapter = W_FuncAdapter(
         w_functype,
         w_repeat,
-        [ArgSpec.Const(w_s), ArgSpec.Arg(0)]
+        [ArgSpec.Const(w_s, Loc.here()), ArgSpec.Arg(0)]
     )
-    w_s = vm.call(w_adapter, [vm.wrap(3)])
+    w_s = vm.fast_call(w_adapter, [vm.wrap(3)])
     assert vm.unwrap_str(w_s) == 'ab ab ab '
     expected = textwrap.dedent("""
     def(n: i32) -> str:
@@ -65,7 +66,7 @@ def test_converter():
         w_repeat,
         [ArgSpec.Arg(1), ArgSpec.Arg(0, OP.w_f64_to_i32)]
     )
-    w_s = vm.call(w_adapter, [vm.wrap(3.5), vm.wrap('ab ')])
+    w_s = vm.fast_call(w_adapter, [vm.wrap(3.5), vm.wrap('ab ')])
     assert vm.unwrap_str(w_s) == 'ab ab ab '
     #
     expected = textwrap.dedent("""

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -198,7 +198,7 @@ class TestVM:
         w_x = vm.wrap('hello')
         msg = 'Invalid cast. Expected `i32`, got `str`'
         with pytest.raises(SPyTypeError, match=msg):
-            vm.call(w_abs, [w_x])
+            vm.fast_call(w_abs, [w_x])
 
     def test_eq(self):
         vm = SPyVM()

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -196,8 +196,15 @@ class TestVM:
         vm = SPyVM()
         w_abs = B.w_abs
         w_x = vm.wrap('hello')
-        msg = 'Invalid cast. Expected `i32`, got `str`'
-        with pytest.raises(SPyTypeError, match=msg):
+        # if we use vm.call(), we get proper type checking and SPyTypeError
+        # XXX implement vm.call!
+        ## msg = 'Invalid cast. Expected `i32`, got `str`'
+        ## with pytest.raises(SPyTypeError, match=msg):
+        ##     vm.call(w_abs, [w_x])
+        #
+        # if we use vm.fast_call(), we don't get proper type checking, but we
+        # get AssertionError
+        with pytest.raises(AssertionError):
             vm.fast_call(w_abs, [w_x])
 
     def test_eq(self):

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -189,7 +189,7 @@ class TestVM:
         vm = SPyVM()
         w_abs = B.w_abs
         w_x = vm.wrap(-42)
-        w_y = vm.call(w_abs, [w_x])
+        w_y = vm.fast_call(w_abs, [w_x])
         assert vm.unwrap(w_y) == 42
 
     def test_call_function_TypeError(self):

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -294,6 +294,7 @@ class ASTFrame:
         if w_func is B.w_STATIC_TYPE:
             return self._eval_STATIC_TYPE(call)
 
+        args_w = [self.eval_expr(arg) for arg in call.args]
         if w_opimpl.is_direct_call():
             # some extra sanity checks
             assert color == 'blue', 'indirect calls not supported'
@@ -308,9 +309,7 @@ class ASTFrame:
                 # if the static type is not `dynamic` and the thing is not a
                 # function, it's a bug in the typechecker
                 assert isinstance(w_func, W_Func)
-
-        args_w = [self.eval_expr(arg) for arg in call.args]
-        return w_opimpl.call(self.vm, [w_func] + args_w)
+        return w_opimpl.fast_call(self.vm, [w_func] + args_w)
 
     def _eval_STATIC_TYPE(self, call: ast.Call) -> W_Object:
         assert len(call.args) == 1

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -214,7 +214,7 @@ class ASTFrame:
         w_target = self.eval_expr(node.target)
         w_index = self.eval_expr(node.index)
         w_value = self.eval_expr(node.value)
-        w_opimpl.call(self.vm, [w_target, w_index, w_value])
+        self.vm.fast_call(w_opimpl, [w_target, w_index, w_value])
 
     def exec_stmt_StmtExpr(self, stmt: ast.StmtExpr) -> None:
         self.eval_expr(stmt.value)
@@ -326,7 +326,7 @@ class ASTFrame:
         w_target = self.eval_expr(op.target)
         w_method = self.vm.wrap(op.method)
         args_w = [self.eval_expr(arg) for arg in op.args]
-        return w_opimpl.call(self.vm, [w_target, w_method] + args_w)
+        return self.vm.fast_call(w_opimpl, [w_target, w_method] + args_w)
 
     def eval_expr_GetItem(self, op: ast.GetItem) -> W_Object:
         w_opimpl = self.t.opimpl[op]

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -112,7 +112,7 @@ class ASTFrame:
             return w_val
         else:
             # apply the type converter, if present
-            return self.vm.call(w_typeconv, [w_val])
+            return self.vm.fast_call(w_typeconv, [w_val])
 
     def eval_expr_type(self, expr: ast.Expr) -> W_Type:
         w_val = self.eval_expr(expr)
@@ -270,7 +270,7 @@ class ASTFrame:
         assert w_opimpl, 'bug in the typechecker'
         w_l = self.eval_expr(binop.left)
         w_r = self.eval_expr(binop.right)
-        w_res = w_opimpl.fast_call(self.vm, [w_l, w_r])
+        w_res = self.vm.fast_call(w_opimpl, [w_l, w_r])
         return w_res
 
     eval_expr_Add = eval_expr_BinOp
@@ -309,7 +309,7 @@ class ASTFrame:
                 # if the static type is not `dynamic` and the thing is not a
                 # function, it's a bug in the typechecker
                 assert isinstance(w_func, W_Func)
-        return w_opimpl.fast_call(self.vm, [w_func] + args_w)
+        return self.vm.fast_call(w_opimpl, [w_func] + args_w)
 
     def _eval_STATIC_TYPE(self, call: ast.Call) -> W_Object:
         assert len(call.args) == 1

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -270,7 +270,7 @@ class ASTFrame:
         assert w_opimpl, 'bug in the typechecker'
         w_l = self.eval_expr(binop.left)
         w_r = self.eval_expr(binop.right)
-        w_res = w_opimpl.call(self.vm, [w_l, w_r])
+        w_res = w_opimpl.fast_call(self.vm, [w_l, w_r])
         return w_res
 
     eval_expr_Add = eval_expr_BinOp

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -207,7 +207,7 @@ class ASTFrame:
         w_target = self.eval_expr(node.target)
         w_attr = self.vm.wrap(node.attr)
         w_value = self.eval_expr(node.value)
-        w_opimpl.call(self.vm, [w_target, w_attr, w_value])
+        self.vm.fast_call(w_opimpl, [w_target, w_attr, w_value])
 
     def exec_stmt_SetItem(self, node: ast.SetItem) -> None:
         w_opimpl = self.t.opimpl[node]
@@ -332,7 +332,7 @@ class ASTFrame:
         w_opimpl = self.t.opimpl[op]
         w_val = self.eval_expr(op.value)
         w_i = self.eval_expr(op.index)
-        return w_opimpl.call(self.vm, [w_val, w_i])
+        return self.vm.fast_call(w_opimpl, [w_val, w_i])
 
     def eval_expr_GetAttr(self, op: ast.GetAttr) -> W_Object:
         # this is suboptimal, but good enough for now: ideally, we would like
@@ -343,7 +343,7 @@ class ASTFrame:
         w_opimpl = self.t.opimpl[op]
         w_val = self.eval_expr(op.value)
         w_attr = self.vm.wrap(op.attr)
-        w_res = w_opimpl.call(self.vm, [w_val, w_attr])
+        w_res = self.vm.fast_call(w_opimpl, [w_val, w_attr])
         return w_res
 
     def eval_expr_List(self, op: ast.List) -> W_Object:

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -10,6 +10,7 @@ from spy.fqn import FQN
 from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type
 from spy.vm.function import W_Func, W_FuncType, W_ASTFunc, Namespace
+from spy.vm.func_adapter import W_FuncAdapter
 from spy.vm.list import W_List, W_ListType
 from spy.vm.tuple import W_Tuple
 from spy.vm.modules.unsafe.struct import W_StructType
@@ -295,6 +296,8 @@ class ASTFrame:
             return self._eval_STATIC_TYPE(call)
 
         args_w = [self.eval_expr(arg) for arg in call.args]
+        # as long as we have the is_direct_call hack, this is needed
+        assert isinstance(w_opimpl, W_FuncAdapter)
         if w_opimpl.is_direct_call():
             # some extra sanity checks
             assert color == 'blue', 'indirect calls not supported'

--- a/spy/vm/func_adapter.py
+++ b/spy/vm/func_adapter.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Sequence
 from dataclasses import dataclass
 import textwrap
 from spy.fqn import FQN
+from spy.location import Loc
 from spy.vm.object import W_Object
 from spy.vm.function import W_Func, W_FuncType, W_DirectCall
 if TYPE_CHECKING:
@@ -19,6 +20,7 @@ class Arg(ArgSpec):
 @dataclass
 class Const(ArgSpec):
     w_const: W_Object
+    loc: Loc
 
 ArgSpec.Arg = Arg
 ArgSpec.Const = Const

--- a/spy/vm/func_adapter.py
+++ b/spy/vm/func_adapter.py
@@ -13,6 +13,7 @@ class ArgSpec:
 @dataclass
 class Arg(ArgSpec):
     i: int
+    w_converter: W_Func = None
 
 @dataclass
 class Const(ArgSpec):
@@ -38,7 +39,10 @@ class W_FuncAdapter(W_Func):
         real_args_w = []
         for spec in self.args:
             if isinstance(spec, Arg):
-                real_args_w.append(args_w[spec.i])
+                w_arg = args_w[spec.i]
+                if spec.w_converter:
+                    w_arg = spec.w_converter.spy_call(vm, [w_arg])
+                real_args_w.append(w_arg)
             elif isinstance(spec, Const):
                 real_args_w.append(spec.w_const)
             else:

--- a/spy/vm/func_adapter.py
+++ b/spy/vm/func_adapter.py
@@ -40,12 +40,12 @@ class W_FuncAdapter(W_Func):
         fqn = self.w_func.fqn
         return f'<spy adapter `{sig}` for `{fqn}`>'
 
-    def spy_call(self, vm: 'SPyVM', args_w: Sequence[W_Object]) -> W_Object:
+    def fast_call(self, vm: 'SPyVM', args_w: Sequence[W_Object]) -> W_Object:
         def getarg(spec):
             if isinstance(spec, Arg):
                 w_arg = args_w[spec.i]
                 if spec.w_converter:
-                    w_arg = spec.w_converter.spy_call(vm, [w_arg])
+                    w_arg = spec.w_converter.fast_call(vm, [w_arg])
                 return w_arg
             elif isinstance(spec, Const):
                 return spec.w_const
@@ -53,7 +53,7 @@ class W_FuncAdapter(W_Func):
                 assert False
 
         real_args_w = [getarg(spec) for spec in self.args]
-        return self.w_func.spy_call(vm, real_args_w)
+        return self.w_func.fast_call(vm, real_args_w)
 
     def pp(self):
         print(self.render())

--- a/spy/vm/func_adapter.py
+++ b/spy/vm/func_adapter.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Sequence, Optional
+from typing import TYPE_CHECKING, Sequence, Optional, ClassVar
 from dataclasses import dataclass
 import textwrap
 from spy.fqn import FQN
@@ -10,7 +10,8 @@ if TYPE_CHECKING:
 
 # simulate Algebraic Data Type
 class ArgSpec:
-    pass
+    Arg: ClassVar[type]
+    Const: ClassVar[type]
 
 @dataclass
 class Arg(ArgSpec):

--- a/spy/vm/func_adapter.py
+++ b/spy/vm/func_adapter.py
@@ -25,7 +25,13 @@ ArgSpec.Const = Const
 
 class W_FuncAdapter(W_Func):
     """
-    WRITE ME
+    Adapt another w_func to a different signature.
+
+    When called, W_FuncAdapter transforms the input args_w into the "real"
+    args_w which is passed to w_func.
+
+    The transformation rules are stored into a list of ArgSpec, which
+    effectively encodes a mini-AST.
     """
     fqn = FQN('builtins::__adapter__')
 

--- a/spy/vm/func_adapter.py
+++ b/spy/vm/func_adapter.py
@@ -35,6 +35,11 @@ class W_FuncAdapter(W_Func):
         self.w_func = w_func
         self.args = args
 
+    def __repr__(self):
+        sig = self.w_functype.signature
+        fqn = self.w_func.fqn
+        return f'<spy adapter `{sig}` for `{fqn}`>'
+
     def spy_call(self, vm: 'SPyVM', args_w: Sequence[W_Object]) -> W_Object:
         def getarg(spec):
             if isinstance(spec, Arg):

--- a/spy/vm/func_adapter.py
+++ b/spy/vm/func_adapter.py
@@ -14,7 +14,12 @@ class ArgSpec:
 class Arg(ArgSpec):
     i: int
 
+@dataclass
+class Const(ArgSpec):
+    w_const: W_Object
+
 ArgSpec.Arg = Arg
+ArgSpec.Const = Const
 
 class W_FuncAdapter(W_Func):
     """
@@ -34,6 +39,8 @@ class W_FuncAdapter(W_Func):
         for spec in self.args:
             if isinstance(spec, Arg):
                 real_args_w.append(args_w[spec.i])
+            elif isinstance(spec, Const):
+                real_args_w.append(spec.w_const)
             else:
                 assert False
         return self.w_func.spy_call(vm, real_args_w)

--- a/spy/vm/func_adapter.py
+++ b/spy/vm/func_adapter.py
@@ -10,8 +10,8 @@ if TYPE_CHECKING:
 
 # simulate Algebraic Data Type
 class ArgSpec:
-    Arg: ClassVar[type]
-    Const: ClassVar[type]
+    Arg: ClassVar[type['Arg']]
+    Const: ClassVar[type['Const']]
 
 @dataclass
 class Arg(ArgSpec):

--- a/spy/vm/func_adapter.py
+++ b/spy/vm/func_adapter.py
@@ -71,7 +71,7 @@ class W_FuncAdapter(W_Func):
                 assert False
 
         real_args_w = [getarg(spec) for spec in self.args]
-        return w_func.fast_call(vm, real_args_w)
+        return vm.fast_call(w_func, real_args_w)
 
     def pp(self):
         print(self.render())

--- a/spy/vm/func_adapter.py
+++ b/spy/vm/func_adapter.py
@@ -1,0 +1,39 @@
+from typing import TYPE_CHECKING, Sequence
+from dataclasses import dataclass
+from spy.fqn import FQN
+from spy.vm.object import W_Object
+from spy.vm.function import W_Func, W_FuncType
+if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
+
+# simulate Algebraic Data Type
+class ArgSpec:
+    pass
+
+@dataclass
+class Arg(ArgSpec):
+    i: int
+
+ArgSpec.Arg = Arg
+
+class W_FuncAdapter(W_Func):
+    """
+    WRITE ME
+    """
+    fqn = FQN('builtins::__adapter__')
+
+
+    def __init__(self, w_functype: W_FuncType, w_func: W_Func,
+                 args: list[ArgSpec]) -> None:
+        self.w_functype = w_functype
+        self.w_func = w_func
+        self.args = args
+
+    def spy_call(self, vm: 'SPyVM', args_w: Sequence[W_Object]) -> W_Object:
+        real_args_w = []
+        for spec in self.args:
+            if isinstance(spec, Arg):
+                real_args_w.append(args_w[spec.i])
+            else:
+                assert False
+        return self.w_func.spy_call(vm, real_args_w)

--- a/spy/vm/func_adapter.py
+++ b/spy/vm/func_adapter.py
@@ -52,7 +52,7 @@ class W_FuncAdapter(W_Func):
         """
         return isinstance(self.w_func, W_DirectCall)
 
-    def fast_call(self, vm: 'SPyVM', args_w: Sequence[W_Object]) -> W_Object:
+    def raw_call(self, vm: 'SPyVM', args_w: Sequence[W_Object]) -> W_Object:
         # hack hack hack, we should kill all of this eventually
         if self.is_direct_call():
             w_func = args_w[0]

--- a/spy/vm/func_adapter.py
+++ b/spy/vm/func_adapter.py
@@ -63,7 +63,7 @@ class W_FuncAdapter(W_Func):
             if isinstance(spec, Arg):
                 w_arg = args_w[spec.i]
                 if spec.w_converter:
-                    w_arg = spec.w_converter.fast_call(vm, [w_arg])
+                    w_arg = vm.fast_call(spec.w_converter, [w_arg])
                 return w_arg
             elif isinstance(spec, Const):
                 return spec.w_const

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -138,17 +138,17 @@ class W_Func(W_Object):
     def spy_get_w_type(self, vm: 'SPyVM') -> W_Type:
         return self.w_functype
 
-    def fast_call(self, vm: 'SPyVM', args_w: Sequence[W_Object]) -> W_Object:
+    def raw_call(self, vm: 'SPyVM', args_w: Sequence[W_Object]) -> W_Object:
         """
         Call the function.
 
-        This is the simplest calling convention: arguments can be passed ONLY
-        positionally, and the must be of the correct type, no conversions are
-        allowed here.
+        This is the simplest calling convention, and it's at the base to
+        everything else. Arguments can be passed ONLY positionally, and they
+        must be of the correct type, no conversions are allowed here.
 
-        Also, fast_call bypasses the blue cache.
+        Also, raw_call bypasses the blue cache.
 
-        If you want to call a generic object, you should use vm.call().
+        You should never call this directly. Use vm.call or vm.fast_call.
         """
         raise NotImplementedError
 
@@ -227,7 +227,7 @@ class W_ASTFunc(W_Func):
             extra = ''
         return f"<spy function '{self.fqn}'{extra}>"
 
-    def fast_call(self, vm: 'SPyVM', args_w: Sequence[W_Object]) -> W_Object:
+    def raw_call(self, vm: 'SPyVM', args_w: Sequence[W_Object]) -> W_Object:
         from spy.vm.astframe import ASTFrame
         frame = ASTFrame(vm, self)
         return frame.run(args_w)
@@ -251,7 +251,7 @@ class W_BuiltinFunc(W_Func):
     def __repr__(self) -> str:
         return f"<spy function '{self.fqn}' (builtin)>"
 
-    def fast_call(self, vm: 'SPyVM', args_w: Sequence[W_Object]) -> W_Object:
+    def raw_call(self, vm: 'SPyVM', args_w: Sequence[W_Object]) -> W_Object:
         from spy.vm.b import B
         w_res = self._pyfunc(vm, *args_w)
         if w_res is None and self.w_functype.w_restype is B.w_void:

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional, Callable, Sequence, Literal
+from typing import (TYPE_CHECKING, Any, Optional, Callable, Sequence, Literal,
+                    Iterator)
 from spy import ast
 from spy.ast import Color
 from spy.fqn import FQN, NSPart
@@ -122,6 +123,19 @@ class W_FuncType(W_Type):
     def is_varargs(self) -> bool:
         return bool(self.params) and self.params[-1].kind == 'varargs'
 
+    def all_params(self) -> Iterator[FuncParam]:
+        """
+        Iterate over all params. Go to infinity in case of varargs
+        """
+        if self.is_varargs:
+            for param in self.params[:-1]:
+                yield param
+            last_param = self.params[-1]
+            while True:
+                yield last_param
+        else:
+            for param in self.params:
+                yield param
 
 
 class W_Func(W_Object):

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -109,6 +109,10 @@ class W_FuncType(W_Type):
         return cls.make(w_restype=w_restype, **kwargs)
 
     @property
+    def is_varargs(self) -> bool:
+        return bool(self.params) and self.params[-1].kind == 'varargs'
+
+    @property
     def arity(self) -> int:
         """
         Return the *minimum* number of arguments expected by the function.
@@ -119,9 +123,11 @@ class W_FuncType(W_Type):
         else:
             return len(self.params)
 
-    @property
-    def is_varargs(self) -> bool:
-        return bool(self.params) and self.params[-1].kind == 'varargs'
+    def is_argcount_ok(self, n: int) -> bool:
+        if self.is_varargs:
+            return n >= self.arity
+        else:
+            return n == self.arity
 
     def all_params(self) -> Iterator[FuncParam]:
         """
@@ -136,6 +142,7 @@ class W_FuncType(W_Type):
         else:
             for param in self.params:
                 yield param
+
 
 
 class W_Func(W_Object):

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -23,18 +23,17 @@ def unwrap_attr_maybe(vm: 'SPyVM', wop_attr: W_OpArg) -> str:
         return '<unknown>'
 
 @OP.builtin_func(color='blue')
-def w_GETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg) -> W_OpImpl:
+def w_GETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg) -> W_Func:
     from spy.vm.typechecker import typecheck_opimpl
     attr = unwrap_attr_maybe(vm, wop_attr)
     w_opimpl = _get_GETATTR_opimpl(vm, wop_obj, wop_attr, attr)
-    typecheck_opimpl(
+    return typecheck_opimpl(
         vm,
         w_opimpl,
         [wop_obj, wop_attr],
         dispatch = 'single',
         errmsg = "type `{0}` has no attribute '%s'" % attr
     )
-    return w_opimpl
 
 def _get_GETATTR_opimpl(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
                         attr: str) -> W_OpImpl:
@@ -54,19 +53,18 @@ def _get_GETATTR_opimpl(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
 
 @OP.builtin_func(color='blue')
 def w_SETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
-            wop_v: W_OpArg) -> W_OpImpl:
+            wop_v: W_OpArg) -> W_Func:
     from spy.vm.typechecker import typecheck_opimpl
     attr = unwrap_attr_maybe(vm, wop_attr)
     w_opimpl = _get_SETATTR_opimpl(vm, wop_obj, wop_attr, wop_v, attr)
     errmsg = "type `{0}` does not support assignment to attribute '%s'" % attr
-    typecheck_opimpl(
+    return typecheck_opimpl(
         vm,
         w_opimpl,
         [wop_obj, wop_attr, wop_v],
         dispatch = 'single',
         errmsg = errmsg
     )
-    return w_opimpl
 
 def _get_SETATTR_opimpl(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
                         wop_v: W_OpArg, attr: str) -> W_OpImpl:

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -4,7 +4,7 @@ from spy.vm.object import W_Object, W_Type
 from spy.vm.primitive import W_Dynamic
 from spy.vm.str import W_Str
 from spy.vm.opimpl import W_OpImpl, W_OpArg
-from spy.vm.function import W_DirectCall, W_FuncType, FuncParam
+from spy.vm.function import W_DirectCall, W_FuncType, FuncParam, W_Func
 
 from . import OP
 from .binop import MM
@@ -67,7 +67,7 @@ def _dynamic_call_opimpl(args_wop: list[W_OpArg]) -> W_OpImpl:
 
 @OP.builtin_func(color='blue')
 def w_CALL_METHOD(vm: 'SPyVM', wop_obj: W_OpArg, wop_method: W_OpArg,
-                  *args_wop: W_OpArg) -> W_OpImpl:
+                  *args_wop: W_OpArg) -> W_Func:
     from spy.vm.typechecker import typecheck_opimpl
     w_opimpl = W_OpImpl.NULL
     w_type = wop_obj.w_static_type
@@ -75,11 +75,10 @@ def w_CALL_METHOD(vm: 'SPyVM', wop_obj: W_OpArg, wop_method: W_OpArg,
     if pyclass.has_meth_overriden('op_CALL_METHOD'):
         w_opimpl = pyclass.op_CALL_METHOD(vm, wop_obj, wop_method, *args_wop)
 
-    typecheck_opimpl(
+    return typecheck_opimpl(
         vm,
         w_opimpl,
         [wop_obj, wop_method] + list(args_wop),
         dispatch = 'single',
         errmsg = 'cannot call methods on type `{0}`'
     )
-    return w_opimpl

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -24,14 +24,13 @@ def w_CALL(vm: 'SPyVM', wop_obj: W_OpArg, *args_wop: W_OpArg) -> W_OpImpl:
     elif pyclass.has_meth_overriden('op_CALL'):
         w_opimpl = pyclass.op_CALL(vm, wop_obj, *args_wop)
 
-    typecheck_opimpl(
+    return typecheck_opimpl(
         vm,
         w_opimpl,
         [wop_obj] + list(args_wop),
         dispatch = 'single',
         errmsg = 'cannot call objects of type `{0}`'
     )
-    return w_opimpl
 
 
 def _dynamic_call_opimpl(args_wop: list[W_OpArg]) -> W_OpImpl:

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 @OP.builtin_func(color='blue')
-def w_CALL(vm: 'SPyVM', wop_obj: W_OpArg, *args_wop: W_OpArg) -> W_OpImpl:
+def w_CALL(vm: 'SPyVM', wop_obj: W_OpArg, *args_wop: W_OpArg) -> W_Func:
     from spy.vm.typechecker import typecheck_opimpl
     w_opimpl = W_OpImpl.NULL
     w_type = wop_obj.w_static_type

--- a/spy/vm/modules/operator/convop.py
+++ b/spy/vm/modules/operator/convop.py
@@ -49,7 +49,7 @@ def get_opimpl(vm: 'SPyVM', w_exp: W_Type, wop_x: W_OpArg) -> W_OpImpl:
         #   - dynamic->*: in this case we SHOULD do actual conversions, but at
         #                 the moment we don't so we conflate the two cases
         #                 into one
-        w_from_dynamic_T = vm.call(OP.w_from_dynamic, [w_exp])
+        w_from_dynamic_T = vm.fast_call(OP.w_from_dynamic, [w_exp])
         assert isinstance(w_from_dynamic_T, W_Func)
         return W_OpImpl(w_from_dynamic_T)
 
@@ -77,7 +77,7 @@ def CONVERT_maybe(
     if vm.issubclass(w_got, w_exp):
         # nothing to do
         return None
-    return vm.call(OP.w_CONVERT, [w_exp, wop_x])  # type: ignore
+    return vm.fast_call(OP.w_CONVERT, [w_exp, wop_x])  # type: ignore
 
 @OP.builtin_func
 def w_i32_to_f64(vm: 'SPyVM', w_x: W_I32) -> W_F64:

--- a/spy/vm/modules/operator/convop.py
+++ b/spy/vm/modules/operator/convop.py
@@ -89,6 +89,11 @@ def w_i32_to_bool(vm: 'SPyVM', w_x: W_I32) -> W_Bool:
     val = vm.unwrap_i32(w_x)
     return vm.wrap(bool(val))  # type: ignore
 
+@OP.builtin_func
+def w_f64_to_i32(vm: 'SPyVM', w_x: W_F64) -> W_I32:
+    val = vm.unwrap_f64(w_x)
+    return vm.wrap(int(val))  # type: ignore
+
 
 @OP.builtin_func(color='blue')
 def w_from_dynamic(vm: 'SPyVM', w_T: W_Type) -> W_Dynamic:
@@ -116,3 +121,4 @@ def w_from_dynamic(vm: 'SPyVM', w_T: W_Type) -> W_Dynamic:
 
 MM.register('convert', 'i32', 'f64', OP.w_i32_to_f64)
 MM.register('convert', 'i32', 'bool', OP.w_i32_to_bool)
+MM.register('convert', 'f64', 'i32', OP.w_f64_to_i32)

--- a/spy/vm/modules/operator/itemop.py
+++ b/spy/vm/modules/operator/itemop.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 from spy.vm.b import B
 from spy.vm.object import W_Type
 from spy.vm.opimpl import W_OpImpl, W_OpArg
+from spy.vm.function import W_Func
 from spy.vm.primitive import W_Dynamic
 
 from . import OP
@@ -10,37 +11,35 @@ if TYPE_CHECKING:
 
 
 @OP.builtin_func(color='blue')
-def w_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg, wop_i: W_OpArg) -> W_OpImpl:
+def w_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg, wop_i: W_OpArg) -> W_Func:
     from spy.vm.typechecker import typecheck_opimpl
     w_opimpl = W_OpImpl.NULL
     pyclass = wop_obj.w_static_type.pyclass
     if pyclass.has_meth_overriden('op_GETITEM'):
         w_opimpl = pyclass.op_GETITEM(vm, wop_obj, wop_i)
 
-    typecheck_opimpl(
+    return typecheck_opimpl(
         vm,
         w_opimpl,
         [wop_obj, wop_i],
         dispatch = 'single',
         errmsg = 'cannot do `{0}`[...]'
     )
-    return w_opimpl
 
 
 @OP.builtin_func(color='blue')
 def w_SETITEM(vm: 'SPyVM', wop_obj: W_OpArg, wop_i: W_OpArg,
-            wop_v: W_OpArg) -> W_OpImpl:
+            wop_v: W_OpArg) -> W_Func:
     from spy.vm.typechecker import typecheck_opimpl
     w_opimpl = W_OpImpl.NULL
     pyclass = wop_obj.w_static_type.pyclass
     if pyclass.has_meth_overriden('op_SETITEM'):
         w_opimpl = pyclass.op_SETITEM(vm, wop_obj, wop_i, wop_v)
 
-    typecheck_opimpl(
+    return typecheck_opimpl(
         vm,
         w_opimpl,
         [wop_obj, wop_i, wop_v],
         dispatch = 'single',
         errmsg = "cannot do `{0}[`{1}`] = ..."
     )
-    return w_opimpl

--- a/spy/vm/modules/operator/multimethod.py
+++ b/spy/vm/modules/operator/multimethod.py
@@ -67,16 +67,15 @@ class MultiMethodTable:
         return W_OpImpl.NULL
 
     def get_opimpl(self, vm: 'SPyVM', op: str,
-                   wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
+                   wop_l: W_OpArg, wop_r: W_OpArg) -> W_Func:
         from spy.vm.typechecker import typecheck_opimpl
         w_ltype = wop_l.w_static_type
         w_rtype = wop_r.w_static_type
         w_opimpl = self.lookup(op, w_ltype, w_rtype)
-        typecheck_opimpl(
+        return typecheck_opimpl(
             vm,
             w_opimpl,
             [wop_l, wop_r],
             dispatch = 'multi',
             errmsg = 'cannot do `{0}` %s `{1}`' % op
         )
-        return w_opimpl

--- a/spy/vm/modules/operator/opimpl_dynamic.py
+++ b/spy/vm/modules/operator/opimpl_dynamic.py
@@ -66,7 +66,7 @@ def w_dynamic_getattr(vm: 'SPyVM', w_obj: W_Dynamic,
     wop_obj = W_OpArg.from_w_obj(vm, w_obj, 'o', 0)
     wop_attr = W_OpArg.from_w_obj(vm, w_attr, 'a', 1)
     w_opimpl = vm.call_OP(OP.w_GETATTR, [wop_obj, wop_attr])
-    return w_opimpl.call(vm, [w_obj, w_attr])
+    return vm.fast_call(w_opimpl, [w_obj, w_attr])
 
 
 # NOT USED, but will be soon (hopefully)
@@ -79,4 +79,4 @@ def w_dynamic_call(vm: 'SPyVM', w_obj: W_Dynamic,
         for i, w_x in enumerate(all_args_w)
     ]
     w_opimpl = vm.call_OP(OP.w_CALL, all_args_wop)
-    return w_opimpl.call(vm, all_args_w)
+    return vm.fast_call(w_opimpl, all_args_w)

--- a/spy/vm/modules/operator/opimpl_dynamic.py
+++ b/spy/vm/modules/operator/opimpl_dynamic.py
@@ -16,7 +16,7 @@ def _dynamic_op(vm: 'SPyVM', w_op: W_Func,
     wop_a = W_OpArg.from_w_obj(vm, w_a, 'a', 0)
     wop_b = W_OpArg.from_w_obj(vm, w_b, 'b', 1)
     w_opimpl = vm.call_OP(w_op, [wop_a, wop_b])
-    return w_opimpl.call(vm, [w_a, w_b])
+    return vm.fast_call(w_opimpl, [w_a, w_b])
 
 @OP.builtin_func
 def w_dynamic_add(vm: 'SPyVM', w_a: W_Dynamic, w_b: W_Dynamic) -> W_Dynamic:
@@ -58,7 +58,7 @@ def w_dynamic_setattr(vm: 'SPyVM', w_obj: W_Dynamic, w_attr: W_Str,
     wop_attr = W_OpArg.from_w_obj(vm, w_attr, 'a', 1)
     wop_v = W_OpArg.from_w_obj(vm, w_value, 'v', 2)
     w_opimpl = vm.call_OP(OP.w_SETATTR, [wop_obj, wop_attr, wop_v])
-    return w_opimpl.call(vm, [w_obj, w_attr, w_value])
+    return vm.fast_call(w_opimpl, [w_obj, w_attr, w_value])
 
 @OP.builtin_func
 def w_dynamic_getattr(vm: 'SPyVM', w_obj: W_Dynamic,

--- a/spy/vm/modules/unsafe/mem.py
+++ b/spy/vm/modules/unsafe/mem.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 @UNSAFE.builtin_func(color='blue')
 def w_gc_alloc(vm: 'SPyVM', w_T: W_Type) -> W_Dynamic:
-    w_ptrtype = vm.call(w_make_ptr_type, [w_T])  # unsafe::ptr[i32]
+    w_ptrtype = vm.fast_call(w_make_ptr_type, [w_T])  # unsafe::ptr[i32]
     assert isinstance(w_ptrtype, W_PtrType)
     ITEMSIZE = sizeof(w_T)
 

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -284,13 +284,13 @@ class W_Ptr(W_BasePtr):
         if opkind == 'get':
             # getfield[field_T](ptr, attr, offset)
             assert wop_v is None
-            w_func = vm.call(UNSAFE.w_getfield, [w_field_T])
+            w_func = vm.fast_call(UNSAFE.w_getfield, [w_field_T])
             assert isinstance(w_func, W_Func)
             return W_OpImpl(w_func, [wop_ptr, wop_attr, wop_offset])
         else:
             # setfield[field_T](ptr, attr, offset, v)
             assert wop_v is not None
-            w_func = vm.call(UNSAFE.w_setfield, [w_field_T])
+            w_func = vm.fast_call(UNSAFE.w_setfield, [w_field_T])
             assert isinstance(w_func, W_Func)
             return W_OpImpl(w_func, [wop_ptr, wop_attr, wop_offset, wop_v])
 
@@ -302,7 +302,7 @@ def w_getfield(vm: 'SPyVM', w_T: W_Type) -> W_Dynamic:
     # returned by value, but struct types are always returned by reference
     # (i.e., we return a pointer to it).
     if w_T.is_struct(vm):
-        w_T = vm.call(w_make_ptr_type, [w_T])  # type: ignore
+        w_T = vm.fast_call(w_make_ptr_type, [w_T])  # type: ignore
         by = 'byref'
     else:
         by = 'byval'

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -248,56 +248,5 @@ class W_OpImpl(W_Object):
         self._args_wop = args_wop[:]
         self._converters_w = [None] * len(args_wop)
 
-    def call(self, vm: 'SPyVM', orig_args_w: list[W_Object]) -> W_Object:
-        assert self.is_valid()
-        assert self._args_wop is not None
-        assert self._converters_w is not None
-        real_args_w = []
-        for wop_arg, w_conv in zip(self._args_wop, self._converters_w):
-            if wop_arg.is_const():
-                w_arg = wop_arg.w_blueval
-            else:
-                assert wop_arg.i is not None
-                w_arg = orig_args_w[wop_arg.i]
-
-            if w_conv is not None:
-                w_arg = vm.call(w_conv, [w_arg])
-            real_args_w.append(w_arg)
-        #
-        if self.is_direct_call():
-            w_func = orig_args_w[0]
-            assert isinstance(w_func, W_Func)
-            return vm.call(w_func, real_args_w)
-        else:
-            assert self._w_func is not None
-            return vm.call(self._w_func, real_args_w)
-
-    def redshift_args(self, vm: 'SPyVM',
-                      orig_args: list[ast.Expr]) -> list[ast.Expr]:
-        from spy.doppler import make_const
-        assert self.is_valid()
-        assert self._args_wop is not None
-        assert self._converters_w is not None
-        real_args = []
-        for wop_arg, w_conv in zip(self._args_wop, self._converters_w):
-            if wop_arg.is_const():
-                w_arg = wop_arg.w_blueval
-                arg = make_const(vm, wop_arg.loc, w_arg)
-            else:
-                assert wop_arg.i is not None
-                arg = orig_args[wop_arg.i]
-
-            if w_conv is not None:
-                arg = ast.Call(
-                    loc = arg.loc,
-                    func = ast.FQNConst(
-                        loc = arg.loc,
-                        fqn = w_conv.fqn
-                    ),
-                    args = [arg]
-                )
-            real_args.append(arg)
-        return real_args
-
 
 W_OpImpl.NULL = W_OpImpl(None)  # type: ignore

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -227,10 +227,5 @@ class W_OpImpl(W_Object):
         assert self._w_func is not None
         return self._w_func.w_functype
 
-    @property
-    def w_restype(self) -> W_Type:
-        assert self._w_func is not None
-        return self._w_func.w_functype.w_restype
-
 
 W_OpImpl.NULL = W_OpImpl(None)  # type: ignore

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -191,18 +191,13 @@ class W_OpImpl(W_Object):
     NULL: ClassVar['W_OpImpl']
     _w_func: Optional[W_Func]
     _args_wop: Optional[list[W_OpArg]]
-    _converters_w: Optional[list[Optional[W_Func]]]
 
     def __init__(self,
                  w_func: W_Func,
                 args_wop: Optional[list[W_OpArg]] = None
                 ) -> None:
         self._w_func = w_func
-        self._typechecked = False
-        if args_wop is None:
-            self._args_wop = None
-        else:
-            self._args_wop = args_wop
+        self._args_wop = args_wop
 
     def __repr__(self) -> str:
         if self._w_func is None:
@@ -227,9 +222,6 @@ class W_OpImpl(W_Object):
         """
         return isinstance(self._w_func, W_DirectCall)
 
-    def is_valid(self) -> bool:
-        return not self.is_null() and self._typechecked
-
     @property
     def w_functype(self) -> W_FuncType:
         assert self._w_func is not None
@@ -239,10 +231,6 @@ class W_OpImpl(W_Object):
     def w_restype(self) -> W_Type:
         assert self._w_func is not None
         return self._w_func.w_functype.w_restype
-
-    def set_args_wop(self, args_wop: list[W_OpArg]) -> None:
-        assert self._args_wop is None
-        self._args_wop = args_wop[:]
 
 
 W_OpImpl.NULL = W_OpImpl(None)  # type: ignore

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -201,10 +201,8 @@ class W_OpImpl(W_Object):
         self._typechecked = False
         if args_wop is None:
             self._args_wop = None
-            self._converters_w = None
         else:
             self._args_wop = args_wop
-            self._converters_w = [None] * len(args_wop)
 
     def __repr__(self) -> str:
         if self._w_func is None:
@@ -244,9 +242,7 @@ class W_OpImpl(W_Object):
 
     def set_args_wop(self, args_wop: list[W_OpArg]) -> None:
         assert self._args_wop is None
-        assert self._converters_w is None
         self._args_wop = args_wop[:]
-        self._converters_w = [None] * len(args_wop)
 
 
 W_OpImpl.NULL = W_OpImpl(None)  # type: ignore

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -497,6 +497,7 @@ def typecheck_opimpl(
     for param, wop_arg in zip(w_out_functype.all_params(), out_args_wop):
         # add a converter if needed (this might raise SPyTypeError)
         w_conv = get_w_conv(vm, param.w_type, wop_arg, def_loc)
+        arg: ArgSpec
         if wop_arg.is_const():
             assert w_conv is None
             arg = ArgSpec.Const(wop_arg.w_blueval, wop_arg.loc)

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -518,10 +518,10 @@ def typecheck_opimpl(
 
     # everything good!
     #
-    # XXX: we should create a W_FuncAdapter only if it's needed
+    argtypes_w = [wop_arg.w_static_type for wop_arg in orig_args_wop]
     params = [
-        FuncParam(f'v{i}', wop_arg.w_static_type, 'simple')
-        for i, wop_arg in enumerate(args_wop)
+        FuncParam(f'v{i}', w_type, 'simple')
+        for i, w_type in enumerate(argtypes_w)
     ]
     w_functype = W_FuncType(params, w_opimpl.w_functype.w_restype,
                             color=w_opimpl.w_functype.color)

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -41,7 +41,7 @@ class TypeChecker:
     funcef: ast.FuncDef
     expr_types: dict[ast.Expr, tuple[Color, W_Type]]
     expr_conv: dict[ast.Expr, W_Func]
-    opimpl: dict[ast.Node, W_OpImpl]
+    opimpl: dict[ast.Node, W_Func]
     locals_types_w: dict[str, W_Type]
 
 
@@ -446,6 +446,7 @@ def typecheck_opimpl(
     """
     if w_opimpl.is_null():
         _opimpl_null_error(in_args_wop, dispatch, errmsg)
+    assert w_opimpl._w_func is not None
 
     # the want to make an adapter that:
     #   - behaves like a function of type w_in_functype
@@ -461,6 +462,7 @@ def typecheck_opimpl(
     if w_opimpl.is_simple():
         out_args_wop = in_args_wop
     else:
+        assert w_opimpl._args_wop is not None
         out_args_wop = w_opimpl._args_wop
 
     # if it's a direct call, we can get extra info about call and def locations
@@ -518,7 +520,7 @@ def functype_from_opargs(args_wop: list[W_OpArg], w_restype: W_Type,
 
 
 def get_w_conv(vm: 'SPyVM', w_type: W_Type, wop_arg: W_OpArg,
-               def_loc: Loc) -> Optional[W_Func]:
+               def_loc: Optional[Loc]) -> Optional[W_Func]:
     """
     Like CONVERT_maybe, but improve the error message if we can
     """

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -484,13 +484,7 @@ def typecheck_opimpl(
     # check that the types of the arguments are compatible
     converters_w = [None] * len(out_args_wop)
     for i, (param, wop_arg) in enumerate(zip(w_out_functype.params, out_args_wop)):
-        try:
-            w_conv = CONVERT_maybe(vm, param.w_type, wop_arg)
-            converters_w[i] = w_conv
-        except SPyTypeError as err:
-            if def_loc:
-                err.add('note', 'function defined here', def_loc)
-            raise
+        converters_w[i] = get_w_conv(vm, param.w_type, wop_arg, def_loc)
 
     # everything good!
     #
@@ -512,6 +506,19 @@ def typecheck_opimpl(
         args.append(arg)
     w_adapter = W_FuncAdapter(w_in_functype, w_opimpl._w_func, args)
     return w_adapter
+
+
+def get_w_conv(vm: 'SPyVM', w_type: W_Type, wop_arg: W_OpArg,
+               def_loc: Loc) -> Optional[W_Func]:
+    """
+    Like CONVERT_maybe, but improve the error message if we can
+    """
+    try:
+        return CONVERT_maybe(vm, w_type, wop_arg)
+    except SPyTypeError as err:
+        if def_loc:
+            err.add('note', 'function defined here', def_loc)
+        raise
 
 
 def _opimpl_null_error(

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -506,11 +506,11 @@ def typecheck_opimpl(
             call_loc = call_loc)
 
     # check that the types of the arguments are compatible
-    assert w_opimpl._converters_w is not None
+    converters_w = [None] * len(w_opimpl._args_wop)
     for i, (param, wop_arg) in enumerate(zip(w_functype.params, args_wop)):
         try:
             w_conv = CONVERT_maybe(vm, param.w_type, wop_arg)
-            w_opimpl._converters_w[i] = w_conv
+            converters_w[i] = w_conv
         except SPyTypeError as err:
             if def_loc:
                 err.add('note', 'function defined here', def_loc)
@@ -526,7 +526,7 @@ def typecheck_opimpl(
     w_functype = W_FuncType(params, w_opimpl.w_functype.w_restype,
                             color=w_opimpl.w_functype.color)
     args = []
-    for wop_arg, w_conv in zip(w_opimpl._args_wop, w_opimpl._converters_w):
+    for wop_arg, w_conv in zip(w_opimpl._args_wop, converters_w):
         if wop_arg.is_const():
             arg = ArgSpec.Const(wop_arg.w_blueval, wop_arg.loc)
             assert w_conv is None

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -478,13 +478,7 @@ def typecheck_opimpl(
     # check that the number of arguments match
     got_nargs = len(out_args_wop)
     exp_nargs = len(w_out_functype.params)
-
-    if w_out_functype.is_varargs:
-        argcount_ok = got_nargs >= exp_nargs
-    else:
-        argcount_ok = got_nargs == exp_nargs
-
-    if not argcount_ok:
+    if not w_out_functype.is_argcount_ok(got_nargs):
         _call_error_wrong_argcount(
             got_nargs,
             exp_nargs,

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -528,7 +528,7 @@ def typecheck_opimpl(
     args = []
     for wop_arg, w_conv in zip(w_opimpl._args_wop, w_opimpl._converters_w):
         if wop_arg.is_const():
-            arg = ArgSpec.Const(wop_arg.w_blueval)
+            arg = ArgSpec.Const(wop_arg.w_blueval, wop_arg.loc)
             assert w_conv is None
         else:
             assert wop_arg.i is not None

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -449,7 +449,7 @@ class SPyVM:
         # By special-casing vm.universal_eq(W_OpArg, W_OpArg), we break the
         # recursion
         if isinstance(w_a, W_OpArg) and isinstance(w_b, W_OpArg):
-            return self.call(w_oparg_eq, [w_a, w_b])  # type: ignore
+            return self.fast_call(w_oparg_eq, [w_a, w_b])  # type: ignore
 
         wop_a = W_OpArg('a', 0, self.dynamic_type(w_a), Loc.here(-2))
         wop_b = W_OpArg('b', 1, self.dynamic_type(w_b), Loc.here(-2))
@@ -463,7 +463,7 @@ class SPyVM:
             assert w_ta is not w_tb, f'EQ missing on type `{w_ta.fqn}`'
             return B.w_False
 
-        w_res = w_opimpl.call(self, [w_a, w_b])
+        w_res = self.fast_call(w_opimpl, [w_a, w_b])
         assert isinstance(w_res, W_Bool)
         return w_res
 

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -364,21 +364,21 @@ class SPyVM:
         # XXX we should delete this code, but let's keep it here while we are
         # developing the branch
 
-        ## w_functype = w_func.w_functype
-        ## n = w_functype.arity
-        ## if w_functype.is_varargs:
-        ##     assert len(args_w) >= n
-        ## else:
-        ##     assert len(args_w) == n
+        w_functype = w_func.w_functype
+        n = w_functype.arity
+        if w_functype.is_varargs:
+            assert len(args_w) >= n
+        else:
+            assert len(args_w) == n
 
-        ## # XXX: this should be a _fast_call ideally, and we shouldn't do
-        ## # typecheck (but only assert that the type are compatible)
-        ## for param, w_arg in zip(w_functype.params[:n], args_w[:n]):
-        ##     self.typecheck(w_arg, param.w_type)
-        ## if w_functype.is_varargs:
-        ##     param = w_functype.params[-1]
-        ##     for w_arg in args_w[n:]:
-        ##         self.typecheck(w_arg, param.w_type)
+        # XXX: this should be a _fast_call ideally, and we shouldn't do
+        # typecheck (but only assert that the type are compatible)
+        for param, w_arg in zip(w_functype.params[:n], args_w[:n]):
+            self.typecheck(w_arg, param.w_type)
+        if w_functype.is_varargs:
+            param = w_functype.params[-1]
+            for w_arg in args_w[n:]:
+                self.typecheck(w_arg, param.w_type)
         return w_func.raw_call(self, args_w)
 
     def eq(self, w_a: W_Dynamic, w_b: W_Dynamic) -> W_Bool:

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -330,11 +330,11 @@ class SPyVM:
 
     def call_OP(self, w_OP: W_Func, args_wop: Sequence[W_OpArg]) -> W_Func:
         """
-        Like vm.call, but ensures that the result is a W_Func.
+        Like vm.fast_call, but ensures that the result is a W_Func.
 
         Mostly useful to call OPERATORs.
         """
-        w_func = self.call(w_OP, args_wop)
+        w_func = self.fast_call(w_OP, args_wop)
         assert isinstance(w_func, W_Func)
         return w_func
 

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -384,7 +384,7 @@ class SPyVM:
         wop_a = W_OpArg('a', 0, self.dynamic_type(w_a), Loc.here(-2))
         wop_b = W_OpArg('b', 1, self.dynamic_type(w_b), Loc.here(-2))
         w_opimpl = self.call_OP(OPERATOR.w_EQ, [wop_a, wop_b])
-        w_res = w_opimpl.call(self, [w_a, w_b])
+        w_res = self.fast_call(w_opimpl, [w_a, w_b])
         assert isinstance(w_res, W_Bool)
         return w_res
 
@@ -392,7 +392,7 @@ class SPyVM:
         wop_a = W_OpArg('a', 0, self.dynamic_type(w_a), Loc.here(-2))
         wop_b = W_OpArg('b', 1, self.dynamic_type(w_b), Loc.here(-2))
         w_opimpl = self.call_OP(OPERATOR.w_NE, [wop_a, wop_b])
-        w_res = w_opimpl.call(self, [w_a, w_b])
+        w_res = self.fast_call(w_opimpl, [w_a, w_b])
         assert isinstance(w_res, W_Bool)
         return w_res
 

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -343,13 +343,17 @@ class SPyVM:
             assert len(args_w) >= n
         else:
             assert len(args_w) == n
+
+        # XXX: this should be a _fast_call ideally, and we shouldn't do
+        # typecheck (but only assert that the type are compatible)
         for param, w_arg in zip(w_functype.params[:n], args_w[:n]):
             self.typecheck(w_arg, param.w_type)
         if w_functype.is_varargs:
             param = w_functype.params[-1]
             for w_arg in args_w[n:]:
                 self.typecheck(w_arg, param.w_type)
-        return w_func.spy_call(self, args_w)
+
+        return w_func.fast_call(self, args_w)
 
     def eq(self, w_a: W_Dynamic, w_b: W_Dynamic) -> W_Bool:
         wop_a = W_OpArg('a', 0, self.dynamic_type(w_a), Loc.here(-2))

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -360,22 +360,24 @@ class SPyVM:
         Like fast_call, but it doesn't handle blue caching. Never call this
         directly unless you know what you are doing.
         """
-        w_functype = w_func.w_functype
-        n = w_functype.arity
-        if w_functype.is_varargs:
-            assert len(args_w) >= n
-        else:
-            assert len(args_w) == n
+        # XXX we should delete this code, but let's keep it here while we are
+        # developing the branch
 
-        # XXX: this should be a _fast_call ideally, and we shouldn't do
-        # typecheck (but only assert that the type are compatible)
-        for param, w_arg in zip(w_functype.params[:n], args_w[:n]):
-            self.typecheck(w_arg, param.w_type)
-        if w_functype.is_varargs:
-            param = w_functype.params[-1]
-            for w_arg in args_w[n:]:
-                self.typecheck(w_arg, param.w_type)
+        ## w_functype = w_func.w_functype
+        ## n = w_functype.arity
+        ## if w_functype.is_varargs:
+        ##     assert len(args_w) >= n
+        ## else:
+        ##     assert len(args_w) == n
 
+        ## # XXX: this should be a _fast_call ideally, and we shouldn't do
+        ## # typecheck (but only assert that the type are compatible)
+        ## for param, w_arg in zip(w_functype.params[:n], args_w[:n]):
+        ##     self.typecheck(w_arg, param.w_type)
+        ## if w_functype.is_varargs:
+        ##     param = w_functype.params[-1]
+        ##     for w_arg in args_w[n:]:
+        ##         self.typecheck(w_arg, param.w_type)
         return w_func.raw_call(self, args_w)
 
     def eq(self, w_a: W_Dynamic, w_b: W_Dynamic) -> W_Bool:

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -311,15 +311,15 @@ class SPyVM:
             # for red functions, we just call them
             return self._call_func(w_func, args_w)
 
-    def call_OP(self, w_OP: W_Func, args_wop: Sequence[W_OpArg]) -> W_OpImpl:
+    def call_OP(self, w_OP: W_Func, args_wop: Sequence[W_OpArg]) -> W_Func:
         """
-        Like vm.call, but ensures that the result is a W_OpImpl.
+        Like vm.call, but ensures that the result is a W_Func.
 
         Mostly useful to call OPERATORs.
         """
-        w_opimpl = self.call(w_OP, args_wop)
-        assert isinstance(w_opimpl, W_OpImpl)
-        return w_opimpl
+        w_func = self.call(w_OP, args_wop)
+        assert isinstance(w_func, W_Func)
+        return w_func
 
     def call_generic(self, w_func: W_Func,
                      generic_args_w: list[W_Object],


### PR DESCRIPTION
W_OpImpl was super messy and complicated because it served two purposes at once:
1. An high-level description of which functions to call to implement a certain OP, e.g. `W_OpImpl(w_foo)` or `W_OpImpl(w_foo, [wop_x, wop_y])`
2. A low-level description of how to actually call it: this was the messy part because `typecheck_opimpl` mutated the opimpl implace to add converters and do a whole mess with `wop.i`, and then consumers needed to check with `.is_valid()`.

The idea is to split concerns into two separate types:
1. W_OpImpl serves the same (1) purpose as before
2. The (2) is now served by `W_FuncAdapter`, which knows how to map/convert input arguments into output arguments and to call w_func.

Hopefully, soon we will also be able to kill other hacks such as `W_OpArg.i` and `is_direct_call`.

Moreover, we also sanitize calling conventions. Until now we used vm.call everywhere, but this was suboptimal because e.g. in case of W_OpImpl we already *knew* that typechecking was done, so it was not necessary to do it again in vm.call.

Now we have three layers of calls:
  - `W_Func.raw_call`, `vm._raw_call`: this is the primitive upon which all the rest is done. No type checking, no blue caching
  - `vm.fast_call`: no typecheking, but respects the bluecache: this is e.g. how you call opimpls after the typechecking was successfull
  - `vm.call`: this is the most generic one, it does typechecking and it can be used on arbitrary objects that implements `op_CALL`.