### PR TITLE
Add bool operators

### DIFF
--- a/spy/libspy/include/spy/operator.h
+++ b/spy/libspy/include/spy/operator.h
@@ -68,4 +68,12 @@ static inline double spy_operator$f64_floordiv(double x, double y) {
     return floor(x / y);
 }
 
+static inline bool spy_operator$bool_eq(bool x, bool y) {
+    return x == y;
+}
+
+static inline bool spy_operator$bool_ne(bool x, bool y) {
+    return x != y;
+}
+
 #endif /* SPY_OPERATOR_H */

--- a/spy/libspy/include/spy/operator.h
+++ b/spy/libspy/include/spy/operator.h
@@ -76,4 +76,32 @@ static inline bool spy_operator$bool_ne(bool x, bool y) {
     return x != y;
 }
 
+static inline bool spy_operator$bool_and(bool x, bool y) {
+    return x && y;
+}
+
+static inline bool spy_operator$bool_or(bool x, bool y) {
+    return x || y;
+}
+
+static inline bool spy_operator$bool_xor(bool x, bool y) {
+    return x != y;
+}
+
+static inline bool spy_operator$bool_lt(bool x, bool y) {
+    return !x && y;
+}
+
+static inline bool spy_operator$bool_le(bool x, bool y) {
+    return !x || y;
+}
+
+static inline bool spy_operator$bool_gt(bool x, bool y) {
+    return x && !y;
+}
+
+static inline bool spy_operator$bool_ge(bool x, bool y) {
+    return x || !y;
+}
+
 #endif /* SPY_OPERATOR_H */

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -420,6 +420,24 @@ class TestBasic(CompilerTest):
         """)
         assert mod.get_True() is True
         assert mod.get_False() is False
+        
+    def test_bool_equality(self):
+        mod = self.compile("""
+        def eq_bool(a: bool, b: bool) -> bool:
+            return a == b
+            
+        def ne_bool(a: bool, b: bool) -> bool:
+            return a != b
+        """)
+        assert mod.eq_bool(True, True) is True
+        assert mod.eq_bool(True, False) is False
+        assert mod.eq_bool(False, True) is False
+        assert mod.eq_bool(False, False) is True
+        
+        assert mod.ne_bool(True, True) is False
+        assert mod.ne_bool(True, False) is True
+        assert mod.ne_bool(False, True) is True
+        assert mod.ne_bool(False, False) is False
 
     def test_CompareOp_error(self):
         src = """

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -438,6 +438,72 @@ class TestBasic(CompilerTest):
         assert mod.ne_bool(True, False) is True
         assert mod.ne_bool(False, True) is True
         assert mod.ne_bool(False, False) is False
+        
+    def test_bool_operations(self):
+        mod = self.compile("""
+        def and_bool(a: bool, b: bool) -> bool:
+            return a & b
+            
+        def or_bool(a: bool, b: bool) -> bool:
+            return a | b
+            
+        def xor_bool(a: bool, b: bool) -> bool:
+            return a ^ b
+            
+        def lt_bool(a: bool, b: bool) -> bool:
+            return a < b
+            
+        def le_bool(a: bool, b: bool) -> bool:
+            return a <= b
+            
+        def gt_bool(a: bool, b: bool) -> bool:
+            return a > b
+            
+        def ge_bool(a: bool, b: bool) -> bool:
+            return a >= b
+        """)
+        
+        # Test AND
+        assert mod.and_bool(True, True) is True
+        assert mod.and_bool(True, False) is False
+        assert mod.and_bool(False, True) is False
+        assert mod.and_bool(False, False) is False
+        
+        # Test OR
+        assert mod.or_bool(True, True) is True
+        assert mod.or_bool(True, False) is True
+        assert mod.or_bool(False, True) is True
+        assert mod.or_bool(False, False) is False
+        
+        # Test XOR
+        assert mod.xor_bool(True, True) is False
+        assert mod.xor_bool(True, False) is True
+        assert mod.xor_bool(False, True) is True
+        assert mod.xor_bool(False, False) is False
+        
+        # Test <
+        assert mod.lt_bool(True, True) is False
+        assert mod.lt_bool(True, False) is False
+        assert mod.lt_bool(False, True) is True
+        assert mod.lt_bool(False, False) is False
+        
+        # Test <=
+        assert mod.le_bool(True, True) is True
+        assert mod.le_bool(True, False) is False
+        assert mod.le_bool(False, True) is True
+        assert mod.le_bool(False, False) is True
+        
+        # Test >
+        assert mod.gt_bool(True, True) is False
+        assert mod.gt_bool(True, False) is True
+        assert mod.gt_bool(False, True) is False
+        assert mod.gt_bool(False, False) is False
+        
+        # Test >=
+        assert mod.ge_bool(True, True) is True
+        assert mod.ge_bool(True, False) is True
+        assert mod.ge_bool(False, True) is False
+        assert mod.ge_bool(False, False) is True
 
     def test_CompareOp_error(self):
         src = """

--- a/spy/tests/compiler/test_typelift.py
+++ b/spy/tests/compiler/test_typelift.py
@@ -98,7 +98,7 @@ class TestTypelift(CompilerTest):
     def test_if_inside_classdef(self):
         src = """
         @blue
-        def make_Foo(K):
+        def make_Foo(DOUBLE):
             @typelift
             class Foo:
                 __ll__: i32
@@ -106,7 +106,7 @@ class TestTypelift(CompilerTest):
                 def __new__(i: i32) -> Foo:
                     return Foo.__lift__(i)
 
-                if K == 2:
+                if DOUBLE:
                     def get(self: Foo) -> i32:
                         return self.__ll__ * 2
                 else:
@@ -116,13 +116,13 @@ class TestTypelift(CompilerTest):
             return Foo
 
         def test1(x: i32) -> i32:
-            a = make_Foo(1)(x)
+            a = make_Foo(True)(x)
             return a.get()
 
         def test2(x: i32) -> i32:
-            b = make_Foo(2)(x)
+            b = make_Foo(False)(x)
             return b.get()
         """
         mod = self.compile(src)
-        assert mod.test1(10) == 10
-        assert mod.test2(10) == 20
+        assert mod.test1(10) == 20
+        assert mod.test2(10) == 10

--- a/spy/tests/wasm_wrapper.py
+++ b/spy/tests/wasm_wrapper.py
@@ -76,7 +76,7 @@ class WasmFuncWrapper:
         self.w_functype = w_functype
 
     def py2wasm(self, pyval: Any, w_type: W_Type) -> Any:
-        if w_type in (B.w_i32, B.w_i8, B.w_u8, B.w_f64):
+        if w_type in (B.w_i32, B.w_i8, B.w_u8, B.w_f64, B.w_bool):
             return pyval
         elif w_type is B.w_str:
             # XXX: with the GC, we need to think how to keep this alive

--- a/spy/vm/modules/operator/__init__.py
+++ b/spy/vm/modules/operator/__init__.py
@@ -65,6 +65,7 @@ from . import opimpl_f64     # noqa: F401 -- side effects
 from . import opimpl_str     # noqa: F401 -- side effects
 from . import opimpl_object  # noqa: F401 -- side effects
 from . import opimpl_dynamic # noqa: F401 -- side effects
+from . import opimpl_bool    # noqa: F401 -- side effects
 from . import unaryop        # noqa: F401 -- side effects
 from . import binop          # noqa: F401 -- side effects
 from . import attrop         # noqa: F401 -- side effects

--- a/spy/vm/modules/operator/binop.py
+++ b/spy/vm/modules/operator/binop.py
@@ -114,6 +114,13 @@ MM.register('!=', 'str', 'str', OP.w_str_ne)
 # bool ops
 MM.register('==', 'bool', 'bool', OP.w_bool_eq)
 MM.register('!=', 'bool', 'bool', OP.w_bool_ne)
+MM.register('&',  'bool', 'bool', OP.w_bool_and)
+MM.register('|',  'bool', 'bool', OP.w_bool_or)
+MM.register('^',  'bool', 'bool', OP.w_bool_xor)
+MM.register('<',  'bool', 'bool', OP.w_bool_lt)
+MM.register('<=', 'bool', 'bool', OP.w_bool_le)
+MM.register('>',  'bool', 'bool', OP.w_bool_gt)
+MM.register('>=', 'bool', 'bool', OP.w_bool_ge)
 
 # dynamic ops
 MM.register_partial('+',  'dynamic', OP.w_dynamic_add)

--- a/spy/vm/modules/operator/binop.py
+++ b/spy/vm/modules/operator/binop.py
@@ -111,6 +111,10 @@ MM.register('*',  'str', 'i32', OP.w_str_mul)
 MM.register('==', 'str', 'str', OP.w_str_eq)
 MM.register('!=', 'str', 'str', OP.w_str_ne)
 
+# bool ops
+MM.register('==', 'bool', 'bool', OP.w_bool_eq)
+MM.register('!=', 'bool', 'bool', OP.w_bool_ne)
+
 # dynamic ops
 MM.register_partial('+',  'dynamic', OP.w_dynamic_add)
 MM.register_partial('*',  'dynamic', OP.w_dynamic_mul)

--- a/spy/vm/modules/operator/opimpl_bool.py
+++ b/spy/vm/modules/operator/opimpl_bool.py
@@ -12,3 +12,35 @@ def w_bool_eq(vm: 'SPyVM', w_a: W_Bool, w_b: W_Bool) -> W_Bool:
 @OP.builtin_func('bool_ne')
 def w_bool_ne(vm: 'SPyVM', w_a: W_Bool, w_b: W_Bool) -> W_Bool:
     return vm.wrap(w_a.value != w_b.value)  # type: ignore
+
+@OP.builtin_func('bool_and')
+def w_bool_and(vm: 'SPyVM', w_a: W_Bool, w_b: W_Bool) -> W_Bool:
+    return vm.wrap(w_a.value and w_b.value)  # type: ignore
+
+@OP.builtin_func('bool_or')
+def w_bool_or(vm: 'SPyVM', w_a: W_Bool, w_b: W_Bool) -> W_Bool:
+    return vm.wrap(w_a.value or w_b.value)  # type: ignore
+
+@OP.builtin_func('bool_xor')
+def w_bool_xor(vm: 'SPyVM', w_a: W_Bool, w_b: W_Bool) -> W_Bool:
+    return vm.wrap(w_a.value != w_b.value)  # type: ignore
+
+@OP.builtin_func('bool_lt')
+def w_bool_lt(vm: 'SPyVM', w_a: W_Bool, w_b: W_Bool) -> W_Bool:
+    # False < True but not True < False
+    return vm.wrap(not w_a.value and w_b.value)  # type: ignore
+
+@OP.builtin_func('bool_le')
+def w_bool_le(vm: 'SPyVM', w_a: W_Bool, w_b: W_Bool) -> W_Bool:
+    # False <= True and True <= True and False <= False
+    return vm.wrap(not w_a.value or w_b.value)  # type: ignore
+
+@OP.builtin_func('bool_gt')
+def w_bool_gt(vm: 'SPyVM', w_a: W_Bool, w_b: W_Bool) -> W_Bool:
+    # True > False but not False > True
+    return vm.wrap(w_a.value and not w_b.value)  # type: ignore
+
+@OP.builtin_func('bool_ge')
+def w_bool_ge(vm: 'SPyVM', w_a: W_Bool, w_b: W_Bool) -> W_Bool:
+    # True >= False and True >= True and False >= False
+    return vm.wrap(w_a.value or not w_b.value)  # type: ignore

--- a/spy/vm/modules/operator/opimpl_bool.py
+++ b/spy/vm/modules/operator/opimpl_bool.py
@@ -1,0 +1,14 @@
+from typing import TYPE_CHECKING
+from spy.vm.primitive import W_Bool
+from . import OP
+
+if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
+
+@OP.builtin_func('bool_eq')
+def w_bool_eq(vm: 'SPyVM', w_a: W_Bool, w_b: W_Bool) -> W_Bool:
+    return vm.wrap(w_a.value == w_b.value)  # type: ignore
+
+@OP.builtin_func('bool_ne')
+def w_bool_ne(vm: 'SPyVM', w_a: W_Bool, w_b: W_Bool) -> W_Bool:
+    return vm.wrap(w_a.value != w_b.value)  # type: ignore


### PR DESCRIPTION
## Summary
- Add boolean equality operators (`==` and `\!=`)
- Add full set of boolean operations (`and`, `or`, `not`)

## Changes
This PR implements boolean comparison and operation capabilities, enabling more expressive conditional logic in SPy code.

## Test plan
- Run test suite to verify proper boolean operator functionality