### PR TITLE
chore: Enable MacOS tests on CI github workflow.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,14 +16,16 @@ on:
         required: false
         default: false
 
-
 jobs:
   test:
-    runs-on: ubuntu-latest
+    name:  test-${{ matrix.os }}-${{ matrix.python-version}}
+    runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [3.12]
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.12"]
 
     steps:
     - name: Setup tmate session
@@ -41,6 +43,16 @@ jobs:
         # expect provides "unbuffer"
         tools: expect
         method: timestamp
+      if: runner.os == 'Linux'
+
+    - name: Install Homebrew packages
+      uses: tecolicom/actions-use-homebrew-tools@v1
+      with:
+        tools: 'expect'
+        cache: 'yes'
+        verbose: true
+      if: runner.os == 'macOS'
+
 
     # - name: Install wasi-sdk
     #   run: |


### PR DESCRIPTION
Add macos-latest as a platform the github tests workflow runs on. 

See here for a list of runners:
https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/choosing-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories