### PR TITLE
Implement __set__, and implement Members using the descriptor protocol

### DIFF
--- a/spy/tests/compiler/operator/test_attrop.py
+++ b/spy/tests/compiler/operator/test_attrop.py
@@ -2,7 +2,7 @@ from typing import Annotated
 import pytest
 from spy.vm.primitive import W_I32
 from spy.vm.b import B
-from spy.vm.object import Member
+from spy.vm.member import Member
 from spy.vm.builtin import (builtin_func, builtin_method, builtin_class_attr,
                             builtin_property)
 from spy.vm.w import W_Object, W_Str

--- a/spy/tests/compiler/operator/test_callop.py
+++ b/spy/tests/compiler/operator/test_callop.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 from spy.vm.primitive import W_I32
-from spy.vm.object import Member
+from spy.vm.member import Member
 from spy.vm.builtin import builtin_func, builtin_method
 from spy.vm.w import W_Type, W_Object
 from spy.vm.opspec import W_OpSpec, W_OpArg

--- a/spy/tests/compiler/operator/test_convop.py
+++ b/spy/tests/compiler/operator/test_convop.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 from spy.vm.primitive import W_I32
 from spy.vm.b import B
-from spy.vm.object import Member
+from spy.vm.member import Member
 from spy.vm.builtin import builtin_func, builtin_method
 from spy.vm.w import W_Type, W_Object, W_Str
 from spy.vm.opspec import W_OpSpec, W_OpArg

--- a/spy/vm/member.py
+++ b/spy/vm/member.py
@@ -1,0 +1,101 @@
+from typing import Annotated, TYPE_CHECKING, Any, Optional
+from spy.vm.b import BUILTINS
+from spy.vm.object import W_Object, W_Type
+from spy.vm.builtin import builtin_method
+from spy.vm.builtin import builtin_func
+
+if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
+    from spy.vm.opspec import W_OpArg, W_OpSpec
+
+
+class Member:
+    """
+    Annotation to turn an interp-level field into an app-level
+    property. Use it like this:
+
+    @builtin_type('MyClass')
+    class W_MyClass(W_Object):
+        w_x: Annotated[W_I32, Member('x')]
+
+    This will add an app-level attribute "x" to the class, corresponding to
+    the interp-level attribute "w_x".
+
+    This is just an annotation. The magic is done by W_Type.define(), which
+    turns Member annotations into W_Member, which does its job thanks to the
+    descriptor protocol.
+    """
+    name: str
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    @staticmethod
+    def from_annotation(t: Any) -> Optional['Member']:
+        """
+        Return the Member instance found in the annotation metadata, if any.
+        """
+        for meta in getattr(t, '__metadata__', []):
+            if isinstance(meta, Member):
+                return meta
+        return None
+
+
+@BUILTINS.builtin_type('member', lazy_definition=True)
+class W_Member(W_Object):
+    """
+    Descriptor object which turns interp-level fields (such as
+    `w_obj.w_x`) into app-level properties (i.e. `obj.x`)
+    """
+    __spy_storage_category__ = 'reference'
+
+    def __init__(self, name: str, field: str, w_type: W_Type) -> None:
+        self.name = name
+        self.field = field
+        self.w_type = w_type
+
+    def __repr__(self) -> str:
+        n = self.name
+        f = self.field
+        T = self.w_type.fqn.human_name
+        return f"<spy member '{n}: {T}'>"
+
+    @builtin_method('__get__', color='blue', kind='metafunc')
+    @staticmethod
+    def w_GET(
+        vm: 'SPyVM', wop_self: 'W_OpArg', wop_obj: 'W_OpArg'
+    ) -> 'W_OpSpec':
+        from spy.vm.opspec import W_OpSpec
+        w_self = wop_self.w_blueval
+        assert isinstance(w_self, W_Member)
+        w_T = wop_obj.w_static_type
+        field = w_self.field # the interp-level name of the attr (e.g, 'w_x')
+        T = Annotated[W_Object, w_T]           # type of the object
+        V = Annotated[W_Object, w_self.w_type] # type of the attribute
+
+        @builtin_func(w_T.fqn, f"__get_{w_self.name}__")
+        def w_get(vm: 'SPyVM', w_obj: T) -> V:
+            return getattr(w_obj, field)
+
+        return W_OpSpec(w_get, [wop_obj])
+
+
+    @builtin_method('__set__', color='blue', kind='metafunc')
+    @staticmethod
+    def w_set(
+        vm: 'SPyVM', wop_self: 'W_OpArg', wop_obj: 'W_OpArg', wop_v: 'W_OpArg'
+    ) -> 'W_OpSpec':
+        from spy.vm.opspec import W_OpSpec
+        from spy.vm.builtin import builtin_func
+        w_self = wop_self.w_blueval
+        assert isinstance(w_self, W_Member)
+        w_T = wop_obj.w_static_type
+        field = w_self.field # the interp-level name of the attr (e.g, 'w_x')
+        T = Annotated[W_Object, w_T]           # type of the object
+        V = Annotated[W_Object, w_self.w_type] # type of the attribute
+
+        @builtin_func(w_T.fqn, f"__set_{w_self.name}__")
+        def w_set(vm: 'SPyVM', w_obj: T, w_val: V)-> None:
+            setattr(w_obj, field, w_val)
+
+        return W_OpSpec(w_set, [wop_obj, wop_v])

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -32,16 +32,6 @@ def w_GETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg) -> W_OpImpl:
         errmsg = "type `{0}` has no attribute '%s'" % attr
     )
 
-DESCR = Literal['__get__', '__set__']
-def lookup_descriptor(vm: 'SPyVM', w_type: W_Type,
-                      attr: str, what: DESCR) -> Optional[W_Func]:
-    w_member = w_type.lookup(attr)
-    if not w_member:
-        return None
-
-    w_member_type = vm.dynamic_type(w_member)
-    return w_member_type.lookup_func('__get__')
-
 def _get_GETATTR_opspec(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
                         attr: str) -> W_OpSpec:
 

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -34,8 +34,8 @@ def w_GETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg) -> W_OpImpl:
 
 def _get_GETATTR_opspec(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
                         attr: str) -> W_OpSpec:
-
     w_type = wop_obj.w_static_type
+
     if w_type is B.w_dynamic:
         return W_OpSpec(OP.w_dynamic_getattr)
 
@@ -50,6 +50,7 @@ def _get_GETATTR_opspec(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
 
     elif w_getattr := w_type.lookup_func(f'__getattr__'):
         return vm.fast_metacall(w_getattr, [wop_obj, wop_attr])
+
     return W_OpSpec.NULL
 
 
@@ -71,13 +72,10 @@ def w_SETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
 def _get_SETATTR_opspec(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
                         wop_v: W_OpArg, attr: str) -> W_OpSpec:
     w_type = wop_obj.w_static_type
+
     if w_type is B.w_dynamic:
         return W_OpSpec(OP.w_dynamic_setattr)
 
-    # XXX: this logic is not fully sound: what happens if we find a member
-    # which has a __get__ but not a __set__? I think we should raise an error,
-    # but the current logic falls back to __setattr__
-    #
     # try to find a descriptor with a __set__ method
     elif w_member := w_type.lookup(attr):
         w_member_type = vm.dynamic_type(w_member)
@@ -89,4 +87,5 @@ def _get_SETATTR_opspec(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
 
     elif w_setattr := w_type.lookup_func('__setattr__'):
         return vm.fast_metacall(w_setattr, [wop_obj, wop_attr, wop_v])
+
     return W_OpSpec.NULL

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -4,7 +4,7 @@ from spy.location import Loc
 from spy.errors import SPyError
 from spy.fqn import FQN
 from spy.vm.primitive import W_I32, W_Dynamic, W_Bool
-from spy.vm.object import Member
+from spy.vm.member import Member
 from spy.vm.b import B
 from spy.vm.builtin import builtin_method
 from spy.vm.w import W_Object, W_Type, W_Str, W_Func

--- a/spy/vm/opspec.py
+++ b/spy/vm/opspec.py
@@ -33,7 +33,8 @@ from spy.location import Loc
 from spy.analyze.symtable import Symbol, Color
 from spy.errors import SPyError
 from spy.vm.b import OPERATOR, B
-from spy.vm.object import Member, W_Type, W_Object
+from spy.vm.object import W_Type, W_Object
+from spy.vm.member import Member
 from spy.vm.function import W_Func, W_FuncType
 from spy.vm.builtin import (builtin_func, builtin_method, builtin_property,
                             builtin_class_attr)

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -19,6 +19,7 @@ from spy.vm.exc import W_Exception, W_TypeError
 from spy.vm.function import W_FuncType, W_Func, W_ASTFunc, W_BuiltinFunc
 from spy.vm.opimpl import W_OpImpl
 from spy.vm.property import W_Property
+from spy.vm.member import W_Member
 from spy.vm.module import W_Module
 from spy.vm.opspec import W_OpSpec, W_OpArg, w_oparg_eq
 from spy.vm.registry import ModuleRegistry
@@ -39,6 +40,7 @@ W_Type._w.define(W_Type)
 W_OpSpec._w.define(W_OpSpec)
 W_OpArg._w.define(W_OpArg)
 W_Property._w.define(W_Property)
+W_Member._w.define(W_Member)
 W_FuncType._w.define(W_FuncType)
 W_I32._w.define(W_I32)
 W_F64._w.define(W_F64)


### PR DESCRIPTION
- Implement the `__set__` part of the descriptor protocol
- Kill `spy_members`, use normal descriptors instead
- while we were at it, kill `W_PtrType.__GETATTR__` and use a property for `NULL` instead