### PR TITLE
Add support for array of structs

### DIFF
--- a/spy/libspy/include/spy/unsafe.h
+++ b/spy/libspy/include/spy/unsafe.h
@@ -39,8 +39,11 @@ WASM_EXPORT(spy_gc_alloc_mem)(size_t size);
         spy_GcRef ref = spy_GcAlloc(sizeof(T) * n);              \
         return ( PTR ){ ref.p };                                 \
     }                                                            \
-    static inline T PTR##$load(PTR p, size_t i) {                \
+    static inline T PTR##$load_byval(PTR p, size_t i) {          \
         return p.p[i];                                           \
+    }                                                            \
+    static inline PTR PTR##$load_byref(PTR p, size_t i) {        \
+        return PTR##_from_addr(p.p + i);                         \
     }                                                            \
     static inline void PTR##$store(PTR p, size_t i, T v) {       \
         p.p[i] = v;                                              \
@@ -64,10 +67,17 @@ WASM_EXPORT(spy_gc_alloc_mem)(size_t size);
         spy_GcRef ref = spy_GcAlloc(sizeof(T) * n);              \
         return ( PTR ){ ref.p, n };                              \
     }                                                            \
-    static inline T PTR##$load(PTR p, size_t i) {                \
+    static inline T PTR##$load_byval(PTR p, size_t i) {          \
         if (i >= p.length)                                       \
-            spy_panic("PanicError", "ptr_load out of bounds", __FILE__, __LINE__); \
+            spy_panic("PanicError", "ptr_load out of bounds",    \
+                      __FILE__, __LINE__);                       \
         return p.p[i];                                           \
+    }                                                            \
+    static inline PTR PTR##$load_byref(PTR p, size_t i) {        \
+        if (i >= p.length)                                       \
+            spy_panic("PanicError", "ptr_load out of bounds",    \
+                      __FILE__, __LINE__);                       \
+        return PTR##_from_addr(p.p + i);                         \
     }                                                            \
     static inline void PTR##$store(PTR p, size_t i, T v) {       \
         if (i >= p.length)                                       \

--- a/spy/libspy/include/spy/unsafe.h
+++ b/spy/libspy/include/spy/unsafe.h
@@ -39,10 +39,10 @@ WASM_EXPORT(spy_gc_alloc_mem)(size_t size);
         spy_GcRef ref = spy_GcAlloc(sizeof(T) * n);              \
         return ( PTR ){ ref.p };                                 \
     }                                                            \
-    static inline T PTR##$load_byval(PTR p, size_t i) {          \
+    static inline T PTR##getitem_byval(PTR p, size_t i) {        \
         return p.p[i];                                           \
     }                                                            \
-    static inline PTR PTR##$load_byref(PTR p, size_t i) {        \
+    static inline PTR PTR##getitem_byref(PTR p, size_t i) {      \
         return PTR##_from_addr(p.p + i);                         \
     }                                                            \
     static inline void PTR##$store(PTR p, size_t i, T v) {       \
@@ -67,15 +67,15 @@ WASM_EXPORT(spy_gc_alloc_mem)(size_t size);
         spy_GcRef ref = spy_GcAlloc(sizeof(T) * n);              \
         return ( PTR ){ ref.p, n };                              \
     }                                                            \
-    static inline T PTR##$load_byval(PTR p, size_t i) {          \
+    static inline T PTR##$getitem_byval(PTR p, size_t i) {       \
         if (i >= p.length)                                       \
-            spy_panic("PanicError", "ptr_load out of bounds",    \
+            spy_panic("PanicError", "ptr_getitem out of bounds", \
                       __FILE__, __LINE__);                       \
         return p.p[i];                                           \
     }                                                            \
-    static inline PTR PTR##$load_byref(PTR p, size_t i) {        \
+    static inline PTR PTR##$getitem_byref(PTR p, size_t i) {     \
         if (i >= p.length)                                       \
-            spy_panic("PanicError", "ptr_load out of bounds",    \
+            spy_panic("PanicError", "ptr_getitem out of bounds", \
                       __FILE__, __LINE__);                       \
         return PTR##_from_addr(p.p + i);                         \
     }                                                            \

--- a/spy/tests/compiler/test_unsafe.py
+++ b/spy/tests/compiler/test_unsafe.py
@@ -62,7 +62,7 @@ class TestUnsafe(CompilerTest):
             return buf[i]
         """)
         assert mod.foo(1) == 100
-        with SPyError.raises("W_PanicError", match="ptr_load out of bounds"):
+        with SPyError.raises("W_PanicError", match="ptr_getitem out of bounds"):
             mod.foo(3)
 
     def test_struct(self):

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -64,6 +64,11 @@ def w_print(vm: 'SPyVM', wop_obj: W_OpArg) -> W_OpImpl:
     elif w_type is B.w_type:
         return W_OpImpl(B.w_print_type)
 
+
+    else:
+        # ???
+        return W_OpImpl(B.w_print_dynamic)
+
     t = w_type.fqn.human_name
     raise SPyError.simple(
         'W_TypeError',

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -168,14 +168,14 @@ class W_Ptr(W_BasePtr):
 
         T = Annotated[W_Object, w_T]
 
-        @builtin_func(w_ptrtype.fqn, f'load_{by}')
-        def w_ptr_load_T(vm: 'SPyVM', w_ptr: PTR, w_i: W_I32) -> T:
+        @builtin_func(w_ptrtype.fqn, f'getitem_{by}')
+        def w_ptr_getitem_T(vm: 'SPyVM', w_ptr: PTR, w_i: W_I32) -> T:
             base = w_ptr.addr
             length = w_ptr.length
             i = vm.unwrap_i32(w_i)
             addr = base + ITEMSIZE * i
             if i >= length:
-                msg = (f"ptr_load out of bounds: 0x{addr:x}[{i}] "
+                msg = (f"ptr_getitem out of bounds: 0x{addr:x}[{i}] "
                        f"(upper bound: {length})")
                 loc = Loc(filename, lineno, lineno, 1, -1)
                 raise SPyError.simple("W_PanicError", msg, "", loc)
@@ -190,7 +190,7 @@ class W_Ptr(W_BasePtr):
                     [vm.wrap(addr)]
                 )
 
-        return W_OpImpl(w_ptr_load_T)
+        return W_OpImpl(w_ptr_getitem_T)
 
     @builtin_method('__SETITEM__', color='blue')
     @staticmethod

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -157,47 +157,40 @@ class W_Ptr(W_BasePtr):
         w_T = w_ptrtype.w_itemtype
         ITEMSIZE = sizeof(w_T)
         PTR = Annotated[W_Ptr, w_ptrtype]
-        T = Annotated[W_Object, w_T]
         filename = wop_ptr.loc.filename
         lineno = wop_ptr.loc.line_start
 
         if w_T.is_struct(vm):
             w_T = vm.fast_call(w_make_ptr_type, [w_T])  # type: ignore
-            T2 = Annotated[W_Object, w_T] # XXX
-
-            @builtin_func(w_ptrtype.fqn, 'load_byref')
-            def w_ptr_load_byref_T(vm: 'SPyVM', w_ptr: PTR, w_i: W_I32) -> T2:
-                base = w_ptr.addr
-                length = w_ptr.length
-                i = vm.unwrap_i32(w_i)
-                addr = base + ITEMSIZE * i
-                if i >= length:
-                    msg = (f"ptr_load out of bounds: 0x{addr:x}[{i}] "
-                           f"(upper bound: {length})")
-                    loc = Loc(filename, lineno, lineno, 1, -1)
-                    raise SPyError.simple("W_PanicError", msg, "", loc)
-                return W_Ptr(w_T, addr, length-i)
-            return W_OpImpl(w_ptr_load_byref_T)
-
+            by = 'byref'
         else:
+            by = 'byval'
 
-            @builtin_func(w_ptrtype.fqn, 'load')
-            def w_ptr_load_T(vm: 'SPyVM', w_ptr: PTR, w_i: W_I32) -> T:
-                base = w_ptr.addr
-                length = w_ptr.length
-                i = vm.unwrap_i32(w_i)
-                addr = base + ITEMSIZE * i
-                if i >= length:
-                    msg = (f"ptr_load out of bounds: 0x{addr:x}[{i}] "
-                           f"(upper bound: {length})")
-                    loc = Loc(filename, lineno, lineno, 1, -1)
-                    raise SPyError.simple("W_PanicError", msg, "", loc)
+        T = Annotated[W_Object, w_T]
+
+        @builtin_func(w_ptrtype.fqn, f'load_{by}')
+        def w_ptr_load_T(vm: 'SPyVM', w_ptr: PTR, w_i: W_I32) -> T:
+            base = w_ptr.addr
+            length = w_ptr.length
+            i = vm.unwrap_i32(w_i)
+            addr = base + ITEMSIZE * i
+            if i >= length:
+                msg = (f"ptr_load out of bounds: 0x{addr:x}[{i}] "
+                       f"(upper bound: {length})")
+                loc = Loc(filename, lineno, lineno, 1, -1)
+                raise SPyError.simple("W_PanicError", msg, "", loc)
+
+            if by == 'byref':
+                assert isinstance(w_T, W_PtrType)
+                return W_Ptr(w_T, addr, length-i)
+            else:
                 return vm.call_generic(
                     UNSAFE.w_mem_read,
                     [w_T],
                     [vm.wrap(addr)]
                 )
-            return W_OpImpl(w_ptr_load_T)
+
+        return W_OpImpl(w_ptr_load_T)
 
     @builtin_method('__SETITEM__', color='blue')
     @staticmethod


### PR DESCRIPTION
Make it possible to index individual items inside an array of structs.

The solution is similar to what we already do for ptr_getfield:
  - primitive types are returned by value
  - struct types are returned by reference

"By reference" means that for now we return a pointer to the struct
(so e.g. p[0] return itself), but we should probably add a proper
"reference" type which is distinct from "ptr".

Fixes #184

