### PR TITLE
Add .gitattributes to highlight .spy files like .py files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.spy linguist-language=Python


### PR DESCRIPTION
Tell GitHub (and other tools) to apply Python syntax highlighting to `.spy` files to make them more readable.

Compare https://github.com/spylang/spy/blob/main/examples/array.spy with https://github.com/hugovk/spy/blob/main/examples/array.spy

It might take a bit time after merge for it to take effect, I think GitHub caches the pages.