### PR TITLE
Add support for a very basic version of the raise statement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,15 @@
 # SPy Language - Dev Reference
 
+## General behavior of claude code
+- NEVER run tests automatically unless explicitly asked
+- when asked to write a test, write just the test without trying to fix it
+- avoid writing useless comments: if you need to write a comment, explain WHY
+  the code does something instead of WHAT it does
+
+
+
 ## Common Commands
+- When running tests, always use the venv: e.g. `./venv/bin/pytest'
 - Run all tests: `pytest`
 - Run single test: `pytest spy/tests/path/to/test_file.py::TestClass::test_function`
 - Run backend-specific tests: `pytest -m interp` or `-m C` or `-m doppler`

--- a/examples/array.spy
+++ b/examples/array.spy
@@ -30,8 +30,7 @@ def ndarray1(DTYPE):
             def getitem(arr: ndarray, i: i32) -> DTYPE:
                 ll = arr.__ll__
                 if i >= ll.length:
-                    print('IndexError')
-                    # raise...
+                    raise IndexError
                 return ll.items[i]
 
             return OpImpl(getitem)

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -516,6 +516,10 @@ class While(Stmt):
     test: Expr
     body: list[Stmt]
 
+@dataclass(eq=False)
+class Raise(Stmt):
+    exc: Expr
+
 
 # ====== Doppler-specific nodes ======
 #

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -10,7 +10,6 @@ from spy.vm.module import W_Module
 from spy.vm.function import W_ASTFunc, W_BuiltinFunc, W_FuncType, W_Func
 from spy.vm.vm import SPyVM
 from spy.vm.b import B
-from spy.vm.modules.builtins import W_Exception
 from spy.vm.modules.types import TYPES, W_LiftedType
 from spy.vm.modules.unsafe.ptr import W_PtrType, W_Ptr
 from spy.vm.modules.unsafe.struct import W_StructType

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -418,18 +418,6 @@ class CFuncWriter:
                 self.emit_stmt(stmt)
         self.tbc.wl('}')
 
-    def emit_stmt_Raise(self, raise_node: ast.Raise) -> None:
-        # for now, "raise" is always translated into a panic. Also, for now we
-        # can raise only blue/constant exceptions.
-        exc = raise_node.exc
-        assert isinstance(exc, ast.FQNConst)
-        w_exc = self.ctx.vm.lookup_global(exc.fqn)
-        assert isinstance(w_exc, W_Exception)
-        msg = w_exc.applevel_str(self.ctx.vm)
-        # use c_ast.Literal so that it takes case of escaping
-        c_msg = C.Literal.from_bytes(msg.encode('utf-8'))
-        self.tbc.wl(f'spy_panic({c_msg});')
-
     # ===== expressions =====
 
     def fmt_expr_Constant(self, const: ast.Constant) -> C.Expr:

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -6,7 +6,6 @@ from spy.vm.vm import SPyVM
 from spy.vm.object import W_Object, W_Type
 from spy.vm.function import W_ASTFunc, FuncParam
 from spy.vm.list import W_List
-from spy.vm.modules.builtins import W_Exception
 from spy.irgen.scope import SymTable
 from spy.util import magic_dispatch
 from spy.textbuilder import TextBuilder
@@ -224,15 +223,6 @@ class SPyBackend:
         return repr(const.value)
 
     def fmt_expr_FQNConst(self, const: ast.FQNConst) -> str:
-        # hack hack hack: in case of prebuilt exceptions, let's emit a more
-        # readable form. This is needed because for now raise supports only
-        # blue exceptions, and so all of them are turned into FQNConst.
-        if str(const.fqn).startswith("builtins::Exception::prebuilt"):
-            w_exc = self.vm.lookup_global(const.fqn)
-            assert isinstance(w_exc, W_Exception)
-            t = self.vm.dynamic_type(w_exc).fqn.symbol_name # e.g. 'Exception'
-            m = self.vm.unwrap_str(w_exc.w_message)
-            return f'{t}({m!r})'
         return self.fmt_fqn(const.fqn)
 
     def fmt_expr_Name(self, name: ast.Name) -> str:

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -163,14 +163,11 @@ class DopplerFrame(ASTFrame):
         )]
 
     def shift_stmt_Raise(self, raise_node: ast.Raise) -> list[ast.Stmt]:
-        new_exc = self.eval_and_shift(raise_node.exc)
-        if not isinstance(new_exc, ast.FQNConst):
-            # if you modify this code, you should also modify the equivalent
-            # one in astframe.py
-            err = SPyTypeError("`raise` only accepts blue values for now")
-            err.add('error', 'this is red', raise_node.exc.loc)
-            raise err
-        return [raise_node.replace(exc=new_exc)]
+        self.exec_stmt(raise_node)
+        w_opimpl = self.opimpl[raise_node]
+        v_exc = self.shifted_expr[raise_node.exc]
+        call = self.shift_opimpl(raise_node, w_opimpl, [v_exc])
+        return [ast.StmtExpr(raise_node.loc, call)]
 
     # ==== expressions ====
 

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -164,7 +164,12 @@ class DopplerFrame(ASTFrame):
 
     def shift_stmt_Raise(self, raise_node: ast.Raise) -> list[ast.Stmt]:
         new_exc = self.eval_and_shift(raise_node.exc)
-        assert isinstance(new_exc, ast.FQNConst) # XXX raise proper exception
+        if not isinstance(new_exc, ast.FQNConst):
+            # if you modify this code, you should also modify the equivalent
+            # one in astframe.py
+            err = SPyTypeError("`raise` only accepts blue values for now")
+            err.add('error', 'this is red', raise_node.exc.loc)
+            raise err
         return [raise_node.replace(exc=new_exc)]
 
     # ==== expressions ====

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -162,6 +162,10 @@ class DopplerFrame(ASTFrame):
             body = newbody
         )]
 
+    def shift_stmt_Raise(self, raise_node: ast.Raise) -> list[ast.Stmt]:
+        new_exc = self.eval_and_shift(raise_node.exc)
+        return [raise_node.replace(exc=new_exc)]
+
     # ==== expressions ====
 
     def eval_and_shift(self, expr: ast.Expr,

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -164,6 +164,7 @@ class DopplerFrame(ASTFrame):
 
     def shift_stmt_Raise(self, raise_node: ast.Raise) -> list[ast.Stmt]:
         new_exc = self.eval_and_shift(raise_node.exc)
+        assert isinstance(new_exc, ast.FQNConst) # XXX raise proper exception
         return [raise_node.replace(exc=new_exc)]
 
     # ==== expressions ====

--- a/spy/errors.py
+++ b/spy/errors.py
@@ -1,4 +1,4 @@
-from typing import Optional, Literal
+from typing import Optional, Literal, ClassVar
 from dataclasses import dataclass
 import linecache
 from spy.location import Loc
@@ -69,7 +69,7 @@ class ErrorFormatter:
 
 
 class SPyError(Exception):
-    LEVEL = 'error'
+    LEVEL: ClassVar[Level] = 'error'
 
     message: str
     annotations: list[Annotation]
@@ -142,5 +142,6 @@ class SPyPanicError(SPyError):
         super().__init__(message)
         self.filename = fname
         self.lineno = lineno
-        loc = Loc(fname, lineno, lineno, 1, -1)
-        self.add('panic', '', loc)
+        if fname is not None:
+            loc = Loc(fname, lineno, lineno, 1, -1)
+            self.add('panic', '', loc)

--- a/spy/errors.py
+++ b/spy/errors.py
@@ -138,7 +138,7 @@ class SPyPanicError(SPyError):
     """
     LEVEL = 'panic'
 
-    def __init__(self, message: str, fname: Optional[str], lineno: int) -> None:
+    def __init__(self, message: str, fname: str, lineno: int) -> None:
         super().__init__(message)
         self.filename = fname
         self.lineno = lineno

--- a/spy/errors.py
+++ b/spy/errors.py
@@ -3,9 +3,8 @@ from dataclasses import dataclass
 import linecache
 from spy.location import Loc
 from spy.textbuilder import ColorFormatter
-from spy.libspy import SPyPanicError
 
-Level = Literal["error", "note"]
+Level = Literal["error", "note", "panic"]
 
 def maybe_plural(n: int, singular: str, plural: Optional[str] = None) -> str:
     if n == 1:
@@ -32,6 +31,7 @@ class ErrorFormatter:
         # add "custom colors" to ColorFormatter, so that we can do
         # self.color.set('error', 'hello')
         self.color.error = self.color.red  # type: ignore
+        self.color.panic = self.color.red  # type: ignore
         self.color.note = self.color.green # type: ignore
         self.lines = []
 
@@ -69,6 +69,8 @@ class ErrorFormatter:
 
 
 class SPyError(Exception):
+    LEVEL = 'error'
+
     message: str
     annotations: list[Annotation]
 
@@ -91,7 +93,7 @@ class SPyError(Exception):
 
     def format(self, use_colors: bool = True) -> str:
         fmt = ErrorFormatter(self, use_colors)
-        fmt.emit_message('error', self.message)
+        fmt.emit_message(self.LEVEL, self.message)
         for ann in self.annotations:
             fmt.emit_annotation(ann)
         return fmt.build()
@@ -127,3 +129,18 @@ class SPyRuntimeError(Exception):
 
 class SPyRuntimeAbort(SPyRuntimeError):
     pass
+
+
+class SPyPanicError(SPyError):
+    """
+    Python-level exception raised when a WASM module aborts with a call to
+    spy_panic().
+    """
+    LEVEL = 'panic'
+
+    def __init__(self, message: str, fname: Optional[str], lineno: int) -> None:
+        super().__init__(message)
+        self.filename = fname
+        self.lineno = lineno
+        loc = Loc(fname, lineno, lineno, 1, -1)
+        self.add('panic', '', loc)

--- a/spy/libspy/__init__.py
+++ b/spy/libspy/__init__.py
@@ -74,14 +74,11 @@ class LibSPyHost(HostModule):
             lineno: int
     ) -> None:
         # ptr_* are const char*
+        assert ptr_msg != 0
+        assert ptr_fname != 0
         self.panic_message = self._read_str(ptr_msg)
-        if ptr_fname == 0:
-            self.panic_filename = None
-        else:
-            self.panic_filename = self._read_str(ptr_fname)
+        self.panic_filename = self._read_str(ptr_fname)
         self.panic_lineno = lineno
-
-
 
 class LLSPyInstance(LLWasmInstance):
     """
@@ -105,6 +102,7 @@ class LLSPyInstance(LLWasmInstance):
             return super().call(name, *args)
         except WasmTrap:
             if self.libspy.panic_message is not None:
+                assert self.libspy.panic_filename is not None
                 raise SPyPanicError(
                     self.libspy.panic_message,
                     self.libspy.panic_filename,

--- a/spy/libspy/__init__.py
+++ b/spy/libspy/__init__.py
@@ -1,6 +1,7 @@
 import sys
 from typing import Any, Optional
 import spy
+from spy.errors import SPyPanicError
 from spy.llwasm import LLWasmModule, LLWasmInstance, HostModule, WasmTrap
 from spy.platform import IS_BROWSER, IS_NODE, IS_PYODIDE
 #from spy.vm.str import ll_spy_Str_read
@@ -80,15 +81,6 @@ class LibSPyHost(HostModule):
             self.panic_filename = self._read_str(ptr_fname)
         self.panic_lineno = lineno
 
-class SPyPanicError(Exception):
-    """
-    Python-level exception raised when a WASM module aborts with a call to
-    spy_panic().
-    """
-    def __init__(self, message: str, fname: Optional[str], lineno: int) -> None:
-        super().__init__(message)
-        self.filename = fname
-        self.lineno = lineno
 
 
 class LLSPyInstance(LLWasmInstance):

--- a/spy/libspy/include/spy/debug.h
+++ b/spy/libspy/include/spy/debug.h
@@ -21,10 +21,16 @@ void IMP(spy_debug_log)(const char *s);
 void IMP(spy_debug_log_i32)(const char *s, int32_t n);
 void IMP(spy_debug_set_panic_message)(const char *s);
 
+
+#ifdef SPY_TARGET_WASI
 static void inline spy_panic(const char *s) {
     spy_debug_log(s);
     spy_debug_set_panic_message(s);
     __builtin_trap();
 }
+#else
+void spy_panic(const char *s); // defined in debug.c
+#endif
+
 
 #endif /* SPY_DEBUG_H */

--- a/spy/libspy/include/spy/debug.h
+++ b/spy/libspy/include/spy/debug.h
@@ -19,18 +19,26 @@ TODO: ideally, we want TWO different WASI modes:
 
 void IMP(spy_debug_log)(const char *s);
 void IMP(spy_debug_log_i32)(const char *s, int32_t n);
-void IMP(spy_debug_set_panic_message)
-     (const char *s, const char *fname, int32_t lineno);
 
 
 #ifdef SPY_TARGET_WASI
+
+// for WASI/reactor targets, we expect the host to provide
+// spy_debug_set_panic_message
+void IMP(spy_debug_set_panic_message)
+     (const char *s, const char *fname, int32_t lineno);
+
 static void inline spy_panic(const char *s, const char *fname, int32_t lineno) {
     spy_debug_log(s);
     spy_debug_set_panic_message(s, fname, lineno);
     __builtin_trap();
 }
+
 #else
-void spy_panic(const char *s); // defined in debug.c
+
+// for other targets, we define spy_panic in debug.c
+void spy_panic(const char *s, const char *fname, int32_t lineno);
+
 #endif
 
 

--- a/spy/libspy/include/spy/debug.h
+++ b/spy/libspy/include/spy/debug.h
@@ -19,13 +19,14 @@ TODO: ideally, we want TWO different WASI modes:
 
 void IMP(spy_debug_log)(const char *s);
 void IMP(spy_debug_log_i32)(const char *s, int32_t n);
-void IMP(spy_debug_set_panic_message)(const char *s);
+void IMP(spy_debug_set_panic_message)
+     (const char *s, const char *fname, int32_t lineno);
 
 
 #ifdef SPY_TARGET_WASI
-static void inline spy_panic(const char *s) {
+static void inline spy_panic(const char *s, const char *fname, int32_t lineno) {
     spy_debug_log(s);
-    spy_debug_set_panic_message(s);
+    spy_debug_set_panic_message(s, fname, lineno);
     __builtin_trap();
 }
 #else

--- a/spy/libspy/include/spy/operator.h
+++ b/spy/libspy/include/spy/operator.h
@@ -8,8 +8,8 @@ static inline int32_t spy_operator$f64_to_i32(double x) { return x; }
 static inline double spy_operator$i32_to_f64(int32_t x) { return x; }
 static inline bool spy_operator$i32_to_bool(int32_t x) { return x; }
 
-static inline void spy_operator$panic(spy_Str *s) {
-    spy_panic(s->utf8, NULL, 0);
+static inline void spy_operator$panic(spy_Str *m, spy_Str *f, int32_t lineno) {
+    spy_panic(m->utf8, f->utf8, lineno);
 }
 
 #endif /* SPY_OPERATOR_H */

--- a/spy/libspy/include/spy/operator.h
+++ b/spy/libspy/include/spy/operator.h
@@ -9,7 +9,7 @@ static inline double spy_operator$i32_to_f64(int32_t x) { return x; }
 static inline bool spy_operator$i32_to_bool(int32_t x) { return x; }
 
 static inline void spy_operator$panic(spy_Str *s) {
-    spy_panic(s->utf8);
+    spy_panic(s->utf8, NULL, 0);
 }
 
 #endif /* SPY_OPERATOR_H */

--- a/spy/libspy/include/spy/operator.h
+++ b/spy/libspy/include/spy/operator.h
@@ -2,9 +2,14 @@
 #define SPY_OPERATOR_H
 
 #include "spy.h"
+#include "spy/debug.h"
 
 static inline int32_t spy_operator$f64_to_i32(double x) { return x; }
 static inline double spy_operator$i32_to_f64(int32_t x) { return x; }
 static inline bool spy_operator$i32_to_bool(int32_t x) { return x; }
+
+static inline void spy_operator$panic(spy_Str *s) {
+    spy_panic(s->utf8);
+}
 
 #endif /* SPY_OPERATOR_H */

--- a/spy/libspy/include/spy/unsafe.h
+++ b/spy/libspy/include/spy/unsafe.h
@@ -71,7 +71,7 @@ WASM_EXPORT(spy_gc_alloc_mem)(size_t size);
     }                                                            \
     static inline void PTR##$store(PTR p, size_t i, T v) {       \
         if (i >= p.length)                                       \
-            spy_panic("ptr_store ouf of bounds" __FILE__, __LINE__);    \
+            spy_panic("ptr_store ouf of bounds", __FILE__, __LINE__);   \
         p.p[i] = v;                                              \
     }                                                            \
     static inline bool PTR##$eq(PTR p0, PTR p1) {                \

--- a/spy/libspy/include/spy/unsafe.h
+++ b/spy/libspy/include/spy/unsafe.h
@@ -66,12 +66,12 @@ WASM_EXPORT(spy_gc_alloc_mem)(size_t size);
     }                                                            \
     static inline T PTR##$load(PTR p, size_t i) {                \
         if (i >= p.length)                                       \
-            spy_panic("ptr_load out of bounds");                 \
+            spy_panic("ptr_load out of bounds", __FILE__, __LINE__);    \
         return p.p[i];                                           \
     }                                                            \
     static inline void PTR##$store(PTR p, size_t i, T v) {       \
         if (i >= p.length)                                       \
-            spy_panic("ptr_store ouf of bounds");                \
+            spy_panic("ptr_store ouf of bounds" __FILE__, __LINE__);    \
         p.p[i] = v;                                              \
     }                                                            \
     static inline bool PTR##$eq(PTR p0, PTR p1) {                \

--- a/spy/libspy/src/debug.c
+++ b/spy/libspy/src/debug.c
@@ -13,12 +13,11 @@ void spy_debug_log_i32(const char *s, int32_t n) {
     printf("%s %d\n", s, n);
 }
 
-void spy_debug_set_panic_message(const char *s) {
-    printf("PANIC: %s\n", s);
-}
-
-void spy_panic(const char *s) {
-    fprintf(stderr, "%s\n", s);
+void spy_panic(const char *s, const char *fname, int32_t lineno) {
+    if (fname != NULL)
+        fprintf(stderr, "%s at %s:%d\n", s, fname, lineno);
+    else
+        fprintf(stderr, "%s\n", s);
     abort();
 }
 

--- a/spy/libspy/src/debug.c
+++ b/spy/libspy/src/debug.c
@@ -56,28 +56,25 @@ void spy_panic(const char *s, const char *fname, int32_t lineno) {
               |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     */
     fprintf(stderr, "panic: %s\n", s);
+    fprintf(stderr, "   --> %s:%d\n", fname, lineno);
 
-    if (fname != NULL) {
-        fprintf(stderr, "   --> %s:%d\n", fname, lineno);
+    char *line_content = read_line_from_file(fname, lineno);
+    if (line_content != NULL) {
+        fprintf(stderr, "%3d | %s\n", lineno, line_content);
 
-        char *line_content = read_line_from_file(fname, lineno);
-        if (line_content != NULL) {
-            fprintf(stderr, "  %d | %s\n", lineno, line_content);
-
-            /* Print the indicator line with carets */
-            fprintf(stderr, "    | ");
-            int i;
-            for (i = 0; i < strlen(line_content); i++) {
-                fprintf(stderr, "^");
-            }
-            fprintf(stderr, "\n");
-
-            free(line_content);
-        } else {
-            /* Couldn't read the line, just show line number */
-            fprintf(stderr, "  %d | <unable to read source line>\n", lineno);
-            fprintf(stderr, "    | ^\n");
+        /* Print the indicator line with carets */
+        fprintf(stderr, "    | ");
+        int i;
+        for (i = 0; i < strlen(line_content); i++) {
+            fprintf(stderr, "^");
         }
+        fprintf(stderr, "\n");
+
+        free(line_content);
+    } else {
+        /* Couldn't read the line, just show line number */
+        fprintf(stderr, "%3d | <unable to read source line>\n", lineno);
+        fprintf(stderr, "    | ^\n");
     }
 
     abort();

--- a/spy/libspy/src/debug.c
+++ b/spy/libspy/src/debug.c
@@ -1,6 +1,7 @@
 #include "spy.h"
 #include <stdio.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 #if !defined(SPY_TARGET_WASI)
 
@@ -14,6 +15,11 @@ void spy_debug_log_i32(const char *s, int32_t n) {
 
 void spy_debug_set_panic_message(const char *s) {
     printf("PANIC: %s\n", s);
+}
+
+void spy_panic(const char *s) {
+    fprintf(stderr, "%s\n", s);
+    abort();
 }
 
 #endif /* !defined(SPY_TARGET_WASI) */

--- a/spy/libspy/src/debug.c
+++ b/spy/libspy/src/debug.c
@@ -13,11 +13,73 @@ void spy_debug_log_i32(const char *s, int32_t n) {
     printf("%s %d\n", s, n);
 }
 
+/* Helper function to read a specific line from a file */
+static char* read_line_from_file(const char *filename, int line_number) {
+    FILE *file;
+    char *line = NULL;
+    size_t len = 0;
+    ssize_t read;
+    int current_line = 1;
+
+    if (filename == NULL) {
+        return NULL;
+    }
+
+    file = fopen(filename, "r");
+    if (file == NULL) {
+        return NULL;
+    }
+
+    while ((read = getline(&line, &len, file)) != -1) {
+        if (current_line == line_number) {
+            /* Remove trailing newline if present */
+            if (read > 0 && line[read-1] == '\n') {
+                line[read-1] = '\0';
+            }
+            fclose(file);
+            return line;
+        }
+        current_line++;
+    }
+
+    /* Line not found */
+    free(line);
+    fclose(file);
+    return NULL;
+}
+
 void spy_panic(const char *s, const char *fname, int32_t lineno) {
-    if (fname != NULL)
-        fprintf(stderr, "%s at %s:%d\n", s, fname, lineno);
-    else
-        fprintf(stderr, "%s\n", s);
+    /* write the error message to stderr, formatted line this:
+          panic: IndexError: hello
+             --> /tmp/prova.spy:2:2
+            2 |     raise IndexError("hello")
+              |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    */
+    fprintf(stderr, "panic: %s\n", s);
+
+    if (fname != NULL) {
+        fprintf(stderr, "   --> %s:%d\n", fname, lineno);
+
+        char *line_content = read_line_from_file(fname, lineno);
+        if (line_content != NULL) {
+            fprintf(stderr, "  %d | %s\n", lineno, line_content);
+
+            /* Print the indicator line with carets */
+            fprintf(stderr, "    | ");
+            int i;
+            for (i = 0; i < strlen(line_content); i++) {
+                fprintf(stderr, "^");
+            }
+            fprintf(stderr, "\n");
+
+            free(line_content);
+        } else {
+            /* Couldn't read the line, just show line number */
+            fprintf(stderr, "  %d | <unable to read source line>\n", lineno);
+            fprintf(stderr, "    | ^\n");
+        }
+    }
+
     abort();
 }
 

--- a/spy/libspy/src/str.c
+++ b/spy/libspy/src/str.c
@@ -46,7 +46,7 @@ spy_str_getitem(spy_Str *s, int32_t i) {
         i += l;
     }
     if (i >= l || i < 0) {
-        spy_panic("string index out of bound");
+        spy_panic("string index out of bound", __FILE__, __LINE__);
         return NULL;
     }
     spy_Str *res = spy_str_alloc(1);

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -420,6 +420,19 @@ class Parser:
             body = self.from_py_body(py_node.body)
         )
 
+    def from_py_stmt_Raise(self, py_node: py_ast.Raise) -> spy.ast.Raise:
+        if py_node.cause:
+            self.unsupported(py_node, 'raise ... from ...')
+
+        if py_node.exc is None:
+            self.unsupported(py_node, 'bare raise')
+
+        exc = self.from_py_expr(py_node.exc)
+        return spy.ast.Raise(
+            loc = py_node.loc,
+            exc = exc
+        )
+
     # ====== spy.ast.Expr ======
 
     def from_py_expr(self, py_node: py_ast.expr) -> spy.ast.Expr:

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -977,3 +977,14 @@ class TestBasic(CompilerTest):
             return cls+1
         """)
         assert mod.foo(3) == 4
+
+    def test_raise(self):
+        mod = self.compile("""
+        def foo(x: i32) -> i32:
+            if x > 0:
+                return x+1
+            else:
+                raise Exception("hello")
+        """)
+        assert mod.foo(3) == 6
+        mod.foo(-1)

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -991,3 +991,15 @@ class TestBasic(CompilerTest):
         assert mod.foo(3) == 4
         with pytest.raises(SPyPanicError, match="Exception: hello"):
             mod.foo(-1)
+
+    def test_cannot_raise_red(self):
+        src = """
+        def foo() -> void:
+            exc = Exception("hello")
+            raise exc
+        """
+        errors = expect_errors(
+            "`raise` only accepts blue values for now",
+            ('this is red', 'exc'),
+            )
+        self.compile_raises(src, "foo", errors)

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -983,14 +983,18 @@ class TestBasic(CompilerTest):
         # in a panic.
         mod = self.compile("""
         def foo(x: i32) -> i32:
-            if x > 0:
-                return x+1
-            else:
+            if x < 0:
+                return 42
+            elif x == 0:
                 raise Exception("hello")
+            else:
+                raise ValueError("world")
         """)
-        assert mod.foo(3) == 4
+        assert mod.foo(-1) == 42
         with pytest.raises(SPyPanicError, match="Exception: hello"):
-            mod.foo(-1)
+            mod.foo(0)
+        with pytest.raises(SPyPanicError, match="ValueError: world"):
+            mod.foo(1)
 
     def test_cannot_raise_red(self):
         src = """

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -986,15 +986,18 @@ class TestBasic(CompilerTest):
             if x == 0:
                 return 42
             elif x == 1:
-                raise Exception("hello")
+                raise Exception("hello")   # <-- line 6
             elif x == 2:
                 raise ValueError("world")
             else:
                 raise IndexError
         """)
         assert mod.foo(0) == 42
-        with pytest.raises(SPyPanicError, match="Exception: hello"):
+        with pytest.raises(SPyPanicError, match="Exception: hello") as exc:
             mod.foo(1)
+        assert exc.value.filename == str(self.tmpdir.join('test.spy'))
+        assert exc.value.lineno == 6
+
         with pytest.raises(SPyPanicError, match="ValueError: world"):
             mod.foo(2)
         with pytest.raises(SPyPanicError, match="IndexError"):

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -1,6 +1,6 @@
 import pytest
 from spy.fqn import FQN
-from spy.errors import SPyTypeError
+from spy.errors import SPyTypeError, SPyPanicError
 from spy.vm.b import B
 from spy.fqn import FQN
 from spy.tests.support import (CompilerTest, skip_backends, no_backend,
@@ -979,6 +979,8 @@ class TestBasic(CompilerTest):
         assert mod.foo(3) == 4
 
     def test_raise(self):
+        # for now, we don't support "except:", and raising an exception result
+        # in a panic.
         mod = self.compile("""
         def foo(x: i32) -> i32:
             if x > 0:
@@ -986,5 +988,6 @@ class TestBasic(CompilerTest):
             else:
                 raise Exception("hello")
         """)
-        assert mod.foo(3) == 6
-        mod.foo(-1)
+        assert mod.foo(3) == 4
+        with pytest.raises(SPyPanicError, match="Exception: hello"):
+            mod.foo(-1)

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -983,18 +983,22 @@ class TestBasic(CompilerTest):
         # in a panic.
         mod = self.compile("""
         def foo(x: i32) -> i32:
-            if x < 0:
+            if x == 0:
                 return 42
-            elif x == 0:
+            elif x == 1:
                 raise Exception("hello")
-            else:
+            elif x == 2:
                 raise ValueError("world")
+            else:
+                raise IndexError
         """)
-        assert mod.foo(-1) == 42
+        assert mod.foo(0) == 42
         with pytest.raises(SPyPanicError, match="Exception: hello"):
-            mod.foo(0)
-        with pytest.raises(SPyPanicError, match="ValueError: world"):
             mod.foo(1)
+        with pytest.raises(SPyPanicError, match="ValueError: world"):
+            mod.foo(2)
+        with pytest.raises(SPyPanicError, match="IndexError"):
+            mod.foo(3)
 
     def test_cannot_raise_red(self):
         src = """

--- a/spy/tests/test_backend_spy.py
+++ b/spy/tests/test_backend_spy.py
@@ -50,7 +50,7 @@ class TestSPyBackend(CompilerTest):
             b = 1 + 2 * 3
             c = (1 + 2) * 3
         """)
-    
+
     def test_binop(self):
         mod = self.compile(r"""
         def foo() -> void:
@@ -77,7 +77,7 @@ class TestSPyBackend(CompilerTest):
             a & b
             a | b
             a ^ b
-        """)        
+        """)
 
     def test_vardef(self):
         mod = self.compile("""
@@ -253,6 +253,14 @@ class TestSPyBackend(CompilerTest):
             class Point:
                 x: i32
                 y: i32
+        """
+        self.compile(src)
+        self.assert_dump(src)
+
+    def test_raise(self):
+        src = """
+        def foo() -> void:
+            raise Exception('foo')
         """
         self.compile(src)
         self.assert_dump(src)

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -274,3 +274,19 @@ class TestDoppler:
         def foo() -> void:
             x = 1
         """)
+
+    def test_format_prebuilt_exception(self):
+        self.redshift("""
+        def foo(x: bool) -> void:
+            if x:
+                raise Exception('foo')
+            else:
+                raise Exception('bar')
+        """)
+        self.assert_dump("""
+        def foo(x: bool) -> void:
+            if x:
+                raise Exception('foo')
+            else:
+                raise Exception('bar')
+        """)

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -276,17 +276,18 @@ class TestDoppler:
         """)
 
     def test_format_prebuilt_exception(self):
+        fname = str(self.tmpdir.join('test.spy'))
         self.redshift("""
         def foo(x: bool) -> void:
             if x:
-                raise TypeError('foo')
+                raise TypeError('foo')  # line 4
             else:
-                raise ValueError('bar')
+                raise ValueError('bar') # line 6
         """)
-        self.assert_dump("""
+        self.assert_dump(f"""
         def foo(x: bool) -> void:
             if x:
-                `operator::panic`('TypeError: foo')
+                `operator::panic`('TypeError: foo', '{fname}', 4)
             else:
-                `operator::panic`('ValueError: bar')
+                `operator::panic`('ValueError: bar', '{fname}', 6)
         """)

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -279,14 +279,14 @@ class TestDoppler:
         self.redshift("""
         def foo(x: bool) -> void:
             if x:
-                raise Exception('foo')
+                raise TypeError('foo')
             else:
-                raise Exception('bar')
+                raise ValueError('bar')
         """)
         self.assert_dump("""
         def foo(x: bool) -> void:
             if x:
-                raise Exception('foo')
+                `operator::panic`('TypeError: foo')
             else:
-                raise Exception('bar')
+                `operator::panic`('ValueError: bar')
         """)

--- a/spy/tests/test_libspy.py
+++ b/spy/tests/test_libspy.py
@@ -85,10 +85,12 @@ class TestLibSPy(CTest):
         #include <spy.h>
 
         void crash(void) {
-            spy_panic("don't panic!");
+            spy_panic("don't panic!", "myfile", 42);
         }
         """
         test_wasm = self.compile_wasm(src, exports=['crash'])
         ll = LLSPyInstance.from_file(test_wasm)
-        with pytest.raises(SPyPanicError, match="don't panic!"):
+        with pytest.raises(SPyPanicError, match="don't panic!") as exc:
             ll.call('crash')
+        assert exc.value.filename == 'myfile'
+        assert exc.value.lineno == 42

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -736,6 +736,24 @@ class TestParser:
         """
         self.assert_dump(stmt, expected)
 
+    def test_Raise(self):
+        mod = self.parse("""
+        def foo() -> void:
+            raise ValueError("error message")
+        """)
+        stmt = mod.get_funcdef('foo').body[0]
+        expected = """
+        Raise(
+            exc=Call(
+                func=Name(id='ValueError'),
+                args=[
+                    StrConst(value='error message'),
+                ],
+            ),
+        )
+        """
+        self.assert_dump(stmt, expected)
+
     def test_from_import(self):
         mod = self.parse("""
         from testmod import a, b as b2

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -754,6 +754,28 @@ class TestParser:
         """
         self.assert_dump(stmt, expected)
 
+    def test_Raise_from(self):
+        src = """
+        def foo() -> void:
+            raise ValueError("error") from TypeError("cause")
+        """
+        self.expect_errors(
+            src,
+            "not implemented yet: raise ... from ...",
+            ("this is not supported", "raise ValueError(\"error\") from TypeError(\"cause\")"),
+        )
+
+    def test_Raise_bare(self):
+        src = """
+        def foo() -> void:
+            raise
+        """
+        self.expect_errors(
+            src,
+            "not implemented yet: bare raise",
+            ("this is not supported", "raise"),
+        )
+
     def test_from_import(self):
         mod = self.parse("""
         from testmod import a, b as b2

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -139,12 +139,12 @@ class TestVM:
         # Create exceptions with the same message
         w_msg1 = vm.wrap("hello")
         w_msg2 = vm.wrap("hello")
-        w_exc1 = W_Exception(w_msg1)
-        w_exc2 = W_Exception(w_msg2)
+        w_exc1 = W_Exception(w_msg1)  # type: ignore
+        w_exc2 = W_Exception(w_msg2)  # type: ignore
 
         # Create an exception with a different message
         w_msg3 = vm.wrap("world")
-        w_exc3 = W_Exception(w_msg3)
+        w_exc3 = W_Exception(w_msg3)  # type: ignore
 
         # Test equality
         assert vm.is_True(vm.eq(w_exc1, w_exc2))

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -131,6 +131,27 @@ class TestVM:
                 match="Cannot wrap interp-level objects of type Foo"):
             vm.wrap(Foo())
 
+    def test_exception_eq(self):
+        """Test equality between W_Exception instances."""
+        vm = SPyVM()
+        from spy.vm.modules.builtins import W_Exception
+
+        # Create exceptions with the same message
+        w_msg1 = vm.wrap("hello")
+        w_msg2 = vm.wrap("hello")
+        w_exc1 = W_Exception(w_msg1)
+        w_exc2 = W_Exception(w_msg2)
+
+        # Create an exception with a different message
+        w_msg3 = vm.wrap("world")
+        w_exc3 = W_Exception(w_msg3)
+
+        # Test equality
+        assert vm.is_True(vm.eq(w_exc1, w_exc2))
+        assert vm.is_False(vm.eq(w_exc1, w_exc3))
+        assert vm.is_False(vm.ne(w_exc1, w_exc2))
+        assert vm.is_True(vm.ne(w_exc1, w_exc3))
+
     def test_w_None(self):
         vm = SPyVM()
         w_None = B.w_None

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -332,6 +332,12 @@ class AbstractFrame:
     def exec_stmt_Raise(self, raise_node: ast.Raise) -> None:
         # for now, raising an exception always result in a panic
         wop_exc = self.eval_expr(raise_node.exc)
+        if wop_exc.color != 'blue':
+            # if you modify this code, you should also modify the equivalent
+            # one in doppler.py
+            err = SPyTypeError("`raise` only accepts blue values for now")
+            err.add('error', 'this is red', raise_node.exc.loc)
+            raise err
         w_exc = wop_exc.w_val
         # XXX raise proper exception
         assert isinstance(w_exc, W_Exception)

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -332,7 +332,7 @@ class AbstractFrame:
     def exec_stmt_Raise(self, raise_node: ast.Raise) -> None:
         wop_exc = self.eval_expr(raise_node.exc)
         w_opimpl = self.vm.call_OP(OP.w_RAISE, [wop_exc])
-        return self.eval_opimpl(raise_node, w_opimpl, [wop_exc])
+        self.eval_opimpl(raise_node, w_opimpl, [wop_exc])
 
     # ==== expressions ====
 

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -330,18 +330,9 @@ class AbstractFrame:
                 self.exec_stmt(stmt)
 
     def exec_stmt_Raise(self, raise_node: ast.Raise) -> None:
-        # for now, raising an exception always result in a panic
         wop_exc = self.eval_expr(raise_node.exc)
-        if wop_exc.color != 'blue':
-            # if you modify this code, you should also modify the equivalent
-            # one in doppler.py
-            err = SPyTypeError("`raise` only accepts blue values for now")
-            err.add('error', 'this is red', raise_node.exc.loc)
-            raise err
-        w_exc = wop_exc.w_val
-        # XXX raise proper exception
-        assert isinstance(w_exc, W_Exception)
-        raise SPyPanicError(w_exc.applevel_str(self.vm))
+        w_opimpl = self.vm.call_OP(OP.w_RAISE, [wop_exc])
+        return self.eval_opimpl(raise_node, w_opimpl, [wop_exc])
 
     # ==== expressions ====
 

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -3,8 +3,7 @@ from types import NoneType
 from dataclasses import dataclass
 from spy import ast
 from spy.location import Loc
-from spy.errors import (SPyPanicError, SPyTypeError, SPyNameError,
-                        SPyRuntimeError, maybe_plural)
+from spy.errors import SPyTypeError, SPyNameError, SPyRuntimeError
 from spy.irgen.symtable import SymTable, Symbol, Color, maybe_blue
 from spy.fqn import FQN
 from spy.vm.b import B
@@ -15,7 +14,6 @@ from spy.vm.function import (W_Func, W_FuncType, W_ASTFunc, Namespace, CLOSURE,
 from spy.vm.func_adapter import W_FuncAdapter
 from spy.vm.list import W_List, W_ListType
 from spy.vm.tuple import W_Tuple
-from spy.vm.modules.builtins import W_Exception
 from spy.vm.modules.types import W_LiftedType
 from spy.vm.modules.unsafe.struct import W_StructType
 from spy.vm.opimpl import W_OpImpl, W_OpArg

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -335,11 +335,7 @@ class AbstractFrame:
         w_exc = wop_exc.w_val
         # XXX raise proper exception
         assert isinstance(w_exc, W_Exception)
-        # ad-hoc stringify logic. Eventually, we should have __STR__
-        w_exc_type = self.vm.dynamic_type(w_exc)
-        t = w_exc_type.fqn.symbol_name
-        m = self.vm.unwrap_str(w_exc.w_message)
-        raise SPyPanicError(f'{t}: {m}')
+        raise SPyPanicError(w_exc.applevel_str(self.vm))
 
     # ==== expressions ====
 

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -186,7 +186,8 @@ class W_Func(W_Object):
         this info on the w_functype.
         """
         # this is a hack, but good enough to constant-fold arithmetic ops
-        return self.fqn.modname == 'operator'
+        return (self.fqn.modname == 'operator'
+                and self.fqn.symbol_name != 'panic')
 
     def spy_get_w_type(self, vm: 'SPyVM') -> W_Type:
         return self.w_functype

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -90,6 +90,7 @@ class W_Exception(W_Object):
     def w_NEW(vm: 'SPyVM', wop_cls: W_OpArg, *args_wop: W_OpArg) -> W_OpImpl:
         # we cannot use the default __new__ because we want to pass w_cls
         w_cls = wop_cls.w_blueval
+        assert isinstance(w_cls, W_Type)
         fqn = w_cls.fqn
         T = Annotated[W_Exception, w_cls]
 
@@ -98,7 +99,9 @@ class W_Exception(W_Object):
         # that Exception("...") is blue
         @builtin_func(fqn, '__new__', color='blue')
         def w_new(vm: 'SPyVM', w_cls: W_Type, w_message: W_Str) -> T:
-            return w_cls.pyclass(w_message)
+            pyclass = w_cls.pyclass
+            assert issubclass(pyclass, W_Exception)
+            return pyclass(w_message)
         return W_OpImpl(w_new, [wop_cls] + list(args_wop))
 
 

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -4,10 +4,10 @@ Second half of the `builtins` module.
 The first half is in vm/b.py. See its docstring for more details.
 """
 
-from typing import TYPE_CHECKING, Any
-from spy.vm.builtin import builtin_func
+from typing import TYPE_CHECKING, Any, Annotated, Self
+from spy.vm.builtin import builtin_func, builtin_method
 from spy.vm.primitive import W_F64, W_I32, W_Bool, W_Dynamic, W_Void
-from spy.vm.object import W_Object, W_Type
+from spy.vm.object import W_Object, W_Type, Member
 from spy.vm.str import W_Str
 from spy.vm.function import W_FuncType
 from spy.vm.b import BUILTINS, B
@@ -74,3 +74,16 @@ def w_print_str(vm: 'SPyVM', w_x: W_Str) -> W_Void:
 @builtin_func('builtins')
 def w_functype_eq(vm: 'SPyVM', w_ft1: W_FuncType, w_ft2: W_FuncType) -> W_Bool:
     return vm.wrap(w_ft1 == w_ft2)  # type: ignore
+
+
+@BUILTINS.builtin_type('Exception')
+class W_Exception(W_Object):
+    w_message: Annotated[W_Str, Member('message')]
+
+    def __init__(self, w_message: W_Str) -> None:
+        self.w_message = w_message
+
+    @builtin_method('__new__')
+    @staticmethod
+    def w_spy_new(vm: 'SPyVM', w_message: W_Str) -> 'W_Exception':
+        return W_Exception(w_message)

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -105,6 +105,44 @@ class W_Exception(W_Object):
         return W_OpImpl(w_new, [wop_cls] + list(args_wop))
 
 
+    @builtin_method('__EQ__', color='blue')
+    @staticmethod
+    def w_EQ(vm: 'SPyVM', wop_a: W_OpArg, wop_b: W_OpArg) -> W_OpImpl:
+        from spy.vm.opimpl import W_OpImpl
+
+        w_atype = wop_a.w_static_type
+        w_btype = wop_b.w_static_type
+
+        # If different exception types, return null implementation
+        if w_atype is not w_btype:
+            return W_OpImpl.NULL
+
+        @builtin_func(w_atype.fqn)
+        def w_eq(vm: 'SPyVM', w_exc1: W_Exception, w_exc2: W_Exception) -> W_Bool:
+            # Compare the message fields
+            return vm.eq(w_exc1.w_message, w_exc2.w_message)
+
+        return W_OpImpl(w_eq)
+
+    @builtin_method('__NE__', color='blue')
+    @staticmethod
+    def w_NE(vm: 'SPyVM', wop_a: W_OpArg, wop_b: W_OpArg) -> W_OpImpl:
+        from spy.vm.opimpl import W_OpImpl
+
+        w_atype = wop_a.w_static_type
+        w_btype = wop_b.w_static_type
+
+        # If different exception types, return null implementation
+        if w_atype is not w_btype:
+            return W_OpImpl.NULL
+
+        @builtin_func(w_atype.fqn)
+        def w_ne(vm: 'SPyVM', w_exc1: W_Exception, w_exc2: W_Exception) -> W_Bool:
+            # Compare the message fields and negate the result
+            return vm.ne(w_exc1.w_message, w_exc2.w_message)
+
+        return W_OpImpl(w_ne)
+
     @builtin_method('__new__', color='blue')
     @staticmethod
     def w_spy_new(vm: 'SPyVM', w_message: W_Str) -> 'W_Exception':
@@ -114,7 +152,7 @@ class W_Exception(W_Object):
         cls = self.__class__.__name__
         return f'{cls}({self.w_message})'
 
-    def applevel_str(self, vm: 'SPyVM') -> str:
+    def spy_str(self, vm: 'SPyVM') -> str:
         """
         Ad-hoc stringify logic. Eventually, we should have __STR__
 

--- a/spy/vm/modules/operator/__init__.py
+++ b/spy/vm/modules/operator/__init__.py
@@ -69,6 +69,7 @@ from . import attrop         # side effects
 from . import itemop         # side effects
 from . import callop         # side effects
 from . import convop         # side effects
+from . import raiseop        # side effects
 
 _from_token: dict[str, W_Func] = {
     '+': OP.w_ADD,

--- a/spy/vm/modules/operator/raiseop.py
+++ b/spy/vm/modules/operator/raiseop.py
@@ -1,0 +1,47 @@
+from typing import TYPE_CHECKING
+from spy.errors import SPyTypeError, SPyPanicError
+from spy.vm.b import B
+from spy.vm.object import W_Type
+from spy.vm.str import W_Str
+from spy.vm.opimpl import W_OpImpl, W_OpArg
+from spy.vm.function import W_Func
+from spy.vm.primitive import W_Dynamic
+from spy.vm.modules.builtins import W_Exception
+
+from . import OP, op_fast_call
+if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
+
+@OP.builtin_func
+def w_panic(vm: 'SPyVM', w_message: W_Str) -> None:
+    msg = vm.unwrap_str(w_message)
+    raise SPyPanicError(msg)
+
+@OP.builtin_func(color='blue')
+def w_RAISE(vm: 'SPyVM', wop_exc: W_OpArg) -> W_Func:
+    from spy.vm.typechecker import typecheck_opimpl
+
+    # We are doing a bit of magic here:
+    #   1. manually turn the blue wop_exc into an hardcoded message
+    #   2. return an w_opimpl which calls w_panic with the hardcoded message,
+    #      ignoring the actual wop_exc
+    if wop_exc.color != 'blue':
+        err = SPyTypeError("`raise` only accepts blue values for now")
+        err.add('error', 'this is red', wop_exc.loc)
+        raise err
+
+    w_exc = wop_exc.w_val
+    assert isinstance(w_exc, W_Exception) # XXX raise proper exception
+
+    msg = w_exc.spy_str(vm) # this is e.g. "Exception: hello"
+    w_msg = vm.wrap(msg)
+    wop_msg = W_OpArg.from_w_obj(vm, w_msg)
+    w_opimpl = W_OpImpl(OP.w_panic, [wop_msg])
+
+    return typecheck_opimpl(
+        vm,
+        w_opimpl,
+        [wop_exc],
+        dispatch='single',
+        errmsg='cannot raise `{0}`'
+    )

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -157,6 +157,8 @@ class W_Ptr(W_BasePtr):
         ITEMSIZE = sizeof(w_T)
         PTR = Annotated[W_Ptr, w_ptrtype]
         T = Annotated[W_Object, w_T]
+        filename = wop_ptr.loc.filename
+        lineno = wop_ptr.loc.line_start
 
         @builtin_func(w_ptrtype.fqn, 'load')
         def w_ptr_load_T(vm: 'SPyVM', w_ptr: PTR, w_i: W_I32) -> T:
@@ -167,7 +169,7 @@ class W_Ptr(W_BasePtr):
             if i >= length:
                 msg = (f"ptr_load out of bounds: 0x{addr:x}[{i}] "
                        f"(upper bound: {length})")
-                raise SPyPanicError(msg)
+                raise SPyPanicError(msg, filename, lineno)
             return vm.call_generic(
                 UNSAFE.w_mem_read,
                 [w_T],
@@ -184,6 +186,8 @@ class W_Ptr(W_BasePtr):
         ITEMSIZE = sizeof(w_T)
         PTR = Annotated[W_Ptr, w_ptrtype]
         T = Annotated[W_Object, w_T]
+        filename = wop_ptr.loc.filename
+        lineno = wop_ptr.loc.line_start
 
         @builtin_func(w_ptrtype.fqn, 'store')
         def w_ptr_store_T(vm: 'SPyVM', w_ptr: PTR, w_i: W_I32, w_v: T)-> None:
@@ -194,7 +198,7 @@ class W_Ptr(W_BasePtr):
             if i >= length:
                 msg = (f"ptr_store out of bounds: 0x{addr:x}[{i}] "
                        f"(upper bound: {length})")
-                raise SPyPanicError(msg)
+                raise SPyPanicError(msg, filename, lineno)
             vm.call_generic(
                 UNSAFE.w_mem_write,
                 [w_T],

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -432,7 +432,7 @@ class W_Type(W_Object):
         assert isinstance(w_type, W_Type)
 
         # Call __NEW__, if present
-        w_NEW = w_type.dict_w.get('__NEW__')
+        w_NEW = w_type.lookup_blue_func('__NEW__')
         if w_NEW is not None:
             assert isinstance(w_NEW, W_Func), 'XXX raise proper exception'
             w_res = vm.fast_call(w_NEW, [wop_t] + list(args_wop))
@@ -440,7 +440,7 @@ class W_Type(W_Object):
             return w_res
 
         # else, fall back to __new__
-        w_new = w_type.dict_w.get('__new__')
+        w_new = w_type.lookup_blue_func('__new__')
         if w_new is not None:
             assert isinstance(w_new, W_Func), 'XXX raise proper exception'
             return W_OpImpl(w_new, list(args_wop))

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -440,7 +440,7 @@ class W_Type(W_Object):
             return w_res
 
         # else, fall back to __new__
-        w_new = w_type.lookup_blue_func('__new__')
+        w_new = w_type.lookup_func('__new__')
         if w_new is not None:
             assert isinstance(w_new, W_Func), 'XXX raise proper exception'
             return W_OpImpl(w_new, list(args_wop))

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -22,7 +22,7 @@ from spy.vm.opimpl import W_OpImpl, W_OpArg, w_oparg_eq
 from spy.vm.registry import ModuleRegistry
 from spy.vm.bluecache import BlueCache
 
-from spy.vm.modules.builtins import BUILTINS
+from spy.vm.modules.builtins import BUILTINS, W_Exception
 from spy.vm.modules.operator import OPERATOR
 from spy.vm.modules.types import TYPES
 from spy.vm.modules.unsafe import UNSAFE
@@ -196,6 +196,16 @@ class SPyVM:
             # we might need to change this when we introduce custom types
             fqn = w_val.fqn
             assert w_val.fqn not in self.globals_w
+        elif isinstance(w_val, W_Exception):
+            # this is a bit of a temporary hack: it's needed to support this:
+            #     raise Exception("...")
+
+            # the argument to "raise" must be blue for now (see also
+            # W_Exception.w_spy_new). Eventually, we will have proper support
+            # for prebuilt constants, but for now we special case W_Exception.
+            w_type = self.dynamic_type(w_val)
+            fqn = w_type.fqn.join('prebuilt')
+            fqn = self.get_unique_FQN(fqn)
         else:
             assert False, 'implement me'
 

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -389,7 +389,8 @@ class SPyVM:
         new_args_wop = [wop.as_red(self) for wop in args_wop]
 
         if w_OP in (OP.w_CALL, OP.w_CALL_METHOD, OP.w_GETATTR,
-                    OP.w_GETITEM, OP.w_SETATTR, OP.w_SETITEM):
+                    OP.w_GETITEM, OP.w_SETATTR, OP.w_SETITEM,
+                    OP.w_RAISE):
             new_args_wop[0] = args_wop[0]
         if w_OP in (OP.w_GETATTR, OP.w_SETATTR, OP.w_CALL_METHOD):
             new_args_wop[1] = args_wop[1]


### PR DESCRIPTION
We don't have proper exceptions yet:
  - all `raise`s result into a panic (i.e., they cannot be caught)
  - to simplify the implementation in the C backend, we support only "blue" exceptions

Moreover, we improve `SPyPanicError` and the C-level implementation of `spy_panic` to takes filename and line number.

The output in case of panic looks like this (and it looks the same both interpreted and compiled):
```
$ spy /tmp/fail.spy 
panic: IndexError: hello
   --> /tmp/fail.spy:2:2
  2 |     raise IndexError("hello")
    |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
```