### PR TITLE
Introduce stdlib/array.spy

### DIFF
--- a/spy/backend/c/cmodwriter.py
+++ b/spy/backend/c/cmodwriter.py
@@ -260,6 +260,7 @@ class CModuleWriter:
 
     def emit_StructType(self, fqn: FQN, w_st: W_StructType) -> None:
         c_st = C_Type(w_st.fqn.c_name)
+        self.tbh_types_decl.wl(f'/* {w_st.fqn.human_name} */')
         self.tbh_types_decl.wl(f'typedef struct {c_st} {c_st};')
 
         # XXX this is VERY wrong: it assumes that the standard C layout

--- a/spy/libspy/include/spy/unsafe.h
+++ b/spy/libspy/include/spy/unsafe.h
@@ -39,10 +39,10 @@ WASM_EXPORT(spy_gc_alloc_mem)(size_t size);
         spy_GcRef ref = spy_GcAlloc(sizeof(T) * n);              \
         return ( PTR ){ ref.p };                                 \
     }                                                            \
-    static inline T PTR##getitem_byval(PTR p, size_t i) {        \
+    static inline T PTR##$getitem_byval(PTR p, size_t i) {       \
         return p.p[i];                                           \
     }                                                            \
-    static inline PTR PTR##getitem_byref(PTR p, size_t i) {      \
+    static inline PTR PTR##$getitem_byref(PTR p, size_t i) {     \
         return PTR##_from_addr(p.p + i);                         \
     }                                                            \
     static inline void PTR##$store(PTR p, size_t i, T v) {       \

--- a/spy/tests/compiler/test_tuple.py
+++ b/spy/tests/compiler/test_tuple.py
@@ -73,3 +73,35 @@ class TestTuple(CompilerTest):
             ('this is `i32`', '42'),
         )
         self.compile_raises(src, 'foo', errors)
+
+    def test_eq(self):
+        mod = self.compile(
+        """
+        def tup1() -> tuple:
+            return 1, 2
+
+        def tup2() -> tuple:
+            return 3, 4
+
+        def foo() -> bool:
+            return tup1() == tup1()
+
+        def bar() -> bool:
+            return tup1() == tup2()
+        """)
+        assert mod.foo()
+        assert not mod.bar()
+
+    def test_blue_tuple(self):
+        mod = self.compile(
+        """
+        @blue
+        def make_pair():
+            return 1, 2
+
+        def foo() -> i32:
+            a, b = make_pair()
+            return a + b
+        """)
+        x = mod.foo()
+        assert x == 3

--- a/spy/tests/stdlib/test_array.py
+++ b/spy/tests/stdlib/test_array.py
@@ -61,16 +61,25 @@ class TestArray(CompilerTest):
         def store(p: ptr[i32], i: i32, v: i32) -> None:
             p[i] = v
 
-        def test(buf: ptr[i32], l: i32) -> int:
-            a = array[int, 1].from_buffer(buf, l)
+        def test1(buf: ptr[i32], l: i32) -> i32:
+            a = array[i32, 1].from_buffer(buf, l)
             return a[0] + a[1] + a[2]
+
+        def test2(buf: ptr[i32], h: i32, w: i32) -> int:
+            a = array[i32, 2].from_buffer(buf, h, w)
+            return a[1, 0]
         """
         mod = self.compile(src)
-        buf = mod.alloc_buf(3)
+        buf = mod.alloc_buf(6)
         mod.store(buf, 0, 10)
         mod.store(buf, 1, 20)
         mod.store(buf, 2, 30)
-        assert mod.test(buf, 3) == 60
+        mod.store(buf, 3, 40)
+        mod.store(buf, 4, 50)
+        mod.store(buf, 5, 60)
+        assert mod.test1(buf, 3) == 60
+        assert mod.test2(buf, 3, 2) == 30
+        assert mod.test2(buf, 2, 3) == 40
 
     def test_zeros(self):
         src = """

--- a/spy/tests/stdlib/test_array.py
+++ b/spy/tests/stdlib/test_array.py
@@ -5,10 +5,10 @@ class TestArray(CompilerTest):
 
     def test_array1_simple(self):
         src = """
-        from array import array1
+        from array import array
 
         def test() -> int:
-            a = array1[int](3)
+            a = array[int, 1](3)
             a[0] = 1
             a[1] = 2
             a[2] = 3
@@ -19,10 +19,10 @@ class TestArray(CompilerTest):
 
     def test_len(self):
         src = """
-        from array import array1
+        from array import array
 
         def test() -> int:
-            a = array1[int](3)
+            a = array[int, 1](3)
             return len(a)
         """
         mod = self.compile(src)

--- a/spy/tests/stdlib/test_array.py
+++ b/spy/tests/stdlib/test_array.py
@@ -49,3 +49,19 @@ class TestArray(CompilerTest):
         mod.store(buf, 1, 20)
         mod.store(buf, 2, 30)
         assert mod.test(buf, 3) == 60
+
+    def test_zeros(self):
+        src = """
+        from array import zeros
+
+        def test_len(n: i32) -> i32:
+            a = zeros[f64](n)
+            return len(a)
+
+        def test_content(n: i32) -> f64:
+            a = zeros[f64](n)
+            return a[0] + a[1] + a[2]
+        """
+        mod = self.compile(src)
+        assert mod.test_len(5) == 5
+        assert mod.test_content(5) == 0

--- a/spy/tests/stdlib/test_array.py
+++ b/spy/tests/stdlib/test_array.py
@@ -17,7 +17,6 @@ class TestArray(CompilerTest):
         mod = self.compile(src)
         assert mod.test() == 6
 
-    @pytest.mark.skip
     def test_len(self):
         src = """
         from array import array1

--- a/spy/tests/stdlib/test_array.py
+++ b/spy/tests/stdlib/test_array.py
@@ -17,16 +17,38 @@ class TestArray(CompilerTest):
         mod = self.compile(src)
         assert mod.test() == 6
 
-    def test_len(self):
+    def test_array2_simple(self):
         src = """
         from array import array
 
         def test() -> int:
+            a = array[int, 2](2, 3)
+            a[0, 0] = 1
+            a[0, 1] = 2
+            a[0, 2] = 3
+            a[1, 0] = 4
+            a[1, 1] = 5
+            a[1, 2] = 6
+            return a[0, 0] + a[1, 2]
+        """
+        mod = self.compile(src)
+        assert mod.test() == 7
+
+    def test_len(self):
+        src = """
+        from array import array
+
+        def test1() -> int:
             a = array[int, 1](3)
+            return len(a)
+
+        def test2() -> int:
+            a = array[int, 2](4, 5)
             return len(a)
         """
         mod = self.compile(src)
-        assert mod.test() == 3
+        assert mod.test1() == 3
+        assert mod.test2() == 4
 
     def test_from_buffer(self):
         src = """

--- a/spy/tests/stdlib/test_array.py
+++ b/spy/tests/stdlib/test_array.py
@@ -1,0 +1,17 @@
+from spy.tests.support import CompilerTest
+
+class TestArray(CompilerTest):
+
+    def test_array1_simple(self):
+        src = """
+        from array import array1
+
+        def test() -> int:
+            a = array1[int](3)
+            a[0] = 1
+            a[1] = 2
+            a[2] = 3
+            return a[0] + a[1] + a[2]
+        """
+        mod = self.compile(src)
+        assert mod.test() == 6

--- a/spy/tests/stdlib/test_array.py
+++ b/spy/tests/stdlib/test_array.py
@@ -27,3 +27,25 @@ class TestArray(CompilerTest):
         """
         mod = self.compile(src)
         assert mod.test() == 3
+
+    def test_from_buffer(self):
+        src = """
+        from array import array, array_from_buffer
+        from unsafe import ptr, gc_alloc
+
+        def alloc_buf(n: i32) -> ptr[i32]:
+            return gc_alloc(i32)(n)
+
+        def store(p: ptr[i32], i: i32, v: i32) -> None:
+            p[i] = v
+
+        def test(buf: ptr[i32], l: i32) -> int:
+            a = array_from_buffer[int, 1](buf, l)
+            return a[0] + a[1] + a[2]
+        """
+        mod = self.compile(src)
+        buf = mod.alloc_buf(3)
+        mod.store(buf, 0, 10)
+        mod.store(buf, 1, 20)
+        mod.store(buf, 2, 30)
+        assert mod.test(buf, 3) == 60

--- a/spy/tests/stdlib/test_array.py
+++ b/spy/tests/stdlib/test_array.py
@@ -1,3 +1,4 @@
+import pytest
 from spy.tests.support import CompilerTest
 
 class TestArray(CompilerTest):
@@ -15,3 +16,15 @@ class TestArray(CompilerTest):
         """
         mod = self.compile(src)
         assert mod.test() == 6
+
+    @pytest.mark.skip
+    def test_len(self):
+        src = """
+        from array import array1
+
+        def test() -> int:
+            a = array1[int](3)
+            return len(a)
+        """
+        mod = self.compile(src)
+        assert mod.test() == 3

--- a/spy/tests/stdlib/test_array.py
+++ b/spy/tests/stdlib/test_array.py
@@ -30,7 +30,7 @@ class TestArray(CompilerTest):
 
     def test_from_buffer(self):
         src = """
-        from array import array, array_from_buffer
+        from array import array
         from unsafe import ptr, gc_alloc
 
         def alloc_buf(n: i32) -> ptr[i32]:
@@ -40,7 +40,7 @@ class TestArray(CompilerTest):
             p[i] = v
 
         def test(buf: ptr[i32], l: i32) -> int:
-            a = array_from_buffer[int, 1](buf, l)
+            a = array[int, 1].from_buffer(buf, l)
             return a[0] + a[1] + a[2]
         """
         mod = self.compile(src)

--- a/spy/vm/tuple.py
+++ b/spy/vm/tuple.py
@@ -1,8 +1,9 @@
 from typing import TYPE_CHECKING, Any
 from spy.vm.b import B
-from spy.vm.primitive import W_I32, W_Dynamic
-from spy.vm.object import (W_Object)
+from spy.vm.primitive import W_I32, W_Dynamic, W_Bool
+from spy.vm.object import W_Object
 from spy.vm.builtin import builtin_method
+from spy.vm.opspec import W_OpSpec, W_MetaArg
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
@@ -37,8 +38,30 @@ class W_Tuple(W_Object):
         # XXX bound check?
         return w_tup.items_w[i]
 
+
     @builtin_method('__len__')
     @staticmethod
     def w_len(vm: 'SPyVM', w_tup: 'W_Tuple') -> W_I32:
         n = len(w_tup.items_w)
         return vm.wrap(n)
+
+    @builtin_method('__eq__', color='blue', kind='metafunc')
+    @staticmethod
+    def w_EQ(vm: 'SPyVM', wam_l: W_MetaArg, wam_r: W_MetaArg) -> W_OpSpec:
+        w_ltype = wam_l.w_static_T
+        w_rtype = wam_r.w_static_T
+        if w_ltype is not w_rtype:
+            return W_OpSpec.NULL
+
+        @vm.register_builtin_func(W_Tuple._w.fqn)
+        def w_eq(vm: 'SPyVM', w_t1: W_Tuple, w_t2: W_Tuple) -> W_Bool:
+            items1_w = w_t1.items_w
+            items2_w = w_t2.items_w
+            if len(items1_w) != len(items2_w):
+                return B.w_False
+            for w_1, w_2 in zip(items1_w, items2_w):
+                if vm.is_False(vm.eq(w_1, w_2)):
+                    return B.w_False
+            return B.w_True
+
+        return W_OpSpec(w_eq)

--- a/spy/vm/tuple.py
+++ b/spy/vm/tuple.py
@@ -31,13 +31,15 @@ class W_Tuple(W_Object):
     def spy_key(self, vm: 'SPyVM') -> Any:
         return tuple(w_item.spy_key(vm) for w_item in self.items_w)
 
+    def __repr__(self) -> str:
+        return f'W_Tuple({self.items_w})'
+
     @builtin_method('__getitem__')
     @staticmethod
     def w_getitem(vm: 'SPyVM', w_tup: 'W_Tuple', w_i: W_I32) -> W_Dynamic:
         i = vm.unwrap_i32(w_i)
         # XXX bound check?
         return w_tup.items_w[i]
-
 
     @builtin_method('__len__')
     @staticmethod

--- a/stdlib/array.spy
+++ b/stdlib/array.spy
@@ -18,18 +18,7 @@ from operator import OpImpl, OpArg
 from unsafe import gc_alloc, ptr
 
 @blue.generic
-def ArrayData1(DTYPE):
-    @struct
-    class S:
-        l: i32
-        items: ptr[DTYPE]
-    return S
-
-
-@blue.generic
-def array1(DTYPE):
-
-    #ArrayData = ArrayData1[DTYPE]
+def _array1(DTYPE):
 
     @struct
     class ArrayData:
@@ -61,12 +50,22 @@ def array1(DTYPE):
         def __len__(self: ndarray) -> i32:
             return self.__ll__.l
 
-    return ndarray
+
+    # ideally this should be a classmethod, but we don't have them yet
+    def from_pointer(buf: ptr[DTYPE], l: i32) -> ndarray:
+        data = gc_alloc(ArrayData)(1)
+        data.items = buf
+        data.l = l
+        return ndarray.__lift__(data)
+
+    return ndarray, from_pointer
 
 
 
 @blue.generic
 def array(DTYPE, NDIM):
     if NDIM == 1:
-        return array1[DTYPE]
+        ndarray, from_pointer = _array1[DTYPE]
+        return ndarray
+
     raise StaticError("number of dimensions not supported")

--- a/stdlib/array.spy
+++ b/stdlib/array.spy
@@ -18,6 +18,20 @@ from operator import OpSpec
 from unsafe import gc_alloc, ptr
 
 @blue.generic
+def array(DTYPE, NDIM):
+    # XXX this is ugly: we hardcode arrays impl for small ndims. We should
+    # autogenerate them.
+
+    if NDIM == 1:
+        return _array1[DTYPE]
+
+    elif NDIM == 2:
+        return _array2[DTYPE]
+
+    raise StaticError("number of dimensions not supported")
+
+
+@blue.generic
 def _array1(DTYPE):
 
     @struct
@@ -60,13 +74,59 @@ def _array1(DTYPE):
     return ndarray
 
 
-
 @blue.generic
-def array(DTYPE, NDIM):
-    if NDIM == 1:
-        ndarray = _array1[DTYPE]
-        return ndarray
-    raise StaticError("number of dimensions not supported")
+def _array2(DTYPE):
+
+    @struct
+    class ArrayData:
+        h: i32
+        w: i32
+        items: ptr[DTYPE]
+
+    @typelift
+    class ndarray:
+        __ll__: ptr[ArrayData]
+
+        def __new__(h: i32, w: i32) -> ndarray:
+            data = gc_alloc(ArrayData)(1)
+            data.h = h
+            data.w = w
+            data.items = gc_alloc(DTYPE)(h*w)
+            return ndarray.__lift__(data)
+
+        ## @staticmethod
+        ## def from_buffer(buf: ptr[DTYPE], l: i32) -> ndarray:
+        ##     data = gc_alloc(ArrayData)(1)
+        ##     data.items = buf
+        ##     data.l = l
+        ##     return ndarray.__lift__(data)
+
+        def __getitem__(self: ndarray, i: i32, j: i32) -> DTYPE:
+            ll = self.__ll__
+            if i >= ll.h:
+                raise IndexError
+            if j >= ll.w:
+                raise IndexError
+            idx = (i * ll.w) + j
+            return ll.items[idx]
+
+        def __setitem__(self: ndarray, i: i32, j: i32, v: DTYPE) -> None:
+            ll = self.__ll__
+            if i >= ll.h:
+                raise IndexError
+            if j >= ll.w:
+                raise IndexError
+            idx = (i * ll.w) + j
+            ll.items[idx] = v
+
+        def __len__(self: ndarray) -> i32:
+            return self.__ll__.h
+
+        # XXX: we don't have a good way to know "w". We need to implement
+        # .shape
+
+    return ndarray
+
 
 @blue.generic
 def zeros(DTYPE):

--- a/stdlib/array.spy
+++ b/stdlib/array.spy
@@ -18,7 +18,18 @@ from operator import OpImpl, OpArg
 from unsafe import gc_alloc, ptr
 
 @blue.generic
+def ArrayData1(DTYPE):
+    @struct
+    class S:
+        l: i32
+        items: ptr[DTYPE]
+    return S
+
+
+@blue.generic
 def array1(DTYPE):
+
+    #ArrayData = ArrayData1[DTYPE]
 
     @struct
     class ArrayData:

--- a/stdlib/array.spy
+++ b/stdlib/array.spy
@@ -94,12 +94,13 @@ def _array2(DTYPE):
             data.items = gc_alloc(DTYPE)(h*w)
             return ndarray.__lift__(data)
 
-        ## @staticmethod
-        ## def from_buffer(buf: ptr[DTYPE], l: i32) -> ndarray:
-        ##     data = gc_alloc(ArrayData)(1)
-        ##     data.items = buf
-        ##     data.l = l
-        ##     return ndarray.__lift__(data)
+        @staticmethod
+        def from_buffer(buf: ptr[DTYPE], h: i32, w: i32) -> ndarray:
+            data = gc_alloc(ArrayData)(1)
+            data.items = buf
+            data.h = h
+            data.w = w
+            return ndarray.__lift__(data)
 
         def __getitem__(self: ndarray, i: i32, j: i32) -> DTYPE:
             ll = self.__ll__

--- a/stdlib/array.spy
+++ b/stdlib/array.spy
@@ -28,6 +28,9 @@ def array(DTYPE, NDIM):
     elif NDIM == 2:
         return _array2[DTYPE]
 
+    elif NDIM == 3:
+        return _array3[DTYPE]
+
     raise StaticError("number of dimensions not supported")
 
 
@@ -125,6 +128,65 @@ def _array2(DTYPE):
 
         # XXX: we don't have a good way to know "w". We need to implement
         # .shape
+
+    return ndarray
+
+
+@blue.generic
+def _array3(DTYPE):
+
+    @struct
+    class ArrayData:
+        d: i32
+        h: i32
+        w: i32
+        items: ptr[DTYPE]
+
+    @typelift
+    class ndarray:
+        __ll__: ptr[ArrayData]
+
+        def __new__(d: i32, h: i32, w: i32) -> ndarray:
+            data = gc_alloc(ArrayData)(1)
+            data.d = d
+            data.h = h
+            data.w = w
+            data.items = gc_alloc(DTYPE)(d*h*w)
+            return ndarray.__lift__(data)
+
+        @staticmethod
+        def from_buffer(buf: ptr[DTYPE], d: i32, h: i32, w: i32) -> ndarray:
+            data = gc_alloc(ArrayData)(1)
+            data.items = buf
+            data.d = d
+            data.h = h
+            data.w = w
+            return ndarray.__lift__(data)
+
+        def __getitem__(self: ndarray, i: i32, j: i32, k: i32) -> DTYPE:
+            ll = self.__ll__
+            if i >= ll.d:
+                raise IndexError
+            if j >= ll.h:
+                raise IndexError
+            if k >= ll.w:
+                raise IndexError
+            idx = (i * ll.h * ll.w) + (j * ll.w) + k
+            return ll.items[idx]
+
+        def __setitem__(self: ndarray, i: i32, j: i32, k: i32, v: DTYPE) -> None:
+            ll = self.__ll__
+            if i >= ll.d:
+                raise IndexError
+            if j >= ll.h:
+                raise IndexError
+            if k >= ll.w:
+                raise IndexError
+            idx = (i * ll.h * ll.w) + (j * ll.w) + k
+            ll.items[idx] = v
+
+        def __len__(self: ndarray) -> i32:
+            return self.__ll__.d
 
     return ndarray
 

--- a/stdlib/array.spy
+++ b/stdlib/array.spy
@@ -31,6 +31,9 @@ def array1(DTYPE):
                 raise IndexError
             ll.items[i] = v
 
+        def __len__(self: ndarray) -> i32:
+            return self.__ll__.l
+
     return ndarray
 
 

--- a/stdlib/array.spy
+++ b/stdlib/array.spy
@@ -1,3 +1,19 @@
+"""
+SPy array module
+
+The end goal is to have something which can be used in place of Python's
+array.array and numpy.ndarray types. At the moment is VERY limited in terms of
+functionalities.
+
+Some functionalities are just not implemented.
+
+Others are implemented but in a suboptimal way, because SPy misses the tools
+needed to do it properly.
+
+In particular:
+  - ...
+"""
+
 from operator import OpImpl, OpArg
 from unsafe import gc_alloc, ptr
 

--- a/stdlib/array.spy
+++ b/stdlib/array.spy
@@ -10,14 +10,8 @@ Some functionalities are just not implemented.
 Others are implemented but in a suboptimal way, because SPy misses the tools
 needed to do it properly.
 
-In particular:
-
-  - we don't have classmethods: so instead of using array[int, 1].from_buffer,
-    you need to use array_from_buffer[int, 1]. This also makes the
-    implementation a bit more complicated, but it's not too bad.
-
-  - we don't support an arbitrary number of dimensions: currently we hardcode
-    _array1, _array2, _array3, etc.
+In particular we don't support an arbitrary number of dimensions: currently we
+hardcode _array1, _array2, _array3, etc.
 """
 
 from unsafe import gc_alloc, ptr
@@ -40,6 +34,13 @@ def _array1(DTYPE):
             data.items = gc_alloc(DTYPE)(l)
             return ndarray.__lift__(data)
 
+        @staticmethod
+        def from_buffer(buf: ptr[DTYPE], l: i32) -> ndarray:
+            data = gc_alloc(ArrayData)(1)
+            data.items = buf
+            data.l = l
+            return ndarray.__lift__(data)
+
         def __getitem__(self: ndarray, i: i32) -> DTYPE:
             ll = self.__ll__
             if i >= ll.l:
@@ -55,28 +56,13 @@ def _array1(DTYPE):
         def __len__(self: ndarray) -> i32:
             return self.__ll__.l
 
-
-    # ideally this should be a classmethod, but we don't have them yet
-    def from_buffer(buf: ptr[DTYPE], l: i32) -> ndarray:
-        data = gc_alloc(ArrayData)(1)
-        data.items = buf
-        data.l = l
-        return ndarray.__lift__(data)
-
-    return ndarray, from_buffer
+    return ndarray
 
 
 
 @blue.generic
 def array(DTYPE, NDIM):
     if NDIM == 1:
-        ndarray, from_buffer = _array1[DTYPE]
+        ndarray = _array1[DTYPE]
         return ndarray
-    raise StaticError("number of dimensions not supported")
-
-@blue.generic
-def array_from_buffer(DTYPE, NDIM):
-    if NDIM == 1:
-        ndarray, from_buffer = _array1[DTYPE]
-        return from_buffer
     raise StaticError("number of dimensions not supported")

--- a/stdlib/array.spy
+++ b/stdlib/array.spy
@@ -1,0 +1,42 @@
+from operator import OpImpl, OpArg
+from unsafe import gc_alloc, ptr
+
+@blue.generic
+def array1(DTYPE):
+
+    @struct
+    class ArrayData:
+        l: i32
+        items: ptr[DTYPE]
+
+    @typelift
+    class ndarray:
+        __ll__: ptr[ArrayData]
+
+        def __new__(l: i32) -> ndarray:
+            data = gc_alloc(ArrayData)(1)
+            data.l = l
+            data.items = gc_alloc(DTYPE)(l)
+            return ndarray.__lift__(data)
+
+        def __getitem__(self: ndarray, i: i32) -> DTYPE:
+            ll = self.__ll__
+            if i >= ll.l:
+                raise IndexError
+            return ll.items[i]
+
+        def __setitem__(self: ndarray, i: i32, v: DTYPE) -> None:
+            ll = self.__ll__
+            if i >= ll.l:
+                raise IndexError
+            ll.items[i] = v
+
+    return ndarray
+
+
+
+@blue.generic
+def array(DTYPE, NDIM):
+    if NDIM == 1:
+        return array1[DTYPE]
+    raise StaticError("number of dimensions not supported")

--- a/stdlib/array.spy
+++ b/stdlib/array.spy
@@ -11,10 +11,15 @@ Others are implemented but in a suboptimal way, because SPy misses the tools
 needed to do it properly.
 
 In particular:
-  - ...
+
+  - we don't have classmethods: so instead of using array[int, 1].from_buffer,
+    you need to use array_from_buffer[int, 1]. This also makes the
+    implementation a bit more complicated, but it's not too bad.
+
+  - we don't support an arbitrary number of dimensions: currently we hardcode
+    _array1, _array2, _array3, etc.
 """
 
-from operator import OpImpl, OpArg
 from unsafe import gc_alloc, ptr
 
 @blue.generic
@@ -52,20 +57,26 @@ def _array1(DTYPE):
 
 
     # ideally this should be a classmethod, but we don't have them yet
-    def from_pointer(buf: ptr[DTYPE], l: i32) -> ndarray:
+    def from_buffer(buf: ptr[DTYPE], l: i32) -> ndarray:
         data = gc_alloc(ArrayData)(1)
         data.items = buf
         data.l = l
         return ndarray.__lift__(data)
 
-    return ndarray, from_pointer
+    return ndarray, from_buffer
 
 
 
 @blue.generic
 def array(DTYPE, NDIM):
     if NDIM == 1:
-        ndarray, from_pointer = _array1[DTYPE]
+        ndarray, from_buffer = _array1[DTYPE]
         return ndarray
+    raise StaticError("number of dimensions not supported")
 
+@blue.generic
+def array_from_buffer(DTYPE, NDIM):
+    if NDIM == 1:
+        ndarray, from_buffer = _array1[DTYPE]
+        return from_buffer
     raise StaticError("number of dimensions not supported")

--- a/stdlib/array.spy
+++ b/stdlib/array.spy
@@ -14,6 +14,7 @@ In particular we don't support an arbitrary number of dimensions: currently we
 hardcode _array1, _array2, _array3, etc.
 """
 
+from operator import OpSpec
 from unsafe import gc_alloc, ptr
 
 @blue.generic
@@ -66,3 +67,23 @@ def array(DTYPE, NDIM):
         ndarray = _array1[DTYPE]
         return ndarray
     raise StaticError("number of dimensions not supported")
+
+@blue.generic
+def zeros(DTYPE):
+
+    @blue.metafunc
+    def metazeros(m_shape):
+        if m_shape.static_type == i32:
+            ArrayT = array[DTYPE, 1]
+            def impl(n: i32) -> ArrayT:
+                return ArrayT(n)
+            return OpSpec(impl)
+
+        elif m_shape.static_type == tuple:
+            raise StaticError('WIP')
+
+        else:
+            raise TypeError('shape must be either int or tuple')
+
+
+    return metazeros


### PR DESCRIPTION
This PR introduces the first stdlib module: `stdlib/array.spy` 🎉.
So far arrays are very limited:
  - only 1, 2 and 3 dimensions (eventually we will be able to have arbitraty n-dimension for any `blue` value of `n`)
  - only getitem, setitem and `from_buffer

