### PR TITLE
Improve parser

### DIFF
--- a/spy/ast.py
+++ b/spy/ast.py
@@ -204,8 +204,6 @@ class Expr(Node):
     # needed to make mypy happy
     precedence = '<Expr.precedence not set>' # type: int # type: ignore
 
-    def is_const(self) -> bool:
-        return isinstance(self, Constant)
 
 @dataclass(eq=False)
 class Name(Expr):
@@ -220,6 +218,20 @@ class Auto(Expr):
 class Constant(Expr):
     precedence = 100 # the highest
     value: object
+
+    def __post_init__(self) -> None:
+        assert type(self.value) is not str, 'use StrConst instead'
+
+@dataclass(eq=False)
+class StrConst(Expr):
+    """
+    Like Constant, but for strings.
+
+    The reason we have a specialized node is that we want to use it for fields
+    than MUST be strings, like GetAttr.attr or Assign.target.
+    """
+    precedence = 100 # the highest
+    value: str
 
 @dataclass(eq=False)
 class GetItem(Expr):

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -483,14 +483,12 @@ class UnpackAssign(Stmt):
 
 @dataclass(eq=False)
 class SetAttr(Stmt):
-    target_loc: Loc = field(repr=False)
     target: Expr
     attr: str
     value: Expr
 
 @dataclass(eq=False)
 class SetItem(Stmt):
-    target_loc: Loc = field(repr=False)
     target: Expr
     index: Expr
     value: Expr

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -259,14 +259,14 @@ class Call(Expr):
 class CallMethod(Expr):
     precedence = 17 # higher than GetAttr
     target: Expr
-    method: str
+    method: StrConst
     args: list[Expr]
 
 @dataclass(eq=False)
 class GetAttr(Expr):
     precedence = 16
     value: Expr
-    attr: str
+    attr: StrConst
 
 # ====== BinOp sub-hierarchy ======
 
@@ -478,25 +478,19 @@ class StmtExpr(Stmt):
 
 @dataclass(eq=False)
 class Assign(Stmt):
-    target_loc: Loc = field(repr=False)
-    target: str
+    target: StrConst
     value: Expr
 
 @dataclass(eq=False)
 class UnpackAssign(Stmt):
-    target_locs: list[Loc] = field(repr=False)
-    targets: list[str]
+    targets: list[StrConst]
     value: Expr
-
-    @property
-    def targlocs(self) -> list[tuple[str, Loc]]:
-        return list(zip(self.targets, self.target_locs))
 
 
 @dataclass(eq=False)
 class SetAttr(Stmt):
     target: Expr
-    attr: str
+    attr: StrConst
     value: Expr
 
 @dataclass(eq=False)

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -334,13 +334,10 @@ class CFuncWriter:
             return C.Literal(str(const.value))
         elif T is bool:
             return C.Literal(str(const.value).lower())
-        elif T is str:
-            assert isinstance(const.value, str)
-            return self._fmt_str_literal(const.value)
         else:
             raise NotImplementedError('WIP')
 
-    def _fmt_str_literal(self, s: str) -> C.Expr:
+    def fmt_expr_StrConst(self, const: ast.StrConst) -> C.Expr:
         # SPy string literals must be initialized as C globals. We want to
         # generate the following:
         #
@@ -355,6 +352,7 @@ class CFuncWriter:
         # readable for humans.
         #
         # Emit the global decl
+        s = const.value
         utf8 = s.encode('utf-8')
         v = self.cmod.new_global_var('str')  # SPY_g_str0
         n = len(utf8)
@@ -473,11 +471,10 @@ class CFuncWriter:
         return C.Call(c_name, c_args)
 
     def fmt_getfield(self, fqn: FQN, call: ast.Call) -> C.Expr:
-        assert isinstance(call.args[1], ast.Constant)
+        assert isinstance(call.args[1], ast.StrConst)
         is_byref = str(fqn).startswith("unsafe::getfield_byref")
         c_ptr = self.fmt_expr(call.args[0])
         attr = call.args[1].value
-        assert isinstance(attr, str)
         offset = call.args[2]  # ignored
         c_field = C.PtrField(c_ptr, attr)
         if is_byref:
@@ -487,10 +484,9 @@ class CFuncWriter:
             return c_field
 
     def fmt_setfield(self, fqn: FQN, call: ast.Call) -> C.Expr:
-        assert isinstance(call.args[1], ast.Constant)
+        assert isinstance(call.args[1], ast.StrConst)
         c_ptr = self.fmt_expr(call.args[0])
         attr = call.args[1].value
-        assert isinstance(attr, str)
         offset = call.args[2]  # ignored
         c_lval = C.PtrField(c_ptr, attr)
         c_rval = self.fmt_expr(call.args[3])

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -284,10 +284,11 @@ class CFuncWriter:
         pass
 
     def emit_stmt_Assign(self, assign: ast.Assign) -> None:
+        varname = assign.target.value
         v = self.fmt_expr(assign.value)
-        sym = self.w_func.funcdef.symtable.lookup(assign.target)
+        sym = self.w_func.funcdef.symtable.lookup(varname)
         if sym.is_local:
-            target = assign.target
+            target = varname
         else:
             target = sym.fqn.c_name
         self.out.wl(f'{target} = {v};')

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -121,17 +121,18 @@ class SPyBackend:
 
     def emit_stmt_Assign(self, assign: ast.Assign) -> None:
         v = self.fmt_expr(assign.value)
-        self.wl(f'{assign.target} = {v}')
+        self.wl(f'{assign.target.value} = {v}')
 
     def emit_stmt_UnpackAssign(self, unpack: ast.UnpackAssign) -> None:
-        targets = ', '.join(unpack.targets)
+        targets = ', '.join([t.value for t in unpack.targets])
         v = self.fmt_expr(unpack.value)
         self.wl(f'{targets} = {v}')
 
     def emit_stmt_SetAttr(self, node: ast.SetAttr) -> None:
         t = self.fmt_expr(node.target)
+        a = node.attr.value
         v = self.fmt_expr(node.value)
-        self.wl(f'{t}.{node.attr} = {v}')
+        self.wl(f'{t}.{a} = {v}')
 
     def emit_stmt_SetItem(self, node: ast.SetItem) -> None:
         t = self.fmt_expr(node.target)
@@ -249,7 +250,7 @@ class SPyBackend:
 
     def fmt_expr_CallMethod(self, callm: ast.CallMethod) -> str:
         t = self.fmt_expr(callm.target)
-        m = callm.method
+        m = callm.method.value
         arglist = [self.fmt_expr(arg) for arg in callm.args]
         args = ', '.join(arglist)
         return f'{t}.{m}({args})'
@@ -261,7 +262,7 @@ class SPyBackend:
 
     def fmt_expr_GetAttr(self, node: ast.GetAttr) -> str:
         v = self.fmt_expr(node.value)
-        return f'{v}.{node.attr}'
+        return f'{v}.{node.attr.value}'
 
     def fmt_expr_List(self, node: ast.List) -> str:
         itemlist = [self.fmt_expr(it) for it in node.items]

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -171,6 +171,9 @@ class SPyBackend:
     def fmt_expr_Constant(self, const: ast.Constant) -> str:
         return repr(const.value)
 
+    def fmt_expr_StrConst(self, const: ast.StrConst) -> str:
+        return repr(const.value)
+
     def fmt_expr_FQNConst(self, const: ast.FQNConst) -> str:
         return self.fmt_fqn(const.fqn)
 

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -127,7 +127,7 @@ class FuncDoppler:
         return [vardef.replace(type=newtype)]
 
     def shift_stmt_Assign(self, assign: ast.Assign) -> list[ast.Stmt]:
-        sym = self.funcdef.symtable.lookup(assign.target)
+        sym = self.funcdef.symtable.lookup(assign.target.value)
         if sym.color == 'red':
             newvalue = self.shift_expr(assign.value)
             return [assign.replace(value=newvalue)]
@@ -136,7 +136,7 @@ class FuncDoppler:
 
     def shift_stmt_SetAttr(self, node: ast.SetAttr) -> list[ast.Stmt]:
         v_target = self.shift_expr(node.target)
-        v_attr = ast.StrConst(node.loc, value=node.attr)
+        v_attr = self.shift_expr(node.attr)
         v_value = self.shift_expr(node.value)
         w_opimpl = self.t.opimpl[node]
         call = self.shift_opimpl(node, w_opimpl, [v_target, v_attr, v_value])
@@ -246,7 +246,7 @@ class FuncDoppler:
 
     def shift_expr_GetAttr(self, op: ast.GetAttr) -> ast.Expr:
         v = self.shift_expr(op.value)
-        v_attr = ast.StrConst(op.loc, value=op.attr)
+        v_attr = self.shift_expr(op.attr)
         w_opimpl = self.t.opimpl[op]
         return self.shift_opimpl(op, w_opimpl, [v, v_attr])
 
@@ -289,6 +289,6 @@ class FuncDoppler:
         assert op in self.t.opimpl
         w_opimpl = self.t.opimpl[op]
         v_target = self.shift_expr(op.target)
-        v_method = ast.StrConst(op.loc, value=op.method)
+        v_method = self.shift_expr(op.method)
         newargs_v = [self.shift_expr(arg) for arg in op.args]
         return self.shift_opimpl(op, w_opimpl, [v_target, v_method] + newargs_v)

--- a/spy/irgen/scope.py
+++ b/spy/irgen/scope.py
@@ -194,24 +194,23 @@ class ScopeAnalyzer:
         self.pop_scope()
 
     def declare_Assign(self, assign: ast.Assign) -> None:
-        self._declare_target_maybe(assign.target, assign.target_loc,
-                                   assign.value)
+        self._declare_target_maybe(assign.target, assign.value)
 
     def declare_UnpackAssign(self, unpack: ast.UnpackAssign) -> None:
-        for target, loc in unpack.targlocs:
-            self._declare_target_maybe(target, loc, unpack.value)
+        for target in unpack.targets:
+            self._declare_target_maybe(target, unpack.value)
 
-    def _declare_target_maybe(self, target: str, target_loc: Loc,
+    def _declare_target_maybe(self, target: ast.StrConst,
                               value: ast.Expr) -> None:
         # if target name does not exist elsewhere, we treat it as an implicit
         # declaration
-        level, sym = self.lookup(target)
+        level, sym = self.lookup(target.value)
         if sym is None:
             # we don't have an explicit type annotation: we consider the
             # "value" to be the type_loc, because it's where the type will be
             # computed from
             type_loc = value.loc
-            self.add_name(target, 'red', target_loc, type_loc)
+            self.add_name(target.value, 'red', target.loc, type_loc)
 
     # ===
 
@@ -262,5 +261,5 @@ class ScopeAnalyzer:
         self.capture_maybe(name.id)
 
     def flatten_Assign(self, assign: ast.Assign) -> None:
-        self.capture_maybe(assign.target)
+        self.capture_maybe(assign.target.value)
         self.flatten(assign.value)

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -357,7 +357,6 @@ class Parser:
         elif isinstance(py_target, py_ast.Attribute):
             return spy.ast.SetAttr(
                 loc = py_node.loc,
-                target_loc = py_target.value.loc,
                 target = self.from_py_expr(py_target.value),
                 attr = py_target.attr,
                 value = self.from_py_expr(py_node.value)
@@ -365,7 +364,6 @@ class Parser:
         elif isinstance(py_target, py_ast.Subscript):
             return spy.ast.SetItem(
                 loc = py_node.loc,
-                target_loc = py_target.value.loc,
                 target = self.from_py_expr(py_target.value),
                 index = self.from_py_expr(py_target.slice),
                 value = self.from_py_expr(py_node.value)

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -297,7 +297,7 @@ class Parser:
             kind = 'var'
         vardef = spy.ast.VarDef(loc=py_node.loc,
                                 kind=kind,
-                                name=assign.target,
+                                name=assign.target.value,
                                 type=spy.ast.Auto(loc=py_node.loc))
         return vardef, assign
 
@@ -333,8 +333,7 @@ class Parser:
         else:
             assign = spy.ast.Assign(
                 loc = py_node.loc,
-                target_loc = py_node.target.loc,
-                target = py_node.target.id,
+                target = spy.ast.StrConst(py_node.target.loc, py_node.target.id),
                 value = self.from_py_expr(py_node.value)
             )
 
@@ -350,15 +349,14 @@ class Parser:
         if isinstance(py_target, py_ast.Name):
             return spy.ast.Assign(
                 loc = py_node.loc,
-                target_loc = py_target.loc,
-                target = py_target.id,
+                target = spy.ast.StrConst(py_target.loc, py_target.id),
                 value = self.from_py_expr(py_node.value)
             )
         elif isinstance(py_target, py_ast.Attribute):
             return spy.ast.SetAttr(
                 loc = py_node.loc,
                 target = self.from_py_expr(py_target.value),
-                attr = py_target.attr,
+                attr = spy.ast.StrConst(py_target.loc, py_target.attr),
                 value = self.from_py_expr(py_node.value)
             )
         elif isinstance(py_target, py_ast.Subscript):
@@ -370,14 +368,11 @@ class Parser:
             )
         elif isinstance(py_target, py_ast.Tuple):
             targets = []
-            target_locs = []
             for item in py_target.elts:
                 assert isinstance(item, py_ast.Name)
-                targets.append(item.id)
-                target_locs.append(item.loc)
+                targets.append(spy.ast.StrConst(item.loc, item.id))
             return spy.ast.UnpackAssign(
                 loc = py_node.loc,
-                target_locs = target_locs,
                 targets = targets,
                 value = self.from_py_expr(py_node.value)
             )
@@ -437,7 +432,7 @@ class Parser:
     def from_py_expr_Attribute(self,
                                py_node: py_ast.Attribute) -> spy.ast.GetAttr:
         value = self.from_py_expr(py_node.value)
-        attr = py_node.attr
+        attr = spy.ast.StrConst(py_node.loc, py_node.attr)
         return spy.ast.GetAttr(py_node.loc, value, attr)
 
     def from_py_expr_List(self, py_node: py_ast.List) -> spy.ast.List:

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -412,13 +412,15 @@ class Parser:
         return spy.ast.Name(py_node.loc, py_node.id)
 
     def from_py_expr_Constant(self,
-                              py_node: py_ast.Constant) -> spy.ast.Constant:
+                              py_node: py_ast.Constant) -> spy.ast.Expr:
         # according to _ast.pyi, the type of const.value can be one of the
         # following:
         #     None, str, bytes, bool, int, float, complex, Ellipsis
         assert py_node.kind is None  # I don't know what is 'kind' here
         T = type(py_node.value)
-        if T in (int, float, bool, str, NoneType):
+        if T is str:
+            return spy.ast.StrConst(py_node.loc, py_node.value)
+        elif T in (int, float, bool, NoneType):
             return spy.ast.Constant(py_node.loc, py_node.value)
         elif T in (bytes, float, complex, Ellipsis):
             self.error(f'unsupported literal: {py_node.value!r}',

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -255,6 +255,20 @@ class TestParser:
             ('this is not supported yet', "42j"),
         )
 
+    def test_StrConst(self):
+        mod = self.parse("""
+        def foo() -> i32:
+            return "hello"
+        """)
+        stmt = mod.get_funcdef('foo').body[0]
+        expected = """
+        Return(
+            value=StrConst(value='hello'),
+        )
+        """
+        self.assert_dump(stmt, expected)
+
+
     def test_GetItem(self):
         mod = self.parse("""
         def foo() -> void:

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -315,7 +315,7 @@ class TestParser:
         """
         assign_expected = """
         Assign(
-            target='x',
+            target=StrConst(value='x'),
             value=Constant(value=42),
         )
         """
@@ -337,7 +337,7 @@ class TestParser:
                         type=Name(id='i32'),
                     ),
                     assign=Assign(
-                        target='x',
+                        target=StrConst(value='x'),
                         value=Constant(value=42),
                     ),
                 ),
@@ -361,7 +361,7 @@ class TestParser:
                         type=Name(id='i32'),
                     ),
                     assign=Assign(
-                        target='x',
+                        target=StrConst(value='x'),
                         value=Constant(value=42),
                     ),
                 ),
@@ -385,7 +385,7 @@ class TestParser:
                         type=Auto(),
                     ),
                     assign=Assign(
-                        target='x',
+                        target=StrConst(value='x'),
                         value=Constant(value=42),
                     ),
                 ),
@@ -409,7 +409,7 @@ class TestParser:
                         type=Auto(),
                     ),
                     assign=Assign(
-                        target='x',
+                        target=StrConst(value='x'),
                         value=Constant(value=42),
                     ),
                 ),
@@ -583,7 +583,7 @@ class TestParser:
         stmt = mod.get_funcdef('foo').body[0]
         expected = """
         Assign(
-            target='x',
+            target=StrConst(value='x'),
             value=Constant(value=42),
         )
         """
@@ -620,9 +620,9 @@ class TestParser:
         expected = """
         UnpackAssign(
             targets=[
-                'a',
-                'b',
-                'c',
+                StrConst(value='a'),
+                StrConst(value='b'),
+                StrConst(value='c'),
             ],
             value=Name(id='x'),
         )
@@ -670,7 +670,7 @@ class TestParser:
         Return(
             value=CallMethod(
                 target=Name(id='a'),
-                method='b',
+                method=StrConst(value='b'),
                 args=[
                     Constant(value=1),
                     Constant(value=2),
@@ -788,11 +788,12 @@ class TestParser:
         assert isclass(nodes[3], 'Name') and nodes[3].id == 'void'
         assert isclass(nodes[4], 'If')
         assert isclass(nodes[5], 'Constant') and nodes[5].value is True
-        assert isclass(nodes[6], 'Assign') and nodes[6].target == 'x'
-        assert isclass(nodes[7], 'Add')
-        assert isclass(nodes[8], 'Name') and nodes[8].id == 'y'
-        assert isclass(nodes[9], 'Constant') and nodes[9].value == 1
-        assert len(nodes) == 10
+        assert isclass(nodes[6], 'Assign')
+        assert isclass(nodes[7], 'StrConst') and nodes[7].value == 'x'
+        assert isclass(nodes[8], 'Add')
+        assert isclass(nodes[9], 'Name') and nodes[9].id == 'y'
+        assert isclass(nodes[10], 'Constant') and nodes[10].value == 1
+        assert len(nodes) == 11
         #
         nodes2 = list(mod.walk(ast.Stmt))
         expected2 = [node for node in nodes if isinstance(node, ast.Stmt)]
@@ -847,7 +848,7 @@ class TestParser:
         StmtExpr(
             value=GetAttr(
                 value=Name(id='a'),
-                attr='b',
+                attr=StrConst(value='b'),
             ),
         )
         """
@@ -862,7 +863,7 @@ class TestParser:
         expected = """
         SetAttr(
             target=Name(id='a'),
-            attr='b',
+            attr=StrConst(value='b'),
             value=Constant(value=42),
         )
         """

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -246,6 +246,9 @@ class ASTFrame:
         assert T in (int, float, bool, str, NoneType)
         return self.vm.wrap(const.value)
 
+    def eval_expr_StrConst(self, const: ast.StrConst) -> W_Object:
+        return self.vm.wrap(const.value)
+
     def eval_expr_FQNConst(self, const: ast.FQNConst) -> W_Object:
         w_value = self.vm.lookup_global(const.fqn)
         assert w_value is not None

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -175,7 +175,7 @@ class ASTFrame:
 
     def exec_stmt_Assign(self, assign: ast.Assign) -> None:
         w_val = self.eval_expr(assign.value)
-        self._exec_assign(assign.target, w_val)
+        self._exec_assign(assign.target.value, w_val)
 
     def exec_stmt_UnpackAssign(self, unpack: ast.UnpackAssign) -> None:
         w_tup = self.eval_expr(unpack.value)
@@ -187,7 +187,7 @@ class ASTFrame:
                 f"Wrong number of values to unpack: expected {exp}, got {got}"
             )
         for target, w_val in zip(unpack.targets, w_tup.items_w):
-            self._exec_assign(target, w_val)
+            self._exec_assign(target.value, w_val)
 
     def _exec_assign(self, target: str, w_val: W_Object) -> None:
         # XXX this is semi-wrong. We need to add an AST field to keep track of
@@ -206,7 +206,7 @@ class ASTFrame:
     def exec_stmt_SetAttr(self, node: ast.SetAttr) -> None:
         w_opimpl = self.t.opimpl[node]
         w_target = self.eval_expr(node.target)
-        w_attr = self.vm.wrap(node.attr)
+        w_attr = self.eval_expr(node.attr)
         w_value = self.eval_expr(node.value)
         self.vm.fast_call(w_opimpl, [w_target, w_attr, w_value])
 
@@ -330,7 +330,7 @@ class ASTFrame:
     def eval_expr_CallMethod(self, op: ast.CallMethod) -> W_Object:
         w_opimpl = self.t.opimpl[op]
         w_target = self.eval_expr(op.target)
-        w_method = self.vm.wrap(op.method)
+        w_method = self.eval_expr(op.method)
         args_w = [self.eval_expr(arg) for arg in op.args]
         return self.vm.fast_call(w_opimpl, [w_target, w_method] + args_w)
 
@@ -348,7 +348,7 @@ class ASTFrame:
         #   2. "specialized" impls, which are called with only [w_val]
         w_opimpl = self.t.opimpl[op]
         w_val = self.eval_expr(op.value)
-        w_attr = self.vm.wrap(op.attr)
+        w_attr = self.eval_expr(op.attr)
         w_res = self.vm.fast_call(w_opimpl, [w_val, w_attr])
         return w_res
 

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -298,18 +298,19 @@ class TypeChecker:
 
     def check_expr_Constant(self, const: ast.Constant) -> tuple[Color, W_Type]:
         T = type(const.value)
-        assert T in (int, float, bool, str, NoneType)
+        assert T in (int, float, bool, NoneType)
         if T is int:
             return 'blue', B.w_i32
         elif T is float:
             return 'blue', B.w_f64
         elif T is bool:
             return 'blue', B.w_bool
-        elif T is str:
-            return 'blue', B.w_str
         elif T is NoneType:
             return 'blue', B.w_void
         assert False
+
+    def check_expr_StrConst(self, const: ast.StrConst) -> tuple[Color, W_Type]:
+        return 'blue', B.w_str
 
     def check_expr_FQNConst(self, const: ast.FQNConst) -> tuple[Color, W_Type]:
         # XXX: I think that FQNConst should remember what was its static type


### PR DESCRIPTION
1. Introduce `ast.StrConst`
2. use it for the following fields, instead of storing bare strings:
    - `GetAttr.attr`
    - `SetAttr.attr`
    - `Assign.target`
    - `UnpackAssign.targets`
    - `CallMethod.metho`

This makes it easier to track their `loc`s, but also it will allow us to make the code in ASTFrame/doppler more uniform, because currently we have to special case these strings and turn them into proper run-time values.