### PR TITLE
Give an explanatory error if user passes a .py file to cli.

### DIFF
--- a/spy/cli.py
+++ b/spy/cli.py
@@ -307,6 +307,10 @@ async def inner_main(args: Arguments) -> None:
         do_pyparse(str(args.filename))
         return
 
+    if args.filename.suffix == '.py':
+        print(f"Error: {args.filename} is a .py file, not a .spy file.", file=sys.stderr)
+        sys.exit(1)
+
     modname = args.filename.stem
     srcdir = args.filename.parent
     vm = await SPyVM.async_new()

--- a/spy/tests/test_cli.py
+++ b/spy/tests/test_cli.py
@@ -75,6 +75,16 @@ class TestMain:
             raise Exception("run_external failed")
         return exit_code, decolorize(stdout)
 
+    def test_py_file_error(self):
+        # Create a .py file instead of .spy
+        py_file = self.tmpdir.join('test.py')
+        py_file.write("print('This is a Python file')")
+
+        # Test that passing a .py file produces an error
+        res = self.runner.invoke(app, [str(py_file)])
+        assert res.exit_code == 1
+        assert "Error:" in res.output and ".py file, not a .spy file" in res.output
+
     def test_pyparse(self):
         res, stdout = self.run('--pyparse', self.main_spy)
         assert stdout.startswith('py:Module(')


### PR DESCRIPTION
Old habits die hard, more than once in development I've mistakenly passed a `.py` file to the cli, which will then spit out a long traceback. For the benefit of new users and old, write a helpful message to stderr and exit with an error code if the user asks to process a `.py` file.

Example:

```
$  spy --redshift foo.py 
Error: foo.py is a .py file, not a .spy file.
```