### PR TITLE
Fix test_py_cffi on MacOS

### DIFF
--- a/spy/build/cffi.py
+++ b/spy/build/cffi.py
@@ -5,8 +5,9 @@ import py.path
 import contextlib
 from spy.util import robust_run
 
+
 @contextlib.contextmanager
-def chdir(path: str|py.path.local) -> Any:
+def chdir(path: str | py.path.local) -> Any:
     """Context manager to temporarily change directory."""
     old_dir = os.getcwd()
     try:
@@ -25,7 +26,8 @@ def cffi_build(build_script: py.path.local) -> py.path.local:
     d = build_script.dirpath()
     with chdir(d):
         proc = robust_run(cmdline)
-    out = proc.stdout.decode('utf-8')
+    # The generated .so file is expected to be in the stdout of the build script
+    out = proc.stdout.decode("utf-8")
     sofile = py.path.local(out.strip())
     assert sofile.exists()
     return sofile

--- a/spy/util.py
+++ b/spy/util.py
@@ -127,11 +127,8 @@ def robust_run(
     """
     cmdline_s = [str(x) for x in cmdline]
     #print(" ".join(cmdline_s))
-    proc = subprocess.run(
-        cmdline_s,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT
-    )
+    # Use capture_output=True to capture stdout and stderr separately
+    proc = subprocess.run(cmdline_s, capture_output=True)
     if proc.returncode != 0:
         FORCE_COLORS = True
         lines = ["subprocess failed:"]


### PR DESCRIPTION
Fixes #164 

On MacOS there are possibly warning messages printed to stderr when compiling the test c extension. To prevent this from confusing the cffi_build function, change the robust_run function to not redirect stderr to stdout. This allows callers of robust_run to read stdout and stderr separately.