### PR TITLE
Pretty print AST with color information 

### DIFF
--- a/spy/ast.py
+++ b/spy/ast.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Optional, Iterator, Any, no_type_check
+from typing import TYPE_CHECKING, Optional, Iterator, Any, no_type_check
 import ast as py_ast
 import dataclasses
 from dataclasses import dataclass, field
@@ -7,6 +7,8 @@ from spy.fqn import FQN
 from spy.location import Loc
 from spy.analyze.symtable import Color, VarKind, ImportRef, Symbol
 from spy.util import extend
+if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
 
 AnyNode = typing.Union[py_ast.AST, 'Node']
 ClassKind = typing.Literal['class', 'struct', 'typelift']
@@ -71,9 +73,9 @@ del AST
 class Node:
     loc: Loc = field(repr=False)
 
-    def pp(self, hl: Any=None) -> None:
+    def pp(self, hl: Any=None, vm: Optional['SPyVM']=None) -> None:
         import spy.ast_dump
-        spy.ast_dump.pprint(self, hl=hl)
+        spy.ast_dump.pprint(self, hl=hl, vm=vm)
 
     @typing.no_type_check
     def ppc(self) -> None:

--- a/spy/ast_dump.py
+++ b/spy/ast_dump.py
@@ -61,7 +61,7 @@ class Dumper(TextBuilder):
         name = node.__class__.__name__
         fields = list(node.__class__.__dataclass_fields__)
         fields = [f for f in fields if f not in self.fields_to_ignore]
-        self._dump_node(node, name, fields, color='blue')
+        self._dump_node(node, name, fields, text_color='blue')
 
     def dump_py_node(self, node: py_ast.AST) -> None:
         name = 'py:' + node.__class__.__name__
@@ -69,12 +69,12 @@ class Dumper(TextBuilder):
         fields = [f for f in fields if f not in self.fields_to_ignore]
         if isinstance(node, py_ast.Name):
             fields.append('is_var')
-        self._dump_node(node, name, fields, color='turquoise')
+        self._dump_node(node, name, fields, text_color='turquoise')
 
     def dump_Symbol(self, sym: Symbol) -> None:
         self.write(f'Symbol({sym.name!r}, {sym.color!r}, {sym.varkind!r}, {sym.storage!r})')
 
-    def _dump_node(self, node: Any, name: str, fields: list[str], color: str) -> None:
+    def _dump_node(self, node: Any, name: str, fields: list[str], text_color: Optional[str]) -> None:
         def is_complex(obj: Any) -> bool:
             return (isinstance(obj, (spy.ast.Node, py_ast.AST, list, Symbol)) and
                     not isinstance(obj, py_ast.expr_context))
@@ -83,8 +83,8 @@ class Dumper(TextBuilder):
         multiline = any(is_complex_field)
         #
         if node is self.highlight:
-            color = 'red'
-        self.write(name, color=color)
+            text_color = 'red'
+        self.write(name, color=text_color)
         self.write('(')
         if multiline:
             self.writeline('')

--- a/spy/ast_dump.py
+++ b/spy/ast_dump.py
@@ -61,7 +61,8 @@ class Dumper(TextBuilder):
         name = node.__class__.__name__
         fields = list(node.__class__.__dataclass_fields__)
         fields = [f for f in fields if f not in self.fields_to_ignore]
-        self._dump_node(node, name, fields, text_color='blue')
+        # Use turquoise text_color to distinguish from blue in --colorize
+        self._dump_node(node, name, fields, text_color='turquoise')
 
     def dump_py_node(self, node: py_ast.AST) -> None:
         name = 'py:' + node.__class__.__name__
@@ -69,6 +70,7 @@ class Dumper(TextBuilder):
         fields = [f for f in fields if f not in self.fields_to_ignore]
         if isinstance(node, py_ast.Name):
             fields.append('is_var')
+        # Use turquoise text_color to distinguish from blue in --colorize
         self._dump_node(node, name, fields, text_color='turquoise')
 
     def dump_Symbol(self, sym: Symbol) -> None:

--- a/spy/ast_dump.py
+++ b/spy/ast_dump.py
@@ -1,23 +1,27 @@
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 import ast as py_ast
 import spy.ast
 from spy.analyze.symtable import Symbol
 from spy.textbuilder import TextBuilder
+if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
 
 def dump(node: Any,
          *,
          use_colors: bool = True,
          fields_to_ignore: Any = (),
          hl: Any = None,
+         vm: Optional['SPyVM'] = None,
          ) -> str:
-    dumper = Dumper(use_colors=use_colors, highlight=hl)
+    dumper = Dumper(use_colors=use_colors, highlight=hl, vm=vm)
     dumper.fields_to_ignore += fields_to_ignore
     dumper.dump_anything(node)
     return dumper.build()
 
 def pprint(node: Any, *, copy_to_clipboard: bool = False,
-           hl: Optional[spy.ast.Node]=None) -> None:
-    print(dump(node, hl=hl))
+           hl: Optional[spy.ast.Node]=None,
+           vm: Optional['SPyVM'] = None) -> None:
+    print(dump(node, hl=hl, vm=vm))
     if copy_to_clipboard:
         import pyperclip  # type: ignore
         out = dump(node, use_colors=False)
@@ -26,15 +30,18 @@ def pprint(node: Any, *, copy_to_clipboard: bool = False,
 
 class Dumper(TextBuilder):
     fields_to_ignore: tuple[str, ...]
+    vm: 'SPyVM | None'
 
     def __init__(self, *,
                  use_colors: bool,
                  highlight: Optional[spy.ast.Node] = None,
+                 vm: Optional['SPyVM'] = None
                  ) -> None:
         super().__init__(use_colors=use_colors)
         self.highlight = highlight
         self.fields_to_ignore = ('loc', 'target_loc', 'target_locs',
                                  'loc_asname')
+        self.vm = vm
 
     def dump_anything(self, obj: Any) -> None:
         if isinstance(obj, spy.ast.Node):

--- a/spy/ast_dump.py
+++ b/spy/ast_dump.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, Any, Optional
 import ast as py_ast
+
+from spy.analyze.symtable import Color
 import spy.ast
 from spy.analyze.symtable import Symbol
 from spy.textbuilder import TextBuilder
@@ -86,7 +88,15 @@ class Dumper(TextBuilder):
         #
         if node is self.highlight:
             text_color = 'red'
-        self.write(name, color=text_color)
+        # If the vm contains an expr_color_map, use the expression's color
+        # as the text background color, and use the default text_color
+        bg_color = None
+        if self.vm and self.vm.expr_color_map:
+            color: Optional[Color] = self.vm.expr_color_map.get(node, None)
+            if color:
+                bg_color = color
+                text_color = None
+        self.write(name, color=text_color, bg=bg_color)
         self.write('(')
         if multiline:
             self.writeline('')

--- a/spy/cli.py
+++ b/spy/cli.py
@@ -364,7 +364,7 @@ async def inner_main(args: Arguments) -> None:
             execute_spy_main(args, vm, w_mod)
         elif args.colorize:
             # --colorize shows us the pre-redshifted AST, with the colors detected by redshifting
-            orig_mod.pp()
+            orig_mod.pp(vm=vm)
         elif args.parse:
             dump_spy_mod_ast(vm, modname)
         else:

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -285,6 +285,8 @@ class DopplerFrame(ASTFrame):
             )
 
         self.shifted_expr[expr] = new_expr
+        if self.vm.expr_color_map is not None:
+            self.vm.expr_color_map[expr] = wam.color
         return wam
 
     def eval_opimpl(self, op: ast.Node, w_opimpl: W_OpImpl,

--- a/spy/tests/test_cli.py
+++ b/spy/tests/test_cli.py
@@ -109,6 +109,10 @@ class TestMain:
         res, stdout = self.run('--redshift', '--execute', self.main_spy)
         assert stdout == "hello world\n"
 
+    def test_colorize(self):
+        res, stdout = self.run('--colorize', self.main_spy)
+        assert stdout.startswith('Module(')
+
     def test_cwrite(self):
         res, stdout = self.run(
             '--cwrite',

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -294,3 +294,40 @@ class TestDoppler:
             raise TypeError('foo') # /.../test.spy:3
             raise ValueError # /.../test.spy:4
         """)
+
+    def test_expr_color_map_populated(self, monkeypatch):
+        # Verify that when vm.expr_color_map is not None, redshift populates it
+        monkeypatch.setattr(self.vm, 'expr_color_map', {})
+        src = """
+        def foo(i: i32) -> i32:
+            return i + 2
+        """
+        self.redshift(src)
+
+        # src contains 4 nodes, 3 red and 1 blue
+        assert self.vm
+        assert self.vm.expr_color_map
+        assert len(self.vm.expr_color_map) == 4
+        assert len([c for c in self.vm.expr_color_map.values() if c == 'blue']) == 1
+        assert len([c for c in self.vm.expr_color_map.values() if c == 'red']) == 3
+
+    def test_dumper_uses_expr_color_map_for_bg(self, monkeypatch):
+        # Verify that Dumper._dump_node passes correct bg argument based on expr_color_map
+        from unittest.mock import Mock
+        from spy.ast_dump import Dumper
+
+        red_node = Mock()
+        blue_node = Mock()
+
+        monkeypatch.setattr(self.vm, 'expr_color_map', {red_node: 'red', blue_node: 'blue'})
+        dumper = Dumper(use_colors=True, vm=self.vm)
+        mock_write = Mock()
+        monkeypatch.setattr(dumper, 'write', mock_write)
+
+        dumper._dump_node(red_node, 'test', [], text_color='turquoise')
+        mock_write.assert_any_call('test', color=None, bg='red')
+
+        mock_write.reset_mock()
+
+        dumper._dump_node(blue_node, 'test', [], text_color='turquoise')
+        mock_write.assert_any_call('test', color=None, bg='blue')

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -4,6 +4,7 @@ from types import FunctionType
 import fixedint
 import py.path
 from spy import ROOT
+from spy import ast
 from spy.fqn import FQN, QUALIFIERS
 from spy.ast import Color, FuncKind
 from spy.location import Loc
@@ -71,6 +72,9 @@ class SPyVM:
     path: list[str]
     bluecache: BlueCache
     emit_warning: Callable[[SPyError], None]
+    # For use by --colorize to remember the red/blue color of each expr
+    expr_color_map: Optional[dict[ast.Expr, Color]]
+
 
     def __init__(self, ll: Optional[LLSPyInstance]=None) -> None:
         if ll is None:
@@ -84,6 +88,8 @@ class SPyVM:
         self.path = [str(STDLIB)]
         self.bluecache = BlueCache(self)
         self.emit_warning = lambda err: None
+        # By default, don't keep track of expr colors.
+        self.expr_color_map = None
         self.make_module(BUILTINS)
         self.make_module(OPERATOR)
         self.make_module(TYPES)


### PR DESCRIPTION
Fixes #168 

I should say first, this is probably a larger PR than you were expecting. I'm totally fine if we abandon this approach and go in a different direction, but I wanted to see what directions I could come up with and if any are useful.

The tl;dr currently is, if you have `foo.spy`:
```
def main(x: i32) -> i32:
    return x + 2 * 3
```
Then run:
```
spy --redshift --colorize foo.spy
```
You will see:
<img width="532" height="524" alt="image" src="https://github.com/user-attachments/assets/11536e5f-0ac7-4e85-b79e-78aafc7e1836" />

This is probably not quite what we were looking for, for one I suspect we don't want the delemiters like () [] colored, or things like the top level Module colored, but the approach is close enough that I wanted to get some feedback first before proceeding in this direction.

I tried to make small atomic commits introducing single concepts at a time:
- In 8c5022b0929af6791bff67cdba394d0fda06bd11 I tried to follow your advice in saving the pre-redshift color in `DopplerFrame` instances. The problem I ran into here is that `DopplerFrame` instances are essentially ephemeral, they are not saved anywhere that is easily retrieved after redshifting. 
- So instead in cbd96b46b724d10a3359fb0eaedc9b2037cc4c51 I added a `color` attribute to `Expr` nodes, and save the original color during the redshifting process. These are the instances that are used in the AST itself that gets pretty printed, so it seemed like the natural place to add them for this use case. I realize this attribute is not used in the actual compilation pipeline, so if we feel this means the methodology here is no good I'm fine with figuring out an alternate method.
- The way that we want to do syntax coloring in this new "mode" is different than before, so to make this work I introduced a concept of `color_mode` in ddc30180766dad413f5c9d0630c1bd3314f7f4ae. This way we can use different coloring logic depending on the `color_mode`.
- To avoid conflation of names and concepts, I separated out the concept of `text_color` from `color` in 1151a7d9700e1f670bf2f430be620eea3cec8d19. When I think "color" I think "red or blue", but "text_color" can be anything, even including "green" or "turquoise".
- I have several commits that made several new ways of setting a new `text_color` that I ultimately all abandoned in favor of 0e9e4596acc6eb6d072a7eee24eee0cf5a9fc6b3, which introduces an `active_text_color` attribute to `TextBuilder`. This feature gets used by the logic now enabled in the new `redshift` `color_mode`, so that multiple nodes and children can automatically get the parent color, as implemented in 0e9e4596acc6eb6d072a7eee24eee0cf5a9fc6b3. However, as noted above, this method might be too broad, so we can work on this before we possibly merge.

This PR will need at the very least some cleanup, squashing, and tweaking before it is ready to merge, which I'm happy to do. Or we might decide the approach is not useful and do something else entirely. But since it does at least come close to the original intent of #168 I wanted to put it up to get some feedback first.