### PR TITLE
Introduce @blue.generic

### DIFF
--- a/examples/array.spy
+++ b/examples/array.spy
@@ -1,7 +1,7 @@
 from operator import OpImpl, OpArg
 from unsafe import gc_alloc, ptr
 
-@blue
+@blue.generic
 def ndarray1(DTYPE):
 
     @struct
@@ -38,7 +38,7 @@ def ndarray1(DTYPE):
     return ndarray
 
 def main() -> void:
-    a_floats = ndarray1(f64)(10)
-    a_ints = ndarray1(i32)(4)
+    a_floats = ndarray1[f64](10)
+    a_ints = ndarray1[i32](4)
     print(a_floats[3])
     print(a_ints[2])

--- a/examples/blue_generic.spy
+++ b/examples/blue_generic.spy
@@ -1,0 +1,9 @@
+@blue.generic
+def add(T):
+    def impl(x:T, y: T) -> T:
+        return x + y
+    return impl
+
+def main() -> void:
+    print(add[i32](1, 2))
+    print(add[str]('hello ', 'world'))

--- a/examples/bluefunc.spy
+++ b/examples/bluefunc.spy
@@ -1,0 +1,32 @@
+# XXX: we need to implement fabs because out builtin::abs supports only i32
+def fabs(x: f64) -> f64:
+    if x < 0:
+        return -1 * x
+    else:
+        return x
+
+@blue
+def get_pi():
+    """
+    Compute an approximation of PI using the Leibniz series
+    """
+    tol = 0.001
+    pi_approx = 0.0
+    k = 0
+    term = 1.0  # Initial term to enter the loop
+
+    while fabs(term) > tol:
+        if k % 2 == 0:
+            term = 1.0 / (2 * k + 1)
+        else:
+            term = -1 * 1.0 / (2 * k + 1)
+
+        pi_approx = pi_approx + term
+        k = k + 1
+
+    return 4 * pi_approx
+
+def main() -> void:
+    pi = get_pi()
+    print("pi:")
+    print(pi)

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -12,6 +12,7 @@ from spy.util import extend
 AnyNode = typing.Union[py_ast.AST, 'Node']
 VarKind = typing.Literal['const', 'var']
 ClassKind = typing.Literal['class', 'struct', 'typelift']
+FuncKind = typing.Literal['plain', 'generic']
 
 @extend(py_ast.AST)
 class AST:
@@ -436,6 +437,7 @@ class FuncArg(Node):
 @dataclass(eq=False)
 class FuncDef(Stmt):
     color: Color
+    kind: FuncKind
     name: str
     args: list[FuncArg]
     return_type: 'Expr'

--- a/spy/backend/c/context.py
+++ b/spy/backend/c/context.py
@@ -3,7 +3,7 @@ from spy.fqn import FQN
 from spy.vm.vm import SPyVM
 from spy.vm.b import B
 from spy.vm.object import W_Type
-from spy.vm.function import W_FuncType, W_Func
+from spy.vm.function import W_FuncType, W_Func, W_ASTFunc
 from spy.vm.modules.types import W_LiftedType
 from spy.vm.modules.rawbuffer import RB
 from spy.vm.modules.jsffi import JSFFI
@@ -93,11 +93,13 @@ class Context:
         w_restype = w_func.w_functype.w_restype
         return self.w2c(w_restype)
 
-    def c_function(self, name: str, w_functype: W_FuncType) -> C_Function:
+    def c_function(self, name: str, w_func: W_ASTFunc) -> C_Function:
+        w_functype = w_func.w_functype
+        argnames = [arg.name for arg in w_func.funcdef.args]
         c_restype = self.w2c(w_functype.w_restype)
         c_params = [
-            C_FuncParam(name=p.name, c_type=self.w2c(p.w_type))
-            for p in w_functype.params
+            C_FuncParam(name=name, c_type=self.w2c(p.w_type))
+            for name, p in zip(argnames, w_functype.params, strict=True)
         ]
         return C_Function(name, c_params, c_restype)
 

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -201,7 +201,8 @@ class CModuleWriter:
         """
         Generate function declaration in mod.h
         """
-        c_func = self.ctx.c_function(fqn.c_name, w_func.w_functype)
+        argnames = [arg.name for arg in w_func.funcdef.args]
+        c_func = self.ctx.c_function(fqn.c_name, w_func)
         self.tbh_funcs.wl(c_func.decl() + ';')
 
     def emit_func(self, fqn: FQN, w_func: W_ASTFunc) -> None:
@@ -291,8 +292,7 @@ class CFuncWriter:
         Emit the code for the whole function
         """
         self.emit_lineno(self.w_func.funcdef.loc.line_start)
-        c_func = self.ctx.c_function(self.fqn.c_name,
-                                     self.w_func.w_functype)
+        c_func = self.ctx.c_function(self.fqn.c_name, self.w_func)
         self.tbc.wl(c_func.decl() + ' {')
         with self.tbc.indent():
             self.emit_local_vars()
@@ -317,7 +317,7 @@ class CFuncWriter:
         see e.g. a VarDef.
         """
         assert self.w_func.locals_types_w is not None
-        param_names = [p.name for p in self.w_func.w_functype.params]
+        param_names = [arg.name for arg in self.w_func.funcdef.args]
         for varname, w_type in self.w_func.locals_types_w.items():
             c_type = self.ctx.w2c(w_type)
             if (varname not in ('@return', '@if', '@while') and

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -58,7 +58,7 @@ class SPyBackend:
         self.w_func = w_func
         self.vars_declared = set()
         w_functype = w_func.w_functype
-        params = self.fmt_params(w_functype.params)
+        params = self.fmt_params(w_func)
         ret = self.fmt_w_obj(w_functype.w_restype)
         self.scope_stack.append(w_func.funcdef.symtable)
         self.wl(f'def {name}({params}) -> {ret}:')
@@ -67,11 +67,13 @@ class SPyBackend:
                 self.emit_stmt(stmt)
         self.scope_stack.pop()
 
-    def fmt_params(self, params: list[FuncParam]) -> str:
+    def fmt_params(self, w_func: W_ASTFunc) -> str:
+        argnames = [arg.name for arg in w_func.funcdef.args]
+        params = w_func.w_functype.params
         l = []
-        for p in params:
+        for argname, p in zip(argnames, params, strict=True):
             t = self.fmt_w_obj(p.w_type)
-            l.append(f'{p.name}: {t}')
+            l.append(f'{argname}: {t}')
         return ', '.join(l)
 
     def fmt_w_obj(self, w_obj: W_Object) -> str:

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -165,7 +165,7 @@ class FQN:
                 new_quals = part.qualifiers.copy() + get_qualifiers(qualifiers)
                 new_part = NSPart(part.name, new_quals, part.suffix)
                 new_parts.append(new_part)
-        
+
         res = FQN(new_parts)
         return res
 
@@ -200,14 +200,25 @@ class FQN:
         Like fullname, but doesn't show 'builtins::',
         and special-case 'def[...]'
         """
-        is_def = (len(self.parts) == 2 and
-                  self.modname == 'builtins' and
-                  self.parts[1].name == 'def')
+        is_def = (
+            len(self.parts) == 2 and
+            self.modname == 'builtins' and
+            self.parts[1].name in ('def', 'blue.def', 'blue.generic.def')
+        )
         if is_def:
-            quals = [fqn.human_name for fqn in self.parts[1].qualifiers]
+            p1 = self.parts[1]
+            if p1.name == 'def':
+                d = 'def'
+            elif p1.name == 'blue.def':
+                d = '@blue def'
+            elif p1.name == 'blue.generic.def':
+                d = '@blue.generic def'
+            else:
+                assert False
+            quals = [fqn.human_name for fqn in p1.qualifiers]
             p = ', '.join(quals[:-1])
             r = quals[-1]
-            return f'def({p}) -> {r}'
+            return f'{d}({p}) -> {r}'
         else:
             return self._fullname(human=True)
 

--- a/spy/location.py
+++ b/spy/location.py
@@ -99,12 +99,28 @@ class Loc:
         Return the piece of source code pointed by this Loc
         """
         filename = self.filename
-        assert self.line_start == self.line_end, 'multi-line not supported'
-        line = self.line_start
-        a = self.col_start
-        b = self.col_end
-        srcline = linecache.getline(filename, line)
-        return srcline[a:b]
+        if self.line_start == self.line_end:
+            # Single line case
+            line = self.line_start
+            a = self.col_start
+            b = self.col_end
+            srcline = linecache.getline(filename, line)
+            return srcline[a:b]
+        else:
+            # Multi-line case
+            lines = []
+            for line_num in range(self.line_start, self.line_end + 1):
+                srcline = linecache.getline(filename, line_num)
+                if line_num == self.line_start:
+                    # First line - start from col_start
+                    lines.append(srcline[self.col_start:])
+                elif line_num == self.line_end:
+                    # Last line - end at col_end
+                    lines.append(srcline[:self.col_end])
+                else:
+                    # Middle lines - include whole line
+                    lines.append(srcline)
+            return ''.join(lines)
 
     def pp(self) -> None:
         """

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -12,6 +12,16 @@ from spy.util import magic_dispatch
 def is_py_Name(py_expr: py_ast.expr, expected: str) -> bool:
     return isinstance(py_expr, py_ast.Name) and py_expr.id == expected
 
+
+def is_blue(py_expr: py_ast.expr) -> bool:
+    return is_py_Name(py_expr, 'blue')
+
+def is_blue_generic(py_expr: py_ast.expr) -> bool:
+    return (isinstance(py_expr, py_ast.Attribute) and
+            isinstance(py_expr.value, py_ast.Name) and
+            py_expr.value.id == "blue" and
+            py_expr.attr == "generic")
+
 class Parser:
     """
     SPy parser: take source code as input, produce a SPy AST as output.
@@ -97,9 +107,13 @@ class Parser:
         color: spy.ast.Color = 'red'
         func_kind: spy.ast.FuncKind = 'plain'
         for deco in py_funcdef.decorator_list:
-            if is_py_Name(deco, 'blue'):
+            if is_blue(deco):
                 # @blue is special-cased
                 color = 'blue'
+            elif is_blue_generic(deco):
+                # @blue.generic is special-cased
+                color = 'blue'
+                func_kind = 'generic'
             else:
                 # other decorators are not supported:
                 self.error('decorators are not supported yet',

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -95,6 +95,7 @@ class Parser:
                                  py_funcdef: py_ast.FunctionDef
                                  ) -> spy.ast.FuncDef:
         color: spy.ast.Color = 'red'
+        func_kind: spy.ast.FuncKind = 'plain'
         for deco in py_funcdef.decorator_list:
             if is_py_Name(deco, 'blue'):
                 # @blue is special-cased
@@ -127,6 +128,7 @@ class Parser:
         return spy.ast.FuncDef(
             loc = py_funcdef.loc,
             color = color,
+            kind = func_kind,
             name = py_funcdef.name,
             args = args,
             return_type = return_type,

--- a/spy/tests/compiler/test_00_bluemod.py
+++ b/spy/tests/compiler/test_00_bluemod.py
@@ -70,7 +70,7 @@ class TestBlueMod:
         w_foo = w_mod.getattr('foo')
         w_bar = self.vm.fast_call(w_foo, [])
         assert isinstance(w_bar, W_ASTFunc)
-        assert w_bar.w_functype == W_FuncType.parse('def(x: i32) -> i32')
+        assert w_bar.w_functype == W_FuncType.parse('def(i32) -> i32')
         w_42 = self.vm.wrap(42)
         assert self.vm.fast_call(w_bar, [w_42]) is w_42
 

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -579,7 +579,7 @@ class TestBasic(CompilerTest):
         """)
         #
         w_functype = mod.foo.w_functype
-        assert w_functype.signature == 'def(x: i32) -> i32'
+        assert w_functype.fqn.human_name == 'def(i32) -> i32'
         assert mod.foo(1) == 2
 
     def test_redshift_nonglobal_function(self):
@@ -625,7 +625,6 @@ class TestBasic(CompilerTest):
         assert mod.foo() == 3
         assert mod.bar() == 'hello world'
 
-    @pytest.mark.skip(reason="WIP")
     def test_cannot_call_blue_generic(self):
         src = """
         @blue.generic
@@ -637,8 +636,8 @@ class TestBasic(CompilerTest):
         """
         errors = expect_errors(
             'generic functions must be called via `[...]`',
-            ('this is a generic function', 'ident'),
-            ("function defined here", "def ident(x):")
+            ('this is `@blue.generic def(dynamic) -> dynamic`', 'ident'),
+            ("`ident` defined here", "def ident(x):")
             )
         self.compile_raises(src, "foo", errors)
 
@@ -966,8 +965,8 @@ class TestBasic(CompilerTest):
         w_ptr_S1 = w_mod.getattr('ptr_S1')
         w_ptr_S2 = w_mod.getattr('ptr_S2')
         #
-        expected_sig = 'def(s: test::S, p: unsafe::ptr[test::S]) -> void'
-        assert w_foo.w_functype.signature == expected_sig
+        expected_sig = 'def(test::S, unsafe::ptr[test::S]) -> void'
+        assert w_foo.w_functype.fqn.human_name == expected_sig
         params = w_foo.w_functype.params
         assert params[0].w_type is w_S
         assert params[1].w_type is w_ptr_S1 is w_ptr_S2

--- a/spy/tests/test_loc.py
+++ b/spy/tests/test_loc.py
@@ -30,3 +30,15 @@ def test_Loc_from_pyfunc():
     loc = Loc.from_pyfunc(bar)
     src = loc.get_src()
     exp = '    def bar():'
+
+def test_get_src_multiline():
+    loc = Loc.here()
+    # 1234567890ABCD
+    #
+    # make a new loc which spans two lines
+    loc2 = loc.replace(line_end=loc.line_end+1)
+    exp = """\
+    loc = Loc.here()
+    # 1234567890ABCD
+    """[:-5]  # remove the last line
+    assert loc2.get_src() == exp

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -49,6 +49,7 @@ class TestParser:
                 GlobalFuncDef(
                     funcdef=FuncDef(
                         color='red',
+                        kind='plain',
                         name='foo',
                         args=[],
                         return_type=Name(id='void'),
@@ -74,6 +75,7 @@ class TestParser:
                 GlobalFuncDef(
                     funcdef=FuncDef(
                         color='red',
+                        kind='plain',
                         name='foo',
                         args=[
                             FuncArg(
@@ -195,6 +197,7 @@ class TestParser:
         expected = """
         FuncDef(
             color='red',
+            kind='plain',
             name='foo',
             args=[],
             return_type=Name(id='i32'),
@@ -217,6 +220,7 @@ class TestParser:
         expected = """
         FuncDef(
             color='blue',
+            kind='plain',
             name='foo',
             args=[],
             return_type=Name(id='i32'),
@@ -228,6 +232,29 @@ class TestParser:
         )
         """
         self.assert_dump(funcdef, expected)
+
+    def test_blue_generic_FuncDef(self):
+        mod = self.parse("""
+        @blue.generic
+        def foo() -> i32:
+            return 42
+        """)
+        funcdef = mod.get_funcdef('foo')
+        expected = """
+        FuncDef(
+            color='blue',
+            name='foo',
+            args=[],
+            return_type=Name(id='i32'),
+            body=[
+                Return(
+                    value=Constant(value=42),
+                ),
+            ],
+        )
+        """
+        self.assert_dump(funcdef, expected)
+
 
     def test_empty_return(self):
         mod = self.parse("""
@@ -857,12 +884,14 @@ class TestParser:
                 GlobalFuncDef(
                     funcdef=FuncDef(
                         color='blue',
+                        kind='plain',
                         name='foo',
                         args=[],
                         return_type=Name(id='dynamic'),
                         body=[
                             FuncDef(
                                 color='red',
+                                kind='plain',
                                 name='bar',
                                 args=[],
                                 return_type=Name(id='void'),
@@ -1031,6 +1060,7 @@ class TestParser:
             methods=[
                 FuncDef(
                     color='red',
+                    kind='plain',
                     name='foo',
                     args=[],
                     return_type=Name(id='void'),

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -243,6 +243,7 @@ class TestParser:
         expected = """
         FuncDef(
             color='blue',
+            kind='generic',
             name='foo',
             args=[],
             return_type=Name(id='i32'),

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -256,6 +256,32 @@ class TestParser:
         """
         self.assert_dump(funcdef, expected)
 
+    def test_FuncDef_prototype_loc(self):
+        # blue functions without return type, are parsed as if they had a
+        # synthetic '-> dynamic' annotation. We also need to generate a
+        # synthetic Loc for the annotation. This is particularly important
+        # because we use return_type.loc to compute prototype_loc, which is
+        # used e.g. in error messages.
+        mod = self.parse("""
+        @blue
+        def a():
+            pass
+
+        @blue
+        def b(x):
+            pass
+
+        @blue
+        def c(
+              x):
+            pass
+        """)
+        adef = mod.get_funcdef('a')
+        bdef = mod.get_funcdef('b')
+        cdef = mod.get_funcdef('c')
+        assert adef.prototype_loc.get_src() == 'def a():'
+        assert bdef.prototype_loc.get_src() == 'def b(x):'
+        assert cdef.prototype_loc.get_src() == 'def c(\n      x):'
 
     def test_empty_return(self):
         mod = self.parse("""

--- a/spy/tests/vm/test_builtin.py
+++ b/spy/tests/vm/test_builtin.py
@@ -16,7 +16,7 @@ class TestBuiltin:
         def foo(vm: 'SPyVM', w_x: W_I32) -> W_Str:
             return W_Str(vm, 'this is never called')
         w_functype = functype_from_sig(foo, 'red')
-        assert w_functype == W_FuncType.parse('def(x: i32) -> str')
+        assert w_functype == W_FuncType.parse('def(i32) -> str')
 
     def test_functype_from_sig_extra_types(self):
         def foo(vm: 'SPyVM', w_x: W_I32) -> 'FooBar':  # type: ignore
@@ -25,14 +25,14 @@ class TestBuiltin:
             'FooBar': W_Str
         }
         w_functype = functype_from_sig(foo, 'red', extra_types=extra_types)
-        assert w_functype == W_FuncType.parse('def(x: i32) -> str')
+        assert w_functype == W_FuncType.parse('def(i32) -> str')
 
     def test_annotated_type(self):
         W_MyType = Annotated[W_Object, B.w_i32]
         def foo(vm: 'SPyVM', w_x: W_MyType) -> None:
             pass
         w_functype = functype_from_sig(foo, 'red')
-        assert w_functype == W_FuncType.parse('def(x: i32) -> void')
+        assert w_functype == W_FuncType.parse('def(i32) -> void')
 
     def test_builtin_func(self):
         vm = SPyVM()

--- a/spy/tests/vm/test_builtin.py
+++ b/spy/tests/vm/test_builtin.py
@@ -79,14 +79,14 @@ class TestBuiltin:
         @builtin_func('mymod')
         def w_foo(vm: 'SPyVM', w_x: W_Dynamic) -> W_Dynamic:  # type: ignore
             pass
-        assert w_foo.w_functype.signature == 'def(x: dynamic) -> dynamic'
+        assert w_foo.w_functype.fqn.human_name == 'def(dynamic) -> dynamic'
 
     def test_return_None(self):
         vm = SPyVM()
         @builtin_func('mymod')
         def w_foo(vm: 'SPyVM') -> None:
             pass
-        assert w_foo.w_functype.signature == 'def() -> void'
+        assert w_foo.w_functype.fqn.human_name == 'def() -> void'
         assert isinstance(w_foo, W_BuiltinFunc)
         w_res = vm.fast_call(w_foo, [])
         assert w_res is B.w_None
@@ -99,7 +99,7 @@ class TestBuiltin:
             x = vm.unwrap_i32(w_x)
             return vm.wrap(x*2)  # type: ignore
 
-        assert w_foo.w_functype.signature == '@blue def(x: i32) -> i32'
+        assert w_foo.w_functype.fqn.human_name == '@blue def(i32) -> i32'
         w_x = vm.fast_call(w_foo, [vm.wrap(21)])
         w_y = vm.fast_call(w_foo, [vm.wrap(21)])
         assert w_x is w_y
@@ -117,7 +117,7 @@ class TestBuiltin:
         w_make = w_foo.dict_w['make']
         assert w_foo.lookup_func('make') is w_make
         assert isinstance(w_make, W_BuiltinFunc)
-        assert w_make.w_functype.signature == "def() -> test::Foo"
+        assert w_make.w_functype.fqn.human_name == "def() -> test::Foo"
         assert w_make.w_functype.w_restype is W_Foo._w
 
     def test_inherit_method(self):

--- a/spy/tests/vm/test_func_adapter.py
+++ b/spy/tests/vm/test_func_adapter.py
@@ -32,7 +32,7 @@ def test_shuffle_args():
     w_s = vm.fast_call(w_adapter, [vm.wrap(3), vm.wrap('ab ')])
     assert vm.unwrap_str(w_s) == 'ab ab ab '
     #
-    r = '<spy adapter `def(n: i32, s: str) -> str` for `test::repeat`>'
+    r = '<spy adapter `def(i32, str) -> str` for `test::repeat`>'
     assert repr(w_adapter) == r
     #
     expected = textwrap.dedent("""

--- a/spy/tests/vm/test_func_adapter.py
+++ b/spy/tests/vm/test_func_adapter.py
@@ -36,8 +36,8 @@ def test_shuffle_args():
     assert repr(w_adapter) == r
     #
     expected = textwrap.dedent("""
-    def(n: i32, s: str) -> str:
-        return `test::repeat`(s, n)
+    def(v0: i32, v1: str) -> str:
+        return `test::repeat`(v1, v0)
     """).strip()
     assert w_adapter.render() == expected
 
@@ -53,8 +53,8 @@ def test_const():
     w_s = vm.fast_call(w_adapter, [vm.wrap(3)])
     assert vm.unwrap_str(w_s) == 'ab ab ab '
     expected = textwrap.dedent("""
-    def(n: i32) -> str:
-        return `test::repeat`(W_Str('ab '), n)
+    def(v0: i32) -> str:
+        return `test::repeat`(W_Str('ab '), v0)
     """).strip()
     assert w_adapter.render() == expected
 
@@ -70,7 +70,7 @@ def test_converter():
     assert vm.unwrap_str(w_s) == 'ab ab ab '
     #
     expected = textwrap.dedent("""
-    def(x: f64, s: str) -> str:
-        return `test::repeat`(s, `operator::f64_to_i32`(x))
+    def(v0: f64, v1: str) -> str:
+        return `test::repeat`(v1, `operator::f64_to_i32`(v0))
     """).strip()
     assert w_adapter.render() == expected

--- a/spy/tests/vm/test_func_adapter.py
+++ b/spy/tests/vm/test_func_adapter.py
@@ -23,7 +23,7 @@ def test_repeat():
 
 def test_shuffle_args():
     vm = SPyVM()
-    w_functype = W_FuncType.parse('def(n: i32, s: str) -> str')
+    w_functype = W_FuncType.parse('def(i32, str) -> str')
     w_adapter = W_FuncAdapter(
         w_functype,
         w_repeat,
@@ -43,7 +43,7 @@ def test_shuffle_args():
 
 def test_const():
     vm = SPyVM()
-    w_functype = W_FuncType.parse('def(n: i32) -> str')
+    w_functype = W_FuncType.parse('def(i32) -> str')
     w_s = vm.wrap('ab ')
     w_adapter = W_FuncAdapter(
         w_functype,
@@ -60,7 +60,7 @@ def test_const():
 
 def test_converter():
     vm = SPyVM()
-    w_functype = W_FuncType.parse('def(x: f64, s: str) -> str')
+    w_functype = W_FuncType.parse('def(f64, str) -> str')
     w_adapter = W_FuncAdapter(
         w_functype,
         w_repeat,

--- a/spy/tests/vm/test_function.py
+++ b/spy/tests/vm/test_function.py
@@ -1,30 +1,48 @@
 import pytest
 from typing import no_type_check
 from spy.fqn import FQN
+from spy.vm.object import W_Type
 from spy.vm.primitive import W_I32
 from spy.vm.vm import SPyVM
 from spy.vm.b import B
 from spy.vm.w import W_FuncType
-from spy.vm.function import W_ASTFunc
+from spy.vm.function import W_ASTFunc, FuncParam, FuncKind, Color
+
+
+def make_FuncType(
+        *types_w: W_Type,
+        w_restype: W_Type,
+        color: Color = 'red',
+        kind: FuncKind = 'plain',
+) -> W_FuncType:
+    """
+    Small helper to make it easier to build W_FuncType.
+    """
+    params = [
+        FuncParam(w_type, 'simple')
+        for w_type in types_w
+    ]
+    return W_FuncType.new(params, w_restype, color=color, kind=kind)
+
 
 class TestFunction:
 
     def test_FunctionType_repr(self):
-        w_functype = W_FuncType.make(x=B.w_i32, y=B.w_i32, w_restype=B.w_bool)
+        w_functype = make_FuncType(B.w_i32, B.w_i32, w_restype=B.w_bool)
         assert str(w_functype.fqn) == 'builtins::def[i32, i32, bool]'
         assert repr(w_functype) == "<spy type 'def(i32, i32) -> bool'>"
 
     def test_FunctionType_parse(self):
         w_ft = W_FuncType.parse('def() -> i32')
-        assert w_ft == W_FuncType.make(w_restype=B.w_i32)
+        assert w_ft == make_FuncType(w_restype=B.w_i32)
         #
-        w_ft = W_FuncType.parse('def(x: str) -> i32')
-        assert w_ft == W_FuncType.make(x=B.w_str, w_restype=B.w_i32)
+        w_ft = W_FuncType.parse('def(str) -> i32')
+        assert w_ft == make_FuncType(B.w_str, w_restype=B.w_i32)
         #
-        w_ft = W_FuncType.parse('def(x: str, y: i32,) -> i32')
-        assert w_ft == W_FuncType.make(
-            x = B.w_str,
-            y = B.w_i32,
+        w_ft = W_FuncType.parse('def(str, i32,) -> i32')
+        assert w_ft == make_FuncType(
+            B.w_str,
+            B.w_i32,
             w_restype = B.w_i32
         )
 
@@ -51,19 +69,22 @@ class TestFunction:
         assert vm.eq(w_a, w_b) is B.w_False
 
     def test_FunctionType_fqn(self):
-        kwargs = dict(
-            x = B.w_i32,
-            y = B.w_i32,
-            w_restype = B.w_str
-        )
-        w_t1 = W_FuncType.make(**kwargs)
+        def make(color: Color, kind: FuncKind):
+            return make_FuncType(
+                B.w_i32,
+                B.w_i32,
+                w_restype = B.w_str,
+                color = color,
+                kind = kind
+            )
+        w_t1 = make('red', 'plain')
         assert w_t1.fqn == FQN('builtins::def[i32, i32, str]')
         assert w_t1.fqn.human_name == 'def(i32, i32) -> str'
 
-        w_t2 = W_FuncType.make(color='blue', **kwargs)
+        w_t2 = make('blue', 'plain')
         assert w_t2.fqn == FQN('builtins::blue.def[i32, i32, str]')
         assert w_t2.fqn.human_name == '@blue def(i32, i32) -> str'
 
-        w_t3 = W_FuncType.make(color='blue', kind='generic', **kwargs)
+        w_t3 = make('blue', 'generic')
         assert w_t3.fqn == FQN('builtins::blue.generic.def[i32, i32, str]')
         assert w_t3.fqn.human_name == '@blue.generic def(i32, i32) -> str'

--- a/spy/tests/vm/test_function.py
+++ b/spy/tests/vm/test_function.py
@@ -12,7 +12,7 @@ class TestFunction:
     def test_FunctionType_repr(self):
         w_functype = W_FuncType.make(x=B.w_i32, y=B.w_i32, w_restype=B.w_bool)
         assert str(w_functype.fqn) == 'builtins::def[i32, i32, bool]'
-        assert repr(w_functype) == "<spy type 'def(x: i32, y: i32) -> bool'>"
+        assert repr(w_functype) == "<spy type 'def(i32, i32) -> bool'>"
 
     def test_FunctionType_parse(self):
         w_ft = W_FuncType.parse('def() -> i32')
@@ -22,9 +22,11 @@ class TestFunction:
         assert w_ft == W_FuncType.make(x=B.w_str, w_restype=B.w_i32)
         #
         w_ft = W_FuncType.parse('def(x: str, y: i32,) -> i32')
-        assert w_ft == W_FuncType.make(x=B.w_str,
-                                           y=B.w_i32,
-                                           w_restype=B.w_i32)
+        assert w_ft == W_FuncType.make(
+            x = B.w_str,
+            y = B.w_i32,
+            w_restype = B.w_i32
+        )
 
     def test_FunctionType_eq(self):
         vm = SPyVM()
@@ -47,3 +49,21 @@ class TestFunction:
         w_b = W_ASTFunc(w_functype, FQN('test::b'), funcdef, closure=None)
         assert vm.eq(w_a, w_a) is B.w_True
         assert vm.eq(w_a, w_b) is B.w_False
+
+    def test_FunctionType_fqn(self):
+        kwargs = dict(
+            x = B.w_i32,
+            y = B.w_i32,
+            w_restype = B.w_str
+        )
+        w_t1 = W_FuncType.make(**kwargs)
+        assert w_t1.fqn == FQN('builtins::def[i32, i32, str]')
+        assert w_t1.fqn.human_name == 'def(i32, i32) -> str'
+
+        w_t2 = W_FuncType.make(color='blue', **kwargs)
+        assert w_t2.fqn == FQN('builtins::blue.def[i32, i32, str]')
+        assert w_t2.fqn.human_name == '@blue def(i32, i32) -> str'
+
+        w_t3 = W_FuncType.make(color='blue', kind='generic', **kwargs)
+        assert w_t3.fqn == FQN('builtins::blue.generic.def[i32, i32, str]')
+        assert w_t3.fqn.human_name == '@blue.generic def(i32, i32) -> str'

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -159,7 +159,6 @@ class AbstractFrame:
         for arg in funcdef.args:
             w_param_type = self.eval_expr_type(arg.type)
             param = FuncParam(
-                name = arg.name,
                 w_type = w_param_type,
                 kind = 'simple'
             )
@@ -654,19 +653,20 @@ class ASTFrame(AbstractFrame):
             return e.w_value
 
     def declare_arguments(self) -> None:
-        w_functype = self.w_func.w_functype
+        w_ft = self.w_func.w_functype
         self.declare_local('@if', B.w_bool)
         self.declare_local('@while', B.w_bool)
-        self.declare_local('@return', w_functype.w_restype)
-        for param in w_functype.params:
-            self.declare_local(param.name, param.w_type)
+        self.declare_local('@return', w_ft.w_restype)
+        for arg, param in zip(self.funcdef.args, w_ft.params, strict=True):
+            self.declare_local(arg.name, param.w_type)
 
     def init_arguments(self, args_w: Sequence[W_Object]) -> None:
         """
         Store the arguments in args_w in the appropriate local var
         """
-        w_functype = self.w_func.w_functype
-        params = self.w_func.w_functype.params
-        for param, w_arg in zip(params, args_w, strict=True):
+        w_ft = self.w_func.w_functype
+        args = self.funcdef.args
+        params = w_ft.params
+        for arg, param, w_arg in zip(args, params, args_w, strict=True):
             assert self.vm.isinstance(w_arg, param.w_type)
-            self.store_local(param.name, w_arg)
+            self.store_local(arg.name, w_arg)

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -165,7 +165,12 @@ class AbstractFrame:
             )
             params.append(param)
         w_restype = self.eval_expr_type(funcdef.return_type)
-        w_functype = W_FuncType.new(params, w_restype, color=funcdef.color)
+        w_functype = W_FuncType.new(
+            params,
+            w_restype,
+            color=funcdef.color,
+            kind=funcdef.kind
+        )
         # create the w_func
         fqn = self.ns.join(funcdef.name)
         fqn = self.vm.get_unique_FQN(fqn)

--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -47,11 +47,6 @@ def to_spy_type(ann: Any, *, allow_None: bool = False) -> W_Type:
     raise ValueError(f"Invalid @builtin_func annotation: {ann}")
 
 def to_spy_FuncParam(p: Any, extra_types: TYPES_DICT) -> FuncParam:
-    if p.name.startswith('w_'):
-        name = p.name[2:]
-    else:
-        name = p.name
-    #
     annotation = extra_types.get(p.annotation, p.annotation)
     w_type = to_spy_type(annotation)
     kind: FuncParamKind
@@ -61,7 +56,7 @@ def to_spy_FuncParam(p: Any, extra_types: TYPES_DICT) -> FuncParam:
         kind = 'varargs'
     else:
         assert False
-    return FuncParam(name, w_type, kind)
+    return FuncParam(w_type, kind)
 
 
 def functype_from_sig(fn: Callable, color: Color, *,

--- a/spy/vm/func_adapter.py
+++ b/spy/vm/func_adapter.py
@@ -51,7 +51,7 @@ class W_FuncAdapter(W_Func):
         self.args = args
 
     def __repr__(self) -> str:
-        sig = self.w_functype.signature
+        sig = self.w_functype.fqn.human_name
         fqn = self.w_func.fqn
         return f'<spy adapter `{sig}` for `{fqn}`>'
 
@@ -94,9 +94,18 @@ class W_FuncAdapter(W_Func):
             else:
                 assert False
 
+        sig = self.func_signature()
         args = [fmt(spec) for spec in self.args]
         arglist = ', '.join(args)
         return textwrap.dedent(f"""
-        {self.w_functype.signature}:
+        {sig}:
             return `{self.w_func.fqn}`({arglist})
         """).strip()
+
+    def func_signature(self) -> str:
+        w_ft = self.w_functype
+        params = [f'{p.name}: {p.w_type.fqn.human_name}' for p in w_ft.params]
+        str_params = ', '.join(params)
+        resname = w_ft.w_restype.fqn.human_name
+        s = f'def({str_params}) -> {resname}'
+        return s

--- a/spy/vm/func_adapter.py
+++ b/spy/vm/func_adapter.py
@@ -80,7 +80,7 @@ class W_FuncAdapter(W_Func):
         """
         Return a human-readable representation of the adapter
         """
-        argnames = [p.name for p in self.w_functype.params]
+        argnames = [f'v{i}' for i, p in enumerate(self.w_functype.params)]
         def fmt(spec: ArgSpec) -> str:
             if isinstance(spec, Arg):
                 arg = argnames[spec.i]
@@ -104,7 +104,10 @@ class W_FuncAdapter(W_Func):
 
     def func_signature(self) -> str:
         w_ft = self.w_functype
-        params = [f'{p.name}: {p.w_type.fqn.human_name}' for p in w_ft.params]
+        params = [
+            f'v{i}: {p.w_type.fqn.human_name}'
+            for i, p in enumerate(w_ft.params)
+        ]
         str_params = ', '.join(params)
         resname = w_ft.w_restype.fqn.human_name
         s = f'def({str_params}) -> {resname}'

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -19,7 +19,6 @@ FuncParamKind = Literal['simple', 'varargs']
 
 @dataclass(frozen=True, eq=True)
 class FuncParam:
-    name: str
     w_type: W_Type
     kind: FuncParamKind
 
@@ -34,15 +33,9 @@ class W_FuncType(W_Type):
     @classmethod
     def new(cls, params: list[FuncParam], w_restype: W_Type,
             *, color: Color = 'red', kind: FuncKind = 'plain') -> 'Self':
-        # sanity check
-        if params:
-            assert isinstance(params[0], FuncParam)
         # build an artificial FQN for the functype.
-        # For 'def(i32, i32) -> bool', the FQN looks like this:
+        # E.g. for 'def(i32, i32) -> bool', the FQN looks like this:
         #    builtins::def[i32, i32, bool]
-        #
-        # XXX the FQN is not necessarily unique, we don't take into account
-        # param names
         qualifiers = [p.w_type.fqn for p in params] + [w_restype.fqn]
         if color == 'red':
             assert kind == 'plain'
@@ -54,6 +47,7 @@ class W_FuncType(W_Type):
         else:
             assert False
         fqn = FQN('builtins').join(t, qualifiers)
+
         w_functype = super().from_pyclass(fqn, W_Func)
         w_functype.params = params
         w_functype.w_restype = w_restype
@@ -86,7 +80,7 @@ class W_FuncType(W_Type):
         Small helper to make it easier to build W_FuncType, especially in
         tests
         """
-        params = [FuncParam(key, w_type, 'simple')
+        params = [FuncParam(w_type, 'simple')
                   for key, w_type in kwargs.items()]
         return cls.new(params, w_restype, color=color, kind=kind)
 

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -69,22 +69,6 @@ class W_FuncType(W_Type):
             return W_OpImpl.NULL
 
     @classmethod
-    def make(cls,
-             *,
-             w_restype: W_Type,
-             color: Color = 'red',
-             kind: FuncKind = 'plain',
-             **kwargs: W_Type
-             ) -> 'W_FuncType':
-        """
-        Small helper to make it easier to build W_FuncType, especially in
-        tests
-        """
-        params = [FuncParam(w_type, 'simple')
-                  for key, w_type in kwargs.items()]
-        return cls.new(params, w_restype, color=color, kind=kind)
-
-    @classmethod
     def parse(cls, s: str) -> 'W_FuncType':
         """
         Quick & dirty function to parse function types.
@@ -103,16 +87,16 @@ class W_FuncType(W_Type):
         args, res = map(str.strip, s.split('->'))
         assert args.startswith('def(')
         assert args.endswith(')')
-        kwargs = {}
+        params = []
         arglist = args[4:-1].split(',')
-        for arg in arglist:
-            if arg == '':
+        for argtype in arglist:
+            if argtype == '':
                 continue
-            argname, argtype = map(str.strip, arg.split(':'))
-            kwargs[argname] = parse_type(argtype)
+            w_type = parse_type(argtype.strip())
+            params.append(FuncParam(w_type, 'simple'))
         #
         w_restype = parse_type(res)
-        return cls.make(w_restype=w_restype, **kwargs)
+        return cls.new(params, w_restype)
 
     @property
     def is_varargs(self) -> bool:

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -21,7 +21,7 @@ def w_CALL(vm: 'SPyVM', wop_obj: W_OpArg, *args_wop: W_OpArg) -> W_Func:
     errmsg = 'cannot call objects of type `{0}`'
 
     if isinstance(w_type, W_FuncType):
-        # W_Func is a special case, as it have a w_CALL for bootstrapping
+        # W_Func is a special case, as it can't have a w_CALL for bootstrapping
         # reasons. Moreover, while we are at it, we can produce a better error
         # message in case we try to call a plain function with [].
         if w_type.kind == 'plain':

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -114,10 +114,7 @@ def typecheck_opimpl(
 
 def functype_from_opargs(args_wop: list[W_OpArg], w_restype: W_Type,
                          color: Color) -> W_FuncType:
-    params = [
-        FuncParam(f'v{i}', wop.w_static_type, 'simple')
-        for i, wop in enumerate(args_wop)
-    ]
+    params = [FuncParam(wop.w_static_type, 'simple') for wop in args_wop]
     return W_FuncType.new(params, w_restype, color=color)
 
 


### PR DESCRIPTION
`@blue.generic` functions are exactly like `@blue`, but they are "called" using square brackets instead of parenthesis.
This makes it possible to write things like this:
```
@blue.generic
def add(T):
    def impl(x:T, y: T) -> T:
        return x + y
    return impl

def main() -> void:
    print(add[i32](1, 2))
    print(add[str]('hello ', 'world'))
```

In addition, there are a couple of minor/related updates:
  - `W_FuncType` no longer includes argument names, only the argument types
  - we have different FQNs for red/blue/blue_generic functions, and we simplified how to generate human-readable versions of them
  - improved Loc.get_src to work also in multiline case
  - fix error reporting of blue functions with implicit return types (before, funcdef.prototype_loc wrongly pointed to the whole function)
  - 