### PR TITLE
Introduce metafunctions

### DIFF
--- a/spy/ast.py
+++ b/spy/ast.py
@@ -11,7 +11,7 @@ from spy.util import extend
 AnyNode = typing.Union[py_ast.AST, 'Node']
 VarKind = typing.Literal['const', 'var']
 ClassKind = typing.Literal['class', 'struct', 'typelift']
-FuncKind = typing.Literal['plain', 'generic']
+FuncKind = typing.Literal['plain', 'generic', 'metafunc']
 
 @extend(py_ast.AST)
 class AST:

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -360,27 +360,7 @@ class DopplerFrame(ASTFrame):
         newfunc = self.shifted_expr[call.func]
         newargs = [self.shifted_expr[arg] for arg in call.args]
         newcall = self.shift_opimpl(call, w_opimpl, [newfunc] + newargs)
-        if (isinstance(newcall.func, ast.FQNConst) and
-            newcall.func.fqn == FQN('builtins::print')):
-            return self.specialize_print(w_opimpl, newcall)
         return newcall
-
-    def specialize_print(self, w_opimpl: W_Func, call: ast.Call) -> ast.Expr:
-        """
-        This is a temporary hack. We specialize print() based on the type
-        of its first argument
-        """
-        assert len(call.args) == 1
-        w_argtype = w_opimpl.w_functype.params[1].w_type
-        t = w_argtype.fqn.symbol_name
-        if w_argtype in (B.w_i32, B.w_f64, B.w_bool, B.w_NoneType, B.w_str,
-                         B.w_dynamic, B.w_type):
-            fqn = FQN(f'builtins::print_{t}')
-        else:
-            raise SPyError('W_TypeError', f"Invalid type for print(): {t}")
-
-        newfunc = call.func.replace(fqn=fqn)
-        return call.replace(func=newfunc)
 
     def shift_expr_CallMethod(self, op: ast.CallMethod) -> ast.Expr:
         w_opimpl = self.opimpl[op]

--- a/spy/libspy/include/spy/str.h
+++ b/spy/libspy/include/spy/str.h
@@ -30,6 +30,9 @@ spy_str_ne(spy_Str *a, spy_Str *b) {
 spy_Str *
 WASM_EXPORT(spy_str_getitem)(spy_Str *s, int32_t i);
 
+int32_t
+WASM_EXPORT(spy_str_len)(spy_Str *s);
+
 spy_Str *
 WASM_EXPORT(spy_builtins$int2str)(int32_t x);
 
@@ -39,5 +42,6 @@ WASM_EXPORT(spy_builtins$int2str)(int32_t x);
 #define spy_operator$str_eq  spy_str_eq
 #define spy_operator$str_ne  spy_str_ne
 #define spy_builtins$str$__getitem__ spy_str_getitem
+#define spy_builtins$str$__len__ spy_str_len
 
 #endif /* SPY_STR_H */

--- a/spy/libspy/src/str.c
+++ b/spy/libspy/src/str.c
@@ -56,6 +56,11 @@ spy_str_getitem(spy_Str *s, int32_t i) {
     return res;
 }
 
+int32_t
+spy_str_len(spy_Str *s) {
+    return (int32_t)s->length;
+}
+
 // XXX probably it would be better to implement it directly, instead of
 // bringing in all the code needed to support sprintf()
 spy_Str *

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -11,13 +11,12 @@ from spy.util import magic_dispatch
 def is_py_Name(py_expr: py_ast.expr, expected: str) -> bool:
     return isinstance(py_expr, py_ast.Name) and py_expr.id == expected
 
-
-def parse_special_decorator(py_expr) -> Optional[str]:
+def parse_special_decorator(py_expr: py_ast.expr) -> Optional[str]:
     """
     If the decorator is a simple @name or @name.attr, return them as
     strings. Else, return None.
     """
-    if is_py_Name(py_expr, 'blue'):
+    if isinstance(py_expr, py_ast.Name):
         return py_expr.id
 
     if (isinstance(py_expr, py_ast.Attribute) and

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -993,7 +993,7 @@ class TestBasic(CompilerTest):
         """)
         assert mod.foo(3) == 4
 
-    def test_blue_metafunc(self):
+    def xxx_test_blue_metafunc(self):
         mod = self.compile("""
         @blue.metafunc
         def foo(v_x):

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -993,19 +993,27 @@ class TestBasic(CompilerTest):
         """)
         assert mod.foo(3) == 4
 
-    def xxx_test_blue_metafunc(self):
+    def test_blue_metafunc(self):
         mod = self.compile("""
+        from operator import OpImpl
+
         @blue.metafunc
         def foo(v_x):
             if v_x.static_type == i32:
                def impl_i32(x: i32) -> i32:
                    return x * 2
-               return impl_i32
+               return OpImpl(impl_i32)
             elif v_x.static_type == str:
                def impl_str(x: str) -> str:
                    return x + ' world'
-               return impl_str
+               return OpImpl(impl_str)
             raise StaticError("unsupported type")
+
+        def test1() -> i32:
+            return foo(5)
+
+        def test2() -> str:
+            return foo('hello')
         """)
-        assert mod.foo(5) == 10
-        assert mod.foo('hello') == 'hello world'
+        assert mod.test1() == 10
+        assert mod.test2() == 'hello world'

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -992,3 +992,20 @@ class TestBasic(CompilerTest):
             return cls+1
         """)
         assert mod.foo(3) == 4
+
+    def test_blue_metafunc(self):
+        mod = self.compile("""
+        @blue.metafunc
+        def foo(v_x):
+            if v_x.static_type == i32:
+               def impl_i32(x: i32) -> i32:
+                   return x * 2
+               return impl_i32
+            elif v_x.static_type == str:
+               def impl_str(x: str) -> str:
+                   return x + ' world'
+               return impl_str
+            raise StaticError("unsupported type")
+        """)
+        assert mod.foo(5) == 10
+        assert mod.foo('hello') == 'hello world'

--- a/spy/tests/compiler/test_builtins.py
+++ b/spy/tests/compiler/test_builtins.py
@@ -1,0 +1,52 @@
+from spy.vm.primitive import W_I32
+from spy.vm.builtin import builtin_func, builtin_method
+from spy.vm.w import W_Object
+from spy.vm.opimpl import W_OpImpl, W_OpArg
+from spy.vm.registry import ModuleRegistry
+from spy.vm.vm import SPyVM
+from spy.tests.support import CompilerTest, no_C
+
+
+class W_MySequence(W_Object):
+    """A custom class that supports len() operation."""
+
+    def __init__(self, w_size: W_I32) -> None:
+        self.w_size = w_size
+
+    @builtin_method('__new__')
+    @staticmethod
+    def w_new(vm: 'SPyVM', w_size: W_I32) -> 'W_MySequence':
+        return W_MySequence(w_size)
+
+    @builtin_method('__LEN__', color='blue')
+    @staticmethod
+    def w_LEN(vm: 'SPyVM', wop_self: W_OpArg) -> W_OpImpl:
+        @builtin_func('ext')
+        def w_len(vm: 'SPyVM', w_self: W_MySequence) -> W_I32:
+            return w_self.w_size
+        return W_OpImpl(w_len)
+
+
+
+class TestBuiltins(CompilerTest):
+    SKIP_SPY_BACKEND_SANITY_CHECK = True
+
+    def setup_ext(self) -> None:
+        EXT = ModuleRegistry('ext')
+        EXT.builtin_type('MySequence')(W_MySequence)
+        self.vm.make_module(EXT)
+
+    @no_C
+    def test_LEN(self):
+        self.setup_ext()
+        src = """
+        from ext import MySequence
+
+        def foo(size: i32) -> i32:
+            obj = MySequence(size)
+            return len(obj)
+        """
+        mod = self.compile(src)
+        assert mod.foo(5) == 5
+        assert mod.foo(42) == 42
+        assert mod.foo(0) == 0

--- a/spy/tests/compiler/test_builtins.py
+++ b/spy/tests/compiler/test_builtins.py
@@ -4,7 +4,7 @@ from spy.vm.w import W_Object
 from spy.vm.opimpl import W_OpImpl, W_OpArg
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM
-from spy.tests.support import CompilerTest, no_C
+from spy.tests.support import CompilerTest, no_C, expect_errors
 
 
 class W_MySequence(W_Object):
@@ -50,3 +50,14 @@ class TestBuiltins(CompilerTest):
         assert mod.foo(5) == 5
         assert mod.foo(42) == 42
         assert mod.foo(0) == 0
+
+    def test_len_not_supported(self):
+        src = """
+        def foo() -> None:
+            return len(42)
+        """
+        errors = expect_errors(
+            'cannot call len(`i32`)',
+            ('this is `i32`', '42'),
+        )
+        self.compile_raises(src, "foo", errors)

--- a/spy/tests/compiler/test_str.py
+++ b/spy/tests/compiler/test_str.py
@@ -76,3 +76,13 @@ class TestStr(CompilerTest):
         assert not mod.eq("aaa", "bbb")
         assert mod.ne("aaa", "bbb")
         assert not mod.ne("aaa", "aaa")
+
+    def test_len(self):
+        src = """
+        def foo(s: str) -> i32:
+            return len(s)
+        """
+        mod = self.compile(src)
+        assert mod.foo("") == 0
+        assert mod.foo("abc") == 3
+        assert mod.foo("hello world") == 11

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -287,6 +287,31 @@ class TestParser:
         """
         self.assert_dump(funcdef, expected)
 
+    def test_blue_metafunc_FuncDef(self):
+        mod = self.parse("""
+        @blue.metafunc
+        def foo() -> i32:
+            return 42
+        """)
+        funcdef = mod.get_funcdef('foo')
+        expected = """
+        FuncDef(
+            color='blue',
+            kind='metafunc',
+            name='foo',
+            args=[],
+            return_type=Name(id='i32'),
+            docstring=None,
+            body=[
+                Return(
+                    value=Constant(value=42),
+                ),
+            ],
+        )
+        """
+        self.assert_dump(funcdef, expected)
+
+
     def test_FuncDef_prototype_loc(self):
         # blue functions without return type, are parsed as if they had a
         # synthetic '-> dynamic' annotation. We also need to generate a

--- a/spy/tests/vm/test_builtin.py
+++ b/spy/tests/vm/test_builtin.py
@@ -15,7 +15,7 @@ class TestBuiltin:
     def test_functype_from_sig(self):
         def foo(vm: 'SPyVM', w_x: W_I32) -> W_Str:
             return W_Str(vm, 'this is never called')
-        w_functype = functype_from_sig(foo, 'red')
+        w_functype = functype_from_sig(foo, 'red', 'plain')
         assert w_functype == W_FuncType.parse('def(i32) -> str')
 
     def test_functype_from_sig_extra_types(self):
@@ -24,14 +24,14 @@ class TestBuiltin:
         extra_types = {
             'FooBar': W_Str
         }
-        w_functype = functype_from_sig(foo, 'red', extra_types=extra_types)
+        w_functype = functype_from_sig(foo, 'red', 'plain', extra_types=extra_types)
         assert w_functype == W_FuncType.parse('def(i32) -> str')
 
     def test_annotated_type(self):
         W_MyType = Annotated[W_Object, B.w_i32]
         def foo(vm: 'SPyVM', w_x: W_MyType) -> None:
             pass
-        w_functype = functype_from_sig(foo, 'red')
+        w_functype = functype_from_sig(foo, 'red', 'plain')
         assert w_functype == W_FuncType.parse('def(i32) -> None')
 
     def test_builtin_func(self):

--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -10,7 +10,7 @@ import inspect
 from typing import (TYPE_CHECKING, Any, Callable, Type, Optional, get_origin,
                     Annotated)
 from spy.fqn import FQN, QUALIFIERS
-from spy.ast import Color
+from spy.ast import Color, FuncKind
 from spy.vm.object import W_Object, W_Type, make_metaclass_maybe
 from spy.vm.object import builtin_method # noqa: F401
 from spy.vm.function import FuncParam, FuncParamKind, W_FuncType, W_BuiltinFunc
@@ -58,7 +58,7 @@ def to_spy_FuncParam(p: Any, extra_types: TYPES_DICT) -> FuncParam:
     return FuncParam(w_type, kind)
 
 
-def functype_from_sig(fn: Callable, color: Color, *,
+def functype_from_sig(fn: Callable, color: Color, kind: FuncKind, *,
                       extra_types: dict = {}) -> W_FuncType:
     sig = inspect.signature(fn)
     params = list(sig.parameters.values())
@@ -73,7 +73,7 @@ def functype_from_sig(fn: Callable, color: Color, *,
     func_params = [to_spy_FuncParam(p, extra_types) for p in params[1:]]
     ret_ann = extra_types.get(sig.return_annotation, sig.return_annotation)
     w_restype = to_spy_type(ret_ann, allow_None=True)
-    return W_FuncType.new(func_params, w_restype, color=color)
+    return W_FuncType.new(func_params, w_restype, color=color, kind=kind)
 
 
 def builtin_func(namespace: FQN|str,
@@ -81,6 +81,7 @@ def builtin_func(namespace: FQN|str,
                  qualifiers: QUALIFIERS = None,
                  *,
                  color: Color = 'red',
+                 kind: FuncKind = 'plain',
                  extra_types: dict = {},
                  ) -> Callable:
     """
@@ -119,7 +120,7 @@ def builtin_func(namespace: FQN|str,
             fname = fn.__name__[2:]
         assert isinstance(namespace, FQN)
         fqn = namespace.join(fname, qualifiers)
-        w_functype = functype_from_sig(fn, color, extra_types=extra_types)
+        w_functype = functype_from_sig(fn, color, kind, extra_types=extra_types)
         return W_BuiltinFunc(w_functype, fqn, fn)
     return decorator
 

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -46,18 +46,31 @@ def w_min(vm: 'SPyVM', w_x: W_I32, w_y: W_I32) -> W_I32:
     return vm.wrap(res) # type: ignore
 
 
-@BUILTINS.builtin_func
-def w_print(vm: 'SPyVM', w_x: W_Dynamic) -> None:
-    """
-    Super minimal implementation of print().
+@BUILTINS.builtin_func(color='blue', kind='metafunc')
+def w_print(vm: 'SPyVM', wop_obj: W_OpArg) -> W_OpImpl:
+    w_type = wop_obj.w_static_type
+    if w_type is B.w_i32:
+        return W_OpImpl(B.w_print_i32)
+    elif w_type is B.w_f64:
+        return W_OpImpl(B.w_print_f64)
+    elif w_type is B.w_bool:
+        return W_OpImpl(B.w_print_bool)
+    elif w_type is B.w_NoneType:
+        return W_OpImpl(B.w_print_NoneType)
+    elif w_type is B.w_str:
+        return W_OpImpl(B.w_print_str)
+    elif w_type is B.w_dynamic:
+        return W_OpImpl(B.w_print_dynamic)
+    elif w_type is B.w_type:
+        return W_OpImpl(B.w_print_type)
 
-    It takes just one argument.
-    """
-    if isinstance(w_x, (W_I32, W_F64, W_Bool, W_Str, W_NoneType)):
-        PY_PRINT(vm.unwrap(w_x))
-    else:
-        PY_PRINT(w_x)
-    return B.w_None
+    t = w_type.fqn.human_name
+    raise SPyError.simple(
+        'W_TypeError',
+        f'cannot call print(`{t}`)',
+        f'this is `{t}`',
+        wop_obj.loc
+    )
 
 
 @BUILTINS.builtin_func
@@ -91,7 +104,6 @@ def w_print_type(vm: 'SPyVM', w_x: W_Type) -> None:
 @BUILTINS.builtin_func(color='blue', kind='metafunc')
 def w_len(vm: 'SPyVM', wop_obj: W_OpArg) -> W_OpImpl:
     from spy.vm.modules.operator import op_fast_call
-    w_opimpl = W_OpImpl.NULL
     w_type = wop_obj.w_static_type
 
     if w_LEN := w_type.lookup_blue_func('__LEN__'):

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -5,7 +5,7 @@ The first half is in vm/b.py. See its docstring for more details.
 """
 
 from typing import TYPE_CHECKING
-from spy.errors import WIP
+from spy.errors import SPyError
 from spy.vm.builtin import builtin_func
 from spy.vm.primitive import W_F64, W_I32, W_Bool, W_Dynamic, W_NoneType
 from spy.vm.opimpl import W_OpArg, W_OpImpl
@@ -101,7 +101,13 @@ def w_len(vm: 'SPyVM', wop_obj: W_OpArg) -> W_OpImpl:
         w_opimpl = W_OpImpl(w_fn, [wop_obj])
         return w_opimpl
 
-    raise WIP('better error message for missing __len__')
+    t = w_type.fqn.human_name
+    raise SPyError.simple(
+        'W_TypeError',
+        f'cannot call len(`{t}`)',
+        f'this is `{t}`',
+        wop_obj.loc
+    )
 
 
 # this should belong to function.py, but we cannot put it there because of

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -5,8 +5,10 @@ The first half is in vm/b.py. See its docstring for more details.
 """
 
 from typing import TYPE_CHECKING
+from spy.errors import WIP
 from spy.vm.builtin import builtin_func
 from spy.vm.primitive import W_F64, W_I32, W_Bool, W_Dynamic, W_NoneType
+from spy.vm.opimpl import W_OpArg, W_OpImpl
 from spy.vm.object import W_Object, W_Type
 from spy.vm.str import W_Str
 from spy.vm.function import W_FuncType
@@ -85,6 +87,18 @@ def w_print_dynamic(vm: 'SPyVM', w_x: W_Dynamic) -> None:
 @BUILTINS.builtin_func
 def w_print_type(vm: 'SPyVM', w_x: W_Type) -> None:
     PY_PRINT(str(w_x))
+
+@BUILTINS.builtin_func(color='blue', kind='metafunc')
+def w_len(vm: 'SPyVM', wop_obj: W_OpArg) -> W_OpImpl:
+    w_opimpl = W_OpImpl.NULL
+    w_type = wop_obj.w_static_type
+
+    if w_LEN := w_type.lookup_blue_func('__LEN__'):
+        raise WIP('support for __LEN__')
+    elif w_fn := w_type.lookup_func('__len__'):
+        return W_OpImpl(w_fn, [wop_obj])
+
+    raise WIP('better error message for missing __len__')
 
 
 # this should belong to function.py, but we cannot put it there because of

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -90,13 +90,16 @@ def w_print_type(vm: 'SPyVM', w_x: W_Type) -> None:
 
 @BUILTINS.builtin_func(color='blue', kind='metafunc')
 def w_len(vm: 'SPyVM', wop_obj: W_OpArg) -> W_OpImpl:
+    from spy.vm.modules.operator import op_fast_call
     w_opimpl = W_OpImpl.NULL
     w_type = wop_obj.w_static_type
 
     if w_LEN := w_type.lookup_blue_func('__LEN__'):
-        raise WIP('support for __LEN__')
+        w_opimpl = op_fast_call(vm, w_LEN, [wop_obj])
+        return w_opimpl
     elif w_fn := w_type.lookup_func('__len__'):
-        return W_OpImpl(w_fn, [wop_obj])
+        w_opimpl = W_OpImpl(w_fn, [wop_obj])
+        return w_opimpl
 
     raise WIP('better error message for missing __len__')
 

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -20,11 +20,14 @@ def w_CALL(vm: 'SPyVM', wop_obj: W_OpArg, *args_wop: W_OpArg) -> W_Func:
         # W_Func is a special case, as it can't have a w_CALL for bootstrapping
         # reasons. Moreover, while we are at it, we can produce a better error
         # message in case we try to call a plain function with [].
-        if w_type.kind == 'plain':
+        if w_type.kind in ('plain', 'metafunc'):
             assert w_type.pyclass is W_Func
             w_opimpl = W_Func.op_CALL(vm, wop_obj, *args_wop) # type: ignore
-        else:
+        elif w_type.kind == 'generic':
             errmsg = 'generic functions must be called via `[...]`'
+        else:
+            assert False, f'unknown FuncKind: {w_type.kind}'
+
     if w_type is B.w_dynamic:
         w_opimpl = W_OpImpl(OP.w_dynamic_call)
     elif w_CALL := w_type.lookup_blue_func('__CALL__'):

--- a/spy/vm/registry.py
+++ b/spy/vm/registry.py
@@ -1,6 +1,6 @@
 from typing import Callable, TYPE_CHECKING, Any, Type
 from types import FunctionType
-from spy.ast import Color
+from spy.ast import Color, FuncKind
 from spy.fqn import FQN, QUALIFIERS
 
 if TYPE_CHECKING:
@@ -78,7 +78,9 @@ class ModuleRegistry:
                      pyfunc_or_funcname: Callable|str|None = None,
                      qualifiers: QUALIFIERS = None,
                      *,
-                     color: Color = 'red') -> Any:
+                     color: Color = 'red',
+                     kind: FuncKind = 'plain',
+                     ) -> Any:
         """
         Register a builtin function on the module. We support three
         different syntaxes:
@@ -117,7 +119,8 @@ class ModuleRegistry:
                 namespace=namespace,
                 funcname=funcname,
                 qualifiers=qualifiers,
-                color=color
+                color=color,
+                kind=kind,
             )(pyfunc)
             setattr(self, f'w_{w_func.fqn.symbol_name}', w_func)
             self.content.append((w_func.fqn, w_func))

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -77,6 +77,13 @@ class W_Str(W_Object):
         ptr_c = vm.ll.call('spy_str_getitem', w_s.ptr, w_i.value)
         return W_Str.from_ptr(vm, ptr_c)
 
+    @builtin_method('__len__')
+    @staticmethod
+    def w_len(vm: 'SPyVM', w_s: 'W_Str') -> W_I32:
+        assert isinstance(w_s, W_Str)
+        length = vm.ll.call('spy_str_len', w_s.ptr)
+        return vm.wrap(length)  # type: ignore
+
     @staticmethod
     def w_meta_CALL(vm: 'SPyVM', wop_obj: W_OpArg,
                     *args_wop: W_OpArg) -> W_OpImpl:


### PR DESCRIPTION
This PR introduces the concept of metafunctions and the `@blue.metafunc` decorator.

Metafunctions are a generalization of the two-phase dispatch concept which is already in place for operators.
Calling a metafunc happens in two step:
1. blue call to the metafunc itself, passing `OpArg` as arguments, and returning and `OpImpl`
2. red call to the returned `OpImpl`

This makes it possible to e.g. implement overloading, and to use it to implement generic functions like `len()` and `print()`.
