### PR TITLE
Better typing for vm.wrap

### DIFF
--- a/spy/tests/compiler/operator/test_attrop.py
+++ b/spy/tests/compiler/operator/test_attrop.py
@@ -46,7 +46,6 @@ class TestAttrOp(CompilerTest):
 
     def test_descriptor_get(self):
         # ========== EXT module for this test ==========
-        w_hello: W_Str = self.vm.wrap('hello')  # type: ignore
         EXT = ModuleRegistry('ext')
 
         @EXT.builtin_type('MyProxy')
@@ -64,7 +63,7 @@ class TestAttrOp(CompilerTest):
 
         @EXT.builtin_type('MyClass')
         class W_MyClass(W_Object):
-            w_x = builtin_class_attr('x', W_MyProxy(w_hello))
+            w_x = builtin_class_attr('x', W_MyProxy(self.vm.wrap('hello')))
 
             @builtin_method('__new__')
             @staticmethod
@@ -103,7 +102,7 @@ class TestAttrOp(CompilerTest):
             @builtin_property('x')
             @staticmethod
             def w_get_x(vm: 'SPyVM', w_self: 'W_MyClass') -> W_I32:
-                return vm.wrap(w_self.x)  # type: ignore
+                return vm.wrap(w_self.x)
 
             @builtin_property('x2', color='blue', kind='metafunc')
             @staticmethod
@@ -116,7 +115,7 @@ class TestAttrOp(CompilerTest):
                 assert W_MyClass._w is w_t
                 @builtin_func(w_t.fqn, 'get_y')
                 def w_get_x2(vm: 'SPyVM', w_self: W_MyClass) -> W_I32:
-                    return vm.wrap(w_self.x * 2)  # type: ignore
+                    return vm.wrap(w_self.x * 2)
                 return W_OpSpec(w_get_x2, [wop_self])
 
 
@@ -199,13 +198,13 @@ class TestAttrOp(CompilerTest):
                     @builtin_func('ext', 'getx')
                     def w_fn(vm: 'SPyVM', w_obj: W_MyClass,
                            w_attr: W_Str) -> W_I32:
-                        return vm.wrap(w_obj.x)  # type: ignore
+                        return vm.wrap(w_obj.x)
                 else:
                     @builtin_func('ext', 'getany')
                     def w_fn(vm: 'SPyVM', w_obj: W_MyClass,
                                       w_attr: W_Str) -> W_Str:
                         attr = vm.unwrap_str(w_attr)
-                        return vm.wrap(attr.upper() + '--42')  # type: ignore
+                        return vm.wrap(attr.upper() + '--42')
                 return W_OpSpec(w_fn)
 
             @builtin_method('__setattr__', color='blue', kind='metafunc')

--- a/spy/tests/compiler/operator/test_binop.py
+++ b/spy/tests/compiler/operator/test_binop.py
@@ -22,112 +22,112 @@ class W_BinOpClass(W_Object):
     def w_add(vm: 'SPyVM', w_self: 'W_BinOpClass', w_other: W_I32) -> W_I32:
         x = vm.unwrap_i32(w_self.w_x)
         other = vm.unwrap_i32(w_other)
-        return vm.wrap(x + other)  # type: ignore
+        return vm.wrap(x + other)
 
     @builtin_method('__sub__')
     @staticmethod
     def w_sub(vm: 'SPyVM', w_self: 'W_BinOpClass', w_other: W_I32) -> W_I32:
         x = vm.unwrap_i32(w_self.w_x)
         other = vm.unwrap_i32(w_other)
-        return vm.wrap(x - other)  # type: ignore
+        return vm.wrap(x - other)
 
     @builtin_method('__mul__')
     @staticmethod
     def w_mul(vm: 'SPyVM', w_self: 'W_BinOpClass', w_other: W_I32) -> W_I32:
         x = vm.unwrap_i32(w_self.w_x)
         other = vm.unwrap_i32(w_other)
-        return vm.wrap(x * other)  # type: ignore
+        return vm.wrap(x * other)
 
     @builtin_method('__div__')
     @staticmethod
     def w_div(vm: 'SPyVM', w_self: 'W_BinOpClass', w_other: W_I32) -> W_I32:
         x = vm.unwrap_i32(w_self.w_x)
         other = vm.unwrap_i32(w_other)
-        return vm.wrap(x // other)  # type: ignore
+        return vm.wrap(x // other)
 
     @builtin_method('__mod__')
     @staticmethod
     def w_mod(vm: 'SPyVM', w_self: 'W_BinOpClass', w_other: W_I32) -> W_I32:
         x = vm.unwrap_i32(w_self.w_x)
         other = vm.unwrap_i32(w_other)
-        return vm.wrap(x % other)  # type: ignore
+        return vm.wrap(x % other)
 
     @builtin_method('__and__')
     @staticmethod
     def w_and(vm: 'SPyVM', w_self: 'W_BinOpClass', w_other: W_I32) -> W_I32:
         x = vm.unwrap_i32(w_self.w_x)
         other = vm.unwrap_i32(w_other)
-        return vm.wrap(x & other)  # type: ignore
+        return vm.wrap(x & other)
 
     @builtin_method('__or__')
     @staticmethod
     def w_or(vm: 'SPyVM', w_self: 'W_BinOpClass', w_other: W_I32) -> W_I32:
         x = vm.unwrap_i32(w_self.w_x)
         other = vm.unwrap_i32(w_other)
-        return vm.wrap(x | other)  # type: ignore
+        return vm.wrap(x | other)
 
     @builtin_method('__xor__')
     @staticmethod
     def w_xor(vm: 'SPyVM', w_self: 'W_BinOpClass', w_other: W_I32) -> W_I32:
         x = vm.unwrap_i32(w_self.w_x)
         other = vm.unwrap_i32(w_other)
-        return vm.wrap(x ^ other)  # type: ignore
+        return vm.wrap(x ^ other)
 
     @builtin_method('__lshift__')
     @staticmethod
     def w_shl(vm: 'SPyVM', w_self: 'W_BinOpClass', w_other: W_I32) -> W_I32:
         x = vm.unwrap_i32(w_self.w_x)
         other = vm.unwrap_i32(w_other)
-        return vm.wrap(x << other)  # type: ignore
+        return vm.wrap(x << other)
 
     @builtin_method('__rshift__')
     @staticmethod
     def w_shr(vm: 'SPyVM', w_self: 'W_BinOpClass', w_other: W_I32) -> W_I32:
         x = vm.unwrap_i32(w_self.w_x)
         other = vm.unwrap_i32(w_other)
-        return vm.wrap(x >> other)  # type: ignore
+        return vm.wrap(x >> other)
 
     @builtin_method('__eq__')
     @staticmethod
     def w_eq(vm: 'SPyVM', w_self: 'W_BinOpClass', w_other: W_I32) -> W_I32:
         x = vm.unwrap_i32(w_self.w_x)
         other = vm.unwrap_i32(w_other)
-        return vm.wrap(1 if x == other else 0)  # type: ignore
+        return vm.wrap(1 if x == other else 0)
 
     @builtin_method('__ne__')
     @staticmethod
     def w_ne(vm: 'SPyVM', w_self: 'W_BinOpClass', w_other: W_I32) -> W_I32:
         x = vm.unwrap_i32(w_self.w_x)
         other = vm.unwrap_i32(w_other)
-        return vm.wrap(1 if x != other else 0)  # type: ignore
+        return vm.wrap(1 if x != other else 0)
 
     @builtin_method('__lt__')
     @staticmethod
     def w_lt(vm: 'SPyVM', w_self: 'W_BinOpClass', w_other: W_I32) -> W_I32:
         x = vm.unwrap_i32(w_self.w_x)
         other = vm.unwrap_i32(w_other)
-        return vm.wrap(1 if x < other else 0)  # type: ignore
+        return vm.wrap(1 if x < other else 0)
 
     @builtin_method('__le__')
     @staticmethod
     def w_le(vm: 'SPyVM', w_self: 'W_BinOpClass', w_other: W_I32) -> W_I32:
         x = vm.unwrap_i32(w_self.w_x)
         other = vm.unwrap_i32(w_other)
-        return vm.wrap(1 if x <= other else 0)  # type: ignore
+        return vm.wrap(1 if x <= other else 0)
 
     @builtin_method('__gt__')
     @staticmethod
     def w_gt(vm: 'SPyVM', w_self: 'W_BinOpClass', w_other: W_I32) -> W_I32:
         x = vm.unwrap_i32(w_self.w_x)
         other = vm.unwrap_i32(w_other)
-        return vm.wrap(1 if x > other else 0)  # type: ignore
+        return vm.wrap(1 if x > other else 0)
 
     @builtin_method('__ge__')
     @staticmethod
     def w_ge(vm: 'SPyVM', w_self: 'W_BinOpClass', w_other: W_I32) -> W_I32:
         x = vm.unwrap_i32(w_self.w_x)
         other = vm.unwrap_i32(w_other)
-        return vm.wrap(1 if x >= other else 0)  # type: ignore
+        return vm.wrap(1 if x >= other else 0)
 
 
 @no_C

--- a/spy/tests/compiler/operator/test_callop.py
+++ b/spy/tests/compiler/operator/test_callop.py
@@ -174,7 +174,7 @@ class TestCallOp(CompilerTest):
             def w_call(vm: 'SPyVM', w_obj: 'W_Adder', w_y: W_I32) -> W_I32:
                 y = vm.unwrap_i32(w_y)
                 res = w_obj.x + y
-                return vm.wrap(res) # type: ignore
+                return vm.wrap(res)
 
         # ========== /EXT module for this test =========
         self.vm.make_module(EXT)

--- a/spy/tests/compiler/operator/test_callop.py
+++ b/spy/tests/compiler/operator/test_callop.py
@@ -143,7 +143,7 @@ class TestCallOp(CompilerTest):
             tot = 0
             for w_x in args_w:
                 tot += vm.unwrap_i32(w_x)
-            return vm.wrap(tot)  # type: ignore
+            return vm.wrap(tot)
         # ========== /EXT module for this test =========
         self.vm.make_module(EXT)
         mod = self.compile("""
@@ -214,7 +214,7 @@ class TestCallOp(CompilerTest):
                     def w_fn(vm: 'SPyVM', w_self: W_Calc,
                              w_arg: W_I32) -> W_I32:
                         y = vm.unwrap_i32(w_arg)
-                        return vm.wrap(w_self.x + y)  # type: ignore
+                        return vm.wrap(w_self.x + y)
                     return W_OpSpec(w_fn, [wop_obj] + list(args_wop))
 
                 elif meth == 'sub':
@@ -222,7 +222,7 @@ class TestCallOp(CompilerTest):
                     def w_fn(vm: 'SPyVM', w_self: W_Calc,
                              w_arg: W_I32) -> W_I32:
                         y = vm.unwrap_i32(w_arg)
-                        return vm.wrap(w_self.x - y)  # type: ignore
+                        return vm.wrap(w_self.x - y)
                     return W_OpSpec(w_fn, [wop_obj] + list(args_wop))
                 else:
                     return W_OpSpec.NULL

--- a/spy/tests/compiler/operator/test_convop.py
+++ b/spy/tests/compiler/operator/test_convop.py
@@ -37,7 +37,7 @@ class W_MyClass(W_Object):
         @builtin_func('ext')
         def w_to_str(vm: 'SPyVM', w_self: W_MyClass) -> W_Str:
             x = vm.unwrap_i32(w_self.w_x)
-            return vm.wrap(str(x))  # type: ignore
+            return vm.wrap(str(x))
 
         if w_target_type is B.w_i32:
             vm.add_global(w_to_i32.fqn, w_to_i32)
@@ -60,7 +60,7 @@ class W_MyClass(W_Object):
         def w_from_str(vm: 'SPyVM', w_val: W_Str) -> W_MyClass:
             s = vm.unwrap_str(w_val)
             w_x = vm.wrap(int(s))
-            return W_MyClass(w_x)  # type: ignore
+            return W_MyClass(w_x)
 
         if w_source_type is B.w_str:
             vm.add_global(w_from_str.fqn, w_from_str)

--- a/spy/tests/compiler/operator/test_itemop.py
+++ b/spy/tests/compiler/operator/test_itemop.py
@@ -28,7 +28,7 @@ class W_MyClass(W_Object):
             return w_self.w_values[idx]
 
         # Otherwise calculate a value based on base and index
-        return vm.wrap(base + idx)  # type: ignore
+        return vm.wrap(base + idx)
 
     @builtin_method('__setitem__')
     @staticmethod
@@ -59,7 +59,7 @@ class W_2DArray(W_Object):
         j = vm.unwrap_i32(w_j)
         k = i + (j * w_self.W)
         val = w_self.data[k]
-        return vm.wrap(val)  # type: ignore
+        return vm.wrap(val)
 
     @builtin_method('__setitem__')
     @staticmethod

--- a/spy/tests/compiler/operator/test_opimpl.py
+++ b/spy/tests/compiler/operator/test_opimpl.py
@@ -58,7 +58,7 @@ class TestOpSpec(CompilerTest):
             @builtin_method('__getitem__')
             @staticmethod
             def w_getitem(vm: 'SPyVM', w_obj: 'W_MyClass') -> W_I32:
-                return vm.wrap(42)  # type: ignore
+                return vm.wrap(42)
         # ========== /EXT module for this test =========
 
         self.vm.make_module(EXT)
@@ -104,7 +104,7 @@ class TestOpSpec(CompilerTest):
             assert isinstance(w_obj, W_MyClass)
             a = vm.unwrap_i32(w_i)
             b = vm.unwrap_i32(w_obj.w_x)
-            return vm.wrap(a+b)  # type: ignore
+            return vm.wrap(a+b)
         # ========== /EXT module for this test =========
 
         self.vm.make_module(EXT)

--- a/spy/tests/compiler/operator/test_unaryop.py
+++ b/spy/tests/compiler/operator/test_unaryop.py
@@ -22,7 +22,7 @@ class W_MyClass(W_Object):
     @staticmethod
     def w_neg(vm: 'SPyVM', w_self: 'W_MyClass') -> W_I32:
         x = vm.unwrap_i32(w_self.w_x)
-        return vm.wrap(-x)  # type: ignore
+        return vm.wrap(-x)
 
 
 @no_C

--- a/spy/tests/vm/test_builtin.py
+++ b/spy/tests/vm/test_builtin.py
@@ -40,7 +40,7 @@ class TestBuiltin:
         @builtin_func('mymod')
         def w_foo(vm: 'SPyVM', w_x: W_I32) -> W_I32:
             x = vm.unwrap_i32(w_x)
-            return vm.wrap(x*2)  # type: ignore
+            return vm.wrap(x*2)
 
         assert isinstance(w_foo, W_BuiltinFunc)
         assert w_foo.fqn == FQN('mymod::foo')
@@ -97,7 +97,7 @@ class TestBuiltin:
         @builtin_func('mymod', color='blue')
         def w_foo(vm: 'SPyVM', w_x: W_I32) -> W_I32:
             x = vm.unwrap_i32(w_x)
-            return vm.wrap(x*2)  # type: ignore
+            return vm.wrap(x*2)
 
         assert w_foo.w_functype.fqn.human_name == '@blue def(i32) -> i32'
         w_x = vm.fast_call(w_foo, [vm.wrap(21)])

--- a/spy/tests/vm/test_opimpl.py
+++ b/spy/tests/vm/test_opimpl.py
@@ -14,7 +14,7 @@ from spy.vm.b import OP
 def w_repeat(vm: 'SPyVM', w_s: W_Str, w_n: W_I32) -> W_Str:
     s = vm.unwrap_str(w_s)
     n = vm.unwrap_i32(w_n)
-    return vm.wrap(s * int(n))  # type: ignore
+    return vm.wrap(s * int(n))
 
 def test_repeat():
     vm = SPyVM()

--- a/spy/tests/vm/test_opimpl.py
+++ b/spy/tests/vm/test_opimpl.py
@@ -1,6 +1,7 @@
 import textwrap
 from spy.location import Loc
 from spy.vm.vm import SPyVM
+from spy.vm.object import W_Object
 from spy.vm.function import W_FuncType
 from spy.vm.opimpl import W_OpImpl, ArgSpec
 from spy.vm.primitive import W_I32
@@ -43,7 +44,7 @@ def test_shuffle_args():
 def test_const():
     vm = SPyVM()
     w_functype = W_FuncType.parse('def(i32) -> str')
-    w_s = vm.wrap('ab ')
+    w_s: W_Object = vm.wrap('ab ')
     w_opimpl = W_OpImpl(
         w_functype,
         w_repeat,

--- a/spy/vm/exc.py
+++ b/spy/vm/exc.py
@@ -88,7 +88,7 @@ class W_Exception(W_Object):
         def w_eq(vm: 'SPyVM', w_e1: W_Exception, w_e2: W_Exception) -> W_Bool:
             res =  (w_e1.message == w_e2.message and
                     w_e1.annotations == w_e2.annotations)
-            return vm.wrap(bool(res))  # type: ignore
+            return vm.wrap(bool(res))
 
         return W_OpSpec(w_eq)
 
@@ -108,7 +108,7 @@ class W_Exception(W_Object):
         def w_ne(vm: 'SPyVM', w_e1: W_Exception, w_e2: W_Exception) -> W_Bool:
             res = not (w_e1.message == w_e2.message and
                        w_e1.annotations == w_e2.annotations)
-            return vm.wrap(bool(res))  # type: ignore
+            return vm.wrap(bool(res))
 
         return W_OpSpec(w_ne)
 

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -29,21 +29,21 @@ def w_STATIC_TYPE(vm: 'SPyVM', w_expr: W_Object) -> W_Type:
 def w_abs(vm: 'SPyVM', w_x: W_I32) -> W_I32:
     x = vm.unwrap_i32(w_x)
     res = vm.ll.call('spy_builtins$abs', x)
-    return vm.wrap(res) # type: ignore
+    return vm.wrap(res)
 
 @BUILTINS.builtin_func
 def w_max(vm: 'SPyVM', w_x: W_I32, w_y: W_I32) -> W_I32:
     x = vm.unwrap_i32(w_x)
     y = vm.unwrap_i32(w_y)
     res = vm.ll.call('spy_builtins$max', x, y)
-    return vm.wrap(res) # type: ignore
+    return vm.wrap(res)
 
 @BUILTINS.builtin_func
 def w_min(vm: 'SPyVM', w_x: W_I32, w_y: W_I32) -> W_I32:
     x = vm.unwrap_i32(w_x)
     y = vm.unwrap_i32(w_y)
     res = vm.ll.call('spy_builtins$min', x, y)
-    return vm.wrap(res) # type: ignore
+    return vm.wrap(res)
 
 
 @BUILTINS.builtin_func(color='blue', kind='metafunc')
@@ -122,7 +122,7 @@ def w_len(vm: 'SPyVM', wop_obj: W_OpArg) -> W_OpSpec:
 # circular import issues
 @builtin_func('builtins')
 def w_functype_eq(vm: 'SPyVM', w_ft1: W_FuncType, w_ft2: W_FuncType) -> W_Bool:
-    return vm.wrap(w_ft1 == w_ft2)  # type: ignore
+    return vm.wrap(w_ft1 == w_ft2)
 
 
 # add aliases for common types. For now we map:

--- a/spy/vm/modules/math.py
+++ b/spy/vm/modules/math.py
@@ -20,90 +20,90 @@ def w_INIT(vm: 'SPyVM') -> None:
 def w_sqrt(vm: 'SPyVM', w_x: W_F64) -> W_F64:
     x = vm.unwrap_f64(w_x)
     res = math.sqrt(x)
-    return vm.wrap(res)  # type: ignore
+    return vm.wrap(res)
 
 @MATH.builtin_func
 def w_cos(vm: 'SPyVM', w_x: W_F64) -> W_F64:
     x = vm.unwrap_f64(w_x)
     res = math.cos(x)
-    return vm.wrap(res)  # type: ignore
+    return vm.wrap(res)
 
 @MATH.builtin_func
 def w_sin(vm: 'SPyVM', w_x: W_F64) -> W_F64:
     x = vm.unwrap_f64(w_x)
     res = math.sin(x)
-    return vm.wrap(res)  # type: ignore
+    return vm.wrap(res)
 
 @MATH.builtin_func
 def w_tan(vm: 'SPyVM', w_x: W_F64) -> W_F64:
     x = vm.unwrap_f64(w_x)
     res = math.tan(x)
-    return vm.wrap(res)  # type: ignore
+    return vm.wrap(res)
 
 @MATH.builtin_func
 def w_log(vm: 'SPyVM', w_x: W_F64) -> W_F64:
     x = vm.unwrap_f64(w_x)
     res = math.log(x)
-    return vm.wrap(res)  # type: ignore
+    return vm.wrap(res)
 
 @MATH.builtin_func
 def w_log10(vm: 'SPyVM', w_x: W_F64) -> W_F64:
     x = vm.unwrap_f64(w_x)
     res = math.log10(x)
-    return vm.wrap(res)  # type: ignore
+    return vm.wrap(res)
 
 @MATH.builtin_func
 def w_exp(vm: 'SPyVM', w_x: W_F64) -> W_F64:
     x = vm.unwrap_f64(w_x)
     res = math.exp(x)
-    return vm.wrap(res)  # type: ignore
+    return vm.wrap(res)
 
 @MATH.builtin_func
 def w_acos(vm: 'SPyVM', w_x: W_F64) -> W_F64:
     x = vm.unwrap_f64(w_x)
     res = math.acos(x)
-    return vm.wrap(res)  # type: ignore
+    return vm.wrap(res)
 
 @MATH.builtin_func
 def w_asin(vm: 'SPyVM', w_x: W_F64) -> W_F64:
     x = vm.unwrap_f64(w_x)
     res = math.asin(x)
-    return vm.wrap(res)  # type: ignore
+    return vm.wrap(res)
 
 @MATH.builtin_func
 def w_atan(vm: 'SPyVM', w_x: W_F64) -> W_F64:
     x = vm.unwrap_f64(w_x)
     res = math.atan(x)
-    return vm.wrap(res)  # type: ignore
+    return vm.wrap(res)
 
 @MATH.builtin_func
 def w_atan2(vm: 'SPyVM', w_y: W_F64, w_x: W_F64) -> W_F64:
     y = vm.unwrap_f64(w_y)
     x = vm.unwrap_f64(w_x)
     res = math.atan2(y, x)
-    return vm.wrap(res)  # type: ignore
+    return vm.wrap(res)
 
 @MATH.builtin_func
 def w_ceil(vm: 'SPyVM', w_x: W_F64) -> W_F64:
     x = vm.unwrap_f64(w_x)
     res = math.ceil(x)
-    return vm.wrap(res)  # type: ignore
+    return vm.wrap(res)
 
 @MATH.builtin_func
 def w_floor(vm: 'SPyVM', w_x: W_F64) -> W_F64:
     x = vm.unwrap_f64(w_x)
     res = math.floor(x)
-    return vm.wrap(res)  # type: ignore
+    return vm.wrap(res)
 
 @MATH.builtin_func
 def w_pow(vm: 'SPyVM', w_x: W_F64, w_y: W_F64) -> W_F64:
     x = vm.unwrap_f64(w_x)
     y = vm.unwrap_f64(w_y)
     res = math.pow(x, y)
-    return vm.wrap(res)  # type: ignore
+    return vm.wrap(res)
 
 @MATH.builtin_func
 def w_fabs(vm: 'SPyVM', w_x: W_F64) -> W_F64:
     x = vm.unwrap_f64(w_x)
     res = math.fabs(x)
-    return vm.wrap(res)  # type: ignore
+    return vm.wrap(res)

--- a/spy/vm/modules/operator/convop.py
+++ b/spy/vm/modules/operator/convop.py
@@ -84,22 +84,22 @@ def CONVERT_maybe(
 @OP.builtin_func
 def w_i32_to_f64(vm: 'SPyVM', w_x: W_I32) -> W_F64:
     val = vm.unwrap_i32(w_x)
-    return vm.wrap(float(val))  # type: ignore
+    return vm.wrap(float(val))
 
 @OP.builtin_func
 def w_i8_to_f64(vm: 'SPyVM', w_x: W_I8) -> W_F64:
     val = vm.unwrap_i8(w_x)
-    return vm.wrap(float(val))  # type: ignore
+    return vm.wrap(float(val))
 
 @OP.builtin_func
 def w_u8_to_f64(vm: 'SPyVM', w_x: W_U8) -> W_F64:
     val = vm.unwrap_u8(w_x)
-    return vm.wrap(float(val))  # type: ignore
+    return vm.wrap(float(val))
 
 @OP.builtin_func
 def w_i32_to_bool(vm: 'SPyVM', w_x: W_I32) -> W_Bool:
     val = vm.unwrap_i32(w_x)
-    return vm.wrap(bool(val))  # type: ignore
+    return vm.wrap(bool(val))
 
 @OP.builtin_func
 def w_i32_to_i8(vm: 'SPyVM', w_x: W_I32) -> W_I8:
@@ -126,7 +126,7 @@ def w_f64_to_i32(vm: 'SPyVM', w_x: W_F64) -> W_I32:
         val = i32_MAX
     elif math.isnan(val):
         val = 0
-    return vm.wrap(int(val))  # type: ignore
+    return vm.wrap(int(val))
 
 
 @OP.builtin_func(color='blue')

--- a/spy/vm/modules/operator/opimpl_bool.py
+++ b/spy/vm/modules/operator/opimpl_bool.py
@@ -7,40 +7,40 @@ if TYPE_CHECKING:
 
 @OP.builtin_func('bool_eq')
 def w_bool_eq(vm: 'SPyVM', w_a: W_Bool, w_b: W_Bool) -> W_Bool:
-    return vm.wrap(w_a.value == w_b.value)  # type: ignore
+    return vm.wrap(w_a.value == w_b.value)
 
 @OP.builtin_func('bool_ne')
 def w_bool_ne(vm: 'SPyVM', w_a: W_Bool, w_b: W_Bool) -> W_Bool:
-    return vm.wrap(w_a.value != w_b.value)  # type: ignore
+    return vm.wrap(w_a.value != w_b.value)
 
 @OP.builtin_func('bool_and')
 def w_bool_and(vm: 'SPyVM', w_a: W_Bool, w_b: W_Bool) -> W_Bool:
-    return vm.wrap(w_a.value and w_b.value)  # type: ignore
+    return vm.wrap(w_a.value and w_b.value)
 
 @OP.builtin_func('bool_or')
 def w_bool_or(vm: 'SPyVM', w_a: W_Bool, w_b: W_Bool) -> W_Bool:
-    return vm.wrap(w_a.value or w_b.value)  # type: ignore
+    return vm.wrap(w_a.value or w_b.value)
 
 @OP.builtin_func('bool_xor')
 def w_bool_xor(vm: 'SPyVM', w_a: W_Bool, w_b: W_Bool) -> W_Bool:
-    return vm.wrap(w_a.value != w_b.value)  # type: ignore
+    return vm.wrap(w_a.value != w_b.value)
 
 @OP.builtin_func('bool_lt')
 def w_bool_lt(vm: 'SPyVM', w_a: W_Bool, w_b: W_Bool) -> W_Bool:
     # False < True but not True < False
-    return vm.wrap(not w_a.value and w_b.value)  # type: ignore
+    return vm.wrap(not w_a.value and w_b.value)
 
 @OP.builtin_func('bool_le')
 def w_bool_le(vm: 'SPyVM', w_a: W_Bool, w_b: W_Bool) -> W_Bool:
     # False <= True and True <= True and False <= False
-    return vm.wrap(not w_a.value or w_b.value)  # type: ignore
+    return vm.wrap(not w_a.value or w_b.value)
 
 @OP.builtin_func('bool_gt')
 def w_bool_gt(vm: 'SPyVM', w_a: W_Bool, w_b: W_Bool) -> W_Bool:
     # True > False but not False > True
-    return vm.wrap(w_a.value and not w_b.value)  # type: ignore
+    return vm.wrap(w_a.value and not w_b.value)
 
 @OP.builtin_func('bool_ge')
 def w_bool_ge(vm: 'SPyVM', w_a: W_Bool, w_b: W_Bool) -> W_Bool:
     # True >= False and True >= True and False >= False
-    return vm.wrap(w_a.value or not w_b.value)  # type: ignore
+    return vm.wrap(w_a.value or not w_b.value)

--- a/spy/vm/modules/operator/opimpl_object.py
+++ b/spy/vm/modules/operator/opimpl_object.py
@@ -8,11 +8,11 @@ if TYPE_CHECKING:
 
 @OP.builtin_func
 def w_object_is(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_Bool:
-    return vm.wrap(w_a is w_b)  # type: ignore
+    return vm.wrap(w_a is w_b)
 
 @OP.builtin_func
 def w_object_isnot(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_Bool:
-    return vm.wrap(w_a is not w_b)  # type: ignore
+    return vm.wrap(w_a is not w_b)
 
 @OP.builtin_func
 def w_object_universal_eq(vm: 'SPyVM', w_a: W_Object, w_b: W_Object) -> W_Bool:

--- a/spy/vm/modules/operator/opimpl_str.py
+++ b/spy/vm/modules/operator/opimpl_str.py
@@ -26,11 +26,11 @@ def w_str_eq(vm: 'SPyVM', w_a: W_Str, w_b: W_Str) -> W_Bool:
     assert isinstance(w_a, W_Str)
     assert isinstance(w_b, W_Str)
     res = vm.ll.call('spy_str_eq', w_a.ptr, w_b.ptr)
-    return vm.wrap(bool(res))  # type: ignore
+    return vm.wrap(bool(res))
 
 @OP.builtin_func
 def w_str_ne(vm: 'SPyVM', w_a: W_Str, w_b: W_Str) -> W_Bool:
     assert isinstance(w_a, W_Str)
     assert isinstance(w_b, W_Str)
     res = vm.ll.call('spy_str_eq', w_a.ptr, w_b.ptr)
-    return vm.wrap(bool(not res))  # type: ignore
+    return vm.wrap(bool(not res))

--- a/spy/vm/modules/rawbuffer.py
+++ b/spy/vm/modules/rawbuffer.py
@@ -40,7 +40,7 @@ def w_rb_set_i32(vm: 'SPyVM', w_rb: W_RawBuffer,
 def w_rb_get_i32(vm: 'SPyVM', w_rb: W_RawBuffer, w_offset: W_I32) -> W_I32:
     offset = vm.unwrap_i32(w_offset)
     val = struct.unpack_from('i', w_rb.buf, offset)[0]
-    return vm.wrap(val)  # type: ignore
+    return vm.wrap(val)
 
 @RB.builtin_func
 def w_rb_set_f64(vm: 'SPyVM', w_rb: W_RawBuffer,
@@ -53,4 +53,4 @@ def w_rb_set_f64(vm: 'SPyVM', w_rb: W_RawBuffer,
 def w_rb_get_f64(vm: 'SPyVM', w_rb: W_RawBuffer, w_offset: W_I32) -> W_F64:
     offset = vm.unwrap_i32(w_offset)
     val = struct.unpack_from('d', w_rb.buf, offset)[0]
-    return vm.wrap(val)  # type: ignore
+    return vm.wrap(val)

--- a/spy/vm/opspec.py
+++ b/spy/vm/opspec.py
@@ -254,7 +254,7 @@ class W_OpArg(W_Object):
         because the applevel type (W_Str) doesn't match the interp-level type
         (Color).
         """
-        return vm.wrap(w_self.color)  # type: ignore
+        return vm.wrap(w_self.color)
 
     @builtin_property('blueval')
     @staticmethod

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -91,10 +91,10 @@ class W_Str(W_Object):
     def w_len(vm: 'SPyVM', w_s: 'W_Str') -> W_I32:
         assert isinstance(w_s, W_Str)
         length = vm.ll.call('spy_str_len', w_s.ptr)
-        return vm.wrap(length)  # type: ignore
+        return vm.wrap(length)
 
 
 @builtin_func('builtins')
 def w_int2str(vm: 'SPyVM', w_i: W_I32) -> W_Str:
     i = vm.unwrap_i32(w_i)
-    return vm.wrap(str(i))  # type: ignore
+    return vm.wrap(str(i))

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Iterable, Sequence, Callable
+from typing import Any, Optional, Iterable, Sequence, Callable, overload
 import itertools
 from types import FunctionType
 import fixedint
@@ -307,6 +307,13 @@ class SPyVM:
 
     def is_False(self, w_obj: W_Bool) -> bool:
         return w_obj is B.w_False
+
+    @overload
+    def wrap(self, value: int) -> W_I32: ...
+
+    @overload
+    def wrap(self, value: Any) -> W_Object: ...
+
 
     def wrap(self, value: Any) -> W_Object:
         """

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Iterable, Sequence, Callable, overload
+from typing import Any, Optional, Iterable, Sequence, Callable, overload, Union
 import itertools
 from types import FunctionType
 import fixedint
@@ -309,11 +309,11 @@ class SPyVM:
         return w_obj is B.w_False
 
     @overload
-    def wrap(self, value: int) -> W_I32: ...
-
+    def wrap(self, value: Union[int, fixedint.Int32]) -> W_I32: ...
+    @overload
+    def wrap(self, value: str) -> W_Str: ...
     @overload
     def wrap(self, value: Any) -> W_Object: ...
-
 
     def wrap(self, value: Any) -> W_Object:
         """

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -10,7 +10,8 @@ from spy.libspy import LLSPyInstance
 from spy.doppler import ErrorMode, redshift
 from spy.errors import SPyError, WIP
 from spy.vm.object import W_Object, W_Type
-from spy.vm.primitive import W_F64, W_I32, W_I8, W_U8, W_Bool, W_Dynamic
+from spy.vm.primitive import (W_F64, W_I32, W_I8, W_U8, W_Bool, W_Dynamic,
+                              W_NoneType)
 from spy.vm.str import W_Str
 from spy.vm.list import W_ListType
 from spy.vm.b import B
@@ -308,12 +309,40 @@ class SPyVM:
     def is_False(self, w_obj: W_Bool) -> bool:
         return w_obj is B.w_False
 
+
+    # ======== <vm.wrap typing> =========
+    # The return type of vm.wrap depends on the type of the argument.
+    #
+    # The following series of @overload try to capture the runtime logic done
+    # by vm.wrap. Note that bool, Int8, UInt8 etc are subclasses of int, so we
+    # need extra care for that. In particular, we need to make sure that they
+    # are listed *before* the overload wrap(int), and we need to ignore
+    # overload-overlap.
+
     @overload
-    def wrap(self, value: Union[int, fixedint.Int32]) -> W_I32: ...
+    def wrap(self, value: None) -> W_NoneType: ...
+
+    @overload
+    def wrap(self, value: bool) -> W_Bool: ... # type: ignore[overload-overlap]
+
+    @overload
+    def wrap(self, value: fixedint.Int8) -> W_I8: ... # type: ignore[overload-overlap]
+
+    @overload
+    def wrap(self, value: fixedint.UInt8) -> W_U8: ... # type: ignore[overload-overlap]
+
+    @overload
+    def wrap(self, value: Union[fixedint.Int32, int]) -> W_I32: ...
+
+    @overload
+    def wrap(self, value: float) -> W_F64: ...
+
     @overload
     def wrap(self, value: str) -> W_Str: ...
+
     @overload
     def wrap(self, value: Any) -> W_Object: ...
+    # ======== </vm.wrap typing> =========
 
     def wrap(self, value: Any) -> W_Object:
         """


### PR DESCRIPTION
This PR annotates vm.wrap with better typing, allowing us to kill a lot of "type: ignore" comments
