### PR TITLE
make it possible to use None in function signatures

### DIFF
--- a/examples/array.spy
+++ b/examples/array.spy
@@ -37,7 +37,7 @@ def ndarray1(DTYPE):
 
     return ndarray
 
-def main() -> void:
+def main() -> None:
     a_floats = ndarray1[f64](10)
     a_ints = ndarray1[i32](4)
     print(a_floats[3])

--- a/examples/array2d.spy
+++ b/examples/array2d.spy
@@ -40,7 +40,7 @@ def array2d(DTYPE):
         @blue
         def __SETITEM__(v_arr: OpArg, v_i: OpArg, v_j: OpArg,
                         v_v: OpArg) -> OpImpl:
-            def setitem(arr: ndarray, i: i32, j: i32, v: DTYPE) -> void:
+            def setitem(arr: ndarray, i: i32, j: i32, v: DTYPE) -> None:
                 ll = arr.__ll__
                 if i >= ll.h:
                     raise IndexError
@@ -50,7 +50,7 @@ def array2d(DTYPE):
                 ll.items[idx] = v
             return OpImpl(setitem)
 
-        def print_flatten(self: ndarray) -> void:
+        def print_flatten(self: ndarray) -> None:
             ll = self.__ll__
             i = 0
             while i < ll.h * ll.w:
@@ -59,7 +59,7 @@ def array2d(DTYPE):
 
     return ndarray
 
-def main() -> void:
+def main() -> None:
     a = array2d[i32](2, 4)
     a[1, 2] = 6
     print(a[1, 2])

--- a/examples/array3d.spy
+++ b/examples/array3d.spy
@@ -54,7 +54,7 @@ def array3d(DTYPE):
         @blue
         def __SETITEM__(v_arr: OpArg, v_i: OpArg, v_j: OpArg, v_k: OpArg,
                         v_v: OpArg) -> OpImpl:
-            def setitem(arr: ndarray, i: i32, j: i32, k: i32, v: DTYPE) -> void:
+            def setitem(arr: ndarray, i: i32, j: i32, k: i32, v: DTYPE) -> None:
                 ll = arr.__ll__
                 if i >= ll.h:
                     raise IndexError
@@ -66,7 +66,7 @@ def array3d(DTYPE):
                 ll.items[idx] = v
             return OpImpl(setitem)
 
-        def print_flatten(self: ndarray) -> void:
+        def print_flatten(self: ndarray) -> None:
             ll = self.__ll__
             i = 0
             while i < ll.h * ll.w * ll.d:
@@ -75,7 +75,7 @@ def array3d(DTYPE):
 
     return ndarray
 
-def main() -> void:
+def main() -> None:
     buf = gc_alloc(i32)(4*3*2)
     i = 0
     while i < 4*3*2:

--- a/examples/blue_generic.spy
+++ b/examples/blue_generic.spy
@@ -4,6 +4,6 @@ def add(T):
         return x + y
     return impl
 
-def main() -> void:
+def main() -> None:
     print(add[i32](1, 2))
     print(add[str]('hello ', 'world'))

--- a/examples/bluefunc.spy
+++ b/examples/bluefunc.spy
@@ -26,7 +26,7 @@ def get_pi():
 
     return 4 * pi_approx
 
-def main() -> void:
+def main() -> None:
     pi = get_pi()
     print("pi:")
     print(pi)

--- a/examples/hello.spy
+++ b/examples/hello.spy
@@ -1,4 +1,4 @@
 #! -*- mode: python -*-
 
-def main() -> void:
+def main() -> None:
     print("Hello world!")

--- a/examples/jsffi/demo.spy
+++ b/examples/jsffi/demo.spy
@@ -4,13 +4,13 @@ from jsffi import init as js_init, get_GlobalThis, get_Console
 
 var counter: i32 = 0
 
-def onclick() -> void:
+def onclick() -> None:
     counter = counter + 1
     window = get_GlobalThis()
     message = window.document.getElementById("message")
     message.innerText = "onclick " + str(counter)
 
-def main() -> void:
+def main() -> None:
     # initialization
     js_init()
     window = get_GlobalThis()

--- a/examples/jsffi/lldemo.spy
+++ b/examples/jsffi/lldemo.spy
@@ -12,11 +12,11 @@ from jsffi import (
     js_setattr)
 
 
-def onclick() -> void:
+def onclick() -> None:
     console = get_Console()
     js_call_method_1(console, "log", js_string("onclick!"))
 
-def main() -> void:
+def main() -> None:
     js_init()
     js_debug("hello world")
     window = get_GlobalThis()

--- a/examples/multifile/array.spy
+++ b/examples/multifile/array.spy
@@ -28,7 +28,7 @@ def array1d(DTYPE):
                 raise IndexError
             return ll.items[i]
 
-        def __setitem__(self: ndarray, i: i32, v: DTYPE) -> void:
+        def __setitem__(self: ndarray, i: i32, v: DTYPE) -> None:
             ll = self.__ll__
             if i >= ll.l:
                 raise IndexError
@@ -73,7 +73,7 @@ def array2d(DTYPE):
             idx = (i * ll.w) + j
             return ll.items[idx]
 
-        def __setitem__(self: ndarray, i: i32, j: i32, v: DTYPE) -> void:
+        def __setitem__(self: ndarray, i: i32, j: i32, v: DTYPE) -> None:
             ll = self.__ll__
             if i >= ll.h:
                 raise IndexError
@@ -95,7 +95,7 @@ def array2d(DTYPE):
             return OpImpl(get, [v_self])
 
 
-        def print_flatten(self: ndarray) -> void:
+        def print_flatten(self: ndarray) -> None:
             ll = self.__ll__
             i = 0
             while i < ll.h * ll.w:

--- a/examples/multifile/main.spy
+++ b/examples/multifile/main.spy
@@ -2,7 +2,7 @@ from array import array, array1d, array2d
 from dot import dot
 
 
-def main() -> void:
+def main() -> None:
     # Create a vector [1, 2, 3]
     vec = array1d[i32](3)
     vec[0] = 1

--- a/examples/point.spy
+++ b/examples/point.spy
@@ -28,7 +28,7 @@ def squared_distance(p0: ptr[Point], p1: ptr[Point]) -> f64:
     dy = p0.y - p1.y
     return dx*dx + dy*dy
 
-def main() -> void:
+def main() -> None:
     p0 = new_point(1, 2)
     p1 = new_point(3, 4)
     print(squared_distance(p0, p1))

--- a/examples/range.spy
+++ b/examples/range.spy
@@ -55,7 +55,7 @@ class Range:
         return OpImpl.NULL
 
 
-def main() -> void:
+def main() -> None:
     r = Range(3, 12, 2)
     ## print(r)
     ## print(r.__ll__)

--- a/examples/smallpoint.spy
+++ b/examples/smallpoint.spy
@@ -80,7 +80,7 @@ class SmallPoint:
             return OpImpl.NULL
 
 
-def main() -> void:
+def main() -> None:
     # all these become super fast bitwise operations. After redshifting, there
     # is ZERO memory allocation as everything is just an i32.
     p = SmallPoint(1, 2)

--- a/examples/vector.spy
+++ b/examples/vector.spy
@@ -23,7 +23,7 @@ def vector_new(capacity: i32) -> ptr[Vector]:
     v.items = gc_alloc(i32)(capacity)
     return v
 
-def vector_append(v: ptr[Vector], item: i32) -> void:
+def vector_append(v: ptr[Vector], item: i32) -> None:
     if v.length >= v.capacity:
         new_capacity = v.capacity * 2
         new_items: ptr[i32] = gc_alloc(i32)(new_capacity)
@@ -43,7 +43,7 @@ def vector_get(v: ptr[Vector], index: i32) -> i32:
         print("Index out of bounds")
     return v.items[index]
 
-def vector_set(v: ptr[Vector], index: i32, item: i32) -> void:
+def vector_set(v: ptr[Vector], index: i32, item: i32) -> None:
     if index < 0:
         print("Index out of bounds")
 
@@ -54,13 +54,13 @@ def vector_set(v: ptr[Vector], index: i32, item: i32) -> void:
 def vector_len(v: ptr[Vector]) -> i32:
     return v.length
 
-def vector_print(v: ptr[Vector]) -> void:
+def vector_print(v: ptr[Vector]) -> None:
     i = 0
     while i < v.length:
         print(v.items[i])
         i = i+1
 
-def test_vector() -> void:
+def test_vector() -> None:
     v = vector_new(2)
     if vector_len(v) != 0:
         print("Test failed: Initial length should be 0")
@@ -92,7 +92,7 @@ def test_vector() -> void:
     print("All tests completed")
 
 
-def test_squares(n: i32) -> void:
+def test_squares(n: i32) -> None:
     v = vector_new(n)
     i = 0
     while i < n:
@@ -100,6 +100,6 @@ def test_squares(n: i32) -> void:
         i = i+1
     vector_print(v)
 
-def main() -> void:
+def main() -> None:
     #test_vector()
     test_squares(100)

--- a/spy/backend/c/context.py
+++ b/spy/backend/c/context.py
@@ -72,7 +72,7 @@ class Context:
         self.tbh_ptrs_def = None   # type: ignore
         self.tbh_types_def = None  # type: ignore
         self._d = {}
-        self._d[B.w_void] = C_Type('void')
+        self._d[B.w_NoneType] = C_Type('void')
         self._d[B.w_i8] = C_Type('int8_t')
         self._d[B.w_u8] = C_Type('uint8_t')
         self._d[B.w_i32] = C_Type('int32_t')

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -59,7 +59,7 @@ class CFuncWriter:
             for stmt in self.w_func.funcdef.body:
                 self.emit_stmt(stmt)
 
-            if self.w_func.w_functype.w_restype is not B.w_void:
+            if self.w_func.w_functype.w_restype is not B.w_NoneType:
                 # this is a non-void function: if we arrive here, it means we
                 # reached the end of the function without a return. Ideally,
                 # we would like to also report an error message, but for now

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -3,6 +3,7 @@ from typing import Literal, Optional
 from spy import ast
 from spy.fqn import FQN
 from spy.vm.vm import SPyVM
+from spy.vm.b import B
 from spy.vm.object import W_Object, W_Type
 from spy.vm.function import W_ASTFunc
 from spy.vm.list import W_List
@@ -61,7 +62,10 @@ class SPyBackend:
         self.vars_declared = set()
         w_functype = w_func.w_functype
         params = self.fmt_params(w_func)
-        ret = self.fmt_w_obj(w_functype.w_restype)
+        if w_functype.w_restype is B.w_NoneType and self.fqn_format == 'short':
+            ret = 'None' # special case: emit '-> None' instead of '-> NoneType'
+        else:
+            ret = self.fmt_w_obj(w_functype.w_restype)
         self.scope_stack.append(w_func.funcdef.symtable)
         self.wl(f'def {name}({params}) -> {ret}:')
         with self.out.indent():

--- a/spy/cli.py
+++ b/spy/cli.py
@@ -340,7 +340,7 @@ async def inner_main(args: Arguments) -> None:
     #vm.pp_modules()
 
     if args.execute:
-        w_main_functype = W_FuncType.parse('def() -> void')
+        w_main_functype = W_FuncType.parse('def() -> None')
         w_main = w_mod.getattr_maybe('main')
         if w_main is None:
             print('Cannot find function main()')

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -33,7 +33,7 @@ def make_const(vm: 'SPyVM', loc: Loc, w_val: W_Object) -> ast.Expr:
     return ast.FQNConst.
     """
     w_type = vm.dynamic_type(w_val)
-    if w_type in (B.w_i32, B.w_f64, B.w_bool, B.w_void):
+    if w_type in (B.w_i32, B.w_f64, B.w_bool, B.w_NoneType):
         # this is a primitive, we can just use ast.Constant
         value = vm.unwrap(w_val)
         if isinstance(value, FixedInt): # type: ignore
@@ -373,7 +373,7 @@ class DopplerFrame(ASTFrame):
         assert len(call.args) == 1
         w_argtype = w_opimpl.w_functype.params[1].w_type
         t = w_argtype.fqn.symbol_name
-        if w_argtype in (B.w_i32, B.w_f64, B.w_bool, B.w_void, B.w_str,
+        if w_argtype in (B.w_i32, B.w_f64, B.w_bool, B.w_NoneType, B.w_str,
                          B.w_dynamic, B.w_type):
             fqn = FQN(f'builtins::print_{t}')
         else:

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -217,7 +217,7 @@ class FQN:
             quals = [fqn.human_name for fqn in p1.qualifiers]
             p = ', '.join(quals[:-1])
             r = quals[-1]
-            if r == 'void':
+            if r == 'NoneType':
                 r = 'None'
             return f'{d}({p}) -> {r}'
         else:

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -217,6 +217,8 @@ class FQN:
             quals = [fqn.human_name for fqn in p1.qualifiers]
             p = ', '.join(quals[:-1])
             r = quals[-1]
+            if r == 'void':
+                r = 'None'
             return f'{d}({p}) -> {r}'
         else:
             return self._fullname(human=True)

--- a/spy/libspy/include/spy/builtins.h
+++ b/spy/libspy/include/spy/builtins.h
@@ -23,7 +23,7 @@ void
 WASM_EXPORT(spy_builtins$print_bool)(bool x);
 
 void
-WASM_EXPORT(spy_builtins$print_void)(void);
+WASM_EXPORT(spy_builtins$print_NoneType)(void);
 
 void
 WASM_EXPORT(spy_builtins$print_str)(spy_Str *s);

--- a/spy/libspy/src/builtins.c
+++ b/spy/libspy/src/builtins.c
@@ -37,7 +37,7 @@ void spy_builtins$print_bool(bool x) {
         printf("False\n");
 }
 
-void spy_builtins$print_void(void) {
+void spy_builtins$print_NoneType(void) {
     printf("None\n");
 }
 

--- a/spy/tests/compiler/operator/test_attrop.py
+++ b/spy/tests/compiler/operator/test_attrop.py
@@ -1,5 +1,5 @@
 from typing import Annotated
-from spy.vm.primitive import W_I32, W_Void
+from spy.vm.primitive import W_I32
 from spy.vm.b import B
 from spy.vm.object import Member
 from spy.vm.builtin import builtin_func, builtin_method
@@ -119,9 +119,8 @@ class TestAttrOp(CompilerTest):
                 if attr == 'x':
                     @builtin_func('ext')
                     def w_setx(vm: 'SPyVM', w_obj: W_MyClass,
-                               w_attr: W_Str, w_val: W_I32) -> W_Void:
+                               w_attr: W_Str, w_val: W_I32) -> None:
                         w_obj.x = vm.unwrap_i32(w_val)
-                        return B.w_None
                     return W_OpImpl(w_setx)
                 else:
                     return W_OpImpl.NULL

--- a/spy/tests/compiler/operator/test_opimpl.py
+++ b/spy/tests/compiler/operator/test_opimpl.py
@@ -133,7 +133,7 @@ class TestOpImpl(CompilerTest):
         mod = self.compile("""
         from operator import OpImpl
 
-        def bar() -> void:
+        def bar() -> None:
             pass
 
         def foo() -> dynamic:

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -19,6 +19,14 @@ class TestBasic(CompilerTest):
         elif self.backend == 'doppler':
             assert mod.foo.w_func.redshifted
 
+    def test_return_None(self):
+        mod = self.compile(
+        """
+        def foo() -> None:
+            pass
+        """)
+        assert mod.foo() is None
+
     def test_NameError(self):
         src = """
         def foo() -> i32:

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -173,7 +173,7 @@ class TestBasic(CompilerTest):
         var x: i32 = 42
         def get_x() -> i32:
             return x
-        def set_x(newval: i32) -> void:
+        def set_x(newval: i32) -> None:
             x = newval
         """)
         vm = self.vm
@@ -186,7 +186,7 @@ class TestBasic(CompilerTest):
     def test_cannot_assign_to_const_globals(self):
         src = """
         x: i32 = 42
-        def set_x() -> void:
+        def set_x() -> None:
             x = 100
         """
         errors = expect_errors(
@@ -212,12 +212,12 @@ class TestBasic(CompilerTest):
     def test_void_return(self):
         mod = self.compile("""
         var x: i32 = 0
-        def foo() -> void:
+        def foo() -> None:
             x = 1
             return
             x = 2
 
-        def bar() -> void:
+        def bar() -> None:
             x = 3
             return None
             x = 4
@@ -230,7 +230,7 @@ class TestBasic(CompilerTest):
     def test_implicit_return(self):
         mod = self.compile("""
         var x: i32 = 0
-        def implicit_return_void() -> void:
+        def implicit_return_void() -> None:
             x = 1
 
         def implicit_return_i32() -> i32:
@@ -248,10 +248,10 @@ class TestBasic(CompilerTest):
 
     def test_BinOp_error(self):
         src = """
-        def bar(a: i32, b: str) -> void:
+        def bar(a: i32, b: str) -> None:
             return a + b
 
-        def foo() -> void:
+        def foo() -> None:
             bar(1, "hello")
         """
         errors = expect_errors(
@@ -328,7 +328,7 @@ class TestBasic(CompilerTest):
         # for improvement
         src = """
         x: i32 = 0
-        def foo() -> void:
+        def foo() -> None:
             return x(0)
         """
         errors = expect_errors(
@@ -342,7 +342,7 @@ class TestBasic(CompilerTest):
         src = """
         def inc(x: i32) -> i32:
             return x+1
-        def foo() -> void:
+        def foo() -> None:
             return inc()
         """
         errors = expect_errors(
@@ -356,7 +356,7 @@ class TestBasic(CompilerTest):
         src = """
         def inc(x: i32) -> i32:
             return x+1
-        def foo() -> void:
+        def foo() -> None:
             return inc(1, 2, 3)
         """
         errors = expect_errors(
@@ -383,10 +383,10 @@ class TestBasic(CompilerTest):
     def test_StmtExpr(self):
         mod = self.compile("""
         var x: i32 = 0
-        def inc() -> void:
+        def inc() -> None:
             x = x + 1
 
-        def foo() -> void:
+        def foo() -> None:
             inc()
             inc()
         """)
@@ -409,7 +409,7 @@ class TestBasic(CompilerTest):
         def bar(a: i32, b: str) -> bool:
             return a == b
 
-        def foo() -> void:
+        def foo() -> None:
             bar(1, "hello")
         """
         errors = expect_errors(
@@ -425,17 +425,17 @@ class TestBasic(CompilerTest):
         var b: i32 = 0
         var c: i32 = 0
 
-        def reset() -> void:
+        def reset() -> None:
             a = 0
             b = 0
             c = 0
 
-        def if_then(x: i32) -> void:
+        def if_then(x: i32) -> None:
             if x == 0:
                 a = 100
             c = 300
 
-        def if_then_else(x: i32) -> void:
+        def if_then_else(x: i32) -> None:
             if x == 0:
                 a = 100
             else:
@@ -480,7 +480,7 @@ class TestBasic(CompilerTest):
 
     def test_pass(self):
         mod = self.compile("""
-        def foo() -> void:
+        def foo() -> None:
             pass
         """)
         assert mod.foo() is None
@@ -497,10 +497,10 @@ class TestBasic(CompilerTest):
 
     def test_getitem_error_1(self):
         src = """
-        def bar(a: i32, i: bool) -> void:
+        def bar(a: i32, i: bool) -> None:
             a[i]
 
-        def foo() -> void:
+        def foo() -> None:
             bar(42, True)
         """
         errors = expect_errors(
@@ -631,7 +631,7 @@ class TestBasic(CompilerTest):
 
     def test_print(self, capfd):
         mod = self.compile("""
-        def foo() -> void:
+        def foo() -> None:
             print("hello world")
             print(42)
             print(12.3)
@@ -657,7 +657,7 @@ class TestBasic(CompilerTest):
     @no_C
     def test_print_type(self, capfd):
         mod = self.compile("""
-        def foo() -> void:
+        def foo() -> None:
             print(i32)
         """)
         mod.foo()
@@ -674,7 +674,7 @@ class TestBasic(CompilerTest):
             @blue
             def b():
                 x2 = 2
-                def c() -> void:
+                def c() -> None:
                     x3 = 3
                     print(x0)
                     print(x1)
@@ -683,7 +683,7 @@ class TestBasic(CompilerTest):
                 return c
             return b
 
-        def foo() -> void:
+        def foo() -> None:
             a()()()
         """)
         mod.foo()
@@ -738,7 +738,7 @@ class TestBasic(CompilerTest):
 
     def test_getattr_error(self):
         src = """
-        def foo() -> void:
+        def foo() -> None:
             x: object = 1
             x.foo
         """
@@ -767,18 +767,18 @@ class TestBasic(CompilerTest):
     def test_wrong__INIT__(self):
         # NOTE: this error is always eager because it happens at import time
         src = """
-        def __INIT__(mod: dynamic) -> void:
+        def __INIT__(mod: dynamic) -> None:
             pass
         """
         errors = expect_errors(
             "the __INIT__ function must be @blue",
-            ("function defined here", "def __INIT__(mod: dynamic) -> void")
+            ("function defined here", "def __INIT__(mod: dynamic) -> None")
         )
         self.compile_raises(src, "", errors, error_reporting="eager")
 
     def test_setattr_error(self):
         src = """
-        def foo() -> void:
+        def foo() -> None:
             s: str = "hello"
             s.x = 42
 
@@ -930,7 +930,7 @@ class TestBasic(CompilerTest):
         from unsafe import ptr
 
         # we can use S even if it's declared later
-        def foo(s: S, p: ptr[S]) -> void:
+        def foo(s: S, p: ptr[S]) -> None:
             pass
 
         ptr_S1 = ptr[S] # using the forward decl
@@ -947,7 +947,7 @@ class TestBasic(CompilerTest):
         w_ptr_S1 = w_mod.getattr('ptr_S1')
         w_ptr_S2 = w_mod.getattr('ptr_S2')
         #
-        expected_sig = 'def(test::S, unsafe::ptr[test::S]) -> void'
+        expected_sig = 'def(test::S, unsafe::ptr[test::S]) -> None'
         assert w_foo.w_functype.fqn.human_name == expected_sig
         params = w_foo.w_functype.params
         assert params[0].w_type is w_S

--- a/spy/tests/compiler/test_dynamic.py
+++ b/spy/tests/compiler/test_dynamic.py
@@ -136,7 +136,7 @@ class TestDynamic(CompilerTest):
 
         mod = self.compile(
         """
-        def foo() -> void:
+        def foo() -> None:
             obj: dynamic = "hello"
             obj.x = 42
         """)
@@ -163,7 +163,7 @@ class TestDynamic(CompilerTest):
         def dyn(x: dynamic) -> dynamic:
             return x
 
-        def foo() -> void:
+        def foo() -> None:
             print(dyn("hello world"))
             print(dyn(42))
             print(dyn(12.3))

--- a/spy/tests/compiler/test_exception.py
+++ b/spy/tests/compiler/test_exception.py
@@ -32,7 +32,7 @@ class TestException(CompilerTest):
 
     def test_cannot_raise_red(self):
         src = """
-        def foo() -> void:
+        def foo() -> None:
             exc = Exception("hello")
             raise exc
         """
@@ -44,7 +44,7 @@ class TestException(CompilerTest):
 
     def test_lazy_error(self):
         src = """
-        def foo() -> void:
+        def foo() -> None:
             1 + "hello"
         """
         mod = self.compile(src, error_mode='lazy')
@@ -86,7 +86,7 @@ class TestException(CompilerTest):
         mod = self.compile("""
         from _testing_helpers import raise_no_loc
 
-        def foo() -> void:
+        def foo() -> None:
             raise_no_loc()
         """)
 

--- a/spy/tests/compiler/test_jsffi.py
+++ b/spy/tests/compiler/test_jsffi.py
@@ -8,7 +8,7 @@ class TestJsFFI(CompilerTest):
     def test_emscripten_run(self):
         exe = self.compile(
         """
-        def main() -> void:
+        def main() -> None:
             print('hello from print')
         """)
         out = exe.run()
@@ -19,7 +19,7 @@ class TestJsFFI(CompilerTest):
         """
         from jsffi import init as js_init, get_Console
 
-        def main() -> void:
+        def main() -> None:
             js_init()
             console = get_Console()
             console.log('hello from console.log')
@@ -33,7 +33,7 @@ class TestJsFFI(CompilerTest):
         """
         from jsffi import init as js_init, get_Console, get_GlobalThis
 
-        def main() -> void:
+        def main() -> None:
             js_init()
             globalThis = get_GlobalThis()
             console = get_Console()
@@ -50,10 +50,10 @@ class TestJsFFI(CompilerTest):
         """
         from jsffi import init as js_init, get_GlobalThis
 
-        def say_hello() -> void:
+        def say_hello() -> None:
             print("hello from callback")
 
-        def main() -> void:
+        def main() -> None:
             js_init()
             globalThis = get_GlobalThis()
             globalThis.setTimeout(say_hello) # XXX allow 2 params and pass 0

--- a/spy/tests/compiler/test_opimpl.py
+++ b/spy/tests/compiler/test_opimpl.py
@@ -13,7 +13,7 @@ class TestOpImpl(CompilerTest):
         """
         from operator import OpImpl
 
-        def bar() -> void:
+        def bar() -> None:
             pass
 
         @blue

--- a/spy/tests/compiler/test_tuple.py
+++ b/spy/tests/compiler/test_tuple.py
@@ -46,7 +46,7 @@ class TestTuple(CompilerTest):
         def make_tuple() -> tuple:
             return 1, 2
 
-        def foo() -> void:
+        def foo() -> None:
             a, b, c = make_tuple()
         """)
         msg = "Wrong number of values to unpack: expected 3, got 2"
@@ -55,7 +55,7 @@ class TestTuple(CompilerTest):
 
     def test_unpacking_wrong_type(self):
         src = """
-        def foo() -> void:
+        def foo() -> None:
             a, b, c = 42
         """
         errors = expect_errors(

--- a/spy/tests/compiler/test_unsafe.py
+++ b/spy/tests/compiler/test_unsafe.py
@@ -96,7 +96,7 @@ class TestUnsafe(CompilerTest):
             x: i32
             y: i32
 
-        def foo() -> void:
+        def foo() -> None:
             p = gc_alloc(Point)(1)
             p.z = 42
         """
@@ -283,7 +283,7 @@ class TestUnsafe(CompilerTest):
             lst.next.next = new_node(c)
             return lst
 
-        def print_list(n: ptr[Node]) -> void:
+        def print_list(n: ptr[Node]) -> None:
             if n:
                 print(n.val)
                 print_list(n.next)

--- a/spy/tests/test_backend_spy.py
+++ b/spy/tests/test_backend_spy.py
@@ -38,13 +38,13 @@ class TestSPyBackend(CompilerTest):
 
     def test_expr_precedence(self):
         mod = self.compile("""
-        def foo() -> void:
+        def foo() -> None:
             a = 1 + 2 * 3
             b = 1 + (2 * 3)
             c = (1 + 2) * 3
         """)
         self.assert_dump("""
-        def foo() -> void:
+        def foo() -> None:
             a = 1 + 2 * 3
             b = 1 + 2 * 3
             c = (1 + 2) * 3
@@ -52,7 +52,7 @@ class TestSPyBackend(CompilerTest):
 
     def test_binop(self):
         mod = self.compile(r"""
-        def foo() -> void:
+        def foo() -> None:
             a + b
             a - b
             a * b
@@ -67,7 +67,7 @@ class TestSPyBackend(CompilerTest):
             -a
         """)
         self.assert_dump(r"""
-        def foo() -> void:
+        def foo() -> None:
             a + b
             a - b
             a * b
@@ -84,12 +84,12 @@ class TestSPyBackend(CompilerTest):
 
     def test_vardef(self):
         mod = self.compile("""
-        def foo() -> void:
+        def foo() -> None:
             x: i32 = 1
             y: f64 = 2.0
         """)
         self.assert_dump("""
-        def foo() -> void:
+        def foo() -> None:
             x: i32
             x = 1
             y: f64
@@ -99,12 +99,12 @@ class TestSPyBackend(CompilerTest):
     def test_implicit_declaration(self):
         self.backend = 'doppler'
         mod = self.compile("""
-        def foo() -> void:
+        def foo() -> None:
             x: i32 = 1
             y = 2.0
         """)
         self.assert_dump("""
-        def foo() -> void:
+        def foo() -> None:
             x: i32
             x = 1
             y: f64
@@ -121,11 +121,11 @@ class TestSPyBackend(CompilerTest):
         def GET_X():
             return 42
 
-        def foo() -> void:
+        def foo() -> None:
             pass
         """)
         self.assert_dump("""
-        def foo() -> void:
+        def foo() -> None:
             pass
         """)
 
@@ -140,7 +140,7 @@ class TestSPyBackend(CompilerTest):
         add_i32 = add[i32]
         add_f64 = add[f64]
 
-        def foo() -> void:
+        def foo() -> None:
             add_i32(1, 2)
             add_f64(3.4, 5.6)
         """)
@@ -151,7 +151,7 @@ class TestSPyBackend(CompilerTest):
         def `test::add[f64]::impl`(x: f64, y: f64) -> f64:
             return x + y
 
-        def foo() -> void:
+        def foo() -> None:
             add_i32(1, 2)
             add_f64(3.4, 5.6)
         """)
@@ -159,7 +159,7 @@ class TestSPyBackend(CompilerTest):
 
     def test_while(self):
         src = """
-        def foo() -> void:
+        def foo() -> None:
             while 1:
                 pass
         """
@@ -168,8 +168,8 @@ class TestSPyBackend(CompilerTest):
 
     def test_FuncDef(self):
         src = """
-        def outer() -> void:
-            def inner(x: i32, y: i32) -> void:
+        def outer() -> None:
+            def inner(x: i32, y: i32) -> None:
                 pass
         """
         self.compile(src)
@@ -196,7 +196,7 @@ class TestSPyBackend(CompilerTest):
 
     def test_getitem(self):
         src = """
-        def foo() -> void:
+        def foo() -> None:
             return x[i, 1]
         """
         self.compile(src)
@@ -204,7 +204,7 @@ class TestSPyBackend(CompilerTest):
 
     def test_setitem(self):
         src = """
-        def foo() -> void:
+        def foo() -> None:
             x[i, 1] = 0
         """
         self.compile(src)
@@ -212,7 +212,7 @@ class TestSPyBackend(CompilerTest):
 
     def test_getattr(self):
         src = """
-        def foo() -> void:
+        def foo() -> None:
             return x.foo
         """
         self.compile(src)
@@ -220,7 +220,7 @@ class TestSPyBackend(CompilerTest):
 
     def test_setattr(self):
         src = """
-        def foo() -> void:
+        def foo() -> None:
             x.foo = 42
         """
         self.compile(src)
@@ -228,7 +228,7 @@ class TestSPyBackend(CompilerTest):
 
     def test_if(self):
         src = """
-        def foo() -> void:
+        def foo() -> None:
             if 1:
                 aaa
             if 2:
@@ -257,7 +257,7 @@ class TestSPyBackend(CompilerTest):
 
     def test_unpack_assign(self):
         src = """
-        def foo() -> void:
+        def foo() -> None:
             a, b, c = x
         """
         self.compile(src)
@@ -265,7 +265,7 @@ class TestSPyBackend(CompilerTest):
 
     def test_aug_assign(self):
         src = """
-        def foo() -> void:
+        def foo() -> None:
             x += 1
         """
         self.compile(src)
@@ -275,11 +275,11 @@ class TestSPyBackend(CompilerTest):
         src = """
         from unsafe import ptr
 
-        def foo(p: ptr[i32]) -> void:
+        def foo(p: ptr[i32]) -> None:
             pass
         """
         expected = """
-        def foo(p: `unsafe::ptr[i32]`) -> void:
+        def foo(p: `unsafe::ptr[i32]`) -> None:
             pass
         """
         self.compile(src)
@@ -287,7 +287,7 @@ class TestSPyBackend(CompilerTest):
 
     def test_classdef(self):
         src = """
-        def foo() -> void:
+        def foo() -> None:
             @struct
             class Point:
                 x: i32
@@ -298,7 +298,7 @@ class TestSPyBackend(CompilerTest):
 
     def test_raise(self):
         src = """
-        def foo() -> void:
+        def foo() -> None:
             raise Exception('foo')
         """
         self.compile(src)

--- a/spy/tests/test_cli.py
+++ b/spy/tests/test_cli.py
@@ -40,7 +40,7 @@ class TestMain:
         self.runner = CliRunner()
         self.main_spy = tmpdir.join('main.spy')
         self.main_spy.write(textwrap.dedent("""
-        def main() -> void:
+        def main() -> None:
             print("hello world")
         """))
 
@@ -89,7 +89,7 @@ class TestMain:
 
     def test_redshift_dump_spy(self):
         res, stdout = self.run('--redshift', self.main_spy)
-        assert stdout.startswith('def main() -> void:')
+        assert stdout.startswith('def main() -> None:')
 
     def test_redshift_dump_ast(self):
         res, stdout = self.run('--redshift', '--parse', self.main_spy)

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -71,7 +71,7 @@ class TestDoppler:
         """
         self.redshift(src)
         expected = """
-        def `test::foo`(x: `builtins::i32`) -> `builtins::void`:
+        def `test::foo`(x: `builtins::i32`) -> `builtins::NoneType`:
             y: `builtins::str`
             y = 'hello'
         """
@@ -282,7 +282,7 @@ class TestDoppler:
         """)
         # in full mode, we show a call to operator::raise
         expected = f"""
-        def `test::foo`() -> `builtins::void`:
+        def `test::foo`() -> `builtins::NoneType`:
             `operator::raise`('TypeError', 'foo', '{fname}', 3)
             `operator::raise`('ValueError', '', '{fname}', 4)
         """

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -66,7 +66,7 @@ class TestDoppler:
 
     def test_fqn_format(self):
         src = """
-        def foo(x: i32) -> void:
+        def foo(x: i32) -> None:
             y: str = 'hello'
         """
         self.redshift(src)
@@ -141,32 +141,32 @@ class TestDoppler:
         self.redshift("""
         @blue
         def make_foo():
-            def fn() -> void:
+            def fn() -> None:
                 print('fn')
 
-            def foo() -> void:
+            def foo() -> None:
                 fn()
                 fn()
             return foo
 
-        def main() -> void:
+        def main() -> None:
             make_foo()()
         """)
         self.assert_dump("""
-        def main() -> void:
+        def main() -> None:
             `test::make_foo::foo`()
 
-        def `test::make_foo::fn`() -> void:
+        def `test::make_foo::fn`() -> None:
             print_str('fn')
 
-        def `test::make_foo::foo`() -> void:
+        def `test::make_foo::foo`() -> None:
             `test::make_foo::fn`()
             `test::make_foo::fn`()
         """)
 
     def test_binops(self):
         src = """
-        def foo(i: i32, f: f64) -> void:
+        def foo(i: i32, f: f64) -> None:
             i + i
             i - i
             i * i
@@ -204,26 +204,26 @@ class TestDoppler:
 
     def test_type_conversion(self):
         src = """
-        def foo(x: f64) -> void:
+        def foo(x: f64) -> None:
             pass
 
-        def convert_in_call() -> void:
+        def convert_in_call() -> None:
             foo(42)
 
         def convert_in_locals(x: i32) -> bool:
             flag: bool = x
             return x
 
-        def convert_in_conditions(x: i32) -> void:
+        def convert_in_conditions(x: i32) -> None:
             if x:
                 pass
         """
         self.redshift(src)
         self.assert_dump("""
-        def foo(x: f64) -> void:
+        def foo(x: f64) -> None:
             pass
 
-        def convert_in_call() -> void:
+        def convert_in_call() -> None:
             `test::foo`(`operator::i32_to_f64`(42))
 
         def convert_in_locals(x: i32) -> bool:
@@ -231,7 +231,7 @@ class TestDoppler:
             flag = `operator::i32_to_bool`(x)
             return `operator::i32_to_bool`(x)
 
-        def convert_in_conditions(x: i32) -> void:
+        def convert_in_conditions(x: i32) -> None:
             if `operator::i32_to_bool`(x):
                 pass
         """)
@@ -244,12 +244,12 @@ class TestDoppler:
                 return x + y
             return impl
 
-        def foo() -> void:
+        def foo() -> None:
             x = add(i32)(1, 2)
             y = add(str)("a", "b")
         """)
         self.assert_dump("""
-        def foo() -> void:
+        def foo() -> None:
             x: i32
             x = `test::add[i32]::impl`(1, 2)
             y: str
@@ -265,18 +265,18 @@ class TestDoppler:
     def test_store_outer_var(self):
         self.redshift("""
         var x: i32 = 0
-        def foo() -> void:
+        def foo() -> None:
             x = 1
         """)
         self.assert_dump("""
-        def foo() -> void:
+        def foo() -> None:
             x = 1
         """)
 
     def test_format_prebuilt_exception(self):
         fname = str(self.tmpdir.join('test.spy'))
         self.redshift("""
-        def foo() -> void:
+        def foo() -> None:
             raise TypeError('foo')
             raise ValueError
         """)
@@ -290,7 +290,7 @@ class TestDoppler:
 
         # in short mode, we show just a raise
         self.assert_dump("""
-        def foo() -> void:
+        def foo() -> None:
             raise TypeError('foo') # /.../test.spy:3
             raise ValueError # /.../test.spy:4
         """)

--- a/spy/tests/test_importing.py
+++ b/spy/tests/test_importing.py
@@ -71,7 +71,7 @@ class TestImportAnalizyer:
     @pytest.mark.skip(reason="parser does not support this")
     def test_import_in_function(self):
         self.write("main.spy", """
-        def foo() -> void:
+        def foo() -> None:
             import mod1
         """)
         self.write("mod1.spy", """

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -53,7 +53,7 @@ class TestParser:
                         kind='plain',
                         name='foo',
                         args=[],
-                        return_type=Name(id='void'),
+                        return_type=Constant(value=None),
                         docstring=None,
                         body=[
                             Pass(),
@@ -90,7 +90,7 @@ class TestParser:
                                 type=Name(id='float'),
                             ),
                         ],
-                        return_type=Name(id='void'),
+                        return_type=Constant(value=None),
                         docstring=None,
                         body=[
                             Pass(),
@@ -930,7 +930,7 @@ class TestParser:
         assert isclass(nodes[0], 'Module')
         assert isclass(nodes[1], 'GlobalFuncDef')
         assert isclass(nodes[2], 'FuncDef')
-        assert isclass(nodes[3], 'Name') and nodes[3].id == 'void'
+        assert isclass(nodes[3], 'Constant') and nodes[3].value is None
         assert isclass(nodes[4], 'If')
         assert isclass(nodes[5], 'Constant') and nodes[5].value is True
         assert isclass(nodes[6], 'Assign')
@@ -974,7 +974,7 @@ class TestParser:
                                 kind='plain',
                                 name='bar',
                                 args=[],
-                                return_type=Name(id='void'),
+                                return_type=Constant(value=None),
                                 docstring=None,
                                 body=[
                                     Pass(),
@@ -1174,7 +1174,7 @@ class TestParser:
                     kind='plain',
                     name='foo',
                     args=[],
-                    return_type=Name(id='void'),
+                    return_type=Constant(value=None),
                     docstring=None,
                     body=[
                         Pass(),

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -39,7 +39,7 @@ class TestParser:
 
     def test_Module(self):
         mod = self.parse("""
-        def foo() -> void:
+        def foo() -> None:
             pass
         """)
         expected = """
@@ -67,7 +67,7 @@ class TestParser:
 
     def test_FuncDef_arguments(self):
         mod = self.parse("""
-        def foo(a: i32, b: float) -> void:
+        def foo(a: i32, b: float) -> None:
             pass
         """)
         expected = """
@@ -116,7 +116,7 @@ class TestParser:
 
     def test_FuncDef_errors_2(self):
         src = """
-        def foo(*args) -> void:
+        def foo(*args) -> None:
             pass
         """
         self.expect_errors(
@@ -127,7 +127,7 @@ class TestParser:
 
     def test_FuncDef_errors_3(self):
         src = """
-        def foo(**kwargs) -> void:
+        def foo(**kwargs) -> None:
             pass
         """
         self.expect_errors(
@@ -138,7 +138,7 @@ class TestParser:
 
     def test_FuncDef_errors_4(self):
         src = """
-        def foo(a: i32 = 42) -> void:
+        def foo(a: i32 = 42) -> None:
             pass
         """
         self.expect_errors(
@@ -149,7 +149,7 @@ class TestParser:
 
     def test_FuncDef_errors_5(self):
         src = """
-        def foo(a: i32, /, b: i32) -> void:
+        def foo(a: i32, /, b: i32) -> None:
             pass
         """
         self.expect_errors(
@@ -160,7 +160,7 @@ class TestParser:
 
     def test_FuncDef_errors_6(self):
         src = """
-        def foo(a: i32, *, b: i32) -> void:
+        def foo(a: i32, *, b: i32) -> None:
             pass
         """
         self.expect_errors(
@@ -171,7 +171,7 @@ class TestParser:
 
     def test_FuncDef_errors_7(self):
         src = """
-        def foo(a, b) -> void:
+        def foo(a, b) -> None:
             pass
         """
         self.expect_errors(
@@ -183,7 +183,7 @@ class TestParser:
     def test_FuncDef_errors_8(self):
         src = """
         @mydecorator
-        def foo() -> void:
+        def foo() -> None:
             pass
         """
         self.expect_errors(
@@ -316,7 +316,7 @@ class TestParser:
 
     def test_empty_return(self):
         mod = self.parse("""
-        def foo() -> void:
+        def foo() -> None:
             return
         """)
         stmt = mod.get_funcdef('foo').body[0]
@@ -356,7 +356,7 @@ class TestParser:
 
     def test_GetItem(self):
         mod = self.parse("""
-        def foo() -> void:
+        def foo() -> None:
             return mylist[0, 1]
         """)
         stmt = mod.get_funcdef('foo').body[0]
@@ -375,7 +375,7 @@ class TestParser:
 
     def test_SetItem(self):
         mod = self.parse("""
-        def foo() -> void:
+        def foo() -> None:
             mylist[0, 1] = 42
         """)
         stmt = mod.get_funcdef('foo').body[0]
@@ -393,7 +393,7 @@ class TestParser:
 
     def test_VarDef(self):
         mod = self.parse("""
-        def foo() -> void:
+        def foo() -> None:
             x: i32 = 42
         """)
         vardef, assign = mod.get_funcdef('foo').body[:2]
@@ -515,7 +515,7 @@ class TestParser:
 
     def test_List(self):
         mod = self.parse("""
-        def foo() -> void:
+        def foo() -> None:
             return [1, 2, 3]
         """)
         stmt = mod.get_funcdef('foo').body[0]
@@ -534,7 +534,7 @@ class TestParser:
 
     def test_Tuple(self):
         mod = self.parse("""
-        def foo() -> void:
+        def foo() -> None:
             return 1, 2, 3
         """)
         stmt = mod.get_funcdef('foo').body[0]
@@ -572,7 +572,7 @@ class TestParser:
     @pytest.mark.parametrize("op", "+ - * / // % ** << >> | ^ & @".split())
     def test_AugAssign(self, op):
         mod = self.parse(f"""
-        def foo() -> void:
+        def foo() -> None:
             x {op}= 42
         """)
         stmt = mod.get_funcdef('foo').body[0]
@@ -653,7 +653,7 @@ class TestParser:
 
     def test_Assign(self):
         mod = self.parse("""
-        def foo() -> void:
+        def foo() -> None:
             x = 42
         """)
         stmt = mod.get_funcdef('foo').body[0]
@@ -667,7 +667,7 @@ class TestParser:
 
     def test_Assign_unsupported_1(self):
         src = """
-        def foo() -> void:
+        def foo() -> None:
             a = b = 1
         """
         self.expect_errors(
@@ -678,7 +678,7 @@ class TestParser:
 
     def test_Assign_unsupported_2(self):
         src = """
-        def foo() -> void:
+        def foo() -> None:
             [a, b] = 1, 2
         """
         self.expect_errors(
@@ -689,7 +689,7 @@ class TestParser:
 
     def test_UnpackAssign(self):
         mod = self.parse("""
-        def foo() -> void:
+        def foo() -> None:
             a, b, c = x
         """)
         stmt = mod.get_funcdef('foo').body[0]
@@ -784,7 +784,7 @@ class TestParser:
 
     def test_StmtExpr(self):
         mod = self.parse("""
-        def foo() -> void:
+        def foo() -> None:
             42
         """)
         stmt = mod.get_funcdef('foo').body[0]
@@ -797,7 +797,7 @@ class TestParser:
 
     def test_While(self):
         mod = self.parse("""
-        def foo() -> void:
+        def foo() -> None:
             while True:
                 pass
         """)
@@ -814,7 +814,7 @@ class TestParser:
 
     def test_Raise(self):
         mod = self.parse("""
-        def foo() -> void:
+        def foo() -> None:
             raise ValueError("error message")
         """)
         stmt = mod.get_funcdef('foo').body[0]
@@ -832,7 +832,7 @@ class TestParser:
 
     def test_Raise_from(self):
         src = """
-        def foo() -> void:
+        def foo() -> None:
             raise ValueError("error") from TypeError("cause")
         """
         self.expect_errors(
@@ -843,7 +843,7 @@ class TestParser:
 
     def test_Raise_bare(self):
         src = """
-        def foo() -> void:
+        def foo() -> None:
             raise
         """
         self.expect_errors(
@@ -922,7 +922,7 @@ class TestParser:
             return x.__class__.__name__ == name
 
         mod = self.parse("""
-        def foo() -> void:
+        def foo() -> None:
             if True:
                 x = y + 1
         """)
@@ -952,7 +952,7 @@ class TestParser:
         mod = self.parse("""
         @blue
         def foo():
-            def bar() -> void:
+            def bar() -> None:
                 pass
         """)
         expected = """
@@ -990,7 +990,7 @@ class TestParser:
 
     def test_GetAttr(self):
         mod = self.parse("""
-        def foo() -> void:
+        def foo() -> None:
             a.b
         """)
         stmt = mod.get_funcdef('foo').body[0]
@@ -1006,7 +1006,7 @@ class TestParser:
 
     def test_SetAttr(self):
         mod = self.parse("""
-        def foo() -> void:
+        def foo() -> None:
             a.b = 42
         """)
         stmt = mod.get_funcdef('foo').body[0]
@@ -1152,7 +1152,7 @@ class TestParser:
         class Foo:
             __ll__: i32
 
-            def foo() -> void:
+            def foo() -> None:
                 pass
         """)
         classdef = mod.get_classdef('Foo')

--- a/spy/tests/test_scope.py
+++ b/spy/tests/test_scope.py
@@ -202,7 +202,6 @@ class TestScopeAnalyzer:
             'y': MatchSymbol('y', 'red'),
             'foo': MatchSymbol('foo', 'blue'),
             'i32': MatchSymbol('i32', 'blue', level=2),
-            'void': MatchSymbol('void', 'blue', level=2),
         }
 
     def test_capture_across_multiple_scopes(self):

--- a/spy/tests/test_scope.py
+++ b/spy/tests/test_scope.py
@@ -72,7 +72,6 @@ class TestScopeAnalyzer:
             'bar': MatchSymbol('bar', 'blue'),
             # captured
             'i32': MatchSymbol('i32', 'blue', level=1),
-            'void': MatchSymbol('void', 'blue', level=1),
         }
 
     def test_funcargs_and_locals(self):

--- a/spy/tests/test_scope.py
+++ b/spy/tests/test_scope.py
@@ -58,10 +58,10 @@ class TestScopeAnalyzer:
         x: i32 = 0
         var y: i32 = 0
 
-        def foo() -> void:
+        def foo() -> None:
             pass
 
-        def bar() -> void:
+        def bar() -> None:
             pass
         """)
         scope = scopes.by_module()
@@ -96,7 +96,7 @@ class TestScopeAnalyzer:
 
     def test_assign_does_not_redeclare(self):
         scopes = self.analyze("""
-        def foo() -> void:
+        def foo() -> None:
             x: i32 = 0
             x = 1
         """)
@@ -136,7 +136,7 @@ class TestScopeAnalyzer:
 
     def test_inner_funcdef(self):
         scopes = self.analyze("""
-        def foo() -> void:
+        def foo() -> None:
             x: i32 = 0
             def bar(y: i32) -> i32:
                 return x + y
@@ -189,7 +189,7 @@ class TestScopeAnalyzer:
             x: i32
             y: i32
 
-            def foo() -> void:
+            def foo() -> None:
                 pass
         """)
         mod_scope = scopes.by_module()

--- a/spy/tests/vm/test_builtin.py
+++ b/spy/tests/vm/test_builtin.py
@@ -32,7 +32,7 @@ class TestBuiltin:
         def foo(vm: 'SPyVM', w_x: W_MyType) -> None:
             pass
         w_functype = functype_from_sig(foo, 'red')
-        assert w_functype == W_FuncType.parse('def(i32) -> void')
+        assert w_functype == W_FuncType.parse('def(i32) -> None')
 
     def test_builtin_func(self):
         vm = SPyVM()
@@ -86,7 +86,7 @@ class TestBuiltin:
         @builtin_func('mymod')
         def w_foo(vm: 'SPyVM') -> None:
             pass
-        assert w_foo.w_functype.fqn.human_name == 'def() -> void'
+        assert w_foo.w_functype.fqn.human_name == 'def() -> None'
         assert isinstance(w_foo, W_BuiltinFunc)
         w_res = vm.fast_call(w_foo, [])
         assert w_res is B.w_None

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -1,6 +1,6 @@
 import fixedint
 import pytest
-from spy.vm.primitive import W_I32, W_Bool, W_Void
+from spy.vm.primitive import W_I32, W_Bool, W_NoneType
 from spy.vm.vm import SPyVM
 from spy.vm.b import B
 from spy.fqn import FQN
@@ -144,8 +144,8 @@ class TestVM:
     def test_w_None(self):
         vm = SPyVM()
         w_None = B.w_None
-        assert isinstance(w_None, W_Void)
-        assert vm.dynamic_type(w_None).fqn == FQN('builtins::void')
+        assert isinstance(w_None, W_NoneType)
+        assert vm.dynamic_type(w_None).fqn == FQN('builtins::NoneType')
         assert repr(w_None) == '<spy None>'
         #
         assert vm.wrap(None) is w_None

--- a/spy/tests/wasm_wrapper.py
+++ b/spy/tests/wasm_wrapper.py
@@ -104,7 +104,7 @@ class WasmFuncWrapper:
         return wasm_args
 
     def to_py_result(self, w_type: W_Type, res: Any) -> Any:
-        if w_type is B.w_void:
+        if w_type is B.w_NoneType:
             assert res is None
             return None
         elif w_type in (B.w_i8, B.w_i32, B.w_f64, B.w_u8):

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -149,7 +149,7 @@ class AbstractFrame:
             return w_val
         elif w_val is B.w_None:
             # special case None and allow to use it as a type even if it's not
-            return B.w_void
+            return B.w_NoneType
         w_valtype = self.vm.dynamic_type(w_val)
         msg = f'expected `type`, got `{w_valtype.fqn.human_name}`'
         raise SPyError.simple("W_TypeError", msg, "expected `type`", expr.loc)
@@ -677,7 +677,7 @@ class ASTFrame(AbstractFrame):
             #
             # we reached the end of the function. If it's void, we can return
             # None, else it's an error.
-            if self.w_func.w_functype.w_restype in (B.w_void, B.w_dynamic):
+            if self.w_func.w_functype.w_restype in (B.w_NoneType, B.w_dynamic):
                 return B.w_None
             else:
                 loc = self.w_func.funcdef.loc.make_end_loc()

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -147,6 +147,9 @@ class AbstractFrame:
         if isinstance(w_val, W_Type):
             self.vm.make_fqn_const(w_val)
             return w_val
+        elif w_val is B.w_None:
+            # special case None and allow to use it as a type even if it's not
+            return B.w_void
         w_valtype = self.vm.dynamic_type(w_val)
         msg = f'expected `type`, got `{w_valtype.fqn.human_name}`'
         raise SPyError.simple("W_TypeError", msg, "expected `type`", expr.loc)

--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -34,11 +34,11 @@ def to_spy_type(ann: Any, *, allow_None: bool = False) -> W_Type:
       W_I32 -> B.w_i32
       W_Dynamic -> B.w_dynamic
       Annotated[W_Object, w_mytype] -> w_mytype
-      None -> B.w_void
+      None -> B.w_NoneType
     """
     from spy.vm.b import B
     if allow_None and ann is None:
-        return B.w_void
+        return B.w_NoneType
     elif is_W_class(ann):
         return ann._w
     elif w_t := get_spy_type_annotation(ann):

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -96,6 +96,9 @@ class W_FuncType(W_Type):
             params.append(FuncParam(w_type, 'simple'))
         #
         w_restype = parse_type(res)
+        if w_restype is B.w_None:
+            # special case None and allow to use it as a type even if it's not
+            w_restype = B.w_NoneType
         return cls.new(params, w_restype)
 
     @property

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -263,6 +263,6 @@ class W_BuiltinFunc(W_Func):
     def raw_call(self, vm: 'SPyVM', args_w: Sequence[W_Object]) -> W_Object:
         from spy.vm.b import B
         w_res = self._pyfunc(vm, *args_w)
-        if w_res is None and self.w_functype.w_restype is B.w_void:
+        if w_res is None and self.w_functype.w_restype is B.w_NoneType:
             return vm.wrap(None)
         return w_res

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -45,7 +45,7 @@ def w_min(vm: 'SPyVM', w_x: W_I32, w_y: W_I32) -> W_I32:
 
 
 @BUILTINS.builtin_func
-def w_print(vm: 'SPyVM', w_x: W_Dynamic) -> W_Void:
+def w_print(vm: 'SPyVM', w_x: W_Dynamic) -> None:
     """
     Super minimal implementation of print().
 
@@ -59,39 +59,32 @@ def w_print(vm: 'SPyVM', w_x: W_Dynamic) -> W_Void:
 
 
 @BUILTINS.builtin_func
-def w_print_i32(vm: 'SPyVM', w_x: W_I32) -> W_Void:
+def w_print_i32(vm: 'SPyVM', w_x: W_I32) -> None:
     PY_PRINT(vm.unwrap(w_x))
-    return B.w_None
 
 @BUILTINS.builtin_func
-def w_print_f64(vm: 'SPyVM', w_x: W_F64) -> W_Void:
+def w_print_f64(vm: 'SPyVM', w_x: W_F64) -> None:
     PY_PRINT(vm.unwrap(w_x))
-    return B.w_None
 
 @BUILTINS.builtin_func
-def w_print_bool(vm: 'SPyVM', w_x: W_Bool) -> W_Void:
+def w_print_bool(vm: 'SPyVM', w_x: W_Bool) -> None:
     PY_PRINT(vm.unwrap(w_x))
-    return B.w_None
 
 @BUILTINS.builtin_func
-def w_print_void(vm: 'SPyVM', w_x: W_Void) -> W_Void:
+def w_print_void(vm: 'SPyVM', w_x: W_Void) -> None:
     PY_PRINT(vm.unwrap(w_x))
-    return B.w_None
 
 @BUILTINS.builtin_func
-def w_print_str(vm: 'SPyVM', w_x: W_Str) -> W_Void:
+def w_print_str(vm: 'SPyVM', w_x: W_Str) -> None:
     PY_PRINT(vm.unwrap(w_x))
-    return B.w_None
 
 @BUILTINS.builtin_func
-def w_print_dynamic(vm: 'SPyVM', w_x: W_Dynamic) -> W_Void:
+def w_print_dynamic(vm: 'SPyVM', w_x: W_Dynamic) -> None:
     PY_PRINT(vm.unwrap(w_x))
-    return B.w_None
 
 @BUILTINS.builtin_func
-def w_print_type(vm: 'SPyVM', w_x: W_Type) -> W_Void:
+def w_print_type(vm: 'SPyVM', w_x: W_Type) -> None:
     PY_PRINT(str(w_x))
-    return B.w_None
 
 
 # this should belong to function.py, but we cannot put it there because of

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -6,7 +6,7 @@ The first half is in vm/b.py. See its docstring for more details.
 
 from typing import TYPE_CHECKING
 from spy.vm.builtin import builtin_func
-from spy.vm.primitive import W_F64, W_I32, W_Bool, W_Dynamic, W_Void
+from spy.vm.primitive import W_F64, W_I32, W_Bool, W_Dynamic, W_NoneType
 from spy.vm.object import W_Object, W_Type
 from spy.vm.str import W_Str
 from spy.vm.function import W_FuncType
@@ -51,7 +51,7 @@ def w_print(vm: 'SPyVM', w_x: W_Dynamic) -> None:
 
     It takes just one argument.
     """
-    if isinstance(w_x, (W_I32, W_F64, W_Bool, W_Str, W_Void)):
+    if isinstance(w_x, (W_I32, W_F64, W_Bool, W_Str, W_NoneType)):
         PY_PRINT(vm.unwrap(w_x))
     else:
         PY_PRINT(w_x)
@@ -71,7 +71,7 @@ def w_print_bool(vm: 'SPyVM', w_x: W_Bool) -> None:
     PY_PRINT(vm.unwrap(w_x))
 
 @BUILTINS.builtin_func
-def w_print_void(vm: 'SPyVM', w_x: W_Void) -> None:
+def w_print_NoneType(vm: 'SPyVM', w_x: W_NoneType) -> None:
     PY_PRINT(vm.unwrap(w_x))
 
 @BUILTINS.builtin_func

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -45,7 +45,7 @@ class W_JsRef(W_Object):
         elif w_T is B.w_i32:
             return W_OpImpl(JSFFI.w_js_i32)
         elif isinstance(w_T, W_FuncType):
-            assert w_T == W_FuncType.parse('def() -> void')
+            assert w_T == W_FuncType.parse('def() -> None')
             return W_OpImpl(JSFFI.w_js_wrap_func)
         else:
             return W_OpImpl.NULL

--- a/spy/vm/modules/rawbuffer.py
+++ b/spy/vm/modules/rawbuffer.py
@@ -4,7 +4,7 @@ SPy `rawbuffer` module.
 
 from typing import TYPE_CHECKING
 import struct
-from spy.vm.primitive import W_F64, W_I32, W_Void
+from spy.vm.primitive import W_F64, W_I32
 from spy.vm.b import B
 from spy.vm.w import W_Object
 from spy.vm.registry import ModuleRegistry
@@ -31,11 +31,10 @@ def w_rb_alloc(vm: 'SPyVM', w_size: W_I32) -> W_RawBuffer:
 
 @RB.builtin_func
 def w_rb_set_i32(vm: 'SPyVM', w_rb: W_RawBuffer,
-               w_offset: W_I32, w_val: W_I32) -> W_Void:
+               w_offset: W_I32, w_val: W_I32) -> None:
     offset = vm.unwrap_i32(w_offset)
     val = vm.unwrap_i32(w_val)
     struct.pack_into('i', w_rb.buf, offset, val)
-    return B.w_None
 
 @RB.builtin_func
 def w_rb_get_i32(vm: 'SPyVM', w_rb: W_RawBuffer, w_offset: W_I32) -> W_I32:
@@ -45,11 +44,10 @@ def w_rb_get_i32(vm: 'SPyVM', w_rb: W_RawBuffer, w_offset: W_I32) -> W_I32:
 
 @RB.builtin_func
 def w_rb_set_f64(vm: 'SPyVM', w_rb: W_RawBuffer,
-               w_offset: W_I32, w_val: W_F64) -> W_Void:
+               w_offset: W_I32, w_val: W_F64) -> None:
     offset = vm.unwrap_i32(w_offset)
     val = vm.unwrap_f64(w_val)
     struct.pack_into('d', w_rb.buf, offset, val)
-    return B.w_None
 
 @RB.builtin_func
 def w_rb_get_f64(vm: 'SPyVM', w_rb: W_RawBuffer, w_offset: W_I32) -> W_F64:

--- a/spy/vm/modules/unsafe/__init__.py
+++ b/spy/vm/modules/unsafe/__init__.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 import fixedint
-from spy.vm.primitive import W_I32, W_Void
+from spy.vm.primitive import W_I32
 from spy.vm.b import B
 from spy.vm.builtin import builtin_type
 from spy.vm.w import W_Object, W_Type

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -55,7 +55,7 @@ from spy.vm.b import B
 
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
-    from spy.vm.primitive import W_Void
+    from spy.vm.primitive import W_NoneType
     from spy.vm.function import W_Func
     from spy.vm.opimpl import W_OpImpl, W_OpArg
 
@@ -350,9 +350,9 @@ class W_Type(W_Object):
         w_meth = decorator(pyfunc)
         self.dict_w[appname] = w_meth
 
-    # Union[W_Type, W_Void] means "either a W_Type or B.w_None"
+    # Union[W_Type, W_NoneType] means "either a W_Type or B.w_None"
     @property
-    def w_base(self) -> Union['W_Type', 'W_Void']:
+    def w_base(self) -> Union['W_Type', 'W_NoneType']:
         from spy.vm.b import B
         if self is B.w_object or self is B.w_dynamic:
             return B.w_None

--- a/spy/vm/primitive.py
+++ b/spy/vm/primitive.py
@@ -16,18 +16,16 @@ if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
     from spy.vm.opimpl import W_OpArg, W_OpImpl
 
-@B.builtin_type('void')
-class W_Void(W_Object):
+@B.builtin_type('NoneType')
+class W_NoneType(W_Object):
     """
-    Equivalent of Python's NoneType.
-
     This is a singleton: there should be only one instance of this class,
     which is w_None.
     """
     def __init__(self) -> None:
         # this is just a sanity check: we don't want people to be able to
-        # create additional instances of W_Void
-        raise Exception("You cannot instantiate W_Void")
+        # create additional <None>s
+        raise Exception("You cannot instantiate W_NoneType")
 
     def __repr__(self) -> str:
         return '<spy None>'
@@ -35,7 +33,7 @@ class W_Void(W_Object):
     def spy_unwrap(self, vm: 'SPyVM') -> None:
         return None
 
-B.add('None', W_Void.__new__(W_Void))
+B.add('None', W_NoneType.__new__(W_NoneType))
 
 
 @B.builtin_type('i32', lazy_definition=True)

--- a/spy/vm/w.py
+++ b/spy/vm/w.py
@@ -2,7 +2,7 @@
 This is just to make it easier to import all the various W_* classes
 """
 
-from spy.vm.primitive import W_F64, W_I32, W_Bool, W_Dynamic, W_Void
+from spy.vm.primitive import W_F64, W_I32, W_Bool, W_Dynamic, W_NoneType
 from spy.vm.function import W_Func, W_FuncType, W_ASTFunc, W_BuiltinFunc
 from spy.vm.builtin import builtin_func, builtin_type
 from spy.vm.module import W_Module


### PR DESCRIPTION
With this PR, we allow to do things like `def main() -> None`.

It is a bit involved, because:
1. `None` is not a type
2. functions `-> None` are expected to `return None`

We *could* probably solve it by creating a special object whose type is itself (i.e. `type(None) is None`), but this would complicate the typesystem unnecessarily.

Instead, we solve the problem by special casing `None` inside function signatures: whenever we see `None`, we treat it as `NoneType`.
And then we apply the special case a bit here and there, mostly for aesthetic reasons (e.g., when rendering function signatures we emit `-> None` instead of `-> NoneType`.
 
Moreover, we rename the old `W_Void` into `W_NoneType`, to be consisten with Python.