### PR TITLE
Use @builtin_method for almost all OPERATORS

### DIFF
--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -63,9 +63,10 @@ class TestOp(CompilerTest):
             def w_spy_new(vm: 'SPyVM', w_cls: W_Type) -> 'W_MyClass':
                 return W_MyClass()
 
+            @builtin_method('__GETITEM__', color='blue')
             @staticmethod
-            def op_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg,
-                           wop_i: W_OpArg) -> W_OpImpl:
+            def w_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg,
+                          wop_i: W_OpArg) -> W_OpImpl:
                 @builtin_func('ext')
                 def w_getitem(vm: 'SPyVM', w_obj: W_MyClass,
                               w_i: W_I32) -> W_I32:
@@ -99,9 +100,10 @@ class TestOp(CompilerTest):
             def w_spy_new(vm: 'SPyVM', w_cls: W_Type) -> 'W_MyClass':
                 return W_MyClass()
 
+            @builtin_method('__GETITEM__', color='blue')
             @staticmethod
-            def op_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg,
-                           wop_i: W_OpArg) -> W_OpImpl:
+            def w_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg,
+                          wop_i: W_OpArg) -> W_OpImpl:
                 @builtin_func('ext')
                 def w_getitem(vm: 'SPyVM', w_obj: W_MyClass) -> W_I32:
                     return vm.wrap(42)  # type: ignore
@@ -136,9 +138,10 @@ class TestOp(CompilerTest):
             def w_spy_new(vm: 'SPyVM', w_cls: W_Type, w_x: W_I32) -> 'W_MyClass':
                 return W_MyClass(w_x)
 
+            @builtin_method('__GETITEM__', color='blue')
             @staticmethod
-            def op_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg,
-                           wop_i: W_OpArg) -> W_OpImpl:
+            def w_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg,
+                          wop_i: W_OpArg) -> W_OpImpl:
                 assert isinstance(wop_obj, W_OpArg)
                 assert isinstance(wop_i, W_OpArg)
                 # NOTE we are reversing the two arguments

--- a/spy/tests/compiler/test_operator_attr.py
+++ b/spy/tests/compiler/test_operator_attr.py
@@ -94,8 +94,9 @@ class TestAttrOp(CompilerTest):
                 return W_MyClass()
 
             @staticmethod
-            def op_GETATTR(vm: 'SPyVM', wop_obj: W_OpArg,
-                           wop_attr: W_OpArg) -> W_OpImpl:
+            @builtin_method('__GETATTR__', color='blue')
+            def w_GETATTR(vm: 'SPyVM', wop_obj: W_OpArg,
+                          wop_attr: W_OpArg) -> W_OpImpl:
                 attr = wop_attr.blue_unwrap_str(vm)
                 if attr == 'x':
                     @builtin_func('ext', 'getx')

--- a/spy/tests/compiler/test_operator_attr.py
+++ b/spy/tests/compiler/test_operator_attr.py
@@ -56,8 +56,9 @@ class TestAttrOp(CompilerTest):
             def w_spy_new(vm: 'SPyVM', w_cls: W_Type) -> 'W_MyClass':
                 return W_MyClass()
 
+            @builtin_method('__GET_x__', color='blue')
             @staticmethod
-            def op_GET_x(vm: 'SPyVM', wop_obj: W_OpArg,
+            def w_GET_x(vm: 'SPyVM', wop_obj: W_OpArg,
                          wop_attr: W_OpArg) -> W_OpImpl:
                 w_t = wop_obj.w_static_type
                 @builtin_func(w_t.fqn, 'get_x')
@@ -93,8 +94,8 @@ class TestAttrOp(CompilerTest):
             def w_spy_new(vm: 'SPyVM', w_cls: W_Type) -> 'W_MyClass':
                 return W_MyClass()
 
-            @staticmethod
             @builtin_method('__GETATTR__', color='blue')
+            @staticmethod
             def w_GETATTR(vm: 'SPyVM', wop_obj: W_OpArg,
                           wop_attr: W_OpArg) -> W_OpImpl:
                 attr = wop_attr.blue_unwrap_str(vm)

--- a/spy/tests/compiler/test_operator_attr.py
+++ b/spy/tests/compiler/test_operator_attr.py
@@ -112,9 +112,10 @@ class TestAttrOp(CompilerTest):
                         return vm.wrap(attr.upper() + '--42')  # type: ignore
                 return W_OpImpl(w_fn)
 
+            @builtin_method('__SETATTR__', color='blue')
             @staticmethod
-            def op_SETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
-                           wop_v: W_OpArg) -> W_OpImpl:
+            def w_SETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
+                          wop_v: W_OpArg) -> W_OpImpl:
                 attr = wop_attr.blue_unwrap_str(vm)
                 if attr == 'x':
                     @builtin_func('ext')

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -152,10 +152,11 @@ class TestCallOp(CompilerTest):
             def w_spy_new(vm: 'SPyVM', w_cls: W_Type, w_x: W_I32) -> 'W_Calc':
                 return W_Calc(vm.unwrap_i32(w_x))
 
+            @builtin_method('__CALL_METHOD__', color='blue')
             @staticmethod
-            def op_CALL_METHOD(vm: 'SPyVM', wop_obj: W_OpArg,
-                               wop_method: W_OpArg,
-                               *args_wop: W_OpArg) -> W_OpImpl:
+            def w_CALL_METHOD(vm: 'SPyVM', wop_obj: W_OpArg,
+                              wop_method: W_OpArg,
+                              *args_wop: W_OpArg) -> W_OpImpl:
                 meth = wop_method.blue_unwrap_str(vm)
                 if meth == 'add':
                     @builtin_func('ext', 'add')

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -49,8 +49,9 @@ class TestCallOp(CompilerTest):
             def w_spy_new(vm: 'SPyVM', w_cls: W_Type, w_x: W_I32) -> 'W_Adder':
                 return W_Adder(vm.unwrap_i32(w_x))
 
+            @builtin_method('__CALL__', color='blue')
             @staticmethod
-            def op_CALL(vm: 'SPyVM', wop_obj: W_OpArg,
+            def w_CALL(vm: 'SPyVM', wop_obj: W_OpArg,
                         *args_wop: W_OpArg) -> W_OpImpl:
                 @builtin_func('ext')
                 def w_call(vm: 'SPyVM', w_obj: W_Adder, w_y: W_I32) -> W_I32:
@@ -85,8 +86,8 @@ class TestCallOp(CompilerTest):
                 self.w_y = w_y
 
             @staticmethod
-            def meta_op_CALL(vm: 'SPyVM', wop_obj: W_OpArg,
-                             *args_wop: W_OpArg) -> W_OpImpl:
+            def w_meta_CALL(vm: 'SPyVM', wop_obj: W_OpArg,
+                            *args_wop: W_OpArg) -> W_OpImpl:
                 @builtin_func('ext')
                 def w_new(vm: 'SPyVM', w_cls: W_Type,
                         w_x: W_I32, w_y: W_I32) -> W_Point:

--- a/spy/tests/vm/test_builtin.py
+++ b/spy/tests/vm/test_builtin.py
@@ -1,5 +1,6 @@
 import pytest
 from typing import Annotated
+from spy.errors import SPyTypeError
 from spy.vm.object import W_Object
 from spy.vm.primitive import W_I32, W_Dynamic
 from spy.vm.vm import SPyVM
@@ -117,3 +118,16 @@ class TestBuiltin:
         assert isinstance(w_make, W_BuiltinFunc)
         assert w_make.w_functype.signature == "def() -> test::Foo"
         assert w_make.w_functype.w_restype is W_Foo._w
+
+    def test_builtin_method_wrong_color(self):
+        class W_Foo(W_Object):
+
+            @builtin_method('__GETITEM__')
+            @staticmethod
+            def w_GETITEM(vm: 'SPyVM') -> 'W_Foo':
+                return W_Foo()
+
+        msg = "method `test::Foo.__GETITEM__` should be blue, but it's red"
+        with pytest.raises(SPyTypeError, match=msg):
+            # simulate @decorator application
+            builtin_type('test', 'Foo')(W_Foo)

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -203,6 +203,8 @@ class W_Func(W_Object):
         """
         raise NotImplementedError
 
+    # NOTE: we cannot use a w_CALL/__CALL__ here, for bootstrapping
+    # reason. OP.CALL on W_Func objects is special-cased, see callop.w_CALL.
     @staticmethod
     def op_CALL(vm: 'SPyVM', wop_func: 'W_OpArg',
                 *args_wop: 'W_OpArg') -> 'W_OpImpl':

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -5,7 +5,7 @@ from spy.vm.b import B, OP
 from spy.vm.primitive import W_I32, W_Bool, W_Dynamic, W_Void
 from spy.vm.object import W_Object, W_Type
 from spy.vm.opimpl import W_OpImpl, W_OpArg
-from spy.vm.builtin import builtin_func, builtin_type
+from spy.vm.builtin import builtin_func, builtin_type, builtin_method
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
@@ -57,7 +57,7 @@ class W_BaseList(W_Object):
 
       - it's the base type for all lists
 
-      - by implementing meta_op_GETITEM, it can be used to create
+      - by implementing w_meta_GETITEM, it can be used to create
        _specialized_ list types, e.g. `list[i32]`.
 
     In other words, `list[i32]` inherits from `list`.
@@ -71,8 +71,8 @@ class W_BaseList(W_Object):
         raise Exception("You cannot instantiate W_BaseList, use W_List")
 
     @staticmethod
-    def meta_op_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg,
-                        wop_i: W_OpArg) -> W_OpImpl:
+    def w_meta_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg,
+                       wop_i: W_OpArg) -> W_OpImpl:
         from spy.vm.opimpl import W_OpImpl
         return W_OpImpl(w_make_list_type)
 
@@ -110,8 +110,9 @@ class W_List(W_BaseList, Generic[T]):
             # opposed to e.g. 'list[i32]'
             assert False, 'FIXME: raise a nice error'
 
+    @builtin_method('__GETITEM__', color='blue')
     @staticmethod
-    def op_GETITEM(vm: 'SPyVM', wop_list: W_OpArg, wop_i: W_OpArg) -> W_OpImpl:
+    def w_GETITEM(vm: 'SPyVM', wop_list: W_OpArg, wop_i: W_OpArg) -> W_OpImpl:
         from spy.vm.opimpl import W_OpImpl
         w_listtype = W_List._get_listtype(wop_list)
         w_T = w_listtype.w_itemtype

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -126,9 +126,10 @@ class W_List(W_BaseList, Generic[T]):
             return w_list.items_w[i]
         return W_OpImpl(w_getitem)
 
+    @builtin_method('__SETITEM__', color='blue')
     @staticmethod
-    def op_SETITEM(vm: 'SPyVM', wop_list: W_OpArg, wop_i: W_OpArg,
-                   wop_v: W_OpArg) -> W_OpImpl:
+    def w_SETITEM(vm: 'SPyVM', wop_list: W_OpArg, wop_i: W_OpArg,
+                  wop_v: W_OpArg) -> W_OpImpl:
         from spy.vm.opimpl import W_OpImpl
         w_listtype = W_List._get_listtype(wop_list)
         w_T = w_listtype.w_itemtype

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -5,7 +5,7 @@ from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type
 from spy.vm.str import W_Str
 from spy.vm.function import W_ASTFunc
-from spy.vm.builtin import builtin_func
+from spy.vm.builtin import builtin_func, builtin_method
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 
 if TYPE_CHECKING:
@@ -32,8 +32,8 @@ class W_Module(W_Object):
 
     # ==== operator impls =====
 
-    @staticmethod
     @builtin_method('__GETATTR__', color='blue')
+    @staticmethod
     def w_GETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg) -> W_OpImpl:
         """
         Ideally, we should create a new subtype for each module, where every

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -33,7 +33,8 @@ class W_Module(W_Object):
     # ==== operator impls =====
 
     @staticmethod
-    def op_GETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg) -> W_OpImpl:
+    @builtin_method('__GETATTR__', color='blue')
+    def w_GETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg) -> W_OpImpl:
         """
         Ideally, we should create a new subtype for each module, where every
         member has its own static type.

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -50,9 +50,10 @@ class W_Module(W_Object):
         return W_OpImpl(w_fn)
 
 
+    @builtin_method('__SETATTR__', color='blue')
     @staticmethod
-    def op_SETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
-                   wop_v: W_OpArg) -> W_OpImpl:
+    def w_SETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
+                  wop_v: W_OpArg) -> W_OpImpl:
         @builtin_func('builtins', 'module_setattr')
         def w_fn(vm: 'SPyVM', w_mod: W_Module, w_attr:
                    W_Str, w_val: W_Dynamic) -> W_Void:

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -22,9 +22,10 @@ class W_JsRef(W_Object):
                   wop_attr: W_OpArg) -> W_OpImpl:
         return W_OpImpl(JSFFI.w_js_getattr)
 
+    @builtin_method('__SETATTR__', color='blue')
     @staticmethod
-    def op_SETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
-                   wop_v: W_OpArg) -> W_OpImpl:
+    def w_SETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
+                  wop_v: W_OpArg) -> W_OpImpl:
         return W_OpImpl(JSFFI.w_js_setattr)
 
     @staticmethod

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -28,9 +28,10 @@ class W_JsRef(W_Object):
                   wop_v: W_OpArg) -> W_OpImpl:
         return W_OpImpl(JSFFI.w_js_setattr)
 
+    @builtin_method('__CALL_METHOD__', color='blue')
     @staticmethod
-    def op_CALL_METHOD(vm: 'SPyVM', wop_obj: W_OpArg, wop_method: W_OpArg,
-                       *args_wop: W_OpArg) -> W_OpImpl:
+    def w_CALL_METHOD(vm: 'SPyVM', wop_obj: W_OpArg, wop_method: W_OpArg,
+                      *args_wop: W_OpArg) -> W_OpImpl:
         n = len(args_wop)
         if n == 1:
             return W_OpImpl(JSFFI.w_js_call_method_1)

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -17,8 +17,9 @@ JSFFI = ModuleRegistry('jsffi')
 class W_JsRef(W_Object):
 
     @staticmethod
-    def op_GETATTR(vm: 'SPyVM', wop_obj: W_OpArg,
-                   wop_attr: W_OpArg) -> W_OpImpl:
+    @builtin_method('__GETATTR__', color='blue')
+    def w_GETATTR(vm: 'SPyVM', wop_obj: W_OpArg,
+                  wop_attr: W_OpArg) -> W_OpImpl:
         return W_OpImpl(JSFFI.w_js_getattr)
 
     @staticmethod

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -5,7 +5,7 @@ from spy.vm.b import B
 from spy.vm.object import Member
 from spy.vm.w import W_Func, W_Type, W_Object, W_Str, W_FuncType
 from spy.vm.opimpl import W_OpImpl, W_OpArg
-from spy.vm.builtin import builtin_func, builtin_type
+from spy.vm.builtin import builtin_func, builtin_type, builtin_method
 from spy.vm.registry import ModuleRegistry
 
 if TYPE_CHECKING:
@@ -16,8 +16,8 @@ JSFFI = ModuleRegistry('jsffi')
 @JSFFI.builtin_type('JsRef')
 class W_JsRef(W_Object):
 
-    @staticmethod
     @builtin_method('__GETATTR__', color='blue')
+    @staticmethod
     def w_GETATTR(vm: 'SPyVM', wop_obj: W_OpArg,
                   wop_attr: W_OpArg) -> W_OpImpl:
         return W_OpImpl(JSFFI.w_js_getattr)

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -39,8 +39,9 @@ class W_JsRef(W_Object):
                 f"unsupported number of arguments for CALL_METHOD: {n}"
             )
 
+    @builtin_method('__CONVERT_FROM__', color='blue')
     @staticmethod
-    def op_CONVERT_FROM(vm: 'SPyVM', w_T: W_Type, wop_x: W_OpArg) -> W_OpImpl:
+    def w_CONVERT_FROM(vm: 'SPyVM', w_T: W_Type, wop_x: W_OpArg) -> W_OpImpl:
         if w_T is B.w_str:
             return W_OpImpl(JSFFI.w_js_string)
         elif w_T is B.w_i32:

--- a/spy/vm/modules/operator/__init__.py
+++ b/spy/vm/modules/operator/__init__.py
@@ -78,3 +78,15 @@ def OP_from_token(token: str) -> W_Func:
     E.g., OPS.from_token('+') returns OPS.w_ADD.
     """
     return _from_token[token]
+
+def print_all_OPERATORS() -> None:
+    """
+    Just a development tool to print the list of all OPERATORs
+    """
+    print('SPy OPERATORS:')
+    for fqn, w_func in OP.content:
+        if fqn.symbol_name.isupper():
+            print("   ", fqn)
+    print()
+
+#print_all_OPERATORS()

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -44,8 +44,8 @@ def _get_GETATTR_opimpl(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
         return opimpl_member('get', vm, w_type, attr)
     elif w_GET := w_type.lookup_blue_func(f'__GET_{attr}__'):
         return vm.fast_call(w_GET, [wop_obj, wop_attr])
-    elif pyclass.has_meth_overriden('op_GETATTR'):
-        return pyclass.op_GETATTR(vm, wop_obj, wop_attr)
+    elif pyclass.has_meth_overriden('w_GETATTR'):
+        return pyclass.w_GETATTR(vm, wop_obj, wop_attr)
     return W_OpImpl.NULL
 
 

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -44,8 +44,8 @@ def _get_GETATTR_opimpl(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
         return opimpl_member('get', vm, w_type, attr)
     elif w_GET := w_type.lookup_blue_func(f'__GET_{attr}__'):
         return vm.fast_call(w_GET, [wop_obj, wop_attr])
-    elif pyclass.has_meth_overriden('w_GETATTR'):
-        return pyclass.w_GETATTR(vm, wop_obj, wop_attr)
+    elif w_GETATTR := w_type.lookup_blue_func(f'__GETATTR__'):
+        return vm.fast_call(w_GETATTR, [wop_obj, wop_attr])
     return W_OpImpl.NULL
 
 

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -37,7 +37,6 @@ def w_GETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg) -> W_Func:
 def _get_GETATTR_opimpl(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
                         attr: str) -> W_OpImpl:
     w_type = wop_obj.w_static_type
-    pyclass = w_type.pyclass
     if w_type is B.w_dynamic:
         return W_OpImpl(OP.w_dynamic_getattr)
     elif attr in w_type.spy_members:
@@ -67,13 +66,12 @@ def w_SETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
 def _get_SETATTR_opimpl(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
                         wop_v: W_OpArg, attr: str) -> W_OpImpl:
     w_type = wop_obj.w_static_type
-    pyclass = w_type.pyclass
     if w_type is B.w_dynamic:
         return W_OpImpl(OP.w_dynamic_setattr)
     elif attr in w_type.spy_members:
         return opimpl_member('set', vm, w_type, attr)
-    elif pyclass.has_meth_overriden('op_SETATTR'):
-        return pyclass.op_SETATTR(vm, wop_obj, wop_attr, wop_v)
+    elif w_SETATTR := w_type.lookup_blue_func('__SETATTR__'):
+        return vm.fast_call(w_SETATTR, [wop_obj, wop_attr, wop_v])
     return W_OpImpl.NULL
 
 

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -42,9 +42,8 @@ def _get_GETATTR_opimpl(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
         return W_OpImpl(OP.w_dynamic_getattr)
     elif attr in w_type.spy_members:
         return opimpl_member('get', vm, w_type, attr)
-    elif hasattr(pyclass, f'op_GET_{attr}'):
-        meth = getattr(pyclass, f'op_GET_{attr}')
-        return meth(vm, wop_obj, wop_attr)
+    elif w_GET := w_type.lookup_blue_func(f'__GET_{attr}__'):
+        return vm.fast_call(w_GET, [wop_obj, wop_attr])
     elif pyclass.has_meth_overriden('op_GETATTR'):
         return pyclass.op_GETATTR(vm, wop_obj, wop_attr)
     return W_OpImpl.NULL

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -17,11 +17,14 @@ def w_CALL(vm: 'SPyVM', wop_obj: W_OpArg, *args_wop: W_OpArg) -> W_Func:
     from spy.vm.typechecker import typecheck_opimpl
     w_opimpl = W_OpImpl.NULL
     w_type = wop_obj.w_static_type
-    pyclass = w_type.pyclass
     if w_type is B.w_dynamic:
         w_opimpl = W_OpImpl(OP.w_dynamic_call)
-    elif pyclass.has_meth_overriden('op_CALL'):
-        w_opimpl = pyclass.op_CALL(vm, wop_obj, *args_wop)
+    elif isinstance(w_type, W_FuncType):
+        # special case: W_Func cannot have a w_CALL for bootstrapping reasons
+        w_opimpl = w_type.pyclass.op_CALL(vm, wop_obj, *args_wop)
+    elif w_CALL := w_type.lookup_blue_func('__CALL__'):
+        newargs_wop = [wop_obj] + list(args_wop)
+        w_opimpl = vm.fast_call(w_CALL, newargs_wop)
 
     return typecheck_opimpl(
         vm,

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -39,9 +39,10 @@ def w_CALL_METHOD(vm: 'SPyVM', wop_obj: W_OpArg, wop_method: W_OpArg,
     from spy.vm.typechecker import typecheck_opimpl
     w_opimpl = W_OpImpl.NULL
     w_type = wop_obj.w_static_type
-    pyclass = w_type.pyclass
-    if pyclass.has_meth_overriden('op_CALL_METHOD'):
-        w_opimpl = pyclass.op_CALL_METHOD(vm, wop_obj, wop_method, *args_wop)
+
+    if w_CALL_METHOD := w_type.lookup_blue_func('__CALL_METHOD__'):
+        newargs_wop = [wop_obj, wop_method] + list(args_wop)
+        w_opimpl = vm.fast_call(w_CALL_METHOD, newargs_wop)
 
     return typecheck_opimpl(
         vm,

--- a/spy/vm/modules/operator/convop.py
+++ b/spy/vm/modules/operator/convop.py
@@ -57,12 +57,10 @@ def get_opimpl(vm: 'SPyVM', w_exp: W_Type, wop_x: W_OpArg) -> W_OpImpl:
     if not w_opimpl.is_null():
         return w_opimpl
 
-    from_pyclass = w_got.pyclass
-    to_pyclass = w_exp.pyclass
-    if from_pyclass.has_meth_overriden('op_CONVERT_TO'):
-        return from_pyclass.op_CONVERT_TO(vm, w_exp, wop_x)
-    elif to_pyclass.has_meth_overriden('op_CONVERT_FROM'):
-        return to_pyclass.op_CONVERT_FROM(vm, w_got, wop_x)
+    if w_CONV_TO := w_got.lookup_blue_func('__CONVERT_TO__'):
+        return vm.fast_call(w_CONV_TO, [w_exp, wop_x])
+    elif w_CONV_FROM := w_exp.lookup_blue_func('__CONVERT_FROM__'):
+        return vm.fast_call(w_CONV_FROM, [w_got, wop_x])
 
     return W_OpImpl.NULL
 

--- a/spy/vm/modules/operator/itemop.py
+++ b/spy/vm/modules/operator/itemop.py
@@ -14,9 +14,11 @@ if TYPE_CHECKING:
 def w_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg, wop_i: W_OpArg) -> W_Func:
     from spy.vm.typechecker import typecheck_opimpl
     w_opimpl = W_OpImpl.NULL
-    pyclass = wop_obj.w_static_type.pyclass
-    if pyclass.has_meth_overriden('op_GETITEM'):
-        w_opimpl = pyclass.op_GETITEM(vm, wop_obj, wop_i)
+    w_type = wop_obj.w_static_type
+
+    w_GETITEM = w_type.lookup_blue_func('__GETITEM__')
+    if w_GETITEM:
+        w_opimpl = vm.fast_call(w_GETITEM, [wop_obj, wop_i])
 
     return typecheck_opimpl(
         vm,

--- a/spy/vm/modules/operator/itemop.py
+++ b/spy/vm/modules/operator/itemop.py
@@ -34,9 +34,11 @@ def w_SETITEM(vm: 'SPyVM', wop_obj: W_OpArg, wop_i: W_OpArg,
             wop_v: W_OpArg) -> W_Func:
     from spy.vm.typechecker import typecheck_opimpl
     w_opimpl = W_OpImpl.NULL
-    pyclass = wop_obj.w_static_type.pyclass
-    if pyclass.has_meth_overriden('op_SETITEM'):
-        w_opimpl = pyclass.op_SETITEM(vm, wop_obj, wop_i, wop_v)
+    w_type = wop_obj.w_static_type
+
+    w_SETITEM = w_type.lookup_blue_func('__SETITEM__')
+    if w_SETITEM:
+        w_opimpl = vm.fast_call(w_SETITEM, [wop_obj, wop_i, wop_v])
 
     return typecheck_opimpl(
         vm,

--- a/spy/vm/modules/operator/itemop.py
+++ b/spy/vm/modules/operator/itemop.py
@@ -16,8 +16,7 @@ def w_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg, wop_i: W_OpArg) -> W_Func:
     w_opimpl = W_OpImpl.NULL
     w_type = wop_obj.w_static_type
 
-    w_GETITEM = w_type.lookup_blue_func('__GETITEM__')
-    if w_GETITEM:
+    if w_GETITEM := w_type.lookup_blue_func('__GETITEM__'):
         w_opimpl = vm.fast_call(w_GETITEM, [wop_obj, wop_i])
 
     return typecheck_opimpl(
@@ -36,8 +35,7 @@ def w_SETITEM(vm: 'SPyVM', wop_obj: W_OpArg, wop_i: W_OpArg,
     w_opimpl = W_OpImpl.NULL
     w_type = wop_obj.w_static_type
 
-    w_SETITEM = w_type.lookup_blue_func('__SETITEM__')
-    if w_SETITEM:
+    if w_SETITEM := w_type.lookup_blue_func('__SETITEM__'):
         w_opimpl = vm.fast_call(w_SETITEM, [wop_obj, wop_i, wop_v])
 
     return typecheck_opimpl(

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -13,7 +13,7 @@ from spy.vm.object import W_Type, W_Object, Member
 from spy.vm.str import W_Str
 from spy.vm.function import W_Func
 from spy.vm.opimpl import W_OpImpl, W_OpArg
-from spy.vm.builtin import builtin_func
+from spy.vm.builtin import builtin_func, builtin_method
 from spy.vm.registry import ModuleRegistry
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -137,8 +137,9 @@ class W_LiftedObject(W_Object):
         hltype = self.w_hltype.fqn.human_name
         return f'<{hltype} (lifted from {ll_repr})>'
 
+    @builtin_method('__GET___ll____', color='blue')
     @staticmethod
-    def op_GET___ll__(vm: 'SPyVM', wop_hl: W_OpArg,
+    def w_GET___ll__(vm: 'SPyVM', wop_hl: W_OpArg,
                       wop_attr: W_OpArg) -> W_OpImpl:
         w_hltype = wop_hl.w_static_type
         HL = Annotated[W_LiftedObject, w_hltype]

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -84,9 +84,10 @@ class W_LiftedType(W_Type):
         lltype = self.w_lltype.fqn.human_name
         return f"<spy type '{self.fqn}' (lifted from '{lltype}')>"
 
+    @builtin_method('__CALL_METHOD__', color='blue')
     @staticmethod
-    def op_CALL_METHOD(vm: 'SPyVM', wop_self: W_OpArg, wop_method: W_OpArg,
-                       *args_wop: W_OpArg) -> W_OpImpl:
+    def w_CALL_METHOD(vm: 'SPyVM', wop_self: W_OpArg, wop_method: W_OpArg,
+                      *args_wop: W_OpArg) -> W_OpImpl:
         meth = wop_method.blue_unwrap_str(vm)
         if meth != '__lift__':
             return W_OpImpl.NULL

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -173,9 +173,10 @@ class W_Ptr(W_BasePtr):
             )
         return W_OpImpl(w_ptr_load_T)
 
+    @builtin_method('__SETITEM__', color='blue')
     @staticmethod
-    def op_SETITEM(vm: 'SPyVM', wop_ptr: W_OpArg, wop_i: W_OpArg,
-                   wop_v: W_OpArg) -> W_OpImpl:
+    def w_SETITEM(vm: 'SPyVM', wop_ptr: W_OpArg, wop_i: W_OpArg,
+                  wop_v: W_OpArg) -> W_OpImpl:
         w_ptrtype = W_Ptr._get_ptrtype(wop_ptr)
         w_T = w_ptrtype.w_itemtype
         ITEMSIZE = sizeof(w_T)

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -59,8 +59,9 @@ class W_PtrType(W_Type):
         self.w_itemtype = w_itemtype
 
     @staticmethod
-    def op_GETATTR(vm: 'SPyVM', wop_ptr: 'W_OpArg',
-                   wop_attr: 'W_OpArg') -> 'W_OpImpl':
+    @builtin_method('__GETATTR__', color='blue')
+    def w_GETATTR(vm: 'SPyVM', wop_ptr: 'W_OpArg',
+                  wop_attr: 'W_OpArg') -> 'W_OpImpl':
         attr = wop_attr.blue_unwrap_str(vm)
         if attr == 'NULL':
             # NOTE: the precise spelling of the FQN of NULL matters! The

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -254,18 +254,19 @@ class W_Ptr(W_BasePtr):
     @staticmethod
     def w_GETATTR(vm: 'SPyVM', wop_ptr: W_OpArg,
                   wop_attr: W_OpArg) -> W_OpImpl:
-        return W_Ptr._op_ATTR('get', vm, wop_ptr, wop_attr, None)
+        return W_Ptr.op_ATTR('get', vm, wop_ptr, wop_attr, None)
+
+    @builtin_method('__SETATTR__', color='blue')
+    @staticmethod
+    def w_SETATTR(vm: 'SPyVM', wop_ptr: W_OpArg, wop_attr: W_OpArg,
+                  wop_v: W_OpArg) -> W_OpImpl:
+        return W_Ptr.op_ATTR('set', vm, wop_ptr, wop_attr, wop_v)
 
     @staticmethod
-    def op_SETATTR(vm: 'SPyVM', wop_ptr: W_OpArg, wop_attr: W_OpArg,
-                   wop_v: W_OpArg) -> W_OpImpl:
-        return W_Ptr._op_ATTR('set', vm, wop_ptr, wop_attr, wop_v)
-
-    @staticmethod
-    def _op_ATTR(opkind: str, vm: 'SPyVM', wop_ptr: W_OpArg, wop_attr: W_OpArg,
-                 wop_v: Optional[W_OpArg]) -> W_OpImpl:
+    def op_ATTR(opkind: str, vm: 'SPyVM', wop_ptr: W_OpArg, wop_attr: W_OpArg,
+                wop_v: Optional[W_OpArg]) -> W_OpImpl:
         """
-        Implement both w_GETATTR and op_SETATTR.
+        Implement both w_GETATTR and w_SETATTR.
         """
         from .struct import W_StructType
         w_ptrtype = W_Ptr._get_ptrtype(wop_ptr)

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -234,8 +234,9 @@ class W_Ptr(W_BasePtr):
             )  # type: ignore
         return W_OpImpl(w_ptr_ne)
 
+    @builtin_method('__CONVERT_TO__', color='blue')
     @staticmethod
-    def op_CONVERT_TO(vm: 'SPyVM', w_T: W_Type, wop_x: W_OpArg) -> W_OpImpl:
+    def w_CONVERT_TO(vm: 'SPyVM', w_T: W_Type, wop_x: W_OpArg) -> W_OpImpl:
         if w_T is not B.w_bool:
             return W_OpImpl.NULL
         w_ptrtype = W_Ptr._get_ptrtype(wop_x)

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -52,16 +52,15 @@ class W_PtrType(W_Type):
     # type PtrType(T), and AFAIK there is no syntax to denote that.
     #
     # The workaround is not to use a Member, but to implement .NULL as a
-    # special case of op_GETATTR.
+    # special case of w_GETATTR.
 
     def __init__(self, fqn: FQN, w_itemtype: W_Type) -> None:
         super().__init__(fqn, W_Ptr)
         self.w_itemtype = w_itemtype
 
-    @staticmethod
     @builtin_method('__GETATTR__', color='blue')
-    def w_GETATTR(vm: 'SPyVM', wop_ptr: 'W_OpArg',
-                  wop_attr: 'W_OpArg') -> 'W_OpImpl':
+    @staticmethod
+    def w_GETATTR(vm: 'SPyVM', wop_ptr: W_OpArg, wop_attr: W_OpArg) -> W_OpImpl:
         attr = wop_attr.blue_unwrap_str(vm)
         if attr == 'NULL':
             # NOTE: the precise spelling of the FQN of NULL matters! The
@@ -251,10 +250,10 @@ class W_Ptr(W_BasePtr):
         vm.add_global(w_ptr_to_bool.fqn, w_ptr_to_bool)
         return W_OpImpl(w_ptr_to_bool)
 
-
+    @builtin_method('__GETATTR__', color='blue')
     @staticmethod
-    def op_GETATTR(vm: 'SPyVM', wop_ptr: W_OpArg,
-                   wop_attr: W_OpArg) -> W_OpImpl:
+    def w_GETATTR(vm: 'SPyVM', wop_ptr: W_OpArg,
+                  wop_attr: W_OpArg) -> W_OpImpl:
         return W_Ptr._op_ATTR('get', vm, wop_ptr, wop_attr, None)
 
     @staticmethod
@@ -266,7 +265,7 @@ class W_Ptr(W_BasePtr):
     def _op_ATTR(opkind: str, vm: 'SPyVM', wop_ptr: W_OpArg, wop_attr: W_OpArg,
                  wop_v: Optional[W_OpArg]) -> W_OpImpl:
         """
-        Implement both op_GETATTR and op_SETATTR.
+        Implement both w_GETATTR and op_SETATTR.
         """
         from .struct import W_StructType
         w_ptrtype = W_Ptr._get_ptrtype(wop_ptr)

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -5,7 +5,7 @@ from spy.fqn import FQN
 from spy.vm.primitive import W_I32, W_Dynamic, W_Void, W_Bool
 from spy.vm.object import Member
 from spy.vm.b import B
-from spy.vm.builtin import builtin_type
+from spy.vm.builtin import builtin_type, builtin_method
 from spy.vm.w import W_Object, W_Type, W_Str, W_Func
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.builtin import builtin_func
@@ -94,7 +94,7 @@ class W_BasePtr(W_Object):
         raise Exception("You cannot instantiate W_BasePtr, use W_Ptr")
 
     @staticmethod
-    def meta_op_GETITEM(vm: 'SPyVM', wop_p: W_OpArg, wop_T: W_OpArg)-> W_OpImpl:
+    def w_meta_GETITEM(vm: 'SPyVM', wop_p: W_OpArg, wop_T: W_OpArg)-> W_OpImpl:
         return W_OpImpl(w_make_ptr_type, [wop_T])
 
 
@@ -147,8 +147,9 @@ class W_Ptr(W_BasePtr):
             # opposed to e.g. 'ptr[i32]'
             assert False, 'FIXME: raise a nice error'
 
+    @builtin_method('__GETITEM__', color='blue')
     @staticmethod
-    def op_GETITEM(vm: 'SPyVM', wop_ptr: W_OpArg, wop_i: W_OpArg) -> W_OpImpl:
+    def w_GETITEM(vm: 'SPyVM', wop_ptr: W_OpArg, wop_i: W_OpArg) -> W_OpImpl:
         w_ptrtype = W_Ptr._get_ptrtype(wop_ptr)
         w_T = w_ptrtype.w_itemtype
         ITEMSIZE = sizeof(w_T)

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -176,8 +176,8 @@ class W_Object:
         raise NotImplementedError('this should never be called')
 
     @staticmethod
-    def op_CALL_METHOD(vm: 'SPyVM', wop_obj: 'W_OpArg', wop_method: 'W_OpArg',
-                       *args_wop: 'W_OpArg') -> 'W_OpImpl':
+    def w_CALL_METHOD(vm: 'SPyVM', wop_obj: 'W_OpArg', wop_method: 'W_OpArg',
+                      *args_wop: 'W_OpArg') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
     @staticmethod

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -161,8 +161,8 @@ class W_Object:
         raise NotImplementedError('this should never be called')
 
     @staticmethod
-    def op_GETITEM(vm: 'SPyVM', wop_obj: 'W_OpArg',
-                   wop_i: 'W_OpArg') -> 'W_OpImpl':
+    def w_GETITEM(vm: 'SPyVM', wop_obj: 'W_OpArg',
+                  wop_i: 'W_OpArg') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
     @staticmethod
@@ -244,11 +244,50 @@ class W_Type(W_Object):
     def is_struct(self, vm: 'SPyVM') -> bool:
         return False
 
+    def lookup_func(self, name: str) -> Optional['W_Func']:
+        """
+        Lookup the given attribute into the applevel dict, and ensure it's
+        a W_Func.
+        """
+        from spy.vm.function import W_Func
+        w_obj = self.dict_w.get(name)
+        if w_obj:
+            assert isinstance(w_obj, W_Func)
+            return w_obj
+        return None
+
+    def lookup_blue_func(self, name: str) -> Optional['W_Func']:
+        """
+        Like lookup_func, but also check that the function is blue
+        """
+        from spy.vm.function import W_Func
+        w_obj = self.dict_w.get(name)
+        if w_obj:
+            assert isinstance(w_obj, W_Func)
+            assert w_obj.color == 'blue'
+            return w_obj
+        return None
+
     def _eval_builtin_method(self, pyname: str, statmeth: staticmethod) -> None:
         "Turn the @builtin_method into a W_BuiltinFunc"
         from spy.vm.builtin import builtin_func
         appname, color = statmeth.spy_builtin_method  # type: ignore
         pyfunc = statmeth.__func__
+
+        # sanity check: __MAGIC__ methods should be blue
+        if appname in (
+                '__ADD__', '__SUB__', '__MUL__', '__DIV__',
+                '__EQ__', '__NE__', '__LT__', '__LE__', '__GT__', '__GE__',
+                '__GETATTR__', '__SETATTR__',
+                '__GETITEM__', '__SETITEM__',
+                '__CALL__', '__CALL_METHOD__',
+                '__CONVERT_FROM__', '__CONVERT_TO__',
+        ) and color != 'blue':
+            # XXX we should raise a more detailed exception
+            fqn = self.fqn.human_name
+            msg = f"method `{fqn}.{appname}` should be blue, but it's {color}"
+            raise SPyTypeError(msg)
+
 
         # create the @builtin_func decorator, and make it possible to use the
         # string 'W_MyClass' in annotations
@@ -340,37 +379,39 @@ def make_metaclass_maybe(fqn: FQN, pyclass: Type[W_Object]) -> Type[W_Type]:
     which is an instance of W_Type.
 
     However, W_Foo can request the creation of a custom metaclass by
-    implementing any of the supported op_meta_* methods.
+    implementing any of the supported w_meta_* methods.
 
     Example:
 
     @builtin_type('ext', 'Foo')
     class W_Foo(W_Object):
         pass
-
     ==> creates:
     w_footype = W_Type('ext::Foo', pyclass=W_Foo)
 
+
     @builtin_type('ext', 'Bar')
     class W_Bar(W_Object):
-        def meta_op_GETITEM(...):
-            ...
-
+        @staticmethod
+        def w_meta_GETITEM(...):
+            ..
     ==> creates:
-
     class W_BarType(W_Type):
-        def op_GETITEM(...):
+        @builtin_method('__GETITEM__', color='blue')
+        @staticmethod
+        def w_GETITEM(...):
             ...
     w_bartype = W_BarType('ext::Bar', pyclass=W_Bar)
 
-    The relationship between Bar and Meta_Bar is the following:
+    The relationship between W_Bar and W_BarType is the following:
 
     w_Bar = vm.wrap(W_Bar)
     w_bar_type = vm.wrap(W_BarType)
     assert vm.dynamic_type(w_Bar) is w_bar_type
     """
+    from spy.vm.builtin import builtin_method
     if (not hasattr(pyclass, 'meta_op_CALL') and
-        not hasattr(pyclass, 'meta_op_GETITEM')):
+        not hasattr(pyclass, 'w_meta_GETITEM')):
         # no metaclass needed
         return W_Type
 
@@ -383,8 +424,10 @@ def make_metaclass_maybe(fqn: FQN, pyclass: Type[W_Object]) -> Type[W_Type]:
 
     if hasattr(pyclass, 'meta_op_CALL'):
         W_MetaType.op_CALL = pyclass.meta_op_CALL  # type: ignore
-    if hasattr(pyclass, 'meta_op_GETITEM'):
-        W_MetaType.op_GETITEM = pyclass.meta_op_GETITEM  # type: ignore
+    if hasattr(pyclass, 'w_meta_GETITEM'):
+        fn = pyclass.w_meta_GETITEM
+        decorator = builtin_method('__GETITEM__', color='blue')
+        W_MetaType.w_GETITEM = decorator(staticmethod(fn))
 
     W_MetaType._w = W_Type(metafqn, W_MetaType)
     return W_MetaType

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -151,8 +151,9 @@ class W_Object:
         raise NotImplementedError('this should never be called')
 
     @staticmethod
-    def op_GETATTR(vm: 'SPyVM', wop_obj: 'W_OpArg',
-                   wop_attr: 'W_OpArg') -> 'W_OpImpl':
+    @builtin_method('__GETATTR__', color='blue')
+    def w_GETATTR(vm: 'SPyVM', wop_obj: 'W_OpArg',
+                  wop_attr: 'W_OpArg') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
     @staticmethod

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -166,8 +166,8 @@ class W_Object:
         raise NotImplementedError('this should never be called')
 
     @staticmethod
-    def op_SETITEM(vm: 'SPyVM', wop_obj: 'W_OpArg', wop_i: 'W_OpArg',
-                   wop_v: 'W_OpArg') -> 'W_OpImpl':
+    def w_SETITEM(vm: 'SPyVM', wop_obj: 'W_OpArg', wop_i: 'W_OpArg',
+                  wop_v: 'W_OpArg') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
     @staticmethod

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -111,7 +111,7 @@ class W_Object:
     #     return opimpl(obj, 'a')
     #
     # Subclasses of W_Object can implement their own operator by overriding
-    # the various op_GETATTR & co.  These must be *static methods* on the
+    # the various w_GETATTR & co.  These must be *static methods* on the
     # class, and must return an opimpl.
     #
     #
@@ -151,7 +151,6 @@ class W_Object:
         raise NotImplementedError('this should never be called')
 
     @staticmethod
-    @builtin_method('__GETATTR__', color='blue')
     def w_GETATTR(vm: 'SPyVM', wop_obj: 'W_OpArg',
                   wop_attr: 'W_OpArg') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -181,13 +181,13 @@ class W_Object:
         raise NotImplementedError('this should never be called')
 
     @staticmethod
-    def op_CONVERT_FROM(vm: 'SPyVM', w_T: 'W_Type',
-                        wop_x: 'W_OpArg') -> 'W_OpImpl':
+    def w_CONVERT_FROM(vm: 'SPyVM', w_T: 'W_Type',
+                       wop_x: 'W_OpArg') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
     @staticmethod
-    def op_CONVERT_TO(vm: 'SPyVM', w_T: 'W_Type',
-                      wop_x: 'W_OpArg') -> 'W_OpImpl':
+    def w_CONVERT_TO(vm: 'SPyVM', w_T: 'W_Type',
+                     wop_x: 'W_OpArg') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
 

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -156,8 +156,8 @@ class W_Object:
         raise NotImplementedError('this should never be called')
 
     @staticmethod
-    def op_SETATTR(vm: 'SPyVM', wop_obj: 'W_OpArg', wop_attr: 'W_OpArg',
-                   wop_v: 'W_OpArg') -> 'W_OpImpl':
+    def w_SETATTR(vm: 'SPyVM', wop_obj: 'W_OpArg', wop_attr: 'W_OpArg',
+                  wop_v: 'W_OpArg') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
     @staticmethod

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -81,8 +81,8 @@ class W_Str(W_Object):
         return W_OpImpl(w_getitem)
 
     @staticmethod
-    def meta_op_CALL(vm: 'SPyVM', wop_obj: W_OpArg,
-                     *args_wop: W_OpArg) -> W_OpImpl:
+    def w_meta_CALL(vm: 'SPyVM', wop_obj: W_OpArg,
+                    *args_wop: W_OpArg) -> W_OpImpl:
         from spy.vm.b import B
         if len(args_wop) == 1 and args_wop[0].w_static_type is B.w_i32:
             wop_i = args_wop[0]

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Any
 from spy.llwasm import LLWasmInstance
 from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type
-from spy.vm.builtin import builtin_func, builtin_type
+from spy.vm.builtin import builtin_func, builtin_type, builtin_method
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.primitive import W_I32, W_Dynamic
 if TYPE_CHECKING:
@@ -69,8 +69,9 @@ class W_Str(W_Object):
     def spy_unwrap(self, vm: 'SPyVM') -> str:
         return self._as_str()
 
+    @builtin_method('__GETITEM__', color='blue')
     @staticmethod
-    def op_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg, wop_i: W_OpArg) -> W_OpImpl:
+    def w_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg, wop_i: W_OpArg) -> W_OpImpl:
         @builtin_func('builtins::str')
         def w_getitem(vm: 'SPyVM', w_s: W_Str, w_i: W_I32) -> W_Str:
             assert isinstance(w_s, W_Str)

--- a/spy/vm/tuple.py
+++ b/spy/vm/tuple.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Any, no_type_check, Optional
 from spy.vm.b import B
 from spy.vm.primitive import W_I32, W_Bool, W_Dynamic, W_Void
 from spy.vm.object import (W_Object, W_Type)
-from spy.vm.builtin import builtin_func, builtin_type
+from spy.vm.builtin import builtin_func, builtin_type, builtin_method
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -27,9 +27,9 @@ class W_Tuple(W_Object):
     def spy_unwrap(self, vm: 'SPyVM') -> tuple:
         return tuple([vm.unwrap(w_item) for w_item in self.items_w])
 
+    @builtin_method('__GETITEM__', color='blue')
     @staticmethod
-    def op_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg,
-                   wop_i: W_OpArg) -> W_OpImpl:
+    def w_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg, wop_i: W_OpArg) -> W_OpImpl:
         return W_OpImpl(w_tuple_getitem)
 
 

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -28,6 +28,10 @@ from spy.vm.modules.unsafe import UNSAFE
 from spy.vm.modules.rawbuffer import RAW_BUFFER
 from spy.vm.modules.jsffi import JSFFI
 
+# manually setup `builtins::type.__CALL__`. We must do it here because of
+# bootstrapping reasons.
+W_Type._w.setup_builtin_method(W_Type.w_CALL, '__CALL__', 'blue')
+
 
 class SPyVM:
     """

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -330,7 +330,7 @@ class SPyVM:
         # <TEMPORARY HACK>
         #
         # we don't want to over-specialize OPERATORs: for example, in case of
-        # W_List.op_GETITEM(obj, i) we care only about the types, and we don't
+        # W_List.w_GETITEM(obj, i) we care only about the types, and we don't
         # care whether "i" is blue.
         #
         # args_wop contains W_OpArgs which directly comes from ASTFrame, and


### PR DESCRIPTION
Turn most of the various `op_*` methods like `op_GETITEM`, `op_GETATTR` etc into proper builtin_methods such as `w_GETITEM`, `w_GETATTR`, etc.

This is an important step to allow user-defined types, where OPERATORS can be written at app level.

The transition is still not 100% complete. In particular the following are still using the old `op_*` convention:
  - `W_Func.op_CALL`
  - all `op_EQ` and `op_NE`

This is because they are used by `W_Func` and/or `W_OpImpl`/`W_OpArg`, and we cannot apply `@builtin_method` to them without causing circular dependencies.

