### PR TITLE
Struct decorator

### DIFF
--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -120,7 +120,8 @@ class SPyBackend:
     def emit_stmt_ClassDef(self, classdef: ast.ClassDef) -> None:
         assert classdef.is_struct, 'IMPLEMENT ME'
         name = classdef.name
-        self.wl(f'class {name}(struct):')
+        self.wl('@struct')
+        self.wl(f'class {name}:')
         with self.out.indent():
             for field in classdef.fields:
                 self.emit_stmt_VarDef(field)

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -174,25 +174,25 @@ class Parser:
     def from_py_stmt_ClassDef(self,
                               py_classdef: py_ast.ClassDef
                               ) -> spy.ast.ClassDef:
-        # base classes are not supported yet, but class X(struct) is
-        # special-cased
-        is_struct = False
-        for py_base in py_classdef.bases:
-            if isinstance(py_base, py_ast.Name) and py_base.id == 'struct':
-                is_struct = True
-            else:
-                self.error('base classes not supported yet',
-                           'this is not supported',
-                           py_base.loc)
+        if py_classdef.bases:
+            self.error('base classes not supported yet',
+                       'this is not supported',
+                       py_classdef.bases[0].loc)
 
         if py_classdef.keywords:
             self.error('keywords in classes not supported yet',
                        'this is not supported',
                        py_classdef.keywords[0].loc)
-        if py_classdef.decorator_list:
-            self.error('class decorators not supported yet',
-                       'this is not supported',
-                       py_classdef.decorator_list[0].loc)
+
+        # decorators are not supported yet, but @struct is special-cased
+        is_struct = False
+        for py_deco in py_classdef.decorator_list:
+            if isinstance(py_deco, py_ast.Name) and py_deco.id == 'struct':
+                is_struct = True
+            else:
+                self.error('class decorators not supported yet',
+                           'this is not supported',
+                           py_deco.loc)
 
         # only few kind of declarations are supported inside a "class:" block
         fields: list[spy.ast.VarDef] = []

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -834,7 +834,8 @@ class TestBasic(CompilerTest):
 
         ptr_S1 = ptr[S] # using the ForwardRef
 
-        class S(struct):
+        @struct
+        class S:
             pass
 
         ptr_S2 = ptr[S] # using the actual S

--- a/spy/tests/compiler/test_unsafe.py
+++ b/spy/tests/compiler/test_unsafe.py
@@ -71,7 +71,8 @@ class TestUnsafe(CompilerTest):
         """
         from unsafe import gc_alloc, ptr
 
-        class Point(struct):
+        @struct
+        class Point:
             x: i32
             y: f64
 
@@ -96,7 +97,8 @@ class TestUnsafe(CompilerTest):
         # module level.
         WORKAROUND: i32 = 0
 
-        class Point(struct):
+        @struct
+        class Point:
             x: i32
             y: i32
 
@@ -115,11 +117,13 @@ class TestUnsafe(CompilerTest):
         """
         from unsafe import gc_alloc, ptr
 
-        class Point(struct):
+        @struct
+        class Point:
             x: i32
             y: i32
 
-        class Rect(struct):
+        @struct
+        class Rect:
             a: Point
             b: Point
 
@@ -166,7 +170,8 @@ class TestUnsafe(CompilerTest):
         mod = self.compile("""
         from unsafe import gc_alloc, ptr
 
-        class Array(struct):
+        @struct
+        class Array:
             n: i32
             buf: ptr[i32]
 
@@ -187,7 +192,8 @@ class TestUnsafe(CompilerTest):
 
         @blue
         def make_Point(T):
-            class Point(struct):
+            @struct
+            class Point:
                 x: T
                 y: T
             return Point
@@ -254,7 +260,8 @@ class TestUnsafe(CompilerTest):
         mod = self.compile("""
         from unsafe import gc_alloc, ptr
 
-        class Node(struct):
+        @struct
+        class Node:
             val: i32
             next: ptr[Node]
 

--- a/spy/tests/test_backend_spy.py
+++ b/spy/tests/test_backend_spy.py
@@ -221,7 +221,8 @@ class TestSPyBackend(CompilerTest):
     def test_classdef(self):
         src = """
         def foo() -> void:
-            class Point(struct):
+            @struct
+            class Point:
                 x: i32
                 y: i32
         """

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -886,7 +886,8 @@ class TestParser:
 
     def test_struct(self):
         mod = self.parse("""
-        class Foo(struct):
+        @struct
+        class Foo:
             pass
         """)
         classdef = mod.get_classdef('Foo')
@@ -901,7 +902,8 @@ class TestParser:
 
     def test_class_fields(self):
         mod = self.parse("""
-        class Point(struct):
+        @struct
+        class Point:
             x: i32
             y: i32
         """)


### PR DESCRIPTION
Change the syntax for declaring structs. Instead of:
```
class Point(struct):
    x: i32
    y: i32
```

we now use:
```
@struct
class Point:
    ...
```

This is needed because it will generalize better to the upcoming `@typedef` feature.
Eventually, once we are brave enough to modify the syntax, these might become:

```
struct Point:
    ...

typedef Foo:
    ...
```

