### PR TITLE
Add type qualifiers to the namespaces created when invoking blue functions

### DIFF
--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -26,8 +26,10 @@ class SPyBackend:
         # these are initialized by dump_w_func
         self.w_func: W_ASTFunc = None       # type: ignore
         self.vars_declared: set[str] = None # type: ignore
+        self.modname = '' # set by dump_mod
 
     def dump_mod(self, modname: str) -> str:
+        self.modname = modname
         w_mod = self.vm.modules_w[modname]
         for fqn, w_obj in w_mod.items_w():
             if isinstance(w_obj, W_ASTFunc) and w_obj.color == 'red':
@@ -36,10 +38,9 @@ class SPyBackend:
         return self.out.build()
 
     def dump_w_func(self, fqn: FQN, w_func: W_ASTFunc) -> None:
-        # Get the last part to check for a suffix
-        last_part = fqn.parts[-1]
-        if last_part.suffix == 0:
-            # this is a global function, we can just use its name
+        if (len(fqn.parts) == 2 and
+            fqn.modname == self.modname
+            and fqn.parts[-1].suffix == 0):
             name = fqn.symbol_name
         else:
             name = self.fmt_fqn(fqn)

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -36,7 +36,9 @@ class SPyBackend:
         return self.out.build()
 
     def dump_w_func(self, fqn: FQN, w_func: W_ASTFunc) -> None:
-        if fqn.suffix == '':
+        # Get the last part to check for a suffix
+        last_part = fqn.parts[-1]
+        if last_part.suffix == 0:
             # this is a global function, we can just use its name
             name = fqn.symbol_name
         else:

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -47,7 +47,7 @@ class SPyBackend:
                 and fqn.parts[-1].suffix == 0)
 
     def dump_w_func(self, fqn: FQN, w_func: W_ASTFunc) -> None:
-        if self.is_module_global(fqn):
+        if self.fqn_format == 'short' and self.is_module_global(fqn):
             # display 'def foo()' instead of 'def `test::foo`()', if possible
             name = fqn.symbol_name
         else:

--- a/spy/cli.py
+++ b/spy/cli.py
@@ -127,12 +127,13 @@ class Arguments:
         )
     ] = ToolchainType.zig
 
-    pretty: Annotated[
+    full_fqn: Annotated[
         bool,
         Option(
-            help="Prettify redshifted modules"
+            "--full-fqn",
+            help="Show full FQNs in redshifted modules"
         )
-    ] = True
+    ] = False
 
     timeit: Annotated[
         bool,
@@ -180,8 +181,8 @@ def do_pyparse(filename: str) -> None:
     mod = magic_py_parse(src)
     mod.pp()
 
-def dump_spy_mod(vm: SPyVM, modname: str, pretty: bool) -> None:
-    fqn_format: FQN_FORMAT = 'short' if pretty else 'full'
+def dump_spy_mod(vm: SPyVM, modname: str, full_fqn: bool) -> None:
+    fqn_format: FQN_FORMAT = 'full' if full_fqn else 'short'
     b = SPyBackend(vm, fqn_format=fqn_format)
     print(b.dump_mod(modname))
 
@@ -281,7 +282,7 @@ async def inner_main(args: Arguments) -> None:
 
     vm.redshift()
     if args.redshift:
-        dump_spy_mod(vm, modname, args.pretty)
+        dump_spy_mod(vm, modname, args.full_fqn)
         return
 
     compiler = Compiler(vm, modname, py.path.local(builddir),

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -55,7 +55,8 @@ class DopplerFrame(ASTFrame):
     opimpl: dict[ast.Node, W_Func]
 
     def __init__(self, vm: 'SPyVM', w_func: W_ASTFunc) -> None:
-        super().__init__(vm, w_func)
+        assert w_func.color == 'red'
+        super().__init__(vm, w_func, args_w=None)
         self.shifted_expr = {}
         self.opimpl = {}
 

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -154,6 +154,7 @@ class FQN:
         """
         Create a new FQN with the specified qualifiers added to the last NSPart.
         """
+        # fix this to avoid mutating the existing FQN, and add a test. AI!
         res = FQN(self.parts)
         res.parts[-1].qualifiers.extend(get_qualifiers(qualifiers))
         return res

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -154,9 +154,19 @@ class FQN:
         """
         Create a new FQN with the specified qualifiers added to the last NSPart.
         """
-        # fix this to avoid mutating the existing FQN, and add a test. AI!
-        res = FQN(self.parts)
-        res.parts[-1].qualifiers.extend(get_qualifiers(qualifiers))
+        new_parts = []
+        for i, part in enumerate(self.parts):
+            if i < len(self.parts) - 1:
+                # For all parts except the last one, create a copy
+                new_part = NSPart(part.name, part.qualifiers.copy(), part.suffix)
+                new_parts.append(new_part)
+            else:
+                # For the last part, create a copy with the new qualifiers added
+                new_quals = part.qualifiers.copy() + get_qualifiers(qualifiers)
+                new_part = NSPart(part.name, new_quals, part.suffix)
+                new_parts.append(new_part)
+        
+        res = FQN(new_parts)
         return res
 
     def __repr__(self) -> str:

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -150,6 +150,8 @@ class FQN:
         res.parts[-1].suffix = suffix
         return res
 
+    # add a "with_qualifiers" method, and write a test. AI!
+
     def __repr__(self) -> str:
         return f"FQN({self.fullname!r})"
 

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -150,7 +150,13 @@ class FQN:
         res.parts[-1].suffix = suffix
         return res
 
-    # add a "with_qualifiers" method, and write a test. AI!
+    def with_qualifiers(self, qualifiers: QUALIFIERS) -> 'FQN':
+        """
+        Create a new FQN with the specified qualifiers added to the last NSPart.
+        """
+        res = FQN(self.parts)
+        res.parts[-1].qualifiers.extend(get_qualifiers(qualifiers))
+        return res
 
     def __repr__(self) -> str:
         return f"FQN({self.fullname!r})"

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -202,7 +202,7 @@ class FQN:
 
     @property
     def symbol_name(self) -> str:
-        return self.parts[-1].name
+        return str(self.parts[-1])
 
     def join(self, name: str, qualifiers: QUALIFIERS=None) -> 'FQN':
         """

--- a/spy/fqn_parser.py
+++ b/spy/fqn_parser.py
@@ -81,11 +81,16 @@ class FQNParser:
 
         if self.peek() == "#":
             self.expect("#")
-            suffix = self.parse_suffix()
-        else:
-            suffix = ''
+            suffix_str = self.parse_suffix()
+            try:
+                # Convert suffix to int
+                suffix = int(suffix_str)
+                # Set suffix on the last part
+                parts[-1].suffix = suffix
+            except ValueError:
+                raise ValueError(f"Suffix must be numeric, got: {suffix_str}")
 
-        return FQN(parts, suffix=suffix)
+        return FQN(parts)
 
     def parse_part(self) -> NSPart:
         name = self.parse_name()

--- a/spy/tests/support.py
+++ b/spy/tests/support.py
@@ -193,7 +193,7 @@ class CompilerTest:
         from spy.cli import dump_spy_mod
         print()
         print()
-        dump_spy_mod(self.vm, modname, pretty=True)
+        dump_spy_mod(self.vm, modname, full_fqn=False)
 
     def compile_raises(self, src: str, funcname: str, ctx: Any,
                        *,

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -237,3 +237,29 @@ class TestDoppler:
             if `operator::i32_to_bool`(x):
                 pass
         """)
+
+    def test_blue_namespace(self):
+        self.redshift("""
+        @blue
+        def add(T):
+            def impl(x: T, y: T) -> T:
+                return x + y
+            return impl
+
+        def foo() -> void:
+            x = add(i32)(1, 2)
+            y = add(str)("a", "b")
+        """)
+        self.assert_dump("""
+        def foo() -> void:
+            x: i32
+            x = `test::add[i32]::impl`(1, 2)
+            y: str
+            y = `test::add[str]::impl`('a', 'b')
+
+        def `test::add[i32]::impl`(x: i32, y: i32) -> i32:
+            return x + y
+
+        def `test::add[str]::impl`(x: str, y: str) -> str:
+            return `operator::str_add`(x, y)
+        """)

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -73,7 +73,7 @@ class TestDoppler:
         """
         self.redshift(src)
         expected = """
-        def foo(x: `builtins::i32`) -> `builtins::void`:
+        def `test::foo`(x: `builtins::i32`) -> `builtins::void`:
             y: `builtins::str`
             y = 'hello'
         """

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -133,9 +133,9 @@ class TestDoppler:
         """)
         self.assert_dump("""
         def foo() -> i32:
-            return `test::make_fn::fn#0`(21)
+            return `test::make_fn::fn`(21)
 
-        def `test::make_fn::fn#0`(x: i32) -> i32:
+        def `test::make_fn::fn`(x: i32) -> i32:
             return x * 2
         """)
 
@@ -156,14 +156,14 @@ class TestDoppler:
         """)
         self.assert_dump("""
         def main() -> void:
-            `test::make_foo::foo#0`()
+            `test::make_foo::foo`()
 
-        def `test::make_foo::fn#0`() -> void:
+        def `test::make_foo::fn`() -> void:
             print_str('fn')
 
-        def `test::make_foo::foo#0`() -> void:
-            `test::make_foo::fn#0`()
-            `test::make_foo::fn#0`()
+        def `test::make_foo::foo`() -> void:
+            `test::make_foo::fn`()
+            `test::make_foo::fn`()
         """)
 
     def test_binops(self):

--- a/spy/tests/test_fqn.py
+++ b/spy/tests/test_fqn.py
@@ -18,7 +18,7 @@ def test_FQN_init_parts():
 def test_FQN_suffix():
     a = FQN("aaa::bbb#1")
     assert a.fullname == "aaa::bbb#1"
-    assert a.suffix == '1'
+    assert a.parts[-1].suffix == 1
 
 def test_many_FQNs():
     assert str(FQN("aaa")) == "aaa"
@@ -65,24 +65,24 @@ def test_FQN_join():
     assert e.fullname == "a::e[mod::y]"
 
 def test_FQN_str():
-    a = FQN("aaa::bbb#0")
-    assert str(a) == "aaa::bbb#0"
-    assert a.c_name == "spy_aaa$bbb$0"
+    a = FQN("aaa::bbb#1")  # Use a non-zero suffix
+    assert str(a) == "aaa::bbb#1"
+    assert a.c_name == "spy_aaa$bbb$1"
     b = FQN("aaa::bbb")
     assert str(b) == "aaa::bbb"
     assert b.c_name == "spy_aaa$bbb"
 
 def test_FQN_c_name_dotted():
-    a = FQN("a.b.c::xxx#0")
-    assert a.c_name == "spy_a_b_c$xxx$0"
+    a = FQN("a.b.c::xxx#1") # Use a non-zero suffix
+    assert a.c_name == "spy_a_b_c$xxx$1"
 
 def test_qualifiers_c_name():
-    a = FQN("a::b[x, y]::c#0")
-    assert a.c_name == "spy_a$b__x_y$c$0"
+    a = FQN("a::b[x, y]::c#2") # Use a non-zero suffix
+    assert a.c_name == "spy_a$b__x_y$c$2"
 
 def test_nested_qualifiers_c_name():
-    a = FQN("a::list[Ptr[x, y]]::c#0")
-    assert a.c_name == "spy_a$list__Ptr__x_y$c$0"
+    a = FQN("a::list[Ptr[x, y]]::c#3") # Use a non-zero suffix
+    assert a.c_name == "spy_a$list__Ptr__x_y$c$3"
 
 def test_FQN_human_name():
     assert FQN("a::b").human_name == "a::b"

--- a/spy/tests/test_fqn.py
+++ b/spy/tests/test_fqn.py
@@ -95,13 +95,19 @@ def test_FQN_with_qualifiers():
     a = FQN("mod::list")
     b = a.with_qualifiers(["i32"])
     assert b.fullname == "mod::list[i32]"
+    # Verify original FQN is not modified
+    assert a.fullname == "mod::list"
 
     # Test adding qualifiers to an FQN that already has qualifiers
     c = FQN("mod::dict[str]")
     d = c.with_qualifiers(["i32"])
     assert d.fullname == "mod::dict[str, i32]"
+    # Verify original FQN is not modified
+    assert c.fullname == "mod::dict[str]"
 
     # Test with FQN objects as qualifiers
     e = FQN("mod::map")
     f = e.with_qualifiers([FQN("mod::key"), FQN("mod::value")])
     assert f.fullname == "mod::map[mod::key, mod::value]"
+    # Verify original FQN is not modified
+    assert e.fullname == "mod::map"

--- a/spy/tests/test_fqn.py
+++ b/spy/tests/test_fqn.py
@@ -90,3 +90,18 @@ def test_FQN_human_name():
     func = FQN("builtins").join('def', ['builtins::i32', 'builtins::f64',
                                         'builtins::str'])
     assert func.human_name == 'def(i32, f64) -> str'
+
+def test_FQN_with_qualifiers():
+    a = FQN("mod::list")
+    b = a.with_qualifiers(["i32"])
+    assert b.fullname == "mod::list[i32]"
+
+    # Test adding qualifiers to an FQN that already has qualifiers
+    c = FQN("mod::dict[str]")
+    d = c.with_qualifiers(["i32"])
+    assert d.fullname == "mod::dict[str, i32]"
+
+    # Test with FQN objects as qualifiers
+    e = FQN("mod::map")
+    f = e.with_qualifiers([FQN("mod::key"), FQN("mod::value")])
+    assert f.fullname == "mod::map[mod::key, mod::value]"

--- a/spy/tests/test_fqn_parser.py
+++ b/spy/tests/test_fqn_parser.py
@@ -12,7 +12,7 @@ def test_single_unqualified_part():
     assert len(fqn.parts) == 1
     assert fqn.parts[0].name == "foo"
     assert fqn.parts[0].qualifiers == []
-    assert fqn.suffix == ''
+    assert fqn.parts[0].suffix == 0
 
 def test_two_parts():
     fqn = FQN("mod::foo")
@@ -52,5 +52,5 @@ def test_suffix():
     assert fqn.parts[0].name == "mod"
     assert fqn.parts[1].name == "foo"
     assert fqn.parts[1].qualifiers[0].parts[0].name == "i32"
-    assert fqn.suffix == '1'
+    assert fqn.parts[1].suffix == 1
     assert str(fqn) == "mod::foo[i32]#1"

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -168,14 +168,6 @@ class AbstractFrame:
         raise Return(wop.w_val)
 
     def exec_stmt_FuncDef(self, funcdef: ast.FuncDef) -> None:
-        # sanity check: if it's the global __INIT__, it must be @blue
-        if (self.is_module_body and
-            funcdef.name == '__INIT__' and
-            funcdef.color != 'blue'):
-            err = SPyTypeError("the __INIT__ function must be @blue")
-            err.add("error", "function defined here", funcdef.prototype_loc)
-            raise err
-
         # evaluate the functype
         params = []
         for arg in funcdef.args:

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -226,7 +226,7 @@ class AbstractFrame:
         # fwdecl_ClassDef. Look it up
         w_type = self.load_local(classdef.name)
         assert isinstance(w_type, W_Type)
-        assert w_type.fqn.symbol_name == classdef.name
+        assert w_type.fqn.parts[-1].name == classdef.name # sanity check
         assert not w_type.is_defined()
 
         # create a frame where to execute the class body

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -40,17 +40,17 @@ class AbstractFrame:
     ClassFrame.
     """
     vm: 'SPyVM'
-    fqn: FQN
+    ns: FQN
     closure: CLOSURE
     symtable: SymTable
     _locals: Namespace
     locals_types_w: dict[str, W_Type]
 
-    def __init__(self, vm: 'SPyVM', fqn: FQN, symtable: SymTable,
+    def __init__(self, vm: 'SPyVM', ns: FQN, symtable: SymTable,
                  closure: CLOSURE) -> None:
         assert type(self) is not AbstractFrame, 'abstract class'
         self.vm = vm
-        self.fqn = fqn
+        self.ns = ns
         self.symtable = symtable
         self.closure = closure
         self._locals = {}
@@ -63,7 +63,7 @@ class AbstractFrame:
 
     @property
     def is_module_body(self) -> bool:
-        return self.fqn.is_module()
+        return self.ns.is_module()
 
     def get_unique_FQN_maybe(self, fqn: FQN) -> FQN:
         """
@@ -189,7 +189,7 @@ class AbstractFrame:
         w_restype = self.eval_expr_type(funcdef.return_type)
         w_functype = W_FuncType.new(params, w_restype, color=funcdef.color)
         # create the w_func
-        fqn = self.fqn.join(funcdef.name)
+        fqn = self.ns.join(funcdef.name)
         fqn = self.get_unique_FQN_maybe(fqn)
         # XXX we should capture only the names actually used in the inner func
         closure = self.closure + (self._locals,)
@@ -211,7 +211,7 @@ class AbstractFrame:
         """
         Create a forward-declaration for the given classdef
         """
-        fqn = self.fqn.join(classdef.name)
+        fqn = self.ns.join(classdef.name)
         fqn = self.get_unique_FQN_maybe(fqn)
         pyclass = self.metaclass_for_classdef(classdef)
         w_typedecl = pyclass.declare(fqn)

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -564,7 +564,7 @@ class ASTFrame(AbstractFrame):
             extra = ' (blue)'
         else:
             extra = ''
-        return f'<{cls} for {self.w_func.fqn}{extra}>'
+        return f'<{cls} for `{self.w_func.fqn}`{extra}>'
 
     def run(self, args_w: Sequence[W_Object]) -> W_Object:
         self.declare_arguments()

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -61,22 +61,6 @@ class AbstractFrame:
     def redshifting(self) -> bool:
         return False
 
-    @property
-    def is_module_body(self) -> bool:
-        return self.ns.is_module()
-
-    def get_unique_FQN_maybe(self, fqn: FQN) -> FQN:
-        """
-        Return an unique FQN to use for a type or function.
-
-        If we are executing a module body, we can assume that the FQN is
-        already unique and just return it, else we ask the VM to compute one.
-        """
-        if self.is_module_body:
-            return fqn
-        else:
-            return self.vm.get_unique_FQN(fqn)
-
     def declare_local(self, name: str, w_type: W_Type) -> None:
         assert name not in self.locals_types_w, \
             f'variable already declared: {name}'
@@ -182,7 +166,7 @@ class AbstractFrame:
         w_functype = W_FuncType.new(params, w_restype, color=funcdef.color)
         # create the w_func
         fqn = self.ns.join(funcdef.name)
-        fqn = self.get_unique_FQN_maybe(fqn)
+        fqn = self.vm.get_unique_FQN(fqn)
         # XXX we should capture only the names actually used in the inner func
         closure = self.closure + (self._locals,)
         w_func = W_ASTFunc(w_functype, fqn, funcdef, closure)
@@ -204,7 +188,7 @@ class AbstractFrame:
         Create a forward-declaration for the given classdef
         """
         fqn = self.ns.join(classdef.name)
-        fqn = self.get_unique_FQN_maybe(fqn)
+        fqn = self.vm.get_unique_FQN(fqn)
         pyclass = self.metaclass_for_classdef(classdef)
         w_typedecl = pyclass.declare(fqn)
         w_meta_type = self.vm.dynamic_type(w_typedecl)

--- a/spy/vm/classframe.py
+++ b/spy/vm/classframe.py
@@ -18,10 +18,10 @@ class ClassFrame(AbstractFrame):
     def __init__(self,
                  vm: 'SPyVM',
                  classdef: ast.ClassDef,
-                 fqn: FQN,
+                 ns: FQN,
                  closure: CLOSURE
                  ) -> None:
-        super().__init__(vm, fqn, classdef.symtable, closure)
+        super().__init__(vm, ns, classdef.symtable, closure)
         self.classdef = classdef
 
     def run(self) -> ClassBody:

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -257,7 +257,7 @@ class W_ASTFunc(W_Func):
 
     def raw_call(self, vm: 'SPyVM', args_w: Sequence[W_Object]) -> W_Object:
         from spy.vm.astframe import ASTFrame
-        frame = ASTFrame(vm, self)
+        frame = ASTFrame(vm, self, args_w)
         return frame.run(args_w)
 
 

--- a/spy/vm/modframe.py
+++ b/spy/vm/modframe.py
@@ -33,10 +33,10 @@ class ModFrame(AbstractFrame):
 
     def __repr__(self):
         cls = self.__class__.__name__
-        return f'<{cls} for `{self.fqn}`>'
+        return f'<{cls} for `{self.ns}`>'
 
     def run(self) -> W_Module:
-        w_mod = W_Module(self.vm, self.fqn.modname, self.mod.filename)
+        w_mod = W_Module(self.vm, self.ns.modname, self.mod.filename)
         self.vm.register_module(w_mod)
 
         # forward declaration of types
@@ -68,7 +68,7 @@ class ModFrame(AbstractFrame):
     def gen_GlobalVarDef(self, decl: ast.GlobalVarDef) -> None:
         vardef = decl.vardef
         assign = decl.assign
-        fqn = self.fqn.join(vardef.name)
+        fqn = self.ns.join(vardef.name)
 
         # evaluate the vardef in the current frame
         if not isinstance(vardef.type, ast.Auto):

--- a/spy/vm/modframe.py
+++ b/spy/vm/modframe.py
@@ -31,6 +31,10 @@ class ModFrame(AbstractFrame):
         super().__init__(vm, fqn, symtable, closure=())
         self.mod = mod
 
+    def __repr__(self):
+        cls = self.__class__.__name__
+        return f'<{cls} for `{self.fqn}`>'
+
     def run(self) -> W_Module:
         w_mod = W_Module(self.vm, self.fqn.modname, self.mod.filename)
         self.vm.register_module(w_mod)

--- a/spy/vm/modframe.py
+++ b/spy/vm/modframe.py
@@ -31,7 +31,7 @@ class ModFrame(AbstractFrame):
         super().__init__(vm, ns, symtable, closure=())
         self.mod = mod
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         cls = self.__class__.__name__
         return f'<{cls} for `{self.ns}`>'
 

--- a/spy/vm/modframe.py
+++ b/spy/vm/modframe.py
@@ -24,11 +24,11 @@ class ModFrame(AbstractFrame):
 
     def __init__(self,
                  vm: SPyVM,
-                 fqn: FQN,
+                 ns: FQN,
                  symtable: SymTable,
                  mod: ast.Module,
                  ) -> None:
-        super().__init__(vm, fqn, symtable, closure=())
+        super().__init__(vm, ns, symtable, closure=())
         self.mod = mod
 
     def __repr__(self):

--- a/spy/vm/modframe.py
+++ b/spy/vm/modframe.py
@@ -60,7 +60,10 @@ class ModFrame(AbstractFrame):
         w_init = w_mod.getattr_maybe('__INIT__')
         if w_init is not None:
             assert isinstance(w_init, W_ASTFunc)
-            assert w_init.color == "blue"
+            if w_init.color != "blue":
+                err = SPyTypeError("the __INIT__ function must be @blue")
+                err.add("error", "function defined here", w_init.def_loc)
+                raise err
             self.vm.fast_call(w_init, [w_mod])
         #
         return w_mod

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -136,7 +136,7 @@ class SPyVM:
         # XXX this is potentially quadratic if we create tons of
         # conflicting FQNs, but for now we don't care
         for n in itertools.count():
-            fqn2 = fqn.with_suffix(str(n))
+            fqn2 = fqn.with_suffix(n)
             if fqn2 not in self.globals_w:
                 return fqn2
         assert False, 'unreachable'


### PR DESCRIPTION
This is easier to explain with an example than with many words:
```python
        @blue
        def add(T):
            def impl(x: T, y: T) -> T:
                return x + y
            return impl

        def foo() -> void:
            x = add(i32)(1, 2)
            y = add(str)("a", "b")
```

Before this PR, it generated `namespace::add::impl` and `namespace::add::impl#1`.
Now it generates `namespace::add[i32]::impl` and `namespace::add[str]::impl`.