### PR TITLE
Improve error messages when calling operators

### DIFF
--- a/spy/location.py
+++ b/spy/location.py
@@ -111,7 +111,7 @@ class Loc:
         Visualize the piece of code which correspond to this Loc
         """
         from spy.errfmt import ErrorFormatter, Annotation
-        fmt = ErrorFormatter(err=None, use_colors=True) # type: ignore
+        fmt = ErrorFormatter(use_colors=True) # type: ignore
         ann = Annotation('note', '', self)
         fmt.emit_annotation(ann)
         print(fmt.build())

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -302,14 +302,22 @@ class AbstractFrame:
         wop_obj = self.eval_expr(node.target)
         wop_attr = self.eval_expr(node.attr)
         wop_value = self.eval_expr(node.value)
-        w_opimpl = self.vm.call_OP(OP.w_SETATTR, [wop_obj, wop_attr, wop_value])
+        w_opimpl = self.vm.call_OP(
+            node.loc,
+            OP.w_SETATTR,
+            [wop_obj, wop_attr, wop_value]
+        )
         self.eval_opimpl(node, w_opimpl, [wop_obj, wop_attr, wop_value])
 
     def exec_stmt_SetItem(self, node: ast.SetItem) -> None:
         wop_obj = self.eval_expr(node.target)
         wop_i = self.eval_expr(node.index)
         wop_v = self.eval_expr(node.value)
-        w_opimpl = self.vm.call_OP(OP.w_SETITEM, [wop_obj, wop_i, wop_v])
+        w_opimpl = self.vm.call_OP(
+            node.loc,
+            OP.w_SETITEM,
+            [wop_obj, wop_i, wop_v]
+        )
         self.eval_opimpl(node, w_opimpl, [wop_obj, wop_i, wop_v])
 
     def exec_stmt_StmtExpr(self, stmt: ast.StmtExpr) -> None:
@@ -336,7 +344,7 @@ class AbstractFrame:
 
     def exec_stmt_Raise(self, raise_node: ast.Raise) -> None:
         wop_exc = self.eval_expr(raise_node.exc)
-        w_opimpl = self.vm.call_OP(OP.w_RAISE, [wop_exc])
+        w_opimpl = self.vm.call_OP(raise_node.loc, OP.w_RAISE, [wop_exc])
         self.eval_opimpl(raise_node, w_opimpl, [wop_exc])
 
     # ==== expressions ====
@@ -424,7 +432,7 @@ class AbstractFrame:
         w_OP = OP_from_token(binop.op) # e.g., w_ADD, w_MUL, etc.
         wop_l = self.eval_expr(binop.left)
         wop_r = self.eval_expr(binop.right)
-        w_opimpl = self.vm.call_OP(w_OP, [wop_l, wop_r])
+        w_opimpl = self.vm.call_OP(binop.loc, w_OP, [wop_l, wop_r])
         return self.eval_opimpl(
             binop,
             w_opimpl,
@@ -454,7 +462,11 @@ class AbstractFrame:
         if wop_func.color == 'blue' and wop_func.w_val is B.w_STATIC_TYPE:
             return self._eval_STATIC_TYPE(wop_func, call)
         args_wop = [self.eval_expr(arg) for arg in call.args]
-        w_opimpl = self.vm.call_OP(OP.w_CALL, [wop_func]+args_wop)
+        w_opimpl = self.vm.call_OP(
+            call.loc,
+            OP.w_CALL,
+            [wop_func]+args_wop
+        )
         return self.eval_opimpl(call, w_opimpl, [wop_func]+args_wop)
 
     def _eval_STATIC_TYPE(self, wop_func: W_OpArg, call: ast.Call) -> W_OpArg:
@@ -468,7 +480,7 @@ class AbstractFrame:
                 )
 
         args_wop = [self.eval_expr(arg) for arg in call.args]
-        w_opimpl = self.vm.call_OP(OP.w_CALL, [wop_func]+args_wop)
+        w_opimpl = self.vm.call_OP(call.loc, OP.w_CALL, [wop_func]+args_wop)
         assert len(call.args) == 1
         w_argtype = args_wop[0].w_static_type
         return W_OpArg.from_w_obj(self.vm, w_argtype)
@@ -478,6 +490,7 @@ class AbstractFrame:
         wop_meth = self.eval_expr(op.method)
         args_wop = [self.eval_expr(arg) for arg in op.args]
         w_opimpl = self.vm.call_OP(
+            op.loc,
             OP.w_CALL_METHOD,
             [wop_obj, wop_meth] + args_wop
         )
@@ -490,13 +503,13 @@ class AbstractFrame:
     def eval_expr_GetItem(self, op: ast.GetItem) -> W_OpArg:
         wop_obj = self.eval_expr(op.value)
         wop_i = self.eval_expr(op.index)
-        w_opimpl = self.vm.call_OP(OP.w_GETITEM, [wop_obj, wop_i])
+        w_opimpl = self.vm.call_OP(op.loc, OP.w_GETITEM, [wop_obj, wop_i])
         return self.eval_opimpl(op, w_opimpl, [wop_obj, wop_i])
 
     def eval_expr_GetAttr(self, op: ast.GetAttr) -> W_OpArg:
         wop_obj = self.eval_expr(op.value)
         wop_attr = self.eval_expr(op.attr)
-        w_opimpl = self.vm.call_OP(OP.w_GETATTR, [wop_obj, wop_attr])
+        w_opimpl = self.vm.call_OP(op.loc, OP.w_GETATTR, [wop_obj, wop_attr])
         return self.eval_opimpl(op, w_opimpl, [wop_obj, wop_attr])
 
     def eval_expr_List(self, op: ast.List) -> W_Object:

--- a/spy/vm/modules/operator/itemop.py
+++ b/spy/vm/modules/operator/itemop.py
@@ -30,7 +30,7 @@ def w_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg, wop_i: W_OpArg) -> W_Func:
 
 @OP.builtin_func(color='blue')
 def w_SETITEM(vm: 'SPyVM', wop_obj: W_OpArg, wop_i: W_OpArg,
-            wop_v: W_OpArg) -> W_Func:
+              wop_v: W_OpArg) -> W_Func:
     from spy.vm.typechecker import typecheck_opimpl
     w_opimpl = W_OpImpl.NULL
     w_type = wop_obj.w_static_type

--- a/spy/vm/modules/operator/opimpl_dynamic.py
+++ b/spy/vm/modules/operator/opimpl_dynamic.py
@@ -14,7 +14,7 @@ def _dynamic_op(vm: 'SPyVM', w_op: W_Func,
                 ) -> W_Dynamic:
     wop_a = W_OpArg.from_w_obj(vm, w_a)
     wop_b = W_OpArg.from_w_obj(vm, w_b)
-    w_opimpl = vm.call_OP(w_op, [wop_a, wop_b])
+    w_opimpl = vm.call_OP(None, w_op, [wop_a, wop_b])
     return vm.fast_call(w_opimpl, [w_a, w_b])
 
 @OP.builtin_func
@@ -56,7 +56,7 @@ def w_dynamic_setattr(vm: 'SPyVM', w_obj: W_Dynamic, w_attr: W_Str,
     wop_obj = W_OpArg.from_w_obj(vm, w_obj)
     wop_attr = W_OpArg.from_w_obj(vm, w_attr)
     wop_v = W_OpArg.from_w_obj(vm, w_value)
-    w_opimpl = vm.call_OP(OP.w_SETATTR, [wop_obj, wop_attr, wop_v])
+    w_opimpl = vm.call_OP(None, OP.w_SETATTR, [wop_obj, wop_attr, wop_v])
     return vm.fast_call(w_opimpl, [w_obj, w_attr, w_value])
 
 @OP.builtin_func
@@ -64,7 +64,7 @@ def w_dynamic_getattr(vm: 'SPyVM', w_obj: W_Dynamic,
                       w_attr: W_Str) -> W_Dynamic:
     wop_obj = W_OpArg.from_w_obj(vm, w_obj)
     wop_attr = W_OpArg.from_w_obj(vm, w_attr)
-    w_opimpl = vm.call_OP(OP.w_GETATTR, [wop_obj, wop_attr])
+    w_opimpl = vm.call_OP(None, OP.w_GETATTR, [wop_obj, wop_attr])
     return vm.fast_call(w_opimpl, [w_obj, w_attr])
 
 
@@ -76,5 +76,5 @@ def w_dynamic_call(vm: 'SPyVM', w_obj: W_Dynamic,
         W_OpArg.from_w_obj(vm, w_x)
         for i, w_x in enumerate(all_args_w)
     ]
-    w_opimpl = vm.call_OP(OP.w_CALL, all_args_wop)
+    w_opimpl = vm.call_OP(None, OP.w_CALL, all_args_wop)
     return vm.fast_call(w_opimpl, all_args_w)

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -39,7 +39,6 @@ from spy.vm.primitive import W_Bool, W_Dynamic
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
-T = TypeVar('T')
 
 @OPERATOR.builtin_type('OpArg', lazy_definition=True)
 class W_OpArg(W_Object):


### PR DESCRIPTION
An example is worth 1000 words.
Consider this:
```python
from operator import OpImpl

@typelift
class MyInt:
    __ll__: i32

    @blue
    def __GETITEM__(v_obj, v_i):
        # this is the mistake, getitem should take an extra arg
        def getitem(m: MyInt) -> i32:
            return m.__ll__ + i*2
        return OpImpl(getitem)

def main() -> void:
    m = MyInt.__lift__(4)
    m[10]
```

Before this PR, you would get this error, which doesn't give any information about which line actually triggered this call:
```
❯ spy /tmp/t.spy 
TypeError: this function takes 1 argument but 2 arguments were supplied
   --> /tmp/t.spy:10:9
 10 |         def getitem(m: MyInt) -> i32:
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
```

With this PR, you get extra info:
```
❯ spy /tmp/t.spy 
TypeError: this function takes 1 argument but 2 arguments were supplied
   --> /tmp/t.spy:10:9
 10 |         def getitem(m: MyInt) -> i32:
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here

   --> /tmp/t.spy:16:5
 16 |     m[10]
    |     ^^^^^ operator::GETITEM called here
```

There is a lot of room for improvement and refinement, but for now this should be good enough.