### PR TITLE
Improve the applevel interface of OpArg and OpImpl

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ include = ["spy*"]
 
 [tool.pytest.ini_options]
 addopts = "--dist-dir=pyodide/node_modules/pyodide"
+asyncio_mode = "strict"
+asyncio_default_fixture_loop_scope = "function"
 
 markers = [
     # compiler_backend

--- a/spy/tests/compiler/test_opimpl.py
+++ b/spy/tests/compiler/test_opimpl.py
@@ -43,6 +43,7 @@ class TestOpImpl(CompilerTest):
         w_opimpl = mod.foo(unwrap=False)
         assert isinstance(w_opimpl, W_OpImpl)
         assert not w_opimpl.is_simple()
+        assert w_opimpl._args_wop is not None
         assert len(w_opimpl._args_wop) == 1
 
         # Check the OpArg stored in the arguments list
@@ -51,6 +52,7 @@ class TestOpImpl(CompilerTest):
         assert wop.color == 'blue'
         assert wop.w_static_type is B.w_i32
         assert wop.is_blue()
+        assert wop._w_val is not None
         assert self.vm.unwrap_i32(wop._w_val) == 42
 
     def test_new_OpArg(self):

--- a/spy/tests/compiler/test_opimpl.py
+++ b/spy/tests/compiler/test_opimpl.py
@@ -2,13 +2,14 @@
 
 import pytest
 from spy.libspy import SPyPanicError
+from spy.vm.b import B
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.tests.support import CompilerTest, skip_backends, only_interp
 
 @only_interp
 class TestOpImpl(CompilerTest):
 
-    def test_simple(self):
+    def test_new_OpImpl(self):
         mod = self.compile(
         """
         from operator import OpImpl
@@ -24,3 +25,31 @@ class TestOpImpl(CompilerTest):
         assert isinstance(w_opimpl, W_OpImpl)
         assert w_opimpl._w_func is mod.bar.w_func
         assert w_opimpl.is_simple()
+
+    def test_new_OpArg(self):
+        mod = self.compile(
+        """
+        from operator import OpArg
+
+        @blue
+        def create_blue_oparg(x: i32) -> OpArg:
+            return OpArg('blue', i32, x)
+
+        @blue
+        def create_red_oparg() -> OpArg:
+            return OpArg('red', i32, None)
+        """)
+
+        # Test blue OpArg creation
+        w_blue_oparg = mod.create_blue_oparg(42, unwrap=False)
+        assert isinstance(w_blue_oparg, W_OpArg)
+        assert w_blue_oparg.color == 'blue'
+        assert w_blue_oparg.w_static_type is B.w_i32
+        assert w_blue_oparg._w_val is not None
+
+        # Test red OpArg creation
+        w_red_oparg = mod.create_red_oparg(unwrap=False)
+        assert isinstance(w_red_oparg, W_OpArg)
+        assert w_red_oparg.color == 'red'
+        assert w_red_oparg.w_static_type is B.w_i32
+        assert w_red_oparg._w_val is None

--- a/spy/tests/compiler/test_opimpl.py
+++ b/spy/tests/compiler/test_opimpl.py
@@ -80,16 +80,18 @@ class TestOpImpl(CompilerTest):
         assert w_red_oparg.color == 'red'
         assert w_red_oparg.w_static_type is B.w_i32
         assert w_red_oparg._w_val is None
-        
+
     def test_oparg_properties(self):
         mod = self.compile(
         """
         from operator import OpArg
-        
-        def test_properties() -> tuple:
+
+        def foo() -> tuple:
             arg = OpArg('blue', i32, 42)
-            return (arg.color, arg.blueval)
+            return (arg.color, arg.static_type, arg.blueval)
         """)
-        color, blueval = mod.test_properties()
-        assert color == "blue"
-        assert blueval == 42
+        w_tup = mod.foo(unwrap=False)
+        w_color, w_type, w_blueval = w_tup.items_w
+        assert self.vm.unwrap_str(w_color) == 'blue'
+        assert w_type is B.w_i32
+        assert self.vm.unwrap_i32(w_blueval) == 42

--- a/spy/tests/compiler/test_opimpl.py
+++ b/spy/tests/compiler/test_opimpl.py
@@ -26,6 +26,33 @@ class TestOpImpl(CompilerTest):
         assert w_opimpl._w_func is mod.bar.w_func
         assert w_opimpl.is_simple()
 
+    def test_OpImpl_with_args(self):
+        mod = self.compile(
+        """
+        from operator import OpImpl, OpArg
+
+        def bar(x: i32) -> i32:
+            return x * 2
+
+        @blue
+        def foo() -> OpImpl:
+            # Create an OpImpl with an argument list
+            arg = OpArg('blue', i32, 42)
+            return OpImpl(bar, [arg])
+        """)
+        w_opimpl = mod.foo(unwrap=False)
+        assert isinstance(w_opimpl, W_OpImpl)
+        assert not w_opimpl.is_simple()
+        assert len(w_opimpl._args_wop) == 1
+
+        # Check the OpArg stored in the arguments list
+        wop = w_opimpl._args_wop[0]
+        assert isinstance(wop, W_OpArg)
+        assert wop.color == 'blue'
+        assert wop.w_static_type is B.w_i32
+        assert wop.is_blue()
+        assert self.vm.unwrap_i32(wop._w_val) == 42
+
     def test_new_OpArg(self):
         mod = self.compile(
         """

--- a/spy/tests/compiler/test_opimpl.py
+++ b/spy/tests/compiler/test_opimpl.py
@@ -95,3 +95,15 @@ class TestOpImpl(CompilerTest):
         assert self.vm.unwrap_str(w_color) == 'blue'
         assert w_type is B.w_i32
         assert self.vm.unwrap_i32(w_blueval) == 42
+
+    def test_opimpl_null(self):
+        mod = self.compile(
+        """
+        from operator import OpImpl
+
+        @blue
+        def get_null() -> OpImpl:
+            return OpImpl.NULL
+        """)
+        w_null = mod.get_null(unwrap=False)
+        assert w_null is W_OpImpl.NULL

--- a/spy/tests/compiler/test_opimpl.py
+++ b/spy/tests/compiler/test_opimpl.py
@@ -80,3 +80,16 @@ class TestOpImpl(CompilerTest):
         assert w_red_oparg.color == 'red'
         assert w_red_oparg.w_static_type is B.w_i32
         assert w_red_oparg._w_val is None
+        
+    def test_oparg_properties(self):
+        mod = self.compile(
+        """
+        from operator import OpArg
+        
+        def test_properties() -> tuple:
+            arg = OpArg('blue', i32, 42)
+            return (arg.color, arg.blueval)
+        """)
+        color, blueval = mod.test_properties()
+        assert color == "blue"
+        assert blueval == 42

--- a/spy/tests/compiler/test_opimpl.py
+++ b/spy/tests/compiler/test_opimpl.py
@@ -1,0 +1,26 @@
+#-*- encoding: utf-8 -*-
+
+import pytest
+from spy.libspy import SPyPanicError
+from spy.vm.opimpl import W_OpImpl, W_OpArg
+from spy.tests.support import CompilerTest, skip_backends, only_interp
+
+@only_interp
+class TestOpImpl(CompilerTest):
+
+    def test_simple(self):
+        mod = self.compile(
+        """
+        from operator import OpImpl
+
+        def bar() -> void:
+            pass
+
+        @blue
+        def foo() -> OpImpl:
+            return OpImpl(bar)
+        """)
+        w_opimpl = mod.foo(unwrap=False)
+        assert isinstance(w_opimpl, W_OpImpl)
+        assert w_opimpl._w_func is mod.bar.w_func
+        assert w_opimpl.is_simple()

--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -146,7 +146,7 @@ def builtin_type(namespace: FQN|str,
         namespace = FQN(namespace)
     fqn = namespace.join(typename, qualifiers)
     def decorator(pyclass: Type[W_Object]) -> Type[W_Object]:
-        W_MetaClass = make_metaclass_maybe(fqn, pyclass)
+        W_MetaClass = make_metaclass_maybe(fqn, pyclass, lazy_definition)
         w_type = W_MetaClass.declare(fqn)
         if not lazy_definition:
             w_type.define(pyclass)

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -178,9 +178,9 @@ class W_List(W_BaseList, Generic[T]):
 # The following commented-out code makes an interp-level type W_OpArgList
 # which corresponds to the interp-level type `list[OpArg]`.
 
-## w_oparglist_type = _make_list_type(OP.w_OpArg)
-## PREBUILT_LIST_TYPES[OP.w_OpArg] = w_oparglist_type
+w_oparglist_type = _make_list_type(OP.w_OpArg)
+PREBUILT_LIST_TYPES[OP.w_OpArg] = w_oparglist_type
 
-## W_OpArgList = Annotated[W_List[W_OpArg], w_oparglist_type]
-## def make_oparg_list(args_wop: list[W_OpArg]) -> W_OpArgList:
-##    return W_List(w_oparglist_type, args_wop)  # type: ignore
+W_OpArgList = Annotated[W_List[W_OpArg], w_oparglist_type]
+def make_oparg_list(args_wop: list[W_OpArg]) -> W_OpArgList:
+   return W_List(w_oparglist_type, args_wop)  # type: ignore

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -435,7 +435,9 @@ class W_Type(W_Object):
         w_NEW = w_type.dict_w.get('__NEW__')
         if w_NEW is not None:
             assert isinstance(w_NEW, W_Func), 'XXX raise proper exception'
-            return vm.fast_call(w_NEW, [wop_t] + list(args_wop))
+            w_res = vm.fast_call(w_NEW, [wop_t] + list(args_wop))
+            assert isinstance(w_res, W_OpImpl)
+            return w_res
 
         # else, fall back to __new__
         w_new = w_type.dict_w.get('__new__')

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -305,6 +305,26 @@ class W_OpImpl(W_Object):
 
     # ======== app-level interface ========
 
+    @builtin_method('__meta_GETATTR__', color='blue')
+    @staticmethod
+    def w_meta_GETATTR(vm: 'SPyVM', wop_cls: W_OpArg, wop_attr: W_OpArg) -> 'W_OpImpl':
+        """
+        Handle class attribute lookups on OpImpl, like OpImpl.NULL
+        """
+        from spy.vm.str import W_Str
+
+        attr_name = wop_attr.blue_unwrap_str(vm)
+
+        if attr_name == 'NULL':
+            # Return the NULL instance directly
+            @builtin_func(W_OpImpl._w.fqn, 'get_null')
+            def w_get_null(vm: 'SPyVM', w_cls: W_Type) -> W_OpImpl:
+                return W_OpImpl.NULL
+
+            return W_OpImpl(w_get_null, [wop_cls])
+
+        return W_OpImpl.NULL
+
     @builtin_method('__NEW__', color='blue')
     @staticmethod
     def w_NEW(vm: 'SPyVM', wop_cls: W_OpArg, *args_wop: W_OpArg) -> 'W_OpImpl':

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -34,7 +34,7 @@ from spy.vm.b import OPERATOR, B
 from spy.vm.object import Member, W_Type, W_Object, builtin_method
 from spy.vm.function import W_Func, W_FuncType
 from spy.vm.builtin import builtin_func, builtin_type
-from spy.vm.primitive import W_Bool
+from spy.vm.primitive import W_Bool, W_Dynamic
 
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -211,6 +211,35 @@ class W_OpArg(W_Object):
         else:
             return W_OpImpl.NULL
 
+    @builtin_method('__GET_color__', color='blue')
+    @staticmethod
+    def w_GET_color(vm: 'SPyVM', wop_x: 'W_OpArg',
+                    wop_attr: 'W_OpArg') -> 'W_OpImpl':
+        from spy.vm.builtin import builtin_func
+        from spy.vm.str import W_Str
+
+        @builtin_func(W_OpArg._w.fqn, 'get_color')
+        def w_get_color(vm: 'SPyVM', w_oparg: W_OpArg) -> W_Str:
+            return vm.wrap(w_oparg.color)
+
+        return W_OpImpl(w_get_color, [wop_x])
+
+    @builtin_method('__GET_blueval__', color='blue')
+    @staticmethod
+    def w_GET_blueval(vm: 'SPyVM', wop_x: 'W_OpArg',
+                      wop_attr: 'W_OpArg') -> 'W_OpImpl':
+        from spy.vm.builtin import builtin_func
+        from spy.vm.primitive import W_Dynamic
+
+        @builtin_func(W_OpArg._w.fqn, 'get_blueval')
+        def w_get_blueval(vm: 'SPyVM', w_oparg: W_OpArg) -> W_Dynamic:
+            if w_oparg.color != 'blue':
+                raise SPyRuntimeError('oparg is not blue')
+            return w_oparg.w_blueval
+
+        return W_OpImpl(w_get_blueval, [wop_x])
+
+
 
 @no_type_check
 @builtin_func('operator')
@@ -289,7 +318,7 @@ class W_OpImpl(W_Object):
 
         w_type = wop_cls.w_blueval
         assert isinstance(w_type, W_Type)
-        
+
         if len(args_wop) == 1:
             # Simple case: OpImpl(func)
             @builtin_func(w_type.fqn, 'new1')
@@ -308,11 +337,6 @@ class W_OpImpl(W_Object):
             return W_OpImpl(w_new2)
         else:
             return W_OpImpl.NULL
-
-    ## @builtin_method('__new__')
-    ## @staticmethod
-    ## def w_spy_new(vm: 'SPyVM', w_cls: W_Type, w_func: W_Func) -> 'W_OpImpl':
-    ##     return W_OpImpl(w_func)
 
 
 W_OpImpl.NULL = W_OpImpl(None)  # type: ignore

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -287,16 +287,19 @@ class W_OpImpl(W_Object):
         from spy.vm.function import W_Func
         from spy.vm.list import W_OpArgList
 
+        w_type = wop_cls.w_blueval
+        assert isinstance(w_type, W_Type)
+        
         if len(args_wop) == 1:
             # Simple case: OpImpl(func)
-            @builtin_func('operator')
+            @builtin_func(w_type.fqn, 'new1')
             def w_new1(vm: 'SPyVM', w_cls: W_Type, w_func: W_Func) -> W_OpImpl:
                 return W_OpImpl(w_func)
             return W_OpImpl(w_new1)
 
         elif len(args_wop) == 2:
             # OpImpl(func, args) case
-            @builtin_func('operator')
+            @builtin_func(w_type.fqn, 'new2')
             def w_new2(vm: 'SPyVM', w_cls: W_Type,
                        w_func: W_Func, w_args: W_OpArgList) -> W_OpImpl:
                 # Convert from applevel w_args into interp-level args_w

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -276,10 +276,40 @@ class W_OpImpl(W_Object):
 
     # ======== app-level interface ========
 
-    @builtin_method('__new__')
+    @builtin_method('__NEW__', color='blue')
     @staticmethod
-    def w_spy_new(vm: 'SPyVM', w_cls: W_Type, w_func: W_Func) -> 'W_OpImpl':
-        return W_OpImpl(w_func)
+    def w_NEW(vm: 'SPyVM', wop_cls: W_OpArg, *args_wop: W_OpArg) -> 'W_OpImpl':
+        """
+        Operator for creating OpImpl instances with different argument counts.
+        - OpImpl(func) -> Simple OpImpl
+        - OpImpl(func, args) -> OpImpl with pre-filled arguments
+        """
+        from spy.vm.function import W_Func
+        from spy.vm.list import W_OpArgList
+
+        if len(args_wop) == 1:
+            # Simple case: OpImpl(func)
+            @builtin_func('operator')
+            def w_new1(vm: 'SPyVM', w_cls: W_Type, w_func: W_Func) -> W_OpImpl:
+                return W_OpImpl(w_func)
+            return W_OpImpl(w_new1)
+
+        elif len(args_wop) == 2:
+            # OpImpl(func, args) case
+            @builtin_func('operator')
+            def w_new2(vm: 'SPyVM', w_cls: W_Type,
+                       w_func: W_Func, w_args: W_OpArgList) -> W_OpImpl:
+                # Convert from applevel w_args into interp-level args_w
+                args_w = w_args.items_w[:]
+                return W_OpImpl(w_func, args_w)
+            return W_OpImpl(w_new2)
+        else:
+            return W_OpImpl.NULL
+
+    ## @builtin_method('__new__')
+    ## @staticmethod
+    ## def w_spy_new(vm: 'SPyVM', w_cls: W_Type, w_func: W_Func) -> 'W_OpImpl':
+    ##     return W_OpImpl(w_func)
 
 
 W_OpImpl.NULL = W_OpImpl(None)  # type: ignore

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -36,6 +36,10 @@ W_OpImpl._w.define(W_OpImpl)
 W_OpArg._w.define(W_OpArg)
 W_FuncType._w.define(W_FuncType)
 
+# W_OpImpl has w_meta_GETATTR, which means it creates a lazily-defined
+# metaclass. Initialize it as well
+W_OpImplType = type(W_OpImpl._w)
+W_OpImplType._w.define(W_OpImplType)
 
 class SPyVM:
     """


### PR DESCRIPTION
Highlights:

  - introduce support for the `__NEW__` operator
  - use `OpImpl.__NEW__` to support ctor overloading
  - make it possible to instantiate `OpArg`
  - add `OpArg.color` and `OpArg.blueval`

Co-Authored-By: Claude <noreply@anthropic.com>