### PR TITLE
Make it possible to create functional custom types using @typelift

### DIFF
--- a/spy/__main__.py
+++ b/spy/__main__.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import time
 import typer
 import py.path
+import pdb as stdlib_pdb # to distinguish from the "--pdb" option
 from spy.magic_py_parse import magic_py_parse
 from spy.errors import SPyError
 from spy.parser import Parser
@@ -44,6 +45,7 @@ def main(filename: Path,
          cwrite: boolopt("create the .c file and exit") = False,
          g: boolopt("generate debug symbols", names=['-g']) = False,
          O: opt(int, "optimization level", names=['-O']) = 0,
+         pdb: boolopt("enter interp-level debugger in case of error") = False,
          release_mode: boolopt(
              "enable release mode", names=['-r', '--release']
          ) = False,
@@ -60,7 +62,10 @@ def main(filename: Path,
                 release_mode, toolchain, pretty, timeit)
     except SPyError as e:
         print(e.format(use_colors=True))
-        #import pdb;pdb.xpm()
+        if pdb:
+            info = sys.exc_info()
+            stdlib_pdb.post_mortem(info[2])
+
 
 def do_main(filename: Path, run: bool, pyparse: bool, parse: bool,
             redshift: bool,

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -455,6 +455,7 @@ class ClassDef(Stmt):
     kind: ClassKind
     fields: list['VarDef']
     methods: list['FuncDef']
+    symtable: Any = field(repr=False, default=None)
 
 @dataclass(eq=False)
 class Pass(Stmt):

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -454,6 +454,7 @@ class ClassDef(Stmt):
     name: str
     kind: ClassKind
     fields: list['VarDef']
+    methods: list['FuncDef']
 
 @dataclass(eq=False)
 class Pass(Stmt):

--- a/spy/irgen/scope.py
+++ b/spy/irgen/scope.py
@@ -191,6 +191,8 @@ class ScopeAnalyzer:
         self.inner_scopes[classdef] = inner_scope
         for vardef in classdef.fields:
             self.declare_VarDef(vardef)
+        for funcdef in classdef.methods:
+            self.declare_FuncDef(funcdef)
         self.pop_scope()
 
     def declare_Assign(self, assign: ast.Assign) -> None:
@@ -255,6 +257,8 @@ class ScopeAnalyzer:
         self.push_scope(inner_scope)
         for vardef in classdef.fields:
             self.flatten(vardef)
+        for funcdef in classdef.methods:
+            self.flatten(funcdef)
         self.pop_scope()
         #
         classdef.symtable = inner_scope

--- a/spy/irgen/scope.py
+++ b/spy/irgen/scope.py
@@ -256,6 +256,8 @@ class ScopeAnalyzer:
         for vardef in classdef.fields:
             self.flatten(vardef)
         self.pop_scope()
+        #
+        classdef.symtable = inner_scope
 
     def flatten_Name(self, name: ast.Name) -> None:
         self.capture_maybe(name.id)

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -215,6 +215,7 @@ class Parser:
 
         # only few kind of declarations are supported inside a "class:" block
         fields: list[spy.ast.VarDef] = []
+        methods: list[spy.ast.FuncDef] = []
         for py_stmt in py_classdef.body:
             if isinstance(py_stmt, py_ast.Pass):
                 pass
@@ -225,6 +226,9 @@ class Parser:
                                'this is not supported',
                                assign.loc)
                 fields.append(vardef)
+            elif isinstance(py_stmt, py_ast.FunctionDef):
+                funcdef = self.from_py_stmt_FunctionDef(py_stmt)
+                methods.append(funcdef)
             else:
                 msg = 'only fields are allowed inside a class def'
                 self.error(msg, 'this is not allowed here', py_stmt.loc)
@@ -234,6 +238,7 @@ class Parser:
             name = py_classdef.name,
             kind = kind,
             fields = fields,
+            methods = methods,
         )
 
 

--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -123,7 +123,7 @@ class TestOp(CompilerTest):
         )
         self.compile_raises(src, "foo", errors)
 
-    def test_Values(self):
+    def test_complex_OpImpl(self):
         # ========== EXT module for this test ==========
         EXT = ModuleRegistry('ext')
 
@@ -165,3 +165,20 @@ class TestOp(CompilerTest):
             return obj[b]
         """)
         assert mod.foo(10, 20) == 30
+
+    def test_OpImpl_new(self):
+        if self.backend == 'doppler':
+            pytest.skip('OpImpl becomes blue? FIXME')
+
+        mod = self.compile("""
+        from operator import OpImpl
+
+        def bar() -> void:
+            pass
+
+        def foo() -> dynamic:
+            return OpImpl(bar)
+        """)
+        w_opimpl = mod.foo(unwrap=False)
+        assert isinstance(w_opimpl, W_OpImpl)
+        assert w_opimpl._w_func is mod.bar.w_func

--- a/spy/tests/compiler/test_typelift.py
+++ b/spy/tests/compiler/test_typelift.py
@@ -12,8 +12,6 @@ class TestTypelift(CompilerTest):
     @only_interp
     def test_repr(self):
         mod = self.compile("""
-        WORKAROUND: i32 = 0
-
         @typelift
         class MyInt:
             __ll__: i32

--- a/spy/tests/compiler/test_typelift.py
+++ b/spy/tests/compiler/test_typelift.py
@@ -42,3 +42,23 @@ class TestTypelift(CompilerTest):
         assert myint.llval == 42
         assert myint.w_hltype.fqn.fullname == 'test::MyInt'
         assert mod.call_lower(43) == 43
+
+    def test_method(self):
+        mod = self.compile("""
+        from operator import OpImpl
+
+        @typelift
+        class MyInt:
+            __ll__: i32
+
+            @blue
+            def __GETITEM__(v_obj, v_i):
+                def getitem(m: MyInt, i: i32) -> i32:
+                    return m.__ll__ + i*2
+                return OpImpl(getitem)
+
+        def foo(x: i32, y: i32) -> i32:
+            m = MyInt.__lift__(x)
+            return m[y]
+        """)
+        assert mod.foo(30, 6) == 42

--- a/spy/tests/compiler/test_unsafe.py
+++ b/spy/tests/compiler/test_unsafe.py
@@ -92,11 +92,6 @@ class TestUnsafe(CompilerTest):
         src = """
         from unsafe import ptr, gc_alloc
 
-        # XXX we should remove this workaround: currently you can use 'i32'
-        # inside 'class Point' only if 'i32' is used somewhere else at the
-        # module level.
-        WORKAROUND: i32 = 0
-
         @struct
         class Point:
             x: i32

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -880,6 +880,7 @@ class TestParser:
             name='Foo',
             kind='class',
             fields=[],
+            methods=[],
         )
         """
         self.assert_dump(classdef, expected)
@@ -896,6 +897,7 @@ class TestParser:
             name='Foo',
             kind='struct',
             fields=[],
+            methods=[],
         )
         """
         self.assert_dump(classdef, expected)
@@ -924,6 +926,7 @@ class TestParser:
                     type=Name(id='i32'),
                 ),
             ],
+            methods=[],
         )
         """
         self.assert_dump(classdef, expected)
@@ -946,6 +949,7 @@ class TestParser:
                     type=Name(id='i32'),
                 ),
             ],
+            methods=[],
         )
         """
         self.assert_dump(classdef, expected)
@@ -962,3 +966,39 @@ class TestParser:
             "cannot use both @struct and @typelift",
             ("this is invalid", "typelift"),
         )
+
+    def test_classdef_methods(self):
+        mod = self.parse("""
+        @typelift
+        class Foo:
+            __ll__: i32
+
+            def foo() -> void:
+                pass
+        """)
+        classdef = mod.get_classdef('Foo')
+        expected = """
+        ClassDef(
+            name='Foo',
+            kind='typelift',
+            fields=[
+                VarDef(
+                    kind='var',
+                    name='__ll__',
+                    type=Name(id='i32'),
+                ),
+            ],
+            methods=[
+                FuncDef(
+                    color='red',
+                    name='foo',
+                    args=[],
+                    return_type=Name(id='void'),
+                    body=[
+                        Pass(),
+                    ],
+                ),
+            ],
+        )
+        """
+        self.assert_dump(classdef, expected)

--- a/spy/tests/test_scope.py
+++ b/spy/tests/test_scope.py
@@ -196,8 +196,7 @@ class TestScopeAnalyzer:
             'Foo': MatchSymbol('Foo', 'blue'),
         }
         classdef = self.mod.get_classdef('Foo')
-        class_scope = scopes.by_classdef(classdef)
-        assert class_scope._symbols == {
+        assert classdef.symtable._symbols == {
             'x': MatchSymbol('x', 'red'),
             'y': MatchSymbol('y', 'red'),
             'i32': MatchSymbol('i32', 'blue', level=2),

--- a/spy/tests/test_scope.py
+++ b/spy/tests/test_scope.py
@@ -190,6 +190,9 @@ class TestScopeAnalyzer:
         class Foo:
             x: i32
             y: i32
+
+            def foo() -> void:
+                pass
         """)
         mod_scope = scopes.by_module()
         assert mod_scope._symbols == {
@@ -199,5 +202,7 @@ class TestScopeAnalyzer:
         assert classdef.symtable._symbols == {
             'x': MatchSymbol('x', 'red'),
             'y': MatchSymbol('y', 'red'),
+            'foo': MatchSymbol('foo', 'blue'),
             'i32': MatchSymbol('i32', 'blue', level=2),
+            'void': MatchSymbol('void', 'blue', level=2),
         }

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -10,7 +10,7 @@ from spy.fqn import FQN
 from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type
 from spy.vm.primitive import W_Bool
-from spy.vm.function import W_Func, W_FuncType, W_ASTFunc, Namespace
+from spy.vm.function import W_Func, W_FuncType, W_ASTFunc, Namespace, CLOSURE
 from spy.vm.func_adapter import W_FuncAdapter
 from spy.vm.list import W_List, W_ListType
 from spy.vm.tuple import W_Tuple
@@ -31,18 +31,24 @@ class Return(Exception):
         self.w_value = w_value
 
 
-class ASTFrame:
+class AbstractFrame:
+    """
+    Frame which is able to run AST expressions/statements.
+
+    This is an abstract class, for concrete execution see ASTFrame and
+    ClassFrame.
+    """
     vm: 'SPyVM'
-    w_func: W_ASTFunc
-    funcdef: ast.FuncDef
+    fqn: FQN
+    closure: CLOSURE
     _locals: Namespace
     locals_types_w: dict[str, W_Type]
 
-    def __init__(self, vm: 'SPyVM', w_func: W_ASTFunc) -> None:
-        assert isinstance(w_func, W_ASTFunc)
+    def __init__(self, vm: 'SPyVM', fqn: FQN, closure: CLOSURE) -> None:
+        assert type(self) is not AbstractFrame, 'abstract class'
         self.vm = vm
-        self.w_func = w_func
-        self.funcdef = w_func.funcdef
+        self.fqn = fqn
+        self.closure = closure
         self._locals = {}
         self.locals_types_w = {}
 
@@ -51,19 +57,9 @@ class ASTFrame:
     def redshifting(self) -> bool:
         return False
 
-    def __repr__(self) -> str:
-        cls = self.__class__.__name__
-        if self.w_func.redshifted:
-            extra = ' (redshifted)'
-        elif self.w_func.color == 'blue':
-            extra = ' (blue)'
-        else:
-            extra = ''
-        return f'<{cls} for {self.w_func.fqn}{extra}>'
-
     @property
     def is_module_body(self) -> bool:
-        return self.w_func.fqn.is_module()
+        return self.fqn.is_module()
 
     def get_unique_FQN_maybe(self, fqn: FQN) -> FQN:
         """
@@ -92,43 +88,6 @@ class ASTFrame:
         if w_obj is None:
             raise SPyRuntimeError('read from uninitialized local')
         return w_obj
-
-    def run(self, args_w: Sequence[W_Object]) -> W_Object:
-        self.declare_arguments()
-        self.init_arguments(args_w)
-        try:
-            for stmt in self.funcdef.body:
-                self.exec_stmt(stmt)
-            #
-            # we reached the end of the function. If it's void, we can return
-            # None, else it's an error.
-            if self.w_func.w_functype.w_restype in (B.w_void, B.w_dynamic):
-                return B.w_None
-            else:
-                loc = self.w_func.funcdef.loc.make_end_loc()
-                msg = 'reached the end of the function without a `return`'
-                raise SPyTypeError.simple(msg, 'no return', loc)
-
-        except Return as e:
-            return e.w_value
-
-    def declare_arguments(self) -> None:
-        w_functype = self.w_func.w_functype
-        self.declare_local('@if', B.w_bool)
-        self.declare_local('@while', B.w_bool)
-        self.declare_local('@return', w_functype.w_restype)
-        for param in w_functype.params:
-            self.declare_local(param.name, param.w_type)
-
-    def init_arguments(self, args_w: Sequence[W_Object]) -> None:
-        """
-        Store the arguments in args_w in the appropriate local var
-        """
-        w_functype = self.w_func.w_functype
-        params = self.w_func.w_functype.params
-        for param, w_arg in zip(params, args_w, strict=True):
-            assert self.vm.isinstance(w_arg, param.w_type)
-            self.store_local(param.name, w_arg)
 
     def exec_stmt(self, stmt: ast.Stmt) -> None:
         return magic_dispatch(self, 'exec_stmt', stmt)
@@ -159,7 +118,7 @@ class ASTFrame:
         wop = magic_dispatch(self, 'eval_expr', expr)
         w_typeconv = self.typecheck_maybe(wop, varname)
 
-        if self.w_func.redshifted:
+        if isinstance(self, ASTFrame) and self.w_func.redshifted:
             # this is just a sanity check. After redshifting, all type
             # conversions should be explicit. If w_typeconv is not None here,
             # it means that Doppler failed to insert the appropriate
@@ -215,10 +174,10 @@ class ASTFrame:
             w_restype = w_restype,
             **d)
         # create the w_func
-        fqn = self.w_func.fqn.join(funcdef.name)
+        fqn = self.fqn.join(funcdef.name)
         fqn = self.get_unique_FQN_maybe(fqn)
         # XXX we should capture only the names actually used in the inner func
-        closure = self.w_func.closure + (self._locals,)
+        closure = self.closure + (self._locals,)
         w_func = W_ASTFunc(w_functype, fqn, funcdef, closure)
         self.declare_local(funcdef.name, w_functype)
         self.store_local(funcdef.name, w_func)
@@ -238,7 +197,7 @@ class ASTFrame:
             assert vardef.kind == 'var'
             d[vardef.name] = self.eval_expr_type(vardef.type)
         #
-        fqn = self.w_func.fqn.join(classdef.name)
+        fqn = self.fqn.join(classdef.name)
         fqn = self.get_unique_FQN_maybe(fqn)
         w_type = W_Metaclass(fqn, d)  # type: ignore
         w_meta_type = self.vm.dynamic_type(w_type)
@@ -408,7 +367,7 @@ class ASTFrame:
 
     def eval_Name_outer(self, name: ast.Name, sym: Symbol) -> W_OpArg:
         color: Color = 'blue'  # closed-over variables are always blue
-        namespace = self.w_func.closure[sym.level]
+        namespace = self.closure[sym.level]
         w_val = namespace[sym.name]
         assert w_val is not None
         w_type = self.vm.dynamic_type(w_val)
@@ -539,3 +498,73 @@ class ASTFrame:
             items_w = [wop.w_val for wop in items_wop]
             w_val = W_Tuple(items_w)
         return W_OpArg(self.vm, color, B.w_tuple, w_val, op.loc)
+
+
+
+class ASTFrame(AbstractFrame):
+    """
+    A frame to execute and ASTFunc
+    """
+    w_func: W_ASTFunc
+    funcdef: ast.FuncDef
+
+    def __init__(self, vm: 'SPyVM', w_func: W_ASTFunc) -> None:
+        assert isinstance(w_func, W_ASTFunc)
+        super().__init__(vm, w_func.fqn, w_func.closure)
+        self.w_func = w_func
+        self.funcdef = w_func.funcdef
+
+    def __repr__(self) -> str:
+        cls = self.__class__.__name__
+        if self.w_func.redshifted:
+            extra = ' (redshifted)'
+        elif self.w_func.color == 'blue':
+            extra = ' (blue)'
+        else:
+            extra = ''
+        return f'<{cls} for {self.w_func.fqn}{extra}>'
+
+    def run(self, args_w: Sequence[W_Object]) -> W_Object:
+        self.declare_arguments()
+        self.init_arguments(args_w)
+        try:
+            for stmt in self.funcdef.body:
+                self.exec_stmt(stmt)
+            #
+            # we reached the end of the function. If it's void, we can return
+            # None, else it's an error.
+            if self.w_func.w_functype.w_restype in (B.w_void, B.w_dynamic):
+                return B.w_None
+            else:
+                loc = self.w_func.funcdef.loc.make_end_loc()
+                msg = 'reached the end of the function without a `return`'
+                raise SPyTypeError.simple(msg, 'no return', loc)
+
+        except Return as e:
+            return e.w_value
+
+    def declare_arguments(self) -> None:
+        w_functype = self.w_func.w_functype
+        self.declare_local('@if', B.w_bool)
+        self.declare_local('@while', B.w_bool)
+        self.declare_local('@return', w_functype.w_restype)
+        for param in w_functype.params:
+            self.declare_local(param.name, param.w_type)
+
+    def init_arguments(self, args_w: Sequence[W_Object]) -> None:
+        """
+        Store the arguments in args_w in the appropriate local var
+        """
+        w_functype = self.w_func.w_functype
+        params = self.w_func.w_functype.params
+        for param, w_arg in zip(params, args_w, strict=True):
+            assert self.vm.isinstance(w_arg, param.w_type)
+            self.store_local(param.name, w_arg)
+
+
+
+class ClassFrame(ASTFrame):
+    """
+    A frame to execute a classdef body
+    """
+    classdef: ast.ClassDef

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -206,14 +206,21 @@ class AbstractFrame:
             assert False, 'only @struct and @typedef are supported for now'
 
         # execute field definitions
-        d = {}
+        fields = {}
         for vardef in classdef.fields:
             assert vardef.kind == 'var'
             classframe.exec_stmt_VarDef(vardef)
-            d[vardef.name] = classframe.locals_types_w[vardef.name]
+            fields[vardef.name] = classframe.locals_types_w[vardef.name]
+
+        # execute method definitions
+        methods = {}
+        for funcdef in classdef.methods:
+            name = funcdef.name
+            classframe.exec_stmt_FuncDef(funcdef)
+            methods[name] = classframe.load_local(name)
 
         # create the type (i.e., instantiate the metaclass)
-        w_type = W_Metaclass(fqn, d)  # type: ignore
+        w_type = W_Metaclass(fqn, fields, methods)  # type: ignore
         w_meta_type = self.vm.dynamic_type(w_type)
 
         # add the new type to the locals and to the globals

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 # dictionary which contains local vars in an ASTFrame. The type is defined
 # here because it's also used by W_ASTFunc.closure.
 Namespace = dict[str, Optional[W_Object]]
+CLOSURE = tuple[Namespace, ...]
 
 FuncParamKind = Literal['simple', 'varargs']
 

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -70,15 +70,19 @@ class W_ForwardRef(W_Type):
 
 
 FIELDS_T = dict[str, W_Type]
+METHODS_T = dict[str, W_Func]
 
 @TYPES.builtin_type('LiftedType')
 class W_LiftedType(W_Type):
     w_lltype: W_Type  # low level type
 
-    def __init__(self, fqn: FQN, fields: FIELDS_T) -> None:
+    def __init__(self, fqn: FQN, fields: FIELDS_T, methods: METHODS_T) -> None:
         super().__init__(fqn, W_LiftedObject)
         assert set(fields.keys()) == {'__ll__'} # XXX raise proper exception
         self.w_lltype = fields['__ll__']
+        for key, w_meth in methods.items():
+            assert isinstance(w_meth, W_Func)
+            self.dict_w[key] = w_meth
 
     def __repr__(self) -> str:
         lltype = self.w_lltype.fqn.human_name

--- a/spy/vm/modules/unsafe/struct.py
+++ b/spy/vm/modules/unsafe/struct.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, Optional, Type, ClassVar
 from dataclasses import dataclass
 import fixedint
 from spy.fqn import FQN
+from spy.vm.function import W_Func
 from spy.vm.primitive import W_I32, W_Void
 from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type
@@ -13,6 +14,7 @@ if TYPE_CHECKING:
     from spy.vm.opimpl import W_OpImpl, W_OpArg
 
 FIELDS_T = dict[str, W_Type]
+METHODS_T = dict[str, W_Func]
 OFFSETS_T = dict[str, int]
 
 @UNSAFE.builtin_type('StructType')
@@ -21,10 +23,11 @@ class W_StructType(W_Type):
     offsets: OFFSETS_T
     size: int
 
-    def __init__(self, fqn: FQN, fields: FIELDS_T) -> None:
+    def __init__(self, fqn: FQN, fields: FIELDS_T, methods: METHODS_T) -> None:
         super().__init__(fqn, W_Struct)
         self.fields = fields
         self.offsets, self.size = calc_layout(fields)
+        assert methods == {}
 
     def __repr__(self) -> str:
         return f"<spy type '{self.fqn}' (struct)>"

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -221,6 +221,11 @@ class W_OpImpl(W_Object):
         self._args_wop = args_wop
         self.is_direct_call = is_direct_call
 
+    # lazy @builtin_method. See vm.py.
+    @staticmethod
+    def w_spy_new(vm: 'SPyVM', w_cls: W_Type, w_func: W_Func) -> 'W_OpImpl':
+        return W_OpImpl(w_func)
+
     def __repr__(self) -> str:
         if self._w_func is None:
             return f"<spy OpImpl NULL>"

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -28,9 +28,10 @@ from spy.vm.modules.unsafe import UNSAFE
 from spy.vm.modules.rawbuffer import RAW_BUFFER
 from spy.vm.modules.jsffi import JSFFI
 
-# manually setup `builtins::type.__CALL__`. We must do it here because of
-# bootstrapping reasons.
+# manually setup some @builtin_method on some core types. We must do it here
+# because of bootstrapping reasons.
 W_Type._w.setup_builtin_method(W_Type.w_CALL, '__CALL__', 'blue')
+W_OpImpl._w.setup_builtin_method(W_OpImpl.w_spy_new, '__new__', 'red')
 
 
 class SPyVM:


### PR DESCRIPTION
- parser support for method definintions inside classdef
- fix scope analyzer for class bodies
- introduce the concept of `ClassFrame`, which is a frame created specifically to executed class bodies
- add enough support here and there so that we can now create a custom `@typelift`ed type with a functions `__GETITEM__` method