### PR TITLE
Kill the ugly W_DirectCall hack

### DIFF
--- a/spy/errors.py
+++ b/spy/errors.py
@@ -21,19 +21,6 @@ class Annotation:
     message: str
     loc: Loc
 
-    def get_src(self) -> str:
-        """
-        Return the piece of source code pointed by the annotation.
-        """
-        loc = self.loc
-        filename = loc.filename
-        assert loc.line_start == loc.line_end, 'multi-line not supported'
-        line = loc.line_start
-        a = loc.col_start
-        b = loc.col_end
-        srcline = linecache.getline(filename, line)
-        return srcline[a:b]
-
 
 class ErrorFormatter:
     err: 'SPyError'

--- a/spy/irgen/symtable.py
+++ b/spy/irgen/symtable.py
@@ -61,14 +61,19 @@ class SymTable:
 
     @classmethod
     def from_builtins(cls, vm: 'SPyVM') -> 'SymTable':
+        from spy.vm.function import W_BuiltinFunc
         scope = cls('builtins')
-        loc = Loc(filename='<builtins>',
-                  line_start=0,
-                  line_end=0,
-                  col_start=0,
-                  col_end=0)
+        generic_loc = Loc(filename='<builtins>',
+                          line_start=0,
+                          line_end=0,
+                          col_start=0,
+                          col_end=0)
         builtins_mod = vm.modules_w['builtins']
         for fqn, w_obj in builtins_mod.items_w():
+            if isinstance(w_obj, W_BuiltinFunc):
+                loc = w_obj.def_loc
+            else:
+                loc = generic_loc
             sym = Symbol(fqn.symbol_name, 'blue', loc=loc, type_loc=loc,
                          level=0, fqn=fqn)
             scope.add(sym)

--- a/spy/location.py
+++ b/spy/location.py
@@ -1,6 +1,7 @@
 import sys
 from types import FunctionType
 import inspect
+import linecache
 import dataclasses
 from dataclasses import dataclass
 
@@ -92,6 +93,18 @@ class Loc:
             return f"<Loc: '{self.filename}'>"
         else:
             return f"<Loc: '{self.filename} {l1}:{c1} {l2}:{c2}'>"
+
+    def get_src(self) -> str:
+        """
+        Return the piece of source code pointed by this Loc
+        """
+        filename = self.filename
+        assert self.line_start == self.line_end, 'multi-line not supported'
+        line = self.line_start
+        a = self.col_start
+        b = self.col_end
+        srcline = linecache.getline(filename, line)
+        return srcline[a:b]
 
     def pp(self) -> None:
         """

--- a/spy/tests/support.py
+++ b/spy/tests/support.py
@@ -259,7 +259,7 @@ def expect_errors(main: str, *anns_to_match: MatchAnnotation) -> Any:
 
     def match_one_annotation(expected_msg: str, expected_src: str) -> bool:
         for ann in err.annotations:
-            got_src = ann.get_src()
+            got_src = ann.loc.get_src()
             if ann.message == expected_msg and expected_src == got_src:
                 return True
         return False

--- a/spy/tests/test_loc.py
+++ b/spy/tests/test_loc.py
@@ -1,17 +1,13 @@
 from spy.location import Loc
 from spy.errors import Annotation
 
-def get_src(loc: Loc) -> str:
-    ann = Annotation("error", "hello", loc)
-    return ann.get_src()
-
 def myfunc() -> Loc:
     loc = Loc.here()
     return loc
 
 def test_Loc_here():
     loc = myfunc()
-    src = get_src(loc)
+    src = loc.get_src()
     exp = '    loc = Loc.here()'
     assert src == exp
 
@@ -27,10 +23,10 @@ def test_Loc_from_pyfunc():
         pass
 
     loc = Loc.from_pyfunc(foo)
-    src = get_src(loc)
+    src = loc.get_src()
     exp = '    def foo():'
     assert src == exp
     #
     loc = Loc.from_pyfunc(bar)
-    src = get_src(loc)
+    src = loc.get_src()
     exp = '    def bar():'

--- a/spy/tests/test_loc.py
+++ b/spy/tests/test_loc.py
@@ -1,13 +1,36 @@
 from spy.location import Loc
 from spy.errors import Annotation
 
+def get_src(loc: Loc) -> str:
+    ann = Annotation("error", "hello", loc)
+    return ann.get_src()
+
 def myfunc() -> Loc:
     loc = Loc.here()
     return loc
 
 def test_Loc_here():
     loc = myfunc()
-    ann = Annotation("error", "hello", loc)
-    src = ann.get_src()
+    src = get_src(loc)
     exp = '    loc = Loc.here()'
     assert src == exp
+
+def test_Loc_from_pyfunc():
+    def decorator(fn):
+        return fn
+
+    def foo():
+        pass
+
+    @decorator
+    def bar():
+        pass
+
+    loc = Loc.from_pyfunc(foo)
+    src = get_src(loc)
+    exp = '    def foo():'
+    assert src == exp
+    #
+    loc = Loc.from_pyfunc(bar)
+    src = get_src(loc)
+    exp = '    def bar():'

--- a/spy/tests/vm/test_function.py
+++ b/spy/tests/vm/test_function.py
@@ -37,9 +37,13 @@ class TestFunction:
 
     @no_type_check
     def test_function_eq(self):
+        class FakeFuncDef:
+            prototype_loc = None
+        funcdef = FakeFuncDef()
+
         vm = SPyVM()
         w_functype = W_FuncType.parse('def() -> i32')
-        w_a = W_ASTFunc(w_functype, FQN('test::a'), funcdef=None, closure=None)
-        w_b = W_ASTFunc(w_functype, FQN('test::b'), funcdef=None, closure=None)
+        w_a = W_ASTFunc(w_functype, FQN('test::a'), funcdef, closure=None)
+        w_b = W_ASTFunc(w_functype, FQN('test::b'), funcdef, closure=None)
         assert vm.eq(w_a, w_a) is B.w_True
         assert vm.eq(w_a, w_b) is B.w_False

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -457,17 +457,6 @@ class ASTFrame:
             return self._eval_STATIC_TYPE(wop_func, call)
         args_wop = [self.eval_expr(arg) for arg in call.args]
         w_opimpl = self.vm.call_OP(OP.w_CALL, [wop_func]+args_wop)
-
-        # XXX: this is needed to catch errors in case the static type is
-        # dynamic but the object is not callable. Ideally, this should be done
-        # by w_dynamic_call, but we cannot yet. See also the docstring of
-        # callop._dynamic_call_opimpl
-        assert isinstance(w_opimpl, W_FuncAdapter)
-        #
-        if w_opimpl.is_direct_call():
-            # some extra sanity checks
-            assert wop_func.color == 'blue', 'indirect calls not supported'
-
         return self.eval_opimpl(call, w_opimpl, [wop_func]+args_wop)
 
     def _eval_STATIC_TYPE(self, wop_func: W_OpArg, call: ast.Call) -> W_OpArg:

--- a/spy/vm/func_adapter.py
+++ b/spy/vm/func_adapter.py
@@ -4,7 +4,7 @@ import textwrap
 from spy.fqn import FQN
 from spy.location import Loc
 from spy.vm.object import W_Object
-from spy.vm.function import W_Func, W_FuncType, W_DirectCall
+from spy.vm.function import W_Func, W_FuncType
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
@@ -58,20 +58,7 @@ class W_FuncAdapter(W_Func):
     def is_pure(self) -> bool:
         return self.w_func.is_pure()
 
-    def is_direct_call(self) -> bool:
-        """
-        This is a hack. See W_Func.op_CALL and ASTFrame.eval_expr_Call.
-        """
-        return isinstance(self.w_func, W_DirectCall)
-
     def raw_call(self, vm: 'SPyVM', args_w: Sequence[W_Object]) -> W_Object:
-        # hack hack hack, we should kill all of this eventually
-        if self.is_direct_call():
-            w_func = args_w[0]
-            assert isinstance(w_func, W_Func)
-        else:
-            w_func = self.w_func
-
         def getarg(spec: ArgSpec) -> W_Object:
             if isinstance(spec, Arg):
                 return args_w[spec.i]
@@ -84,7 +71,7 @@ class W_FuncAdapter(W_Func):
                 assert False
 
         real_args_w = [getarg(spec) for spec in self.args]
-        return vm.fast_call(w_func, real_args_w)
+        return vm.fast_call(self.w_func, real_args_w)
 
     def pp(self) -> None:
         print(self.render())

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -206,44 +206,13 @@ class W_Func(W_Object):
     @staticmethod
     def op_CALL(vm: 'SPyVM', wop_func: 'W_OpArg',
                 *args_wop: 'W_OpArg') -> 'W_OpImpl':
-        """
-        This is a bit of a hack.
-
-        The correct opimpl for a W_Func object is something which says "please
-        just call it". Ideally, we would like to do something like that:
-
-            w_func = wop_func.blue_unwrap()
-            return W_OpImpl(w_func, ...)
-
-        However, we cannot because at the current moment, wop_func doesn't
-        carry around it's blue value: this is something which needs to be
-        fixed in the typechecker, eventually.
-
-        The workaround is to wrap the functype inside a special W_DirectCall
-        object, which is special cased by ASTFrame.
-        """
         from spy.vm.opimpl import W_OpImpl
-        w_functype = wop_func.w_static_type
-        assert isinstance(w_functype, W_FuncType)
         w_func = wop_func.w_blueval
         return W_OpImpl(
-            W_DirectCall(w_functype, w_func.def_loc),
+            w_func,
             list(args_wop),
+            is_direct_call = True,
         )
-
-
-class W_DirectCall(W_Func):
-    """
-    See W_Func.op_CALL.
-    """
-    fqn = FQN("builtins::__direct_call__")
-
-    def __init__(self, w_functype: W_FuncType, def_loc: Loc) -> None:
-        self.w_functype = w_functype
-        self.def_loc = def_loc
-
-    def __repr__(self) -> str:
-        return f'W_DirectCall({self.w_functype})'
 
 
 class W_ASTFunc(W_Func):

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -4,7 +4,7 @@ from spy.vm.object import W_Object, W_Type
 from spy.vm.primitive import W_Dynamic
 from spy.vm.str import W_Str
 from spy.vm.opimpl import W_OpImpl, W_OpArg
-from spy.vm.function import W_DirectCall, W_FuncType, FuncParam, W_Func
+from spy.vm.function import W_FuncType, FuncParam, W_Func
 
 from . import OP
 from .binop import MM

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -32,7 +32,7 @@ from spy.irgen.symtable import Symbol, Color
 from spy.errors import SPyTypeError
 from spy.vm.b import OPERATOR, B
 from spy.vm.object import Member, W_Type, W_Object
-from spy.vm.function import W_Func, W_FuncType, W_DirectCall
+from spy.vm.function import W_Func, W_FuncType
 from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.primitive import W_Bool
 
@@ -209,13 +209,17 @@ class W_OpImpl(W_Object):
     NULL: ClassVar['W_OpImpl']
     _w_func: Optional[W_Func]
     _args_wop: Optional[list[W_OpArg]]
+    is_direct_call: bool
 
     def __init__(self,
                  w_func: W_Func,
-                args_wop: Optional[list[W_OpArg]] = None
+                 args_wop: Optional[list[W_OpArg]] = None,
+                 *,
+                 is_direct_call: bool = False,
                 ) -> None:
         self._w_func = w_func
         self._args_wop = args_wop
+        self.is_direct_call = is_direct_call
 
     def __repr__(self) -> str:
         if self._w_func is None:
@@ -232,12 +236,6 @@ class W_OpImpl(W_Object):
 
     def is_simple(self) -> bool:
         return self._args_wop is None
-
-    def is_direct_call(self) -> bool:
-        """
-        This is a hack. See W_Func.op_CALL and ASTFrame.eval_expr_Call.
-        """
-        return isinstance(self._w_func, W_DirectCall)
 
     @property
     def w_functype(self) -> W_FuncType:

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -64,11 +64,10 @@ def typecheck_opimpl(
         assert w_opimpl._args_wop is not None
         out_args_wop = w_opimpl._args_wop
 
+    # if it's a direct call, we can display extra info about call location
     def_loc = w_opimpl._w_func.def_loc
-
-    # if it's a direct call, we can get extra info about call and def locations
     call_loc = None
-    if w_opimpl.is_direct_call():
+    if w_opimpl.is_direct_call:
         wop_func = in_args_wop[0]
         call_loc = wop_func.loc
 

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -64,15 +64,13 @@ def typecheck_opimpl(
         assert w_opimpl._args_wop is not None
         out_args_wop = w_opimpl._args_wop
 
+    def_loc = w_opimpl._w_func.def_loc
+
     # if it's a direct call, we can get extra info about call and def locations
     call_loc = None
-    def_loc = None
     if w_opimpl.is_direct_call():
         wop_func = in_args_wop[0]
         call_loc = wop_func.loc
-        # not all direct calls targets have a sym (e.g. if we call a builtin)
-        if wop_func.sym is not None:
-            def_loc = wop_func.sym.loc
 
     # check that the number of arguments match
     got_nargs = len(out_args_wop)


### PR DESCRIPTION
The need for this hack was explained by this now-removed comment in `W_Func.op_CALL`:
```python
        """
        This is a bit of a hack.

        The correct opimpl for a W_Func object is something which says "please
        just call it". Ideally, we would like to do something like that:

            w_func = wop_func.blue_unwrap()
            return W_OpImpl(w_func, ...)

        However, we cannot because at the current moment, wop_func doesn't
        carry around it's blue value: this is something which needs to be
        fixed in the typechecker, eventually.

        The workaround is to wrap the functype inside a special W_DirectCall
        object, which is special cased by ASTFrame.
        """
```

But after #106 now we DO know the blue `w_func` at `op_CALL` time, so we can kill all the crap described there.

As a bonus point, we also put a `def_loc` attribute on every `W_Func`, so that we can always report the "true" definition line of functions in case of errors.
