### PR TITLE
Introduce a proper frame type where to evaluate module content

### DIFF
--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -68,6 +68,11 @@ class DopplerFrame(ASTFrame):
         self.declare_arguments()
         funcdef = self.w_func.funcdef
         new_body = []
+        # fwdecl of types
+        for stmt in funcdef.body:
+            if isinstance(stmt, ast.ClassDef):
+                self.fwdecl_ClassDef(stmt)
+
         for stmt in funcdef.body:
             new_body += self.shift_stmt(stmt)
 

--- a/spy/irgen/irgen.py
+++ b/spy/irgen/irgen.py
@@ -1,9 +1,11 @@
 from typing import Any
 import py.path
 import spy.ast
+from spy.fqn import FQN
 from spy.parser import Parser
 from spy.irgen.scope import ScopeAnalyzer
-from spy.irgen.modgen import ModuleGen
+from spy.vm.modframe import ModFrame
+
 from spy.vm.vm import SPyVM
 from spy.vm.module import W_Module
 
@@ -18,5 +20,8 @@ def make_w_mod_from_file(vm: SPyVM, f: py.path.local) -> W_Module:
     modname = f.purebasename
     scopes = ScopeAnalyzer(vm, modname, mod)
     scopes.analyze()
-    modgen = ModuleGen(vm, scopes, modname, mod, f)
-    return modgen.make_w_mod()
+    symtable = scopes.by_module()
+    fqn = FQN(modname)
+    modframe = ModFrame(vm, fqn, symtable, mod)
+    w_mod = modframe.run()
+    return w_mod

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -853,6 +853,25 @@ class TestBasic(CompilerTest):
         assert params[1].w_type is w_ptr_S1 is w_ptr_S2
 
     @only_interp
+    def test_forward_declaration_in_funcdef(self):
+        mod = self.compile("""
+        from unsafe import ptr, gc_alloc
+
+        @blue
+        def foo() -> i32:
+            p: ptr[S]  # S is forward-declared at this point
+
+            @struct
+            class S:
+                x: i32
+
+            p = gc_alloc(S)(1)
+            p.x = 42
+            return p.x
+        """)
+        assert mod.foo() == 42
+
+    @only_interp
     def test_eager_blue_eval(self):
         mod = self.compile("""
         @blue

--- a/spy/tests/vm/test_builtin.py
+++ b/spy/tests/vm/test_builtin.py
@@ -120,7 +120,7 @@ class TestBuiltin:
         assert w_make.w_functype.signature == "def() -> test::Foo"
         assert w_make.w_functype.w_restype is W_Foo._w
 
-    def test_builtin_method(self):
+    def test_inherit_method(self):
         @builtin_type('test', 'Super')
         class W_Super(W_Object):
 

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -168,6 +168,14 @@ class AbstractFrame:
         raise Return(wop.w_val)
 
     def exec_stmt_FuncDef(self, funcdef: ast.FuncDef) -> None:
+        # sanity check: if it's the global __INIT__, it must be @blue
+        if (self.is_module_body and
+            funcdef.name == '__INIT__' and
+            funcdef.color != 'blue'):
+            err = SPyTypeError("the __INIT__ function must be @blue")
+            err.add("error", "function defined here", funcdef.prototype_loc)
+            raise err
+
         # evaluate the functype
         params = []
         for arg in funcdef.args:
@@ -198,7 +206,6 @@ class AbstractFrame:
             return W_LiftedType
         else:
             assert False, 'only @struct and @typedef are supported for now'
-
 
     def exec_stmt_ClassDef(self, classdef: ast.ClassDef) -> None:
         from spy.vm.classframe import ClassFrame

--- a/spy/vm/classframe.py
+++ b/spy/vm/classframe.py
@@ -1,0 +1,43 @@
+from typing import TYPE_CHECKING
+from spy import ast
+from spy.fqn import FQN
+from spy.vm.object import ClassBody
+from spy.vm.astframe import AbstractFrame
+from spy.vm.function import W_Func, CLOSURE
+
+if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
+
+
+class ClassFrame(AbstractFrame):
+    """
+    A frame to execute a classdef body
+    """
+    classdef: ast.ClassDef
+
+    def __init__(self,
+                 vm: 'SPyVM',
+                 classdef: ast.ClassDef,
+                 fqn: FQN,
+                 closure: CLOSURE
+                 ) -> None:
+        super().__init__(vm, fqn, classdef.symtable, closure)
+        self.classdef = classdef
+
+    def run(self) -> ClassBody:
+        # execute field definitions
+        body = ClassBody(fields={}, methods={})
+        for vardef in self.classdef.fields:
+            assert vardef.kind == 'var'
+            self.exec_stmt_VarDef(vardef)
+            body.fields[vardef.name] = self.locals_types_w[vardef.name]
+
+        # execute method definitions
+        for funcdef in self.classdef.methods:
+            name = funcdef.name
+            self.exec_stmt_FuncDef(funcdef)
+            w_meth = self.load_local(name)
+            assert isinstance(w_meth, W_Func)
+            body.methods[name] = w_meth
+
+        return body

--- a/spy/vm/modframe.py
+++ b/spy/vm/modframe.py
@@ -71,13 +71,12 @@ class ModFrame(AbstractFrame):
         vardef = decl.vardef
         assign = decl.assign
         fqn = self.fqn.join(vardef.name)
-        if isinstance(vardef.type, ast.Auto):
-            # type inference
-            wop = self.eval_expr(assign.value)
-            self.vm.add_global(fqn, wop.w_val)
-        else:
-            # eval the type and use it in the globals declaration
-            w_type = self.eval_expr_type(vardef.type)
-            wop = self.eval_expr(assign.value)
-            assert self.vm.isinstance(wop.w_val, w_type)
-            self.vm.add_global(fqn, wop.w_val)
+
+        # evaluate the vardef in the current frame
+        if not isinstance(vardef.type, ast.Auto):
+            self.exec_stmt_VarDef(vardef)
+        self.exec_stmt_Assign(assign)
+
+        # add it to the globals
+        w_val = self.load_local(vardef.name)
+        self.vm.add_global(fqn, w_val)

--- a/spy/vm/modframe.py
+++ b/spy/vm/modframe.py
@@ -38,13 +38,7 @@ class ModFrame(AbstractFrame):
         # forward declaration of types
         for decl in self.mod.decls:
             if isinstance(decl, ast.GlobalClassDef):
-                type_fqn = self.fqn.join(decl.classdef.name)
-                pyclass = self.metaclass_for_classdef(decl.classdef)
-                w_typedecl = pyclass.declare(type_fqn)
-                w_meta_type = self.vm.dynamic_type(w_typedecl)
-                self.declare_local(decl.classdef.name, w_meta_type)
-                self.store_local(decl.classdef.name, w_typedecl)
-                self.vm.add_global(type_fqn, w_typedecl)
+                self.fwdecl_ClassDef(decl.classdef)
 
         for decl in self.mod.decls:
             if isinstance(decl, ast.Import):

--- a/spy/vm/modframe.py
+++ b/spy/vm/modframe.py
@@ -50,9 +50,9 @@ class ModFrame(AbstractFrame):
             if isinstance(decl, ast.Import):
                 pass
             elif isinstance(decl, ast.GlobalFuncDef):
-                self.gen_FuncDef(decl.funcdef)
+                self.exec_stmt_FuncDef(decl.funcdef)
             elif isinstance(decl, ast.GlobalClassDef):
-                self.gen_ClassDef(decl.classdef)
+                self.exec_stmt_ClassDef(decl.classdef)
             elif isinstance(decl, ast.GlobalVarDef):
                 self.gen_GlobalVarDef(decl)
             else:
@@ -66,19 +66,6 @@ class ModFrame(AbstractFrame):
             self.vm.fast_call(w_init, [w_mod])
         #
         return w_mod
-
-    def gen_FuncDef(self, funcdef: ast.FuncDef) -> None:
-        # sanity check: if it's the global __INIT__, it must be @blue
-        if funcdef.name == '__INIT__' and funcdef.color != 'blue':
-            err = SPyTypeError("the __INIT__ function must be @blue")
-            err.add("error", "function defined here", funcdef.prototype_loc)
-            raise err
-        self.exec_stmt_FuncDef(funcdef)
-
-    def gen_ClassDef(self, classdef: ast.ClassDef) -> None:
-        # NOTE: executing the ClassDef automatically add the new w_type to the
-        # globals
-        self.exec_stmt_ClassDef(classdef)
 
     def gen_GlobalVarDef(self, decl: ast.GlobalVarDef) -> None:
         vardef = decl.vardef

--- a/spy/vm/modframe.py
+++ b/spy/vm/modframe.py
@@ -38,12 +38,12 @@ class ModFrame(AbstractFrame):
         # forward declaration of types
         for decl in self.mod.decls:
             if isinstance(decl, ast.GlobalClassDef):
-                type_fqn = fqn.join(decl.classdef.name)
-                pyclass = ASTFrame.metaclass_for_classdef(decl.classdef)
+                type_fqn = self.fqn.join(decl.classdef.name)
+                pyclass = self.metaclass_for_classdef(decl.classdef)
                 w_typedecl = pyclass.declare(type_fqn)
                 w_meta_type = self.vm.dynamic_type(w_typedecl)
-                frame.declare_local(decl.classdef.name, w_meta_type)
-                frame.store_local(decl.classdef.name, w_typedecl)
+                self.declare_local(decl.classdef.name, w_meta_type)
+                self.store_local(decl.classdef.name, w_typedecl)
                 self.vm.add_global(type_fqn, w_typedecl)
 
         for decl in self.mod.decls:
@@ -83,14 +83,14 @@ class ModFrame(AbstractFrame):
     def gen_GlobalVarDef(self, decl: ast.GlobalVarDef) -> None:
         vardef = decl.vardef
         assign = decl.assign
-        fqn = FQN([self.modname, vardef.name])
+        fqn = self.fqn.join(vardef.name)
         if isinstance(vardef.type, ast.Auto):
             # type inference
             wop = self.eval_expr(assign.value)
             self.vm.add_global(fqn, wop.w_val)
         else:
             # eval the type and use it in the globals declaration
-            w_type = frame.eval_expr_type(vardef.type)
+            w_type = self.eval_expr_type(vardef.type)
             wop = self.eval_expr(assign.value)
             assert self.vm.isinstance(wop.w_val, w_type)
             self.vm.add_global(fqn, wop.w_val)


### PR DESCRIPTION
This PR introduces `ModFrame`, which is the brother of `ASTFrame` and `ClassFrame`, and it's responsible to evaluate the content of a module.

`ModFrame` replaces the old `ModGen`, which did something similar by instantiating a fake function where to evaluate statements.

With this change we are able to share the logic to forward-declare types between ModFrame and ASTFrame, which means that now forward declaration of types work also inside a funciton.