### PR TITLE
Introduce a more proper "lazy initialization" of builtin types

### DIFF
--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -11,7 +11,7 @@ from typing import (TYPE_CHECKING, Any, Callable, Type, Optional, get_origin,
                     Annotated)
 from spy.fqn import FQN, QUALIFIERS
 from spy.ast import Color
-from spy.vm.object import W_Object, W_Type, make_metaclass_maybe
+from spy.vm.object import W_Object, W_Type, make_metaclass_maybe, builtin_method
 from spy.vm.function import FuncParam, FuncParamKind, W_FuncType, W_BuiltinFunc
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -129,20 +129,6 @@ def builtin_func(namespace: FQN|str,
         return W_BuiltinFunc(w_functype, fqn, fn)
     return decorator
 
-def builtin_method(name: str, *, color: Color = 'red') -> Any:
-    """
-    Like @builtin_func, but allows to use 'W_MyClass' annotations in
-    string form.
-
-    Because of that, they are evaluated lazily: this decorator only sets the
-    attribute spy_builtin_method on the function object, then the actual logic
-    is performed by W_Type.__init__.
-    """
-    def decorator(fn: Callable) -> Callable:
-        assert isinstance(fn, staticmethod), 'missing @staticmethod'
-        fn.spy_builtin_method = (name, color)  # type: ignore
-        return fn
-    return decorator
 
 def builtin_type(namespace: FQN|str,
                  typename: str,

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -5,7 +5,7 @@ from spy import ast
 from spy.location import Loc
 from spy.ast import Color
 from spy.fqn import FQN, NSPart
-from spy.vm.object import W_Object, W_Type
+from spy.vm.object import W_Object, W_Type, builtin_method
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
     from spy.vm.opimpl import W_OpImpl, W_OpArg
@@ -26,6 +26,7 @@ class FuncParam:
 
 @dataclass(repr=False, eq=True)
 class W_FuncType(W_Type):
+    __spy_lazy_init__ = True
     color: Color
     params: list[FuncParam]
     w_restype: W_Type
@@ -65,8 +66,9 @@ class W_FuncType(W_Type):
     def __hash__(self) -> int:
         return hash((self.fqn, self.color, tuple(self.params), self.w_restype))
 
+    @builtin_method('__EQ__', color='blue')
     @staticmethod
-    def op_EQ(vm: 'SPyVM', wop_l: 'W_OpArg', wop_r: 'W_OpArg') -> 'W_OpImpl':
+    def w_EQ(vm: 'SPyVM', wop_l: 'W_OpArg', wop_r: 'W_OpArg') -> 'W_OpImpl':
         from spy.vm.opimpl import W_OpImpl
         from spy.vm.modules.builtins import w_functype_eq
         if wop_l.w_static_type is wop_r.w_static_type:

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -143,8 +143,9 @@ class W_List(W_BaseList, Generic[T]):
             w_list.items_w[i] = w_v
         return W_OpImpl(w_setitem)
 
+    @builtin_method('__EQ__', color='blue')
     @staticmethod
-    def op_EQ(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
+    def w_EQ(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
         from spy.vm.opimpl import W_OpImpl
         w_ltype = wop_l.w_static_type
         w_rtype = wop_r.w_static_type

--- a/spy/vm/modules/operator/binop.py
+++ b/spy/vm/modules/operator/binop.py
@@ -4,7 +4,7 @@ from spy.vm.object import W_Type
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.function import W_Func
 from spy.vm.primitive import W_Dynamic
-from . import OP
+from . import OP, op_fast_call
 from .multimethod import MultiMethodTable
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -106,8 +106,8 @@ def w_EQ(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_Func:
     from spy.vm.typechecker import typecheck_opimpl
     w_ltype = wop_l.w_static_type
     w_rtype = wop_r.w_static_type
-    if w_ltype.pyclass.has_meth_overriden('op_EQ'):
-        w_opimpl = w_ltype.pyclass.op_EQ(vm, wop_l, wop_r)
+    if w_EQ := w_ltype.lookup_blue_func('__EQ__'):
+        w_opimpl = op_fast_call(vm, w_EQ, [wop_l, wop_r])
         return typecheck_opimpl(vm, w_opimpl, [wop_l, wop_r],
                                 dispatch='multi',
                                 errmsg='cannot do `{0}` == `{1}`')
@@ -124,8 +124,8 @@ def w_NE(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_Func:
     from spy.vm.typechecker import typecheck_opimpl
     w_ltype = wop_l.w_static_type
     w_rtype = wop_r.w_static_type
-    if w_ltype.pyclass.has_meth_overriden('op_NE'):
-        w_opimpl = w_ltype.pyclass.op_NE(vm, wop_l, wop_r)
+    if w_NE := w_ltype.lookup_blue_func('__NE__'):
+        w_opimpl = op_fast_call(vm, w_NE, [wop_l, wop_r])
         return typecheck_opimpl(vm, w_opimpl, [wop_l, wop_r],
                                 dispatch='multi',
                                 errmsg='cannot do `{0}` != `{1}`')

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -200,8 +200,9 @@ class W_Ptr(W_BasePtr):
             )
         return W_OpImpl(w_ptr_store_T)
 
+    @builtin_method('__EQ__', color='blue')
     @staticmethod
-    def op_EQ(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
+    def w_EQ(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
         w_ltype = wop_l.w_static_type
         w_rtype = wop_r.w_static_type
         if w_ltype is not w_rtype:
@@ -217,8 +218,9 @@ class W_Ptr(W_BasePtr):
             )  # type: ignore
         return W_OpImpl(w_ptr_eq)
 
+    @builtin_method('__NE__', color='blue')
     @staticmethod
-    def op_NE(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
+    def w_NE(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
         w_ltype = wop_l.w_static_type
         w_rtype = wop_r.w_static_type
         if w_ltype is not w_rtype:

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -159,11 +159,11 @@ class W_Object:
         return True
 
     @staticmethod
-    def op_EQ(vm: 'SPyVM', wop_a: 'W_OpArg', wop_b: 'W_OpArg') -> 'W_OpImpl':
+    def w_EQ(vm: 'SPyVM', wop_a: 'W_OpArg', wop_b: 'W_OpArg') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
     @staticmethod
-    def op_NE(vm: 'SPyVM', wop_a: 'W_OpArg', wop_b: 'W_OpArg') -> 'W_OpImpl':
+    def w_NE(vm: 'SPyVM', wop_a: 'W_OpArg', wop_b: 'W_OpArg') -> 'W_OpImpl':
         raise NotImplementedError('this should never be called')
 
     @staticmethod

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -58,6 +58,20 @@ if TYPE_CHECKING:
     from spy.vm.function import W_Func
     from spy.vm.opimpl import W_OpImpl, W_OpArg
 
+def builtin_method(name: str, *, color: Color = 'red') -> Any:
+    """
+    Turn an interp-level method into an app-level one.
+
+    This decorator just put a mark on the method. The actual job is done by
+    W_Type.__init__(), or by calling W_MyType._w.lazy_init() for W_* classes
+    with __spy_lazy_init__ = True.
+    """
+    def decorator(fn: Callable) -> Callable:
+        assert isinstance(fn, staticmethod), 'missing @staticmethod'
+        fn.spy_builtin_method = (name, color)  # type: ignore
+        return fn
+    return decorator
+
 # Basic setup of the object model: <object> and <type>
 # =====================================================
 
@@ -199,6 +213,7 @@ class W_Type(W_Object):
 
     This is basically a thin wrapper around W_* classes.
     """
+    __spy_lazy_init__ = True
     __spy_storage_category__ = 'reference'
     fqn: FQN
     pyclass: Type[W_Object]
@@ -210,10 +225,31 @@ class W_Type(W_Object):
         self.fqn = fqn
         self.pyclass = pyclass
         self.dict_w = {}
+        lazy_init = pyclass.__dict__.get('__spy_lazy_init__', False)
+        if not lazy_init:
+            self._init()
 
+    def lazy_init(self) -> None:
+        """
+        Most app-level types are fully initialized when calling
+        W_Type.__init__().
+
+        However, for some core types this is not possible, because of
+        bootstrapping reasons: in particular, in order to evaluate
+        @builtin_method we need to import vm.opimpl and vm.function, so any
+        type which needs @builtin_method in vm/object.py, vm/opimpl.py and
+        vm/function.py needs a lazy init.
+
+        This can be achieved by setting __spy_lazy_init__ = True, and then
+        manually call W_MyType._w.lazy_init() at the beginning of spy/vm.py.
+        """
+        assert self.pyclass.__dict__.get('__spy_lazy_init__', False)
+        self._init()
+
+    def _init(self) -> None:
         # setup spy_members
         self.spy_members = {}
-        for field, t in pyclass.__annotations__.items():
+        for field, t in self.pyclass.__annotations__.items():
             member = Member.from_annotation_maybe(t)
             if member is not None:
                 member.field = field
@@ -221,12 +257,48 @@ class W_Type(W_Object):
                 self.spy_members[member.name] = member
 
         # lazy evaluation of @builtin methods decorators
-        for name, value in pyclass.__dict__.items():
+        for name, value in self.pyclass.__dict__.items():
             if hasattr(value, 'spy_builtin_method'):
-                statmeth = value
-                assert isinstance(statmeth, staticmethod)
-                appname, color = statmeth.spy_builtin_method  # type: ignore
-                self.setup_builtin_method(statmeth.__func__, appname, color)
+                self._init_builtin_method(value)
+
+    def _init_builtin_method(self, statmeth: staticmethod) -> None:
+        "Turn the @builtin_method into a W_BuiltinFunc"
+        from spy.vm.builtin import builtin_func
+        from spy.vm.opimpl import W_OpArg, W_OpImpl
+        appname, color = statmeth.spy_builtin_method  # type: ignore
+        pyfunc = statmeth.__func__
+
+        # sanity check: __MAGIC__ methods should be blue
+        if appname in (
+                '__ADD__', '__SUB__', '__MUL__', '__DIV__',
+                '__EQ__', '__NE__', '__LT__', '__LE__', '__GT__', '__GE__',
+                '__GETATTR__', '__SETATTR__',
+                '__GETITEM__', '__SETITEM__',
+                '__CALL__', '__CALL_METHOD__',
+                '__CONVERT_FROM__', '__CONVERT_TO__',
+        ) and color != 'blue':
+            # XXX we should raise a more detailed exception
+            fqn = self.fqn.human_name
+            msg = f"method `{fqn}.{appname}` should be blue, but it's {color}"
+            raise SPyTypeError(msg)
+
+        # create the @builtin_func decorator, and make it possible to use the
+        # string 'W_MyClass' in annotations
+        extra_types = {
+            self.pyclass.__name__: Annotated[self.pyclass, self],
+            'W_OpArg': W_OpArg,
+            'W_OpImpl': W_OpImpl,
+        }
+        decorator = builtin_func(
+            namespace = self.fqn,
+            funcname = appname,
+            qualifiers = [],
+            color = color,
+            extra_types = extra_types,
+        )
+        # apply the decorator and store the method in the applevel dict
+        w_meth = decorator(pyfunc)
+        self.dict_w[appname] = w_meth
 
     # Union[W_Type, W_Void] means "either a W_Type or B.w_None"
     @property
@@ -272,49 +344,9 @@ class W_Type(W_Object):
             return w_obj
         return None
 
-    def setup_builtin_method(self,
-                             pyfunc: Callable,
-                             appname: str,
-                             color: Color
-                             ) -> None:
-        "Turn the @builtin_method into a W_BuiltinFunc"
-        from spy.vm.builtin import builtin_func
-        from spy.vm.opimpl import W_OpArg, W_OpImpl
+    # ======== app-level interface ========
 
-        # sanity check: __MAGIC__ methods should be blue
-        if appname in (
-                '__ADD__', '__SUB__', '__MUL__', '__DIV__',
-                '__EQ__', '__NE__', '__LT__', '__LE__', '__GT__', '__GE__',
-                '__GETATTR__', '__SETATTR__',
-                '__GETITEM__', '__SETITEM__',
-                '__CALL__', '__CALL_METHOD__',
-                '__CONVERT_FROM__', '__CONVERT_TO__',
-        ) and color != 'blue':
-            # XXX we should raise a more detailed exception
-            fqn = self.fqn.human_name
-            msg = f"method `{fqn}.{appname}` should be blue, but it's {color}"
-            raise SPyTypeError(msg)
-
-        # create the @builtin_func decorator, and make it possible to use the
-        # string 'W_MyClass' in annotations
-        extra_types = {
-            self.pyclass.__name__: Annotated[self.pyclass, self],
-            'W_OpArg': W_OpArg,
-            'W_OpImpl': W_OpImpl,
-        }
-        decorator = builtin_func(
-            namespace = self.fqn,
-            funcname = appname,
-            qualifiers = [],
-            color = color,
-            extra_types = extra_types,
-        )
-        # apply the decorator and store the method in the applevel dict
-        w_meth = decorator(pyfunc)
-        self.dict_w[appname] = w_meth
-
-    # we cannot use @builtin_method due to circular imports. See the manual
-    # call to setup_builtin_method() at the top of vm.py
+    @builtin_method('__CALL__', color='blue')
     @staticmethod
     def w_CALL(vm: 'SPyVM', wop_t: 'W_OpArg',
                *args_wop: 'W_OpArg') -> 'W_OpImpl':
@@ -346,7 +378,6 @@ class W_Type(W_Object):
 
         assert isinstance(w_new, W_Func), 'XXX raise proper exception'
         return W_OpImpl(w_new)
-
 
 
 # helpers

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -31,7 +31,7 @@ from spy.location import Loc
 from spy.irgen.symtable import Symbol, Color
 from spy.errors import SPyTypeError
 from spy.vm.b import OPERATOR, B
-from spy.vm.object import Member, W_Type, W_Object
+from spy.vm.object import Member, W_Type, W_Object, builtin_method
 from spy.vm.function import W_Func, W_FuncType
 from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.primitive import W_Bool
@@ -206,6 +206,8 @@ def w_oparg_eq(vm: 'SPyVM', wop1: W_OpArg, wop2: W_OpArg) -> W_Bool:
 
 @OPERATOR.builtin_type('OpImpl')
 class W_OpImpl(W_Object):
+    __spy_lazy_init__ = True
+
     NULL: ClassVar['W_OpImpl']
     _w_func: Optional[W_Func]
     _args_wop: Optional[list[W_OpArg]]
@@ -220,11 +222,6 @@ class W_OpImpl(W_Object):
         self._w_func = w_func
         self._args_wop = args_wop
         self.is_direct_call = is_direct_call
-
-    # lazy @builtin_method. See vm.py.
-    @staticmethod
-    def w_spy_new(vm: 'SPyVM', w_cls: W_Type, w_func: W_Func) -> 'W_OpImpl':
-        return W_OpImpl(w_func)
 
     def __repr__(self) -> str:
         if self._w_func is None:
@@ -246,6 +243,13 @@ class W_OpImpl(W_Object):
     def w_functype(self) -> W_FuncType:
         assert self._w_func is not None
         return self._w_func.w_functype
+
+    # ======== app-level interface ========
+
+    @builtin_method('__new__')
+    @staticmethod
+    def w_spy_new(vm: 'SPyVM', w_cls: W_Type, w_func: W_Func) -> 'W_OpImpl':
+        return W_OpImpl(w_func)
 
 
 W_OpImpl.NULL = W_OpImpl(None)  # type: ignore

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -74,6 +74,7 @@ class W_OpArg(W_Object):
 
     Blue OpArg always have an associated value.
     """
+    __spy_lazy_init__ = True
     color: Color
     w_static_type: Annotated[W_Type, Member('static_type')]
     loc: Loc
@@ -168,8 +169,9 @@ class W_OpArg(W_Object):
         assert self.w_val is not None
         return vm.unwrap_str(self.w_val)
 
+    @builtin_method('__EQ__', color='blue')
     @staticmethod
-    def op_EQ(vm: 'SPyVM', wop_l: 'W_OpArg', wop_r: 'W_OpArg') -> 'W_OpImpl':
+    def w_EQ(vm: 'SPyVM', wop_l: 'W_OpArg', wop_r: 'W_OpArg') -> 'W_OpImpl':
         w_ltype = wop_l.w_static_type
         w_rtype = wop_r.w_static_type
         assert w_ltype.pyclass is W_OpArg

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -28,10 +28,9 @@ from spy.vm.modules.unsafe import UNSAFE
 from spy.vm.modules.rawbuffer import RAW_BUFFER
 from spy.vm.modules.jsffi import JSFFI
 
-# manually setup some @builtin_method on some core types. We must do it here
-# because of bootstrapping reasons.
-W_Type._w.setup_builtin_method(W_Type.w_CALL, '__CALL__', 'blue')
-W_OpImpl._w.setup_builtin_method(W_OpImpl.w_spy_new, '__new__', 'red')
+# lazy init of some some core types. See the docstring for W_Type.lazy_init.
+W_Type._w.lazy_init()
+W_OpImpl._w.lazy_init()
 
 
 class SPyVM:

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -31,6 +31,8 @@ from spy.vm.modules.jsffi import JSFFI
 # lazy init of some some core types. See the docstring for W_Type.lazy_init.
 W_Type._w.lazy_init()
 W_OpImpl._w.lazy_init()
+W_OpArg._w.lazy_init()
+W_FuncType._w.lazy_init()
 
 
 class SPyVM:


### PR DESCRIPTION
In PR #112 we couldn't complete the migration of all `op_*` into proper `@builtin_method`s for bootstrapping reasons.

With lazy_init, we are now able to use builtin_method also for `EQ` and `NE`, and apply it to `W_OpArg` and `W_FuncType`.