### PR TITLE
Use a simpler signature for applevel __new__

### DIFF
--- a/examples/array.spy
+++ b/examples/array.spy
@@ -13,7 +13,7 @@ def ndarray1(DTYPE):
     class ndarray:
         __ll__: ptr[ArrayData]
 
-        def __new__(cls: type, length: i32) -> ndarray:
+        def __new__(length: i32) -> ndarray:
             data = gc_alloc(ArrayData)(1)
             data.length = length
             data.items = gc_alloc(DTYPE)(length)

--- a/spy/tests/compiler/test_operator.py
+++ b/spy/tests/compiler/test_operator.py
@@ -60,7 +60,7 @@ class TestOp(CompilerTest):
 
             @builtin_method('__new__')
             @staticmethod
-            def w_spy_new(vm: 'SPyVM', w_cls: W_Type) -> 'W_MyClass':
+            def w_spy_new(vm: 'SPyVM') -> 'W_MyClass':
                 return W_MyClass()
 
             @builtin_method('__GETITEM__', color='blue')
@@ -97,7 +97,7 @@ class TestOp(CompilerTest):
 
             @builtin_method('__new__')
             @staticmethod
-            def w_spy_new(vm: 'SPyVM', w_cls: W_Type) -> 'W_MyClass':
+            def w_spy_new(vm: 'SPyVM') -> 'W_MyClass':
                 return W_MyClass()
 
             @builtin_method('__GETITEM__', color='blue')
@@ -135,7 +135,7 @@ class TestOp(CompilerTest):
 
             @builtin_method('__new__')
             @staticmethod
-            def w_spy_new(vm: 'SPyVM', w_cls: W_Type, w_x: W_I32) -> 'W_MyClass':
+            def w_spy_new(vm: 'SPyVM', w_x: W_I32) -> 'W_MyClass':
                 return W_MyClass(w_x)
 
             @builtin_method('__GETITEM__', color='blue')

--- a/spy/tests/compiler/test_operator_attr.py
+++ b/spy/tests/compiler/test_operator_attr.py
@@ -27,7 +27,7 @@ class TestAttrOp(CompilerTest):
 
             @builtin_method('__new__')
             @staticmethod
-            def w_spy_new(vm: 'SPyVM', w_cls: W_Type) -> 'W_MyClass':
+            def w_spy_new(vm: 'SPyVM') -> 'W_MyClass':
                 return W_MyClass()
         # ========== /EXT module for this test =========
         self.vm.make_module(EXT)
@@ -53,7 +53,7 @@ class TestAttrOp(CompilerTest):
 
             @builtin_method('__new__')
             @staticmethod
-            def w_spy_new(vm: 'SPyVM', w_cls: W_Type) -> 'W_MyClass':
+            def w_spy_new(vm: 'SPyVM') -> 'W_MyClass':
                 return W_MyClass()
 
             @builtin_method('__GET_x__', color='blue')
@@ -91,7 +91,7 @@ class TestAttrOp(CompilerTest):
 
             @builtin_method('__new__')
             @staticmethod
-            def w_spy_new(vm: 'SPyVM', w_cls: W_Type) -> 'W_MyClass':
+            def w_spy_new(vm: 'SPyVM') -> 'W_MyClass':
                 return W_MyClass()
 
             @builtin_method('__GETATTR__', color='blue')

--- a/spy/tests/compiler/test_operator_call.py
+++ b/spy/tests/compiler/test_operator_call.py
@@ -46,7 +46,7 @@ class TestCallOp(CompilerTest):
 
             @builtin_method('__new__')
             @staticmethod
-            def w_spy_new(vm: 'SPyVM', w_cls: W_Type, w_x: W_I32) -> 'W_Adder':
+            def w_spy_new(vm: 'SPyVM', w_x: W_I32) -> 'W_Adder':
                 return W_Adder(vm.unwrap_i32(w_x))
 
             @builtin_method('__CALL__', color='blue')
@@ -121,8 +121,7 @@ class TestCallOp(CompilerTest):
 
             @builtin_method('__new__')
             @staticmethod
-            def w_spy_new(vm: 'SPyVM', w_cls: W_Type,
-                        w_x: W_I32, w_y: W_I32) -> 'W_Point':
+            def w_spy_new(vm: 'SPyVM', w_x: W_I32, w_y: W_I32) -> 'W_Point':
                 return W_Point(w_x, w_y)
         # ========== /EXT module for this test =========
         self.vm.make_module(EXT)
@@ -206,7 +205,7 @@ class TestCallOp(CompilerTest):
 
             @builtin_method('__new__')
             @staticmethod
-            def w_spy_new(vm: 'SPyVM', w_cls: W_Type, w_x: W_I32) -> 'W_Calc':
+            def w_spy_new(vm: 'SPyVM', w_x: W_I32) -> 'W_Calc':
                 return W_Calc(vm.unwrap_i32(w_x))
 
             @builtin_method('__CALL_METHOD__', color='blue')

--- a/spy/tests/conftest.py
+++ b/spy/tests/conftest.py
@@ -9,29 +9,27 @@ from pytest_pyodide import get_global_config
 ROOT = py.path.local(__file__).dirpath()
 HAVE_EMCC = shutil.which("emcc") is not None
 
+@pytest.hookimpl(hookwrapper=True)
 def pytest_collection_modifyitems(session, config, items):
     """
     Reorder the test to have a "better" order. In particular:
 
       - test_zz_mypy.py is always the last, after the subdirectories
       - test_backend_spy.py must run after compiler/*
-      - compiler/*.py comes after everythig else (apart mypy)
-
-    The reasoning is that compiler/*.py tests are integration tests and it
-    makes sense to run them after the unit tests. And mypy should be last
-    because we are not interested in type errors if there are failures.
 
     The reason for why test_backend_spy must be run after compiler/* is
     explained in test_zz_sanity_check in that file.
     """
+    # run all other plugins first (in particular, pyest_slow_last)
+    # https://github.com/david26694/pytest-slow-last
+    yield
+
     def key(item):
         filename = item.fspath.relto(ROOT)
         if filename == 'test_zz_mypy.py':
             return 100 # last
         elif filename == 'test_backend_spy.py':
             return 99  # second to last
-        elif filename.startswith('compiler/'):
-            return 98  # third to last
         else:
             return 0   # don't touch
 

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -443,7 +443,7 @@ class W_Type(W_Object):
         w_new = w_type.dict_w.get('__new__')
         if w_new is not None:
             assert isinstance(w_new, W_Func), 'XXX raise proper exception'
-            return W_OpImpl(w_new)
+            return W_OpImpl(w_new, list(args_wop))
 
         # no __NEW__ nor __new__, error out
         clsname = w_type.fqn.human_name

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -104,9 +104,12 @@ class W_OpArg(W_Object):
 
     @builtin_method('__new__')
     @staticmethod
-    def w_spy_new(vm: 'SPyVM', w_cls: W_Type,
-                 w_color: W_Object, w_static_type: W_Type,
-                 w_val: W_Object) -> 'W_OpArg':
+    def w_spy_new(
+            vm: 'SPyVM',
+            w_color: W_Object,
+            w_static_type: W_Type,
+            w_val: W_Object
+    ) -> 'W_OpArg':
         """
         Create a new OpArg from SPy code:
         - color: 'red' or 'blue'


### PR DESCRIPTION
This is a slight departure from Python's semantics: by default, `__new__` doesn't get the class.
This makes a lot of sense after translation, because most of the time the class is not needed.
If a type really wants to do dynamic dispatch depending of the type, it should override `__NEW__`