### PR TITLE
Implement the descriptor protocol (__get__)

### DIFF
--- a/spy/tests/compiler/operator/test_attrop.py
+++ b/spy/tests/compiler/operator/test_attrop.py
@@ -83,7 +83,7 @@ class TestAttrOp(CompilerTest):
         x = mod.foo()
         assert x == 'hello'
 
-    def test_property(self):
+    def test_instance_property(self):
         # ========== EXT module for this test ==========
         EXT = ModuleRegistry('ext')
 
@@ -139,6 +139,40 @@ class TestAttrOp(CompilerTest):
         assert x == 42
         x2 = mod.get_x2()
         assert x2 == 86
+
+
+    @pytest.mark.skip(reason='implement me')
+    def test_class_property(self):
+        # ========== EXT module for this test ==========
+        EXT = ModuleRegistry('ext')
+
+        @EXT.builtin_type('MyClass')
+        class W_MyClass(W_Object):
+
+            @builtin_method('__new__')
+            @staticmethod
+            def w_new(vm: 'SPyVM') -> 'W_MyClass':
+                return W_MyClass()
+
+            @builtin_property('NULL', color='blue', kind='metafunc')
+            @staticmethod
+            def w_GET_NULL(vm: 'SPyVM', wop_self: 'W_OpArg') -> W_OpSpec:
+                breakpoint()
+
+
+        # ========== /EXT module for this test =========
+        self.vm.make_module(EXT)
+        mod = self.compile(
+                """
+        from ext import MyClass
+
+        @blue
+        def get_NULL():
+            return MyClass.NULL
+
+        """)
+        x = mod.get_NULL()
+        breakpoint()
 
     def test_getattr_setattr_custom(self):
         # ========== EXT module for this test ==========

--- a/spy/tests/compiler/operator/test_attrop.py
+++ b/spy/tests/compiler/operator/test_attrop.py
@@ -123,7 +123,7 @@ class TestAttrOp(CompilerTest):
         # ========== /EXT module for this test =========
         self.vm.make_module(EXT)
         mod = self.compile(
-                """
+        """
         from ext import MyClass
 
         @blue
@@ -164,7 +164,7 @@ class TestAttrOp(CompilerTest):
         # ========== /EXT module for this test =========
         self.vm.make_module(EXT)
         mod = self.compile(
-                """
+        """
         from ext import MyClass
 
         @blue

--- a/spy/tests/compiler/operator/test_attrop.py
+++ b/spy/tests/compiler/operator/test_attrop.py
@@ -3,7 +3,7 @@ import pytest
 from spy.vm.primitive import W_I32
 from spy.vm.b import B
 from spy.vm.object import Member
-from spy.vm.builtin import builtin_func, builtin_method
+from spy.vm.builtin import builtin_func, builtin_method, builtin_class_attr
 from spy.vm.w import W_Object, W_Str
 from spy.vm.opspec import W_OpSpec, W_OpArg
 from spy.vm.registry import ModuleRegistry
@@ -65,13 +65,12 @@ class TestAttrOp(CompilerTest):
 
         @EXT.builtin_type('MyClass')
         class W_MyClass(W_Object):
+            w_x = builtin_class_attr('x', W_MyProxy(self.vm.wrap('hello')))
 
             @builtin_method('__new__')
             @staticmethod
             def w_new(vm: 'SPyVM') -> 'W_MyClass':
                 return W_MyClass()
-
-        W_MyClass._w.dict_w['x'] = W_MyProxy(W_Str(self.vm, 'hello'))
 
         # ========== /EXT module for this test =========
         self.vm.make_module(EXT)

--- a/spy/tests/compiler/operator/test_attrop.py
+++ b/spy/tests/compiler/operator/test_attrop.py
@@ -3,7 +3,8 @@ import pytest
 from spy.vm.primitive import W_I32
 from spy.vm.b import B
 from spy.vm.object import Member
-from spy.vm.builtin import builtin_func, builtin_method, builtin_class_attr
+from spy.vm.builtin import (builtin_func, builtin_method, builtin_class_attr,
+                            builtin_property)
 from spy.vm.w import W_Object, W_Str
 from spy.vm.opspec import W_OpSpec, W_OpArg
 from spy.vm.registry import ModuleRegistry
@@ -82,40 +83,62 @@ class TestAttrOp(CompilerTest):
         x = mod.foo()
         assert x == 'hello'
 
-    def test_op_GET(self):
+    def test_property(self):
         # ========== EXT module for this test ==========
         EXT = ModuleRegistry('ext')
 
         @EXT.builtin_type('MyClass')
         class W_MyClass(W_Object):
 
+            def __init__(self, x: int) -> None:
+                self.x = x
+
             @builtin_method('__new__')
             @staticmethod
-            def w_new(vm: 'SPyVM') -> 'W_MyClass':
-                return W_MyClass()
+            def w_new(vm: 'SPyVM', w_x: W_I32) -> 'W_MyClass':
+                x = vm.unwrap_i32(w_x)
+                return W_MyClass(x)
 
-            @builtin_method('__GET_x__', color='blue')
+            @builtin_property('x')
             @staticmethod
-            def w_GET_x(vm: 'SPyVM', wop_obj: W_OpArg,
-                         wop_attr: W_OpArg) -> W_OpSpec:
-                w_t = wop_obj.w_static_type
-                @builtin_func(w_t.fqn, 'get_x')
-                def w_get_x(vm: 'SPyVM', w_obj: W_MyClass) -> W_I32:
-                    return vm.wrap(42)  # type: ignore
-                return W_OpSpec(w_get_x, [wop_obj])
+            def w_get_x(vm: 'SPyVM', w_self: 'W_MyClass') -> W_I32:
+                return vm.wrap(w_self.x)  # type: ignore
+
+            @builtin_property('x2', color='blue', kind='metafunc')
+            @staticmethod
+            def w_GET_x2(vm: 'SPyVM', wop_self: 'W_OpArg') -> W_OpSpec:
+                """
+                This exist just to test that we can have a metafunc as a
+                @builtin_property
+                """
+                w_t = wop_self.w_static_type
+                assert W_MyClass._w is w_t
+                @builtin_func(w_t.fqn, 'get_y')
+                def w_get_x2(vm: 'SPyVM', w_self: W_MyClass) -> W_I32:
+                    return vm.wrap(w_self.x * 2)
+                return W_OpSpec(w_get_x2, [wop_self])
+
 
         # ========== /EXT module for this test =========
         self.vm.make_module(EXT)
-        mod = self.compile("""
+        mod = self.compile(
+                """
         from ext import MyClass
 
         @blue
-        def foo():
-            obj =  MyClass()
+        def get_x():
+            obj = MyClass(42)
             return obj.x
+
+        @blue
+        def get_x2():
+            obj = MyClass(43)
+            return obj.x2
         """)
-        x = mod.foo()
+        x = mod.get_x()
         assert x == 42
+        x2 = mod.get_x2()
+        assert x2 == 86
 
     def test_getattr_setattr_custom(self):
         # ========== EXT module for this test ==========

--- a/spy/tests/compiler/operator/test_attrop.py
+++ b/spy/tests/compiler/operator/test_attrop.py
@@ -46,6 +46,7 @@ class TestAttrOp(CompilerTest):
 
     def test_descriptor_get(self):
         # ========== EXT module for this test ==========
+        w_hello: W_Str = self.vm.wrap('hello')  # type: ignore
         EXT = ModuleRegistry('ext')
 
         @EXT.builtin_type('MyProxy')
@@ -63,7 +64,7 @@ class TestAttrOp(CompilerTest):
 
         @EXT.builtin_type('MyClass')
         class W_MyClass(W_Object):
-            w_x = builtin_class_attr('x', W_MyProxy(self.vm.wrap('hello')))
+            w_x = builtin_class_attr('x', W_MyProxy(w_hello))
 
             @builtin_method('__new__')
             @staticmethod
@@ -115,7 +116,7 @@ class TestAttrOp(CompilerTest):
                 assert W_MyClass._w is w_t
                 @builtin_func(w_t.fqn, 'get_y')
                 def w_get_x2(vm: 'SPyVM', w_self: W_MyClass) -> W_I32:
-                    return vm.wrap(w_self.x * 2)
+                    return vm.wrap(w_self.x * 2)  # type: ignore
                 return W_OpSpec(w_get_x2, [wop_self])
 
 
@@ -157,7 +158,7 @@ class TestAttrOp(CompilerTest):
             @builtin_property('NULL', color='blue', kind='metafunc')
             @staticmethod
             def w_GET_NULL(vm: 'SPyVM', wop_self: 'W_OpArg') -> W_OpSpec:
-                breakpoint()
+                raise NotImplementedError('WIP')
 
 
         # ========== /EXT module for this test =========

--- a/spy/tests/compiler/operator/test_attrop.py
+++ b/spy/tests/compiler/operator/test_attrop.py
@@ -44,9 +44,6 @@ class TestAttrOp(CompilerTest):
         assert x == 123
 
     def test_descriptor_get(self):
-        if self.backend == 'doppler':
-            pytest.skip('XXX think about this')
-
         # ========== EXT module for this test ==========
         EXT = ModuleRegistry('ext')
 
@@ -77,6 +74,7 @@ class TestAttrOp(CompilerTest):
         mod = self.compile("""
         from ext import MyClass
 
+        @blue
         def foo() -> str:
             obj =  MyClass()
             return obj.x

--- a/spy/tests/vm/test_builtin.py
+++ b/spy/tests/vm/test_builtin.py
@@ -8,7 +8,7 @@ from spy.vm.w import W_FuncType, W_BuiltinFunc, W_Str
 from spy.vm.b import B
 from spy.fqn import FQN
 from spy.vm.builtin import (builtin_func, functype_from_sig,
-                            builtin_type, builtin_method)
+                            builtin_type, builtin_method, builtin_class_attr)
 
 class TestBuiltin:
 
@@ -119,6 +119,18 @@ class TestBuiltin:
         assert isinstance(w_make, W_BuiltinFunc)
         assert w_make.w_functype.fqn.human_name == "def() -> test::Foo"
         assert w_make.w_functype.w_restype is W_Foo._w
+
+    def test_builtin_class_attr(self):
+        vm = SPyVM()
+        w_42 = vm.wrap(42)
+
+        @builtin_type('test', 'Foo')
+        class W_Foo(W_Object):
+            w_attr = builtin_class_attr('attr', w_42)
+
+        assert W_Foo.w_attr is w_42
+        assert W_Foo._w.dict_w['attr'] is w_42
+
 
     def test_inherit_method(self):
         @builtin_type('test', 'Super')

--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -13,7 +13,7 @@ from spy.fqn import FQN, QUALIFIERS
 from spy.errors import SPyError
 from spy.ast import Color, FuncKind
 from spy.vm.object import W_Object, W_Type
-from spy.vm.object import builtin_method # noqa: F401
+from spy.vm.object import builtin_method, builtin_class_attr # noqa: F401
 from spy.vm.function import FuncParam, FuncParamKind, W_FuncType, W_BuiltinFunc
 
 TYPES_DICT = dict[str, W_Type]

--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -13,7 +13,9 @@ from spy.fqn import FQN, QUALIFIERS
 from spy.errors import SPyError
 from spy.ast import Color, FuncKind
 from spy.vm.object import W_Object, W_Type
-from spy.vm.object import builtin_method, builtin_class_attr # noqa: F401
+from spy.vm.object import (builtin_method,
+                           builtin_property,
+                           builtin_class_attr) # noqa: F401
 from spy.vm.function import FuncParam, FuncParamKind, W_FuncType, W_BuiltinFunc
 
 TYPES_DICT = dict[str, W_Type]

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -60,11 +60,6 @@ def _get_GETATTR_opspec(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
             wop_member = W_OpArg.from_w_obj(vm, w_member)
             return vm.fast_metacall(w_get, [wop_member, wop_obj])
 
-    elif w_GET := w_type.lookup_blue_func(f'__GET_{attr}__'):
-        # XXX this should be killed and become a descriptor
-        w_opspec = vm.fast_call(w_GET, [wop_obj, wop_attr])
-        assert isinstance(w_opspec, W_OpSpec)
-        return w_opspec
     elif w_getattr := w_type.lookup_func(f'__getattr__'):
         return vm.fast_metacall(w_getattr, [wop_obj, wop_attr])
     return W_OpSpec.NULL

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -8,7 +8,7 @@ from spy.vm.module import W_Module
 from spy.vm.object import W_Type, W_Object, ClassBody
 from spy.vm.function import W_Func
 from spy.vm.opspec import W_OpSpec, W_OpArg
-from spy.vm.builtin import builtin_func, builtin_method
+from spy.vm.builtin import builtin_func, builtin_method, builtin_property
 from spy.vm.registry import ModuleRegistry
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
@@ -91,10 +91,9 @@ class W_LiftedObject(W_Object):
         hltype = self.w_hltype.fqn.human_name
         return f'<{hltype} (lifted from {ll_repr})>'
 
-    @builtin_method('__GET___ll____', color='blue')
+    @builtin_property('__ll__', color='blue', kind='metafunc')
     @staticmethod
-    def w_GET___ll__(vm: 'SPyVM', wop_hl: W_OpArg,
-                      wop_attr: W_OpArg) -> W_OpSpec:
+    def w_GET_ll(vm: 'SPyVM', wop_hl: W_OpArg) -> W_OpSpec:
         w_hltype = wop_hl.w_static_type
         HL = Annotated[W_LiftedObject, w_hltype]
         LL = Annotated[W_Object, w_hltype.w_lltype]

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -97,8 +97,9 @@ class builtin_class_attr:
     def __repr__(self) -> str:
         return f"<builtin_class_attr '{self.name}' = {self.w_val}>"
 
-    def __get__(self, instance, owner) -> 'W_Object':
+    def __get__(self, instance: Any, owner: type) -> 'W_Object':
         return self.w_val
+
 
 # Basic setup of the object model: <object> and <type>
 # =====================================================

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -388,15 +388,12 @@ class W_Type(W_Object):
     def is_struct(self, vm: 'SPyVM') -> bool:
         return False
 
-    def lookup_func(self, name: str) -> Optional['W_Func']:
+    def lookup(self, name: str) -> Optional[W_Object]:
         """
-        Lookup the given attribute into the applevel dict, and ensure it's
-        a W_Func.
+        Lookup the given attribute into the applevel dict
         """
-        from spy.vm.function import W_Func
         # look in our dict
         if w_obj := self.dict_w.get(name):
-            assert isinstance(w_obj, W_Func)
             return w_obj
 
         # look in the superclass
@@ -407,14 +404,28 @@ class W_Type(W_Object):
         # not found
         return None
 
+    def lookup_func(self, name: str) -> Optional['W_Func']:
+        """
+        Like lookup, but ensure it's a W_Func.
+        """
+        from spy.vm.function import W_Func
+        w_obj = self.lookup(name)
+        if w_obj:
+            assert isinstance(w_obj, W_Func)
+            return w_obj
+        return None
+
     def lookup_blue_func(self, name: str) -> Optional['W_Func']:
         """
         Like lookup_func, but also check that the function is blue
         """
-        w_obj = self.lookup_func(name)
+        from spy.vm.function import W_Func
+        w_obj = self.lookup(name)
         if w_obj:
+            assert isinstance(w_obj, W_Func)
             assert w_obj.color == 'blue'
-        return w_obj
+            return w_obj
+        return None
 
     # ======== app-level interface ========
 
@@ -445,7 +456,7 @@ class W_Type(W_Object):
             # __new__: when it's a metafunc we also want to pass the OpArg of
             # the type itself (so that the function can reach
             # e.g. wop_p.w_blueval), but for normal __new__ by default we
-            # don't pass it (because usually it's not needed0
+            # don't pass it (because usually it's not needed)
             if w_new.w_functype.kind == 'metafunc':
                 new_args_wop = [wop_t] + list(args_wop)
             else:

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -74,6 +74,23 @@ def builtin_method(name: str, *, color: Color = 'red',
         return fn
     return decorator
 
+class builtin_class_attr:
+    """
+    Turn an interp-level class attribute into an app-level one.
+
+    See test_builtin.py::test_builtin_class_attr for usage.
+    """
+
+    def __init__(self, name: str, w_val: 'W_Object') -> None:
+        self.name = name
+        self.w_val = w_val
+
+    def __repr__(self) -> str:
+        return f"<builtin_class_attr '{self.name}' = {self.w_val}>"
+
+    def __get__(self, instance, owner) -> 'W_Object':
+        return self.w_val
+
 # Basic setup of the object model: <object> and <type>
 # =====================================================
 
@@ -327,6 +344,8 @@ class W_Type(W_Object):
         for name, value in self._pyclass.__dict__.items():
             if hasattr(value, 'spy_builtin_method'):
                 self._init_builtin_method(value)
+            elif isinstance(value, builtin_class_attr):
+                self._dict_w[value.name] = value.w_val
 
     def define_from_classbody(self, body: 'ClassBody') -> None:
         raise NotImplementedError

--- a/spy/vm/opspec.py
+++ b/spy/vm/opspec.py
@@ -41,6 +41,7 @@ from spy.vm.property import W_Property
 
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
+    from spy.vm.primitive import W_Dynamic
     from spy.vm.str import W_Str
 
 
@@ -253,7 +254,7 @@ class W_OpArg(W_Object):
         because the applevel type (W_Str) doesn't match the interp-level type
         (Color).
         """
-        return vm.wrap(w_self.color)
+        return vm.wrap(w_self.color)  # type: ignore
 
     @builtin_property('blueval')
     @staticmethod
@@ -295,7 +296,9 @@ class W_MetaOpSpec(W_Type):
     """
     This exists solely to implement OpSpec.NULL.
 
-    I hope to be able to kill it as soon as we have descriptors
+    Hopefully we should be able to kill this as soon as we have class
+    properties / class attributes. See e.g. test_attrop::test_class_property
+    (now skipped)
     """
 
     @builtin_method('__getattr__', color='blue', kind='metafunc')

--- a/spy/vm/opspec.py
+++ b/spy/vm/opspec.py
@@ -33,13 +33,15 @@ from spy.location import Loc
 from spy.analyze.symtable import Symbol, Color
 from spy.errors import SPyError
 from spy.vm.b import OPERATOR, B
-from spy.vm.object import Member, W_Type, W_Object, builtin_method
+from spy.vm.object import Member, W_Type, W_Object
 from spy.vm.function import W_Func, W_FuncType
-from spy.vm.builtin import builtin_func
+from spy.vm.builtin import builtin_func, builtin_method, builtin_property
 from spy.vm.primitive import W_Bool
+from spy.vm.property import W_Property
 
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
+    from spy.vm.str import W_Str
 
 
 @OPERATOR.builtin_type('OpArg', lazy_definition=True)
@@ -243,34 +245,27 @@ class W_OpArg(W_Object):
         else:
             return W_OpSpec.NULL
 
-    @builtin_method('__GET_color__', color='blue')
+    @builtin_property('color')
     @staticmethod
-    def w_GET_color(vm: 'SPyVM', wop_x: 'W_OpArg',
-                    wop_attr: 'W_OpArg') -> 'W_OpSpec':
-        from spy.vm.builtin import builtin_func
-        from spy.vm.str import W_Str
+    def w_get_color(vm: 'SPyVM', w_self: 'W_OpArg') -> 'W_Str':
+        """
+        Applevel property to get the color. We cannot use a simple Member
+        because the applevel type (W_Str) doesn't match the interp-level type
+        (Color).
+        """
+        return vm.wrap(w_self.color)
 
-        @builtin_func(W_OpArg._w.fqn, 'get_color')
-        def w_get_color(vm: 'SPyVM', w_oparg: W_OpArg) -> W_Str:
-            return vm.wrap(w_oparg.color)  # type: ignore
-
-        return W_OpSpec(w_get_color, [wop_x])
-
-    @builtin_method('__GET_blueval__', color='blue')
+    @builtin_property('blueval')
     @staticmethod
-    def w_GET_blueval(vm: 'SPyVM', wop_x: 'W_OpArg',
-                      wop_attr: 'W_OpArg') -> 'W_OpSpec':
-        from spy.vm.builtin import builtin_func
-        from spy.vm.primitive import W_Dynamic
-
-        @builtin_func(W_OpArg._w.fqn, 'get_blueval')
-        def w_get_blueval(vm: 'SPyVM', w_oparg: W_OpArg) -> W_Dynamic:
-            if w_oparg.color != 'blue':
-                raise SPyError('W_ValueError', 'oparg is not blue')
-            return w_oparg.w_blueval
-
-        return W_OpSpec(w_get_blueval, [wop_x])
-
+    def w_get_blueval(vm: 'SPyVM', w_self: 'W_OpArg') -> 'W_Dynamic':
+        """
+        Applevel property to get the blueval. We cannot use a simple
+        Member because we want to do an extra check and raise W_ValueError if
+        the color is not blue.
+        """
+        if w_self.color != 'blue':
+            raise SPyError('W_ValueError', 'oparg is not blue')
+        return w_self.w_blueval
 
 
 @no_type_check

--- a/spy/vm/property.py
+++ b/spy/vm/property.py
@@ -2,8 +2,10 @@ from typing import TYPE_CHECKING
 from spy.vm.b import BUILTINS
 from spy.vm.object import W_Object
 from spy.vm.builtin import builtin_method
+from spy.vm.function import W_Func
 
 if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
     from spy.vm.opspec import W_OpArg, W_OpSpec
 
 
@@ -11,7 +13,7 @@ if TYPE_CHECKING:
 class W_Property(W_Object):
     __spy_storage_category__ = 'reference'
 
-    def __init__(self, w_func):
+    def __init__(self, w_func: W_Func) -> None:
         self.w_func = w_func
 
     @builtin_method('__get__', color='blue', kind='metafunc')

--- a/spy/vm/property.py
+++ b/spy/vm/property.py
@@ -1,0 +1,23 @@
+from typing import TYPE_CHECKING
+from spy.vm.b import BUILTINS
+from spy.vm.object import W_Object
+from spy.vm.builtin import builtin_method
+
+if TYPE_CHECKING:
+    from spy.vm.opspec import W_OpArg, W_OpSpec
+
+
+@BUILTINS.builtin_type('property', lazy_definition=True)
+class W_Property(W_Object):
+    __spy_storage_category__ = 'reference'
+
+    def __init__(self, w_func):
+        self.w_func = w_func
+
+    @builtin_method('__get__', color='blue', kind='metafunc')
+    @staticmethod
+    def w_GET(vm: 'SPyVM', wop_self: 'W_OpArg', wop_o: 'W_OpArg') -> 'W_OpSpec':
+        w_prop = wop_self.w_blueval
+        assert isinstance(w_prop, W_Property)
+        w_func = w_prop.w_func
+        return vm.fast_metacall(w_func, [wop_o])

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -23,7 +23,7 @@ def ll_spy_Str_new(ll: LLWasmInstance, s: str) -> int:
     return ptr
 
 
-@B.builtin_type('str')
+@B.builtin_type('str', lazy_definition=True)
 class W_Str(W_Object):
     """
     An unicode string, internally represented as UTF-8.

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -8,7 +8,7 @@ from spy.location import Loc
 from spy import libspy
 from spy.libspy import LLSPyInstance
 from spy.doppler import ErrorMode, redshift
-from spy.errors import SPyError
+from spy.errors import SPyError, WIP
 from spy.vm.object import W_Object, W_Type
 from spy.vm.primitive import W_F64, W_I32, W_I8, W_U8, W_Bool, W_Dynamic
 from spy.vm.str import W_Str
@@ -234,6 +234,10 @@ class SPyVM:
             fqn = w_type.fqn.join('prebuilt')
             fqn = self.get_unique_FQN(fqn)
         else:
+            w_type = self.dynamic_type(w_val)
+            T = w_type.fqn.human_name
+            msg = f"This prebuilt constant cannot be redshifted (yet): {w_val}"
+            raise WIP(msg)
             assert False, 'implement me'
 
         assert fqn is not None

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -17,6 +17,7 @@ from spy.vm.b import B
 from spy.vm.exc import W_Exception, W_TypeError
 from spy.vm.function import W_FuncType, W_Func, W_ASTFunc, W_BuiltinFunc
 from spy.vm.opimpl import W_OpImpl
+from spy.vm.property import W_Property
 from spy.vm.module import W_Module
 from spy.vm.opspec import W_MetaOpSpec, W_OpSpec, W_OpArg, w_oparg_eq
 from spy.vm.registry import ModuleRegistry
@@ -37,6 +38,7 @@ W_Type._w.define(W_Type)
 W_MetaOpSpec._w.define(W_MetaOpSpec)
 W_OpSpec._w.define(W_OpSpec)
 W_OpArg._w.define(W_OpArg)
+W_Property._w.define(W_Property)
 W_FuncType._w.define(W_FuncType)
 W_I32._w.define(W_I32)
 W_F64._w.define(W_F64)

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -42,6 +42,7 @@ W_Property._w.define(W_Property)
 W_FuncType._w.define(W_FuncType)
 W_I32._w.define(W_I32)
 W_F64._w.define(W_F64)
+W_Str._w.define(W_Str)
 
 STDLIB = ROOT.join('..', 'stdlib')
 


### PR DESCRIPTION
This is the first a multiple PR to implement the descriptor protocol, only `__get__` for now.

- add support for `__get__`
- introduce `@builtin_property` and `W_Property`
- introduce `@builtin_class_attr
- remove the ugly `__GET_xxx__`, and use `@builtin_property` instead
