### PR TITLE
disable implicit float-to-int conversion

### DIFF
--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -346,15 +346,10 @@ class TestBasic(CompilerTest):
 
         def b(x: i32) -> bool:
             return x
-
-        def c(x: f64) -> i32:
-            return x
         """)
         res = mod.a(1)
         assert res == 1.0 and type(res) is float
         assert mod.b(1) is True
-        assert mod.c(2.5) == 2
-
 
     def test_cannot_call_non_functions(self):
         # it would be nice to report also the location where 'inc' is defined,

--- a/spy/vm/modules/operator/convop.py
+++ b/spy/vm/modules/operator/convop.py
@@ -119,4 +119,8 @@ def w_from_dynamic(vm: 'SPyVM', w_T: W_Type) -> W_Dynamic:
 
 MM.register('convert', 'i32', 'f64', OP.w_i32_to_f64)
 MM.register('convert', 'i32', 'bool', OP.w_i32_to_bool)
-MM.register('convert', 'f64', 'i32', OP.w_f64_to_i32)
+
+# this is wrong: we don't want implicit truncation from float to int. Maybe
+# eventually we will want a distinction between implicit and explicit
+# conversions?
+#MM.register('convert', 'f64', 'i32', OP.w_f64_to_i32)


### PR DESCRIPTION
This is wrong because it causes a truncation, which we don't want to do implicitly.  It was added by commit de70fbda: it's unclear what was the original goal, but I think it was just a mistake