### PR TITLE
Improve importing logic

### DIFF
--- a/spy/analyze/importing.py
+++ b/spy/analyze/importing.py
@@ -155,7 +155,7 @@ class ImportAnalizyer:
         result = []
         visited = set()
 
-        def visit(modname):
+        def visit(modname: str) -> None:
             if modname in visited:
                 return
             visited.add(modname)
@@ -216,7 +216,7 @@ class ImportAnalizyer:
             for i, path in enumerate(self.vm.path):
                 paths[path+'/'] = f'$p{i}'
 
-        def shorten_path(path):
+        def shorten_path(path: str) -> str:
             if not path:
                 return path
             for base_path, alias in paths.items():

--- a/spy/analyze/importing.py
+++ b/spy/analyze/importing.py
@@ -135,12 +135,16 @@ class ImportAnalizyer:
         scopes.analyze()
         return scopes
 
-    def import_all(self) -> None:
-        assert self.mods, 'call .parse_all() first'
+    def get_import_list(self) -> list[str]:
         # XXX: the following logic is broken and doesn't do what the class
         # docstring says
-        all_mods = reversed(self.mods.items())
-        for modname, mod in all_mods:
+        return list(reversed(self.mods))
+
+    def import_all(self) -> None:
+        assert self.mods, 'call .parse_all() first'
+        import_list = self.get_import_list()
+        for modname in import_list:
+            mod = self.mods[modname]
             if isinstance(mod, ast.Module):
                 self.import_one(modname, mod)
 
@@ -156,7 +160,9 @@ class ImportAnalizyer:
         from spy.vm.module import W_Module
         color = ColorFormatter(use_colors=True)
         n = max(len(modname) for modname in self.mods)
-        for modname, mod in self.mods.items():
+        import_list = self.get_import_list()
+        for modname in import_list:
+            mod = self.mods[modname]
             if isinstance(mod, ast.Module):
                 what = color.set('green', mod.filename)
             elif isinstance(mod, W_Module):

--- a/spy/analyze/importing.py
+++ b/spy/analyze/importing.py
@@ -190,25 +190,51 @@ class ImportAnalizyer:
         self.vm.modules_w[modname] = w_mod
 
     def pp(self) -> None:
-        print('Import tree')
+        print('Import tree:')
         self.pp_tree()
         print()
-        print('Import order')
+        print('vm.path:')
+        self.pp_path()
+        print()
+        print('Import order:')
         self.pp_list()
+
+    def pp_path(self) -> None:
+        color = ColorFormatter(use_colors=True)
+        for i, p in enumerate(self.vm.path):
+            print(f'  p{i} = {p}')
 
     def pp_list(self) -> None:
         from spy.vm.module import W_Module
         color = ColorFormatter(use_colors=True)
         n = max(len(modname) for modname in self.mods)
         import_list = self.get_import_list()
+
+        # identify common paths
+        paths = {}
+        if self.vm.path:
+            for i, path in enumerate(self.vm.path):
+                paths[path+'/'] = f'$p{i}'
+
+        def shorten_path(path):
+            if not path:
+                return path
+            for base_path, alias in paths.items():
+                if path.startswith(base_path):
+                    suffix = path[len(base_path):]
+                    suffix = color.set('green', suffix)
+                    return f"{alias}/{suffix}"
+            return path
+
+        # Print import list with shortened paths
         for i, modname in enumerate(import_list):
             mod = self.mods[modname]
             if isinstance(mod, ast.Module):
-                what = color.set('green', mod.filename)
+                # The alias is already colored in shorten_path
+                what = shorten_path(mod.filename)
             elif isinstance(mod, W_Module):
                 what = color.set('blue', str(mod)) + ' (already imported)'
             elif mod is None:
-                c = 'red'
                 what = color.set('red', 'ImportError')
             else:
                 assert False

--- a/spy/cli.py
+++ b/spy/cli.py
@@ -332,6 +332,9 @@ async def inner_main(args: Arguments) -> None:
     importer.import_all()
     w_mod = vm.modules_w[modname]
 
+    #vm.pp_globals()
+    #vm.pp_modules()
+
     if args.execute:
         w_main_functype = W_FuncType.parse('def() -> void')
         w_main = w_mod.getattr_maybe('main')

--- a/spy/tests/compiler/test_importing.py
+++ b/spy/tests/compiler/test_importing.py
@@ -1,5 +1,5 @@
 import pytest
-from spy.tests.support import CompilerTest, no_C, expect_errors
+from spy.tests.support import CompilerTest, no_C, expect_errors, only_interp
 
 class TestImporting(CompilerTest):
 
@@ -75,3 +75,54 @@ class TestImporting(CompilerTest):
         """)
 
         assert mod.foo(3, 4) == 7
+
+    @only_interp
+    def test_nested_imports(self, capsys):
+        self.write_file("aaa.spy", """
+        import a1
+        import a2
+
+        @blue
+        def __INIT__(mod):
+            print('aaa')
+        """)
+        self.write_file("bbb.spy", """
+        import aaa
+        import b1
+        import b2
+
+        @blue
+        def __INIT__(mod):
+            print('bbb')
+        """)
+        self.write_file("a1.spy", """
+        @blue
+        def __INIT__(mod):
+            print('a1')
+        """)
+        self.write_file("a2.spy", """
+        @blue
+        def __INIT__(mod):
+            print('a2')
+        """)
+        self.write_file("b1.spy", """
+        @blue
+        def __INIT__(mod):
+            print('b1')
+        """)
+        self.write_file("b2.spy", """
+        @blue
+        def __INIT__(mod):
+            print('b2')
+        """)
+        mod = self.compile("""
+        import aaa
+        import bbb
+
+        @blue
+        def __INIT__(mod):
+            print('main')
+        """)
+        out, err = capsys.readouterr()
+        mods = out.strip().split('\n')
+        assert mods == ['a1', 'a2', 'aaa', 'b1', 'b2', 'bbb', 'main']

--- a/spy/tests/compiler/test_importing.py
+++ b/spy/tests/compiler/test_importing.py
@@ -78,6 +78,7 @@ class TestImporting(CompilerTest):
 
     @only_interp
     def test_nested_imports(self, capsys):
+        self.SKIP_SPY_BACKEND_SANITY_CHECK = True
         self.write_file("aaa.spy", """
         import a1
         import a2

--- a/spy/tests/test_importing.py
+++ b/spy/tests/test_importing.py
@@ -42,26 +42,35 @@ class TestImportAnalizyer:
 
     def test_nested_imports(self):
         self.write("main.spy", """
-        import mod1
-        import mod2
+        import aaa
+        import bbb
         """)
-        self.write("mod1.spy", """
-        import mod3
+        self.write("aaa.spy", """
+        import a1
+        import a2
         """)
-        self.write("mod2.spy", """
-        import mod3
-        import mod4
+        self.write("bbb.spy", """
+        import aaa
+        import b1
+        import b2
         """)
-        self.write("mod3.spy", """
-        x: i32 = 42
+        self.write("a1.spy", """
+        x = 'a1'
         """)
-        self.write("mod4.spy", """
-        y: i32 = 43
+        self.write("a2.spy", """
+        x = 'a2'
+        """)
+        self.write("b1.spy", """
+        x = 'b1'
+        """)
+        self.write("b2.spy", """
+        x = 'b2'
         """)
 
         analyzer = ImportAnalizyer(self.vm, 'main')
         analyzer.parse_all()
-        assert list(analyzer.mods) == ['main', 'mod1', 'mod2', 'mod3', 'mod4']
+        mods = analyzer.get_import_list()
+        assert mods == ['a1', 'a2', 'aaa', 'b1', 'b2', 'bbb', 'main']
 
     @pytest.mark.skip(reason="parser does not support this")
     def test_import_in_function(self):

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -185,6 +185,17 @@ class SPyVM:
                 return fqn
         return None
 
+    def pp_globals(self) -> None:
+        all_fqns = sorted(self.globals_w, key=lambda fqn: str(fqn))
+        for fqn in all_fqns:
+            print(fqn)
+
+    def pp_modules(self) -> None:
+        for modname, w_mod in self.modules_w.items():
+            w_mod.pp()
+            print()
+
+
     def make_fqn_const(self, w_val: W_Object) -> FQN:
         """
         Check whether the given w_val has a corresponding FQN, and create

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -195,7 +195,6 @@ class SPyVM:
             w_mod.pp()
             print()
 
-
     def make_fqn_const(self, w_val: W_Object) -> FQN:
         """
         Check whether the given w_val has a corresponding FQN, and create


### PR DESCRIPTION
Now SPy determines the order of imports as it's indicated by `ImportAnalyzer.__doc__`:
https://github.com/spylang/spy/blob/71a6f94d649e2a3db9886b510304ce56db8b90ba/spy/analyze/importing.py#L18-L83

Moreover, this PR adds better pretty printer for `spy --imports`:
![image](https://github.com/user-attachments/assets/1d430146-4344-45f4-bb2e-3e446345d258)
