### PR TITLE
Kill W_ForwardRef, introduce types declaration/definition

### DIFF
--- a/spy/irgen/modgen.py
+++ b/spy/irgen/modgen.py
@@ -8,7 +8,7 @@ from spy.errors import SPyTypeError
 from spy.vm.vm import SPyVM
 from spy.vm.b import B
 from spy.vm.module import W_Module
-from spy.vm.object import W_Type
+from spy.vm.object import W_Type, W_Object
 from spy.vm.function import W_FuncType, W_ASTFunc
 from spy.vm.astframe import ASTFrame
 from spy.vm.modules.types import W_ForwardRef
@@ -55,7 +55,7 @@ class ModuleGen:
         for decl in self.mod.decls:
             if isinstance(decl, ast.GlobalClassDef):
                 type_fqn = fqn.join(decl.classdef.name)
-                w_fw = W_ForwardRef(type_fqn)
+                w_fw = W_ForwardRef.define(type_fqn, W_Object)
                 self.vm.add_global(type_fqn, w_fw)
 
         for decl in self.mod.decls:

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -865,3 +865,10 @@ class TestBasic(CompilerTest):
         """)
         w_type = mod.foo(unwrap=False)
         assert w_type is B.w_i32
+
+    def test_cls_as_param_name(self):
+        mod = self.compile("""
+        def foo(cls: i32) -> i32:
+            return cls+1
+        """)
+        assert mod.foo(3) == 4

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -824,7 +824,7 @@ class TestBasic(CompilerTest):
         self.compile_raises(src, 'foo', errors)
 
     @only_interp
-    def test_forwardref(self):
+    def test_automatic_forward_declaration(self):
         mod = self.compile("""
         from unsafe import ptr
 
@@ -832,7 +832,7 @@ class TestBasic(CompilerTest):
         def foo(s: S, p: ptr[S]) -> void:
             pass
 
-        ptr_S1 = ptr[S] # using the ForwardRef
+        ptr_S1 = ptr[S] # using the forward decl
 
         @struct
         class S:

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -10,7 +10,6 @@ from spy.vm.str import W_Str
 from spy.vm.function import W_BuiltinFunc
 from spy.vm.module import W_Module
 from spy.vm.builtin import builtin_type
-from spy.vm.modules.types import W_ForwardRef
 from spy.tests.support import expect_errors
 
 class TestVM:
@@ -234,16 +233,6 @@ class TestVM:
         with errors:
             vm.getitem(w_a, w_b) # hello
 
-    def test_forwardref_become(self):
-        vm = SPyVM()
-        w_fw = W_ForwardRef.define(FQN('test::hello'), W_Object)
-        w_HelloType = W_Type.define(FQN('test::hello'), W_Object)
-        w_fw.become(w_HelloType)
-        assert isinstance(w_fw, W_Type)
-        assert w_fw.fqn == FQN('test::hello')
-        assert w_fw.pyclass is W_Object
-        assert w_fw is not w_HelloType
-
     def test_add_global(self):
         vm = SPyVM()
         fqn = FQN('builtins::x')
@@ -252,13 +241,3 @@ class TestVM:
         assert vm.lookup_global(fqn) is w_x
         with pytest.raises(ValueError, match="'builtins::x' already exists"):
             vm.add_global(fqn, vm.wrap(43))
-
-    def test_add_global_forwardref(self):
-        vm = SPyVM()
-        fqn = FQN('builtins::hello')
-        w_fw = W_ForwardRef.define(fqn, W_Object)
-        w_HelloType = W_Type.define(fqn, W_Object)
-        vm.add_global(fqn, w_fw)
-        vm.add_global(fqn, w_HelloType)
-        assert vm.lookup_global(fqn) is w_fw
-        assert isinstance(w_fw, W_Type)

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -236,8 +236,8 @@ class TestVM:
 
     def test_forwardref_become(self):
         vm = SPyVM()
-        w_fw = W_ForwardRef(FQN('test::hello'))
-        w_HelloType = W_Type(FQN('test::hello'), W_Object)
+        w_fw = W_ForwardRef.define(FQN('test::hello'), W_Object)
+        w_HelloType = W_Type.define(FQN('test::hello'), W_Object)
         w_fw.become(w_HelloType)
         assert isinstance(w_fw, W_Type)
         assert w_fw.fqn == FQN('test::hello')
@@ -256,8 +256,8 @@ class TestVM:
     def test_add_global_forwardref(self):
         vm = SPyVM()
         fqn = FQN('builtins::hello')
-        w_fw = W_ForwardRef(fqn)
-        w_HelloType = W_Type(fqn, W_Object)
+        w_fw = W_ForwardRef.define(fqn, W_Object)
+        w_HelloType = W_Type.define(fqn, W_Object)
         vm.add_global(fqn, w_fw)
         vm.add_global(fqn, w_HelloType)
         assert vm.lookup_global(fqn) is w_fw

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -52,8 +52,11 @@ class TestVM:
         assert repr(B.w_object) == "<spy type 'object'>"
         assert repr(B.w_type) == "<spy type 'type'>"
         assert repr(B.w_dynamic) == "<spy type 'dynamic'>"
+        #
+        w_t = W_Type.declare(FQN('foo::t'))
+        assert repr(w_t) == "<spy type 'foo::t' (fwdecl)>"
 
-    def test_spytype_decorator(self):
+    def test_builtin_type_decorator(self):
         @builtin_type('test', 'foo')
         class W_Foo(W_Object):
             pass

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -224,7 +224,9 @@ class AbstractFrame:
         # in the locals
         w_type = self.load_local(classdef.name)
         assert w_type.fqn == fqn
+        assert not w_type.is_defined()
         w_type.setup(fields, methods)
+        assert w_type.is_defined()
 
     def exec_stmt_VarDef(self, vardef: ast.VarDef) -> None:
         w_type = self.eval_expr_type(vardef.type)

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -186,6 +186,16 @@ class AbstractFrame:
         self.store_local(funcdef.name, w_func)
         self.vm.add_global(fqn, w_func)
 
+    @staticmethod
+    def metaclass_for_classdef(classdef: ast.ClassDef) -> type[W_Type]:
+        if classdef.kind == 'struct':
+            return W_StructType
+        elif classdef.kind == 'typelift':
+            return W_LiftedType
+        else:
+            assert False, 'only @struct and @typedef are supported for now'
+
+
     def exec_stmt_ClassDef(self, classdef: ast.ClassDef) -> None:
         # compute the FQN of the class we are defining
         fqn = self.fqn.join(classdef.name)
@@ -195,15 +205,6 @@ class AbstractFrame:
         # XXX we should capture only the names actually used in the inner frame
         closure = self.closure + (self._locals,)
         classframe = ClassFrame(self.vm, classdef, fqn, closure)
-
-        # find the appropriate metaclass
-        W_Metaclass: type[W_Type]
-        if classdef.kind == 'struct':
-            W_Metaclass = W_StructType
-        elif classdef.kind == 'typelift':
-            W_Metaclass = W_LiftedType
-        else:
-            assert False, 'only @struct and @typedef are supported for now'
 
         # execute field definitions
         fields = {}
@@ -219,14 +220,11 @@ class AbstractFrame:
             classframe.exec_stmt_FuncDef(funcdef)
             methods[name] = classframe.load_local(name)
 
-        # create the type (i.e., instantiate the metaclass)
-        w_type = W_Metaclass.define(fqn, fields, methods)  # type: ignore
-        w_meta_type = self.vm.dynamic_type(w_type)
-
-        # add the new type to the locals and to the globals
-        self.declare_local(classdef.name, w_meta_type)
-        self.store_local(classdef.name, w_type)
-        self.vm.add_global(fqn, w_type)
+        # finalize type definition: we expect to find a forward-declared type
+        # in the locals
+        w_type = self.load_local(classdef.name)
+        assert w_type.fqn == fqn
+        w_type.setup(fields, methods)
 
     def exec_stmt_VarDef(self, vardef: ast.VarDef) -> None:
         w_type = self.eval_expr_type(vardef.type)

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -10,7 +10,8 @@ from spy.fqn import FQN
 from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type, ClassBody
 from spy.vm.primitive import W_Bool
-from spy.vm.function import W_Func, W_FuncType, W_ASTFunc, Namespace, CLOSURE
+from spy.vm.function import (W_Func, W_FuncType, W_ASTFunc, Namespace, CLOSURE,
+                             FuncParam)
 from spy.vm.func_adapter import W_FuncAdapter
 from spy.vm.list import W_List, W_ListType
 from spy.vm.tuple import W_Tuple
@@ -168,14 +169,17 @@ class AbstractFrame:
 
     def exec_stmt_FuncDef(self, funcdef: ast.FuncDef) -> None:
         # evaluate the functype
-        d = {}
+        params = []
         for arg in funcdef.args:
-            d[arg.name] = self.eval_expr_type(arg.type)
+            w_param_type = self.eval_expr_type(arg.type)
+            param = FuncParam(
+                name = arg.name,
+                w_type = w_param_type,
+                kind = 'simple'
+            )
+            params.append(param)
         w_restype = self.eval_expr_type(funcdef.return_type)
-        w_functype = W_FuncType.make(
-            color = funcdef.color,
-            w_restype = w_restype,
-            **d)
+        w_functype = W_FuncType.new(params, w_restype, color=funcdef.color)
         # create the w_func
         fqn = self.fqn.join(funcdef.name)
         fqn = self.get_unique_FQN_maybe(fqn)

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -220,7 +220,7 @@ class AbstractFrame:
             methods[name] = classframe.load_local(name)
 
         # create the type (i.e., instantiate the metaclass)
-        w_type = W_Metaclass(fqn, fields, methods)  # type: ignore
+        w_type = W_Metaclass.define(fqn, fields, methods)  # type: ignore
         w_meta_type = self.vm.dynamic_type(w_type)
 
         # add the new type to the locals and to the globals

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -221,12 +221,15 @@ class AbstractFrame:
         for funcdef in classdef.methods:
             name = funcdef.name
             classframe.exec_stmt_FuncDef(funcdef)
-            body.methods[name] = classframe.load_local(name)
+            w_meth = classframe.load_local(name)
+            assert isinstance(w_meth, W_Func)
+            body.methods[name] = w_meth
 
         # finalize type definition: we expect to find a forward-declared type
         # in the locals
         if self.is_module_body:
             w_type = self.load_local(classdef.name)
+            assert isinstance(w_type, W_Type)
             assert w_type.fqn == fqn
             assert not w_type.is_defined()
             w_type.define_from_classbody(body)

--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -79,7 +79,7 @@ def functype_from_sig(fn: Callable, color: Color, *,
     func_params = [to_spy_FuncParam(p, extra_types) for p in params[1:]]
     ret_ann = extra_types.get(sig.return_annotation, sig.return_annotation)
     w_restype = to_spy_type(ret_ann, allow_None=True)
-    return W_FuncType.define(func_params, w_restype, color=color)
+    return W_FuncType.new(func_params, w_restype, color=color)
 
 
 def builtin_func(namespace: FQN|str,
@@ -134,10 +134,10 @@ def builtin_type(namespace: FQN|str,
                  typename: str,
                  qualifiers: QUALIFIERS = None,
                  *,
-                 lazy_setup: bool = False
+                 lazy_definition: bool = False
                  ) -> Any:
     """
-    Class decorator to simplify the creation of SPy types.
+    Class decorator to simplify the creation of builtin SPy types.
 
     Given a W_* class, it automatically creates the corresponding instance of
     W_Type and attaches it to the W_* class.
@@ -147,8 +147,9 @@ def builtin_type(namespace: FQN|str,
     fqn = namespace.join(typename, qualifiers)
     def decorator(pyclass: Type[W_Object]) -> Type[W_Object]:
         W_MetaClass = make_metaclass_maybe(fqn, pyclass)
-        pyclass._w = W_MetaClass.declare(fqn, pyclass)
-        if not lazy_setup:
-            pyclass._w.setup()
+        w_type = W_MetaClass.declare(fqn)
+        if not lazy_definition:
+            w_type.define(pyclass)
+        pyclass._w = w_type
         return pyclass
     return decorator

--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -79,7 +79,7 @@ def functype_from_sig(fn: Callable, color: Color, *,
     func_params = [to_spy_FuncParam(p, extra_types) for p in params[1:]]
     ret_ann = extra_types.get(sig.return_annotation, sig.return_annotation)
     w_restype = to_spy_type(ret_ann, allow_None=True)
-    return W_FuncType(func_params, w_restype, color=color)
+    return W_FuncType.define(func_params, w_restype, color=color)
 
 
 def builtin_func(namespace: FQN|str,
@@ -132,7 +132,9 @@ def builtin_func(namespace: FQN|str,
 
 def builtin_type(namespace: FQN|str,
                  typename: str,
-                 qualifiers: QUALIFIERS = None
+                 qualifiers: QUALIFIERS = None,
+                 *,
+                 lazy_setup: bool = False
                  ) -> Any:
     """
     Class decorator to simplify the creation of SPy types.
@@ -145,6 +147,9 @@ def builtin_type(namespace: FQN|str,
     fqn = namespace.join(typename, qualifiers)
     def decorator(pyclass: Type[W_Object]) -> Type[W_Object]:
         W_MetaClass = make_metaclass_maybe(fqn, pyclass)
-        pyclass._w = W_MetaClass(fqn, pyclass)
+        if lazy_setup:
+            pyclass._w = W_MetaClass.declare(fqn, pyclass)
+        else:
+            pyclass._w = W_MetaClass.define(fqn, pyclass)
         return pyclass
     return decorator

--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -147,9 +147,8 @@ def builtin_type(namespace: FQN|str,
     fqn = namespace.join(typename, qualifiers)
     def decorator(pyclass: Type[W_Object]) -> Type[W_Object]:
         W_MetaClass = make_metaclass_maybe(fqn, pyclass)
-        if lazy_setup:
-            pyclass._w = W_MetaClass.declare(fqn, pyclass)
-        else:
-            pyclass._w = W_MetaClass.define(fqn, pyclass)
+        pyclass._w = W_MetaClass.declare(fqn, pyclass)
+        if not lazy_setup:
+            pyclass._w.setup()
         return pyclass
     return decorator

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -31,8 +31,8 @@ class W_FuncType(W_Type):
     w_restype: W_Type
 
     @classmethod
-    def declare(cls, params: list[FuncParam], w_restype: W_Type,
-                *, color: Color = 'red') -> 'Self':
+    def new(cls, params: list[FuncParam], w_restype: W_Type,
+            *, color: Color = 'red') -> 'Self':
         # sanity check
         if params:
             assert isinstance(params[0], FuncParam)
@@ -44,7 +44,7 @@ class W_FuncType(W_Type):
         # param names
         qualifiers = [p.w_type.fqn for p in params] + [w_restype.fqn]
         fqn = FQN('builtins').join('def', qualifiers)
-        w_functype = super().declare(fqn, W_Func)
+        w_functype = super().from_pyclass(fqn, W_Func)
         w_functype.params = params
         w_functype.w_restype = w_restype
         w_functype.color = color
@@ -89,7 +89,7 @@ class W_FuncType(W_Type):
         """
         params = [FuncParam(key, w_type, 'simple')
                   for key, w_type in kwargs.items()]
-        return cls.define(params, w_restype, color=color)
+        return cls.new(params, w_restype, color=color)
 
     @classmethod
     def parse(cls, s: str) -> 'W_FuncType':
@@ -158,7 +158,7 @@ class W_FuncType(W_Type):
 
 # we cannot use @builtin_type because of circular import issues. Let's build
 # the app-level type manually
-W_FuncType._w = W_Type.declare(FQN('builtins::functype'), W_FuncType)
+W_FuncType._w = W_Type.declare(FQN('builtins::functype'))
 
 class W_Func(W_Object):
     __spy_storage_category__ = 'reference'

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -26,29 +26,29 @@ class FuncParam:
 
 @dataclass(repr=False, eq=True)
 class W_FuncType(W_Type):
-    __spy_lazy_init__ = True
     color: Color
     params: list[FuncParam]
     w_restype: W_Type
 
-    def __init__(self, params: list[FuncParam], w_restype: W_Type,
-                 *, color: Color = 'red') -> None:
+    @classmethod
+    def declare(cls, params: list[FuncParam], w_restype: W_Type,
+                *, color: Color = 'red') -> 'Self':
         # sanity check
         if params:
             assert isinstance(params[0], FuncParam)
-        self.params = params
-        self.w_restype = w_restype
-        self.color = color
-        #
         # build an artificial FQN for the functype.
         # For 'def(i32, i32) -> bool', the FQN looks like this:
         #    builtins::def[i32, i32, bool]
         #
         # XXX the FQN is not necessarily unique, we don't take into account
         # param names
-        qualifiers = [p.w_type.fqn for p in self.params] + [w_restype.fqn]
+        qualifiers = [p.w_type.fqn for p in params] + [w_restype.fqn]
         fqn = FQN('builtins').join('def', qualifiers)
-        super().__init__(fqn, W_Func)
+        w_functype = super().declare(fqn, W_Func)
+        w_functype.params = params
+        w_functype.w_restype = w_restype
+        w_functype.color = color
+        return w_functype
 
     @property
     def signature(self) -> str:
@@ -89,7 +89,7 @@ class W_FuncType(W_Type):
         """
         params = [FuncParam(key, w_type, 'simple')
                   for key, w_type in kwargs.items()]
-        return cls(params, w_restype, color=color)
+        return cls.define(params, w_restype, color=color)
 
     @classmethod
     def parse(cls, s: str) -> 'W_FuncType':
@@ -158,8 +158,7 @@ class W_FuncType(W_Type):
 
 # we cannot use @builtin_type because of circular import issues. Let's build
 # the app-level type manually
-W_FuncType._w = W_Type(FQN('builtins::functype'), W_FuncType)
-
+W_FuncType._w = W_Type.declare(FQN('builtins::functype'), W_FuncType)
 
 class W_Func(W_Object):
     __spy_storage_category__ = 'reference'

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from typing import (TYPE_CHECKING, Any, Optional, Callable, Sequence, Literal,
-                    Iterator)
+                    Iterator, Self)
 from spy import ast
 from spy.location import Loc
 from spy.ast import Color

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -18,9 +18,11 @@ class W_ListType(W_Type):
     """
     w_itemtype: W_Type
 
-    def __init__(self, fqn: FQN, w_itemtype: W_Type) -> None:
-        super().__init__(fqn, W_List)
-        self.w_itemtype = w_itemtype
+    @classmethod
+    def declare(cls, fqn: FQN, w_itemtype: W_Type) -> 'Self':
+        w_listtype = super().declare(fqn, W_List)
+        w_listtype.w_itemtype = w_itemtype
+        return w_listtype
 
 
 # PREBUILT list types are instantiated the end of the file
@@ -45,7 +47,7 @@ def w_make_list_type(vm: 'SPyVM', w_list: W_Object, w_T: W_Type) -> W_ListType:
 
 def _make_list_type(w_T: W_Type) -> W_ListType:
     fqn = FQN('builtins').join('list', [w_T.fqn])  # builtins::list[i32]
-    return W_ListType(fqn, w_T)
+    return W_ListType.define(fqn, w_T)
 
 
 @B.builtin_type('list')

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -1,5 +1,5 @@
 from typing import (TYPE_CHECKING, Any, Optional, Type, ClassVar,
-                    TypeVar, Generic, Annotated)
+                    TypeVar, Generic, Annotated, Self)
 from spy.fqn import FQN
 from spy.vm.b import B, OP
 from spy.vm.primitive import W_I32, W_Bool, W_Dynamic, W_Void
@@ -19,7 +19,7 @@ class W_ListType(W_Type):
     w_itemtype: W_Type
 
     @classmethod
-    def from_itemtype(cls, fqn: FQN, w_itemtype: W_Type) -> 'Self':
+    def from_itemtype(cls, fqn: FQN, w_itemtype: W_Type) -> Self:
         w_type = cls.from_pyclass(fqn, W_List)
         w_type.w_itemtype = w_itemtype
         return w_type

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -19,10 +19,10 @@ class W_ListType(W_Type):
     w_itemtype: W_Type
 
     @classmethod
-    def declare(cls, fqn: FQN, w_itemtype: W_Type) -> 'Self':
-        w_listtype = super().declare(fqn, W_List)
-        w_listtype.w_itemtype = w_itemtype
-        return w_listtype
+    def from_itemtype(cls, fqn: FQN, w_itemtype: W_Type) -> 'Self':
+        w_type = cls.from_pyclass(fqn, W_List)
+        w_type.w_itemtype = w_itemtype
+        return w_type
 
 
 # PREBUILT list types are instantiated the end of the file
@@ -47,7 +47,7 @@ def w_make_list_type(vm: 'SPyVM', w_list: W_Object, w_T: W_Type) -> W_ListType:
 
 def _make_list_type(w_T: W_Type) -> W_ListType:
     fqn = FQN('builtins').join('list', [w_T.fqn])  # builtins::list[i32]
-    return W_ListType.define(fqn, w_T)
+    return W_ListType.from_itemtype(fqn, w_T)
 
 
 @B.builtin_type('list')

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -30,14 +30,16 @@ class W_LiftedType(W_Type):
     w_lltype: W_Type  # low level type
 
     @classmethod
-    def define(cls, fqn: FQN, fields: FIELDS_T, methods: METHODS_T) -> 'Self':
-        w_type = super().define(fqn, W_LiftedObject)
+    def declare(cls, fqn: FQN) -> 'Self':
+        return super().declare(fqn, W_LiftedObject)
+
+    def setup(self, fields: FIELDS_T, methods: METHODS_T) -> None:
+        super().setup()
         assert set(fields.keys()) == {'__ll__'} # XXX raise proper exception
-        w_type.w_lltype = fields['__ll__']
+        self.w_lltype = fields['__ll__']
         for key, w_meth in methods.items():
             assert isinstance(w_meth, W_Func)
-            w_type.dict_w[key] = w_meth
-        return w_type
+            self.dict_w[key] = w_meth
 
     def __repr__(self) -> str:
         lltype = self.w_lltype.fqn.human_name

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -9,7 +9,7 @@ from spy.vm.builtin import builtin_type
 from spy.vm.primitive import W_Dynamic, W_Void
 from spy.vm.module import W_Module
 from spy.vm.b import B
-from spy.vm.object import W_Type, W_Object, Member
+from spy.vm.object import W_Type, W_Object, Member, ClassBody
 from spy.vm.str import W_Str
 from spy.vm.function import W_Func
 from spy.vm.opimpl import W_OpImpl, W_OpArg
@@ -29,15 +29,11 @@ METHODS_T = dict[str, W_Func]
 class W_LiftedType(W_Type):
     w_lltype: W_Type  # low level type
 
-    @classmethod
-    def declare(cls, fqn: FQN) -> 'Self':
-        return super().declare(fqn, W_LiftedObject)
-
-    def setup(self, fields: FIELDS_T, methods: METHODS_T) -> None:
-        super().setup()
-        assert set(fields.keys()) == {'__ll__'} # XXX raise proper exception
-        self.w_lltype = fields['__ll__']
-        for key, w_meth in methods.items():
+    def define_from_classbody(self, body: ClassBody) -> None:
+        super().define(W_LiftedObject)
+        assert set(body.fields.keys()) == {'__ll__'} # XXX raise proper exc
+        self.w_lltype = body.fields['__ll__']
+        for key, w_meth in body.methods.items():
             assert isinstance(w_meth, W_Func)
             self.dict_w[key] = w_meth
 

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -54,11 +54,6 @@ class W_ForwardRef(W_Type):
         `test::Point`.become(Point)
         # now, foo's signature is 'def(x: Point)'.
     """
-    fqn: FQN
-
-    def __init__(self, fqn: FQN) -> None:
-        super().__init__(fqn, pyclass=W_Object)
-
     def __repr__(self) -> str:
         return f"<ForwardRef '{self.fqn}'>"
 
@@ -76,13 +71,15 @@ METHODS_T = dict[str, W_Func]
 class W_LiftedType(W_Type):
     w_lltype: W_Type  # low level type
 
-    def __init__(self, fqn: FQN, fields: FIELDS_T, methods: METHODS_T) -> None:
-        super().__init__(fqn, W_LiftedObject)
+    @classmethod
+    def define(cls, fqn: FQN, fields: FIELDS_T, methods: METHODS_T) -> 'Self':
+        w_type = super().define(fqn, W_LiftedObject)
         assert set(fields.keys()) == {'__ll__'} # XXX raise proper exception
-        self.w_lltype = fields['__ll__']
+        w_type.w_lltype = fields['__ll__']
         for key, w_meth in methods.items():
             assert isinstance(w_meth, W_Func)
-            self.dict_w[key] = w_meth
+            w_type.dict_w[key] = w_meth
+        return w_type
 
     def __repr__(self) -> str:
         lltype = self.w_lltype.fqn.human_name

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -22,48 +22,6 @@ TYPES = ModuleRegistry('types')
 TYPES.add('module', W_Module._w)
 
 
-@TYPES.builtin_type('ForwardRef')
-class W_ForwardRef(W_Type):
-    """
-    A ForwardRef represent a type which has been declared but not defined
-    yet.
-    It can `become()` an actual type while preserving identity, so that
-    existing references to the forward ref are automatically updated.
-
-    It is primarily used to predeclare types in a module, so they can be
-    referenced in advance before their actual definition. Consider the
-    following example:
-
-        def foo(p: Point) -> void:
-            pass
-
-        class Point:
-            pass
-
-    When executing the module, there are implicit statements, shown below:
-
-        Point = ForwardRef('test::Point')
-
-        def foo(p: Point) -> void:
-            pass
-
-        # here foo's signature is 'def(x: ForwardRef(`test::Point`))'
-
-        class Point:
-            ...
-        `test::Point`.become(Point)
-        # now, foo's signature is 'def(x: Point)'.
-    """
-    def __repr__(self) -> str:
-        return f"<ForwardRef '{self.fqn}'>"
-
-    def become(self, w_T: W_Type) -> None:
-        assert self.fqn == w_T.fqn
-        self.__class__ = w_T.__class__  # type: ignore
-        self.__dict__ = w_T.__dict__
-
-
-
 FIELDS_T = dict[str, W_Type]
 METHODS_T = dict[str, W_Func]
 

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -37,9 +37,10 @@ class W_LiftedType(W_Type):
             assert isinstance(w_meth, W_Func)
             self.dict_w[key] = w_meth
 
-    def __repr__(self) -> str:
+    def repr_hints(self) -> list[str]:
         lltype = self.w_lltype.fqn.human_name
-        return f"<spy type '{self.fqn}' (lifted from '{lltype}')>"
+        h = f"lifted from '{lltype}'"
+        return [h]
 
     @builtin_method('__CALL_METHOD__', color='blue')
     @staticmethod

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 @UNSAFE.builtin_func(color='blue')
 def w_make_ptr_type(vm: 'SPyVM', w_T: W_Type) -> W_Dynamic:
     fqn = FQN('unsafe').join('ptr', [w_T.fqn])  # unsafe::ptr[i32]
-    w_ptrtype = W_PtrType.define(fqn, w_T)
+    w_ptrtype = W_PtrType.from_itemtype(fqn, w_T)
     return w_ptrtype
 
 
@@ -55,10 +55,10 @@ class W_PtrType(W_Type):
     # special case of w_GETATTR.
 
     @classmethod
-    def declare(cls, fqn: FQN, w_itemtype: W_Type) -> 'Self':
-        w_ptrtype = super().declare(fqn, W_Ptr)
-        w_ptrtype.w_itemtype = w_itemtype
-        return w_ptrtype
+    def from_itemtype(cls, fqn: FQN, w_itemtype: W_Type) -> 'Self':
+        w_type = cls.from_pyclass(fqn, W_Ptr)
+        w_type.w_itemtype = w_itemtype
+        return w_type
 
     @builtin_method('__GETATTR__', color='blue')
     @staticmethod

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, ClassVar, Optional, Annotated
+from typing import TYPE_CHECKING, ClassVar, Optional, Annotated, Self
 import fixedint
 from spy.errors import SPyPanicError
 from spy.fqn import FQN
@@ -55,7 +55,7 @@ class W_PtrType(W_Type):
     # special case of w_GETATTR.
 
     @classmethod
-    def from_itemtype(cls, fqn: FQN, w_itemtype: W_Type) -> 'Self':
+    def from_itemtype(cls, fqn: FQN, w_itemtype: W_Type) -> Self:
         w_type = cls.from_pyclass(fqn, W_Ptr)
         w_type.w_itemtype = w_itemtype
         return w_type

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 @UNSAFE.builtin_func(color='blue')
 def w_make_ptr_type(vm: 'SPyVM', w_T: W_Type) -> W_Dynamic:
     fqn = FQN('unsafe').join('ptr', [w_T.fqn])  # unsafe::ptr[i32]
-    w_ptrtype = W_PtrType(fqn, w_T)
+    w_ptrtype = W_PtrType.define(fqn, w_T)
     return w_ptrtype
 
 
@@ -54,9 +54,11 @@ class W_PtrType(W_Type):
     # The workaround is not to use a Member, but to implement .NULL as a
     # special case of w_GETATTR.
 
-    def __init__(self, fqn: FQN, w_itemtype: W_Type) -> None:
-        super().__init__(fqn, W_Ptr)
-        self.w_itemtype = w_itemtype
+    @classmethod
+    def declare(cls, fqn: FQN, w_itemtype: W_Type) -> 'Self':
+        w_ptrtype = super().declare(fqn, W_Ptr)
+        w_ptrtype.w_itemtype = w_itemtype
+        return w_ptrtype
 
     @builtin_method('__GETATTR__', color='blue')
     @staticmethod

--- a/spy/vm/modules/unsafe/struct.py
+++ b/spy/vm/modules/unsafe/struct.py
@@ -28,6 +28,7 @@ class W_StructType(W_Type):
         return super().declare(fqn, W_Struct)
 
     def setup(self, fields: FIELDS_T, methods: METHODS_T) -> None:
+        super().setup()
         self.fields = fields
         self.offsets, self.size = calc_layout(fields)
         assert methods == {}

--- a/spy/vm/modules/unsafe/struct.py
+++ b/spy/vm/modules/unsafe/struct.py
@@ -5,7 +5,7 @@ from spy.fqn import FQN
 from spy.vm.function import W_Func
 from spy.vm.primitive import W_I32, W_Void
 from spy.vm.b import B
-from spy.vm.object import W_Object, W_Type
+from spy.vm.object import W_Object, W_Type, ClassBody, FIELDS_T
 from spy.vm.builtin import builtin_func
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from . import UNSAFE
@@ -23,15 +23,11 @@ class W_StructType(W_Type):
     offsets: OFFSETS_T
     size: int
 
-    @classmethod
-    def declare(cls, fqn: FQN) -> 'Self':
-        return super().declare(fqn, W_Struct)
-
-    def setup(self, fields: FIELDS_T, methods: METHODS_T) -> None:
-        super().setup()
-        self.fields = fields
-        self.offsets, self.size = calc_layout(fields)
-        assert methods == {}
+    def define_from_classbody(self, body: ClassBody) -> None:
+        super().define(W_Struct)
+        self.fields = body.fields
+        self.offsets, self.size = calc_layout(body.fields)
+        assert body.methods == {}
 
     def __repr__(self) -> str:
         if self.is_defined():

--- a/spy/vm/modules/unsafe/struct.py
+++ b/spy/vm/modules/unsafe/struct.py
@@ -13,8 +13,6 @@ if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
     from spy.vm.opimpl import W_OpImpl, W_OpArg
 
-FIELDS_T = dict[str, W_Type]
-METHODS_T = dict[str, W_Func]
 OFFSETS_T = dict[str, int]
 
 @UNSAFE.builtin_type('StructType')

--- a/spy/vm/modules/unsafe/struct.py
+++ b/spy/vm/modules/unsafe/struct.py
@@ -23,11 +23,13 @@ class W_StructType(W_Type):
     offsets: OFFSETS_T
     size: int
 
-    def __init__(self, fqn: FQN, fields: FIELDS_T, methods: METHODS_T) -> None:
-        super().__init__(fqn, W_Struct)
-        self.fields = fields
-        self.offsets, self.size = calc_layout(fields)
+    @classmethod
+    def define(cls, fqn: FQN, fields: FIELDS_T, methods: METHODS_T) -> 'Self':
+        w_type = super().define(fqn, W_Struct)
+        w_type.fields = fields
+        w_type.offsets, w_type.size = calc_layout(fields)
         assert methods == {}
+        return w_type
 
     def __repr__(self) -> str:
         return f"<spy type '{self.fqn}' (struct)>"

--- a/spy/vm/modules/unsafe/struct.py
+++ b/spy/vm/modules/unsafe/struct.py
@@ -24,15 +24,20 @@ class W_StructType(W_Type):
     size: int
 
     @classmethod
-    def define(cls, fqn: FQN, fields: FIELDS_T, methods: METHODS_T) -> 'Self':
-        w_type = super().define(fqn, W_Struct)
-        w_type.fields = fields
-        w_type.offsets, w_type.size = calc_layout(fields)
+    def declare(cls, fqn: FQN) -> 'Self':
+        return super().declare(fqn, W_Struct)
+
+    def setup(self, fields: FIELDS_T, methods: METHODS_T) -> None:
+        self.fields = fields
+        self.offsets, self.size = calc_layout(fields)
         assert methods == {}
-        return w_type
 
     def __repr__(self) -> str:
-        return f"<spy type '{self.fqn}' (struct)>"
+        if self.is_defined():
+            fw = ''
+        else:
+            fw = 'fwdecl '
+        return f"<spy {fw}type '{self.fqn}' (struct)>"
 
     def is_struct(self, vm: 'SPyVM') -> bool:
         return True

--- a/spy/vm/modules/unsafe/struct.py
+++ b/spy/vm/modules/unsafe/struct.py
@@ -27,12 +27,8 @@ class W_StructType(W_Type):
         self.offsets, self.size = calc_layout(body.fields)
         assert body.methods == {}
 
-    def __repr__(self) -> str:
-        if self.is_defined():
-            fw = ''
-        else:
-            fw = 'fwdecl '
-        return f"<spy {fw}type '{self.fqn}' (struct)>"
+    def repr_hints(self) -> list[str]:
+        return super().repr_hints() + ['struct']
 
     def is_struct(self, vm: 'SPyVM') -> bool:
         return True

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -46,7 +46,7 @@ basically a thin wrapper around the correspindig interp-level W_* class.
 
 import typing
 from typing import (TYPE_CHECKING, ClassVar, Type, Any, Optional, Union,
-                    Callable, Annotated)
+                    Callable, Annotated, Self)
 from dataclasses import dataclass
 from spy.ast import Color
 from spy.fqn import FQN
@@ -237,11 +237,11 @@ class W_Type(W_Object):
     """
     __spy_storage_category__ = 'reference'
     fqn: FQN
-    _pyclass: Type[W_Object]
+    _pyclass: Optional[Type[W_Object]]
     spy_members: dict[str, 'Member']
     _dict_w: Optional[dict[str, W_Object]]
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         cls = self.__class__.__name__
         raise TypeError(
             f'cannot instantiate {cls} directly. Use {cls}.declare ' +
@@ -268,7 +268,7 @@ class W_Type(W_Object):
             return self._pyclass
 
     @classmethod
-    def declare(cls, fqn: FQN) -> 'Self':
+    def declare(cls, fqn: FQN) -> Self:
         """
         Create a new type in the "forward declaration" state
         """
@@ -279,7 +279,7 @@ class W_Type(W_Object):
         return w_type
 
     @classmethod
-    def from_pyclass(cls, fqn: FQN, pyclass: Type[W_Object]) -> 'Self':
+    def from_pyclass(cls, fqn: FQN, pyclass: Type[W_Object]) -> Self:
         """
         Declare AND define a new builtin type.
         """

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -217,9 +217,8 @@ class W_Type(W_Object):
       2. definition
 
     - `W_Type.declare(fqn)` creates a type in "forward declared" mode.
-    - `W_Type.new(fqn, ...)` creates a type in "defined" mode.
-    - `w_t.define_from_*()` takes a declared type and turn it into a defined
-      type.
+    - `w_t.define()` turns a declared type into a defined one.
+    - `W_Type.from_pyclass()` combines the two above.
 
     Most builtin types are created by calling @builtin_type, which takes care
     of both declaration and definition.

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -363,7 +363,17 @@ class W_Type(W_Object):
         return basecls._w
 
     def __repr__(self) -> str:
-        return f"<spy type '{self.fqn.human_name}'>"
+        hints = [] if self.is_defined() else ['fwdecl']
+        hints += self.repr_hints()
+        if hints:
+            s_hints = ', '.join(hints)
+            s_hints = f' ({s_hints})'
+        else:
+            s_hints = ''
+        return f"<spy type '{self.fqn.human_name}'{s_hints}>"
+
+    def repr_hints(self) -> list[str]:
+        return []
 
     def is_reference_type(self, vm: 'SPyVM') -> bool:
         return self.pyclass.__spy_storage_category__ == 'reference'

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 
 T = TypeVar('T')
 
-@OPERATOR.builtin_type('OpArg')
+@OPERATOR.builtin_type('OpArg', lazy_setup=True)
 class W_OpArg(W_Object):
     """
     A value which carries some extra information.
@@ -74,7 +74,6 @@ class W_OpArg(W_Object):
 
     Blue OpArg always have an associated value.
     """
-    __spy_lazy_init__ = True
     color: Color
     w_static_type: Annotated[W_Type, Member('static_type')]
     loc: Loc
@@ -206,10 +205,8 @@ def w_oparg_eq(vm: 'SPyVM', wop1: W_OpArg, wop2: W_OpArg) -> W_Bool:
 
 
 
-@OPERATOR.builtin_type('OpImpl')
+@OPERATOR.builtin_type('OpImpl', lazy_setup=True)
 class W_OpImpl(W_Object):
-    __spy_lazy_init__ = True
-
     NULL: ClassVar['W_OpImpl']
     _w_func: Optional[W_Func]
     _args_wop: Optional[list[W_OpArg]]

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 
 T = TypeVar('T')
 
-@OPERATOR.builtin_type('OpArg', lazy_setup=True)
+@OPERATOR.builtin_type('OpArg', lazy_definition=True)
 class W_OpArg(W_Object):
     """
     A value which carries some extra information.
@@ -205,7 +205,7 @@ def w_oparg_eq(vm: 'SPyVM', wop1: W_OpArg, wop2: W_OpArg) -> W_Bool:
 
 
 
-@OPERATOR.builtin_type('OpImpl', lazy_setup=True)
+@OPERATOR.builtin_type('OpImpl', lazy_definition=True)
 class W_OpImpl(W_Object):
     NULL: ClassVar['W_OpImpl']
     _w_func: Optional[W_Func]

--- a/spy/vm/primitive.py
+++ b/spy/vm/primitive.py
@@ -134,6 +134,6 @@ B.add('NotImplemented', W_NotImplementedType.__new__(W_NotImplementedType))
 # just an annotated version of W_Object, which @builtin_func knows how to deal
 # with.
 
-w_DynamicType = W_Type.define(FQN('builtins::dynamic'), W_Object)
+w_DynamicType = W_Type.from_pyclass(FQN('builtins::dynamic'), W_Object)
 B.add('dynamic', w_DynamicType)
 W_Dynamic = Annotated[W_Object, B.w_dynamic]

--- a/spy/vm/primitive.py
+++ b/spy/vm/primitive.py
@@ -134,6 +134,6 @@ B.add('NotImplemented', W_NotImplementedType.__new__(W_NotImplementedType))
 # just an annotated version of W_Object, which @builtin_func knows how to deal
 # with.
 
-w_DynamicType = W_Type(FQN('builtins::dynamic'), W_Object)
+w_DynamicType = W_Type.define(FQN('builtins::dynamic'), W_Object)
 B.add('dynamic', w_DynamicType)
 W_Dynamic = Annotated[W_Object, B.w_dynamic]

--- a/spy/vm/registry.py
+++ b/spy/vm/registry.py
@@ -48,7 +48,9 @@ class ModuleRegistry:
 
     def builtin_type(self,
                      typename: str,
-                     qualifiers: QUALIFIERS = None
+                     qualifiers: QUALIFIERS = None,
+                     *,
+                     lazy_setup: bool = False,
                      ) -> Callable:
         """
         Register a type on the module.
@@ -66,7 +68,9 @@ class ModuleRegistry:
         """
         from spy.vm.builtin import builtin_type
         def decorator(pyclass: Type['W_Object']) -> Type['W_Object']:
-            W_class = builtin_type(self.fqn, typename, qualifiers)(pyclass)
+            bt_deco = builtin_type(self.fqn, typename, qualifiers,
+                                   lazy_setup=lazy_setup)
+            W_class = bt_deco(pyclass)
             self.add(typename, W_class._w)
             return W_class
         return decorator

--- a/spy/vm/registry.py
+++ b/spy/vm/registry.py
@@ -50,7 +50,7 @@ class ModuleRegistry:
                      typename: str,
                      qualifiers: QUALIFIERS = None,
                      *,
-                     lazy_setup: bool = False,
+                     lazy_definition: bool = False,
                      ) -> Callable:
         """
         Register a type on the module.
@@ -69,7 +69,7 @@ class ModuleRegistry:
         from spy.vm.builtin import builtin_type
         def decorator(pyclass: Type['W_Object']) -> Type['W_Object']:
             bt_deco = builtin_type(self.fqn, typename, qualifiers,
-                                   lazy_setup=lazy_setup)
+                                   lazy_definition=lazy_definition)
             W_class = bt_deco(pyclass)
             self.add(typename, W_class._w)
             return W_class

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -109,7 +109,7 @@ def functype_from_opargs(args_wop: list[W_OpArg], w_restype: W_Type,
         FuncParam(f'v{i}', wop.w_static_type, 'simple')
         for i, wop in enumerate(args_wop)
     ]
-    return W_FuncType(params, w_restype, color=color)
+    return W_FuncType.define(params, w_restype, color=color)
 
 
 def get_w_conv(vm: 'SPyVM', w_type: W_Type, wop_arg: W_OpArg,

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -109,7 +109,7 @@ def functype_from_opargs(args_wop: list[W_OpArg], w_restype: W_Type,
         FuncParam(f'v{i}', wop.w_static_type, 'simple')
         for i, wop in enumerate(args_wop)
     ]
-    return W_FuncType.define(params, w_restype, color=color)
+    return W_FuncType.new(params, w_restype, color=color)
 
 
 def get_w_conv(vm: 'SPyVM', w_type: W_Type, wop_arg: W_OpArg,

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -28,12 +28,12 @@ from spy.vm.modules.unsafe import UNSAFE
 from spy.vm.modules.rawbuffer import RAW_BUFFER
 from spy.vm.modules.jsffi import JSFFI
 
-# lazy setup of some some core types. See the docstring of W_Type.
-W_Object._w.setup()
-W_Type._w.setup()
-W_OpImpl._w.setup()
-W_OpArg._w.setup()
-W_FuncType._w.setup()
+# lazy definition of some some core types. See the docstring of W_Type.
+W_Object._w.define(W_Object)
+W_Type._w.define(W_Type)
+W_OpImpl._w.define(W_OpImpl)
+W_OpArg._w.define(W_OpArg)
+W_FuncType._w.define(W_FuncType)
 
 
 class SPyVM:

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -23,7 +23,7 @@ from spy.vm.bluecache import BlueCache
 
 from spy.vm.modules.builtins import BUILTINS
 from spy.vm.modules.operator import OPERATOR
-from spy.vm.modules.types import TYPES, W_ForwardRef
+from spy.vm.modules.types import TYPES
 from spy.vm.modules.unsafe import UNSAFE
 from spy.vm.modules.rawbuffer import RAW_BUFFER
 from spy.vm.modules.jsffi import JSFFI
@@ -129,9 +129,6 @@ class SPyVM:
         w_existing = self.globals_w.get(fqn)
         if w_existing is None:
             self.globals_w[fqn] = w_value
-        elif isinstance(w_existing, W_ForwardRef):
-            assert isinstance(w_value, W_Type)
-            w_existing.become(w_value)
         else:
             raise ValueError(f"'{fqn}' already exists")
 

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -28,11 +28,12 @@ from spy.vm.modules.unsafe import UNSAFE
 from spy.vm.modules.rawbuffer import RAW_BUFFER
 from spy.vm.modules.jsffi import JSFFI
 
-# lazy init of some some core types. See the docstring for W_Type.lazy_init.
-W_Type._w.lazy_init()
-W_OpImpl._w.lazy_init()
-W_OpArg._w.lazy_init()
-W_FuncType._w.lazy_init()
+# lazy setup of some some core types. See the docstring of W_Type.
+W_Object._w.setup()
+W_Type._w.setup()
+W_OpImpl._w.setup()
+W_OpArg._w.setup()
+W_FuncType._w.setup()
 
 
 class SPyVM:


### PR DESCRIPTION
Kill `W_ForwardRef`.
The big problem of `W_ForwardRef` is that they could work reliably only for module-level definitions (because the `.become` happened in `vm.add_global`): this means that e.g. this code:

```
@typelift
class MyClass:
    __ll__: i32
    def __new__(cls) -> MyClass:
        ...
```

worked well at module level, but crashed inside the function.

Instead, introduce a two-step type initialization mechanism: types can be in "declared" state, and then transition into a "defined" state. In the next PRs, we will use this new feature to fix the case above.

Among the other things, this plays well with the need of lazy initialization of some core types: instead of using an ad-hoc "lazy setup" mechanism, we can just use the standard declare/define split.
