### PR TITLE
Refactor getattribute

### DIFF
--- a/spy/libspy/include/spy/jsffi.h
+++ b/spy/libspy/include/spy/jsffi.h
@@ -55,7 +55,7 @@ static inline JsRef spy_jsffi$js_call_method_1(
     return jsffi_call_method_1(target, name->utf8, arg0);
 }
 
-static inline JsRef spy_jsffi$JsRef$__getattr__(JsRef target, spy_Str *name) {
+static inline JsRef spy_jsffi$JsRef$__getattribute__(JsRef target, spy_Str *name) {
     return jsffi_getattr(target, name->utf8);
 }
 

--- a/spy/tests/compiler/operator/test_attrop.py
+++ b/spy/tests/compiler/operator/test_attrop.py
@@ -259,8 +259,8 @@ class TestAttrOp(CompilerTest):
             @builtin_method('__getattribute__', color='blue', kind='metafunc')
             @staticmethod
             def w_GETATTRIBUTE(vm: 'SPyVM', wop_obj: W_OpArg,
-                               wop_attr: W_OpArg) -> W_OpSpec:
-                attr = wop_attr.blue_unwrap_str(vm)
+                               wop_name: W_OpArg) -> W_OpSpec:
+                attr = wop_name.blue_unwrap_str(vm)
                 if attr == 'x':
                     @builtin_func('ext', 'getx')
                     def w_fn(vm: 'SPyVM', w_obj: W_MyClass,
@@ -276,9 +276,9 @@ class TestAttrOp(CompilerTest):
 
             @builtin_method('__setattr__', color='blue', kind='metafunc')
             @staticmethod
-            def w_SETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
+            def w_SETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_name: W_OpArg,
                           wop_v: W_OpArg) -> W_OpSpec:
-                attr = wop_attr.blue_unwrap_str(vm)
+                attr = wop_name.blue_unwrap_str(vm)
                 if attr == 'x':
                     @builtin_func('ext')
                     def w_setx(vm: 'SPyVM', w_obj: W_MyClass,

--- a/spy/tests/compiler/operator/test_attrop.py
+++ b/spy/tests/compiler/operator/test_attrop.py
@@ -256,10 +256,10 @@ class TestAttrOp(CompilerTest):
             def w_new(vm: 'SPyVM') -> 'W_MyClass':
                 return W_MyClass()
 
-            @builtin_method('__getattr__', color='blue', kind='metafunc')
+            @builtin_method('__getattribute__', color='blue', kind='metafunc')
             @staticmethod
-            def w_GETATTR(vm: 'SPyVM', wop_obj: W_OpArg,
-                          wop_attr: W_OpArg) -> W_OpSpec:
+            def w_GETATTRIBUTE(vm: 'SPyVM', wop_obj: W_OpArg,
+                               wop_attr: W_OpArg) -> W_OpSpec:
                 attr = wop_attr.blue_unwrap_str(vm)
                 if attr == 'x':
                     @builtin_func('ext', 'getx')

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -353,14 +353,14 @@ class AbstractFrame:
 
     def exec_stmt_SetAttr(self, node: ast.SetAttr) -> None:
         wop_obj = self.eval_expr(node.target)
-        wop_attr = self.eval_expr(node.attr)
+        wop_name = self.eval_expr(node.attr)
         wop_value = self.eval_expr(node.value)
         w_opimpl = self.vm.call_OP(
             node.loc,
             OP.w_SETATTR,
-            [wop_obj, wop_attr, wop_value]
+            [wop_obj, wop_name, wop_value]
         )
-        self.eval_opimpl(node, w_opimpl, [wop_obj, wop_attr, wop_value])
+        self.eval_opimpl(node, w_opimpl, [wop_obj, wop_name, wop_value])
 
     def exec_stmt_SetItem(self, node: ast.SetItem) -> None:
         wop_obj = self.eval_expr(node.target)
@@ -562,9 +562,9 @@ class AbstractFrame:
 
     def eval_expr_GetAttr(self, op: ast.GetAttr) -> W_OpArg:
         wop_obj = self.eval_expr(op.value)
-        wop_attr = self.eval_expr(op.attr)
-        w_opimpl = self.vm.call_OP(op.loc, OP.w_GETATTR, [wop_obj, wop_attr])
-        return self.eval_opimpl(op, w_opimpl, [wop_obj, wop_attr])
+        wop_name = self.eval_expr(op.attr)
+        w_opimpl = self.vm.call_OP(op.loc, OP.w_GETATTR, [wop_obj, wop_name])
+        return self.eval_opimpl(op, w_opimpl, [wop_obj, wop_name])
 
     def eval_expr_List(self, op: ast.List) -> W_Object:
         items_wop = []

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -38,9 +38,10 @@ class W_Module(W_Object):
 
     # ==== applevel interface =====
 
-    @builtin_method('__getattr__')
+    @builtin_method('__getattribute__')
     @staticmethod
-    def w_getattr(vm: 'SPyVM', w_mod: 'W_Module', w_attr: W_Str) -> W_Dynamic:
+    def w_getattribute(vm: 'SPyVM', w_mod: 'W_Module',
+                       w_attr: W_Str) -> W_Dynamic:
         attr = vm.unwrap_str(w_attr)
         return w_mod.getattr(attr)
 

--- a/spy/vm/modules/jsffi.py
+++ b/spy/vm/modules/jsffi.py
@@ -14,9 +14,9 @@ JSFFI = ModuleRegistry('jsffi')
 @JSFFI.builtin_type('JsRef')
 class W_JsRef(W_Object):
 
-    @builtin_method('__getattr__')
+    @builtin_method('__getattribute__')
     @staticmethod
-    def w_getattr(vm: 'SPyVM', w_self: 'W_JsRef', name: W_Str) -> 'W_JsRef':
+    def w_getattribute(vm: 'SPyVM', w_self: 'W_JsRef', name: W_Str) -> 'W_JsRef':
         raise NotImplementedError
 
     @builtin_method('__setattr__')

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -39,6 +39,10 @@ def _get_GETATTR_opspec(vm: 'SPyVM', wop_obj: W_OpArg, wop_name: W_OpArg,
     if w_T is B.w_dynamic:
         return W_OpSpec(OP.w_dynamic_getattr)
 
+    if w_getattribute := w_T.lookup_func(f'__getattribute__'):
+        return vm.fast_metacall(w_getattribute, [wop_obj, wop_name])
+
+
     # this is more or less the equivalent to object.__getattribute__, with a
     # big difference: in Python, obj.__dict__ has precedence over
     # type(obj).__dict__. In SPy, it's the opposite, because we want to be
@@ -56,9 +60,6 @@ def _get_GETATTR_opspec(vm: 'SPyVM', wop_obj: W_OpArg, wop_name: W_OpArg,
             return vm.fast_metacall(w_get, [wop_member, wop_obj])
         else:
             return W_OpSpec.const(w_val)
-
-    elif w_getattribute := w_T.lookup_func(f'__getattribute__'):
-        return vm.fast_metacall(w_getattribute, [wop_obj, wop_name])
 
     return W_OpSpec.NULL
 

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -57,8 +57,8 @@ def _get_GETATTR_opspec(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
         else:
             return W_OpSpec.const(w_val)
 
-    elif w_getattr := w_T.lookup_func(f'__getattr__'):
-        return vm.fast_metacall(w_getattr, [wop_obj, wop_attr])
+    elif w_getattribute := w_T.lookup_func(f'__getattribute__'):
+        return vm.fast_metacall(w_getattribute, [wop_obj, wop_attr])
 
     return W_OpSpec.NULL
 

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -13,27 +13,27 @@ if TYPE_CHECKING:
 
 OpKind = Literal['get', 'set']
 
-def unwrap_attr_maybe(vm: 'SPyVM', wop_attr: W_OpArg) -> str:
-    if wop_attr.is_blue() and wop_attr.w_static_type is B.w_str:
-        return vm.unwrap_str(wop_attr.w_blueval)
+def unwrap_name_maybe(vm: 'SPyVM', wop_name: W_OpArg) -> str:
+    if wop_name.is_blue() and wop_name.w_static_type is B.w_str:
+        return vm.unwrap_str(wop_name.w_blueval)
     else:
         return '<unknown>'
 
 @OP.builtin_func(color='blue')
-def w_GETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg) -> W_OpImpl:
+def w_GETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_name: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
-    attr = unwrap_attr_maybe(vm, wop_attr)
-    w_opspec = _get_GETATTR_opspec(vm, wop_obj, wop_attr, attr)
+    name = unwrap_name_maybe(vm, wop_name)
+    w_opspec = _get_GETATTR_opspec(vm, wop_obj, wop_name, name)
     return typecheck_opspec(
         vm,
         w_opspec,
-        [wop_obj, wop_attr],
+        [wop_obj, wop_name],
         dispatch = 'single',
-        errmsg = "type `{0}` has no attribute '%s'" % attr
+        errmsg = "type `{0}` has no attribute '%s'" % name
     )
 
-def _get_GETATTR_opspec(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
-                        attr: str) -> W_OpSpec:
+def _get_GETATTR_opspec(vm: 'SPyVM', wop_obj: W_OpArg, wop_name: W_OpArg,
+                        name: str) -> W_OpSpec:
     w_T = wop_obj.w_static_type
 
     if w_T is B.w_dynamic:
@@ -47,7 +47,7 @@ def _get_GETATTR_opspec(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
     #
     # The nice result is that the logic is much simpler now, because we don't
     # have to worry about data/non-data descriptors.
-    elif w_val := w_T.lookup(attr):
+    elif w_val := w_T.lookup(name):
         w_val_type = vm.dynamic_type(w_val)
         w_get = w_val_type.lookup_func('__get__')
         if w_get:
@@ -58,35 +58,35 @@ def _get_GETATTR_opspec(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
             return W_OpSpec.const(w_val)
 
     elif w_getattribute := w_T.lookup_func(f'__getattribute__'):
-        return vm.fast_metacall(w_getattribute, [wop_obj, wop_attr])
+        return vm.fast_metacall(w_getattribute, [wop_obj, wop_name])
 
     return W_OpSpec.NULL
 
 
 @OP.builtin_func(color='blue')
-def w_SETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
+def w_SETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_name: W_OpArg,
             wop_v: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
-    attr = unwrap_attr_maybe(vm, wop_attr)
-    w_opspec = _get_SETATTR_opspec(vm, wop_obj, wop_attr, wop_v, attr)
-    errmsg = "type `{0}` does not support assignment to attribute '%s'" % attr
+    name = unwrap_name_maybe(vm, wop_name)
+    w_opspec = _get_SETATTR_opspec(vm, wop_obj, wop_name, wop_v, name)
+    errmsg = "type `{0}` does not support assignment to attribute '%s'" % name
     return typecheck_opspec(
         vm,
         w_opspec,
-        [wop_obj, wop_attr, wop_v],
+        [wop_obj, wop_name, wop_v],
         dispatch = 'single',
         errmsg = errmsg
     )
 
-def _get_SETATTR_opspec(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
-                        wop_v: W_OpArg, attr: str) -> W_OpSpec:
+def _get_SETATTR_opspec(vm: 'SPyVM', wop_obj: W_OpArg, wop_name: W_OpArg,
+                        wop_v: W_OpArg, name: str) -> W_OpSpec:
     w_type = wop_obj.w_static_type
 
     if w_type is B.w_dynamic:
         return W_OpSpec(OP.w_dynamic_setattr)
 
     # try to find a descriptor with a __set__ method
-    elif w_member := w_type.lookup(attr):
+    elif w_member := w_type.lookup(name):
         w_member_type = vm.dynamic_type(w_member)
         w_set = w_member_type.lookup_func('__set__')
         if w_set:
@@ -95,6 +95,6 @@ def _get_SETATTR_opspec(vm: 'SPyVM', wop_obj: W_OpArg, wop_attr: W_OpArg,
             return vm.fast_metacall(w_set, [wop_member, wop_obj, wop_v])
 
     elif w_setattr := w_type.lookup_func('__setattr__'):
-        return vm.fast_metacall(w_setattr, [wop_obj, wop_attr, wop_v])
+        return vm.fast_metacall(w_setattr, [wop_obj, wop_name, wop_v])
 
     return W_OpSpec.NULL

--- a/spy/vm/modules/operator/opimpl_dynamic.py
+++ b/spy/vm/modules/operator/opimpl_dynamic.py
@@ -49,21 +49,21 @@ def w_dynamic_ge(vm: 'SPyVM', w_a: W_Dynamic, w_b: W_Dynamic) -> W_Dynamic:
     return _dynamic_op(vm, OP.w_GE, w_a, w_b)
 
 @OP.builtin_func
-def w_dynamic_setattr(vm: 'SPyVM', w_obj: W_Dynamic, w_attr: W_Str,
+def w_dynamic_setattr(vm: 'SPyVM', w_obj: W_Dynamic, w_name: W_Str,
                     w_value: W_Dynamic) -> W_Dynamic:
     wop_obj = W_OpArg.from_w_obj(vm, w_obj)
-    wop_attr = W_OpArg.from_w_obj(vm, w_attr)
+    wop_name = W_OpArg.from_w_obj(vm, w_name)
     wop_v = W_OpArg.from_w_obj(vm, w_value)
-    w_opimpl = vm.call_OP(None, OP.w_SETATTR, [wop_obj, wop_attr, wop_v])
-    return w_opimpl.execute(vm, [w_obj, w_attr, w_value])
+    w_opimpl = vm.call_OP(None, OP.w_SETATTR, [wop_obj, wop_name, wop_v])
+    return w_opimpl.execute(vm, [w_obj, w_name, w_value])
 
 @OP.builtin_func
 def w_dynamic_getattr(vm: 'SPyVM', w_obj: W_Dynamic,
-                      w_attr: W_Str) -> W_Dynamic:
+                      w_name: W_Str) -> W_Dynamic:
     wop_obj = W_OpArg.from_w_obj(vm, w_obj)
-    wop_attr = W_OpArg.from_w_obj(vm, w_attr)
-    w_opimpl = vm.call_OP(None, OP.w_GETATTR, [wop_obj, wop_attr])
-    return w_opimpl.execute(vm, [w_obj, w_attr])
+    wop_name = W_OpArg.from_w_obj(vm, w_name)
+    w_opimpl = vm.call_OP(None, OP.w_GETATTR, [wop_obj, wop_name])
+    return w_opimpl.execute(vm, [w_obj, w_name])
 
 @OP.builtin_func
 def w_dynamic_call(vm: 'SPyVM', w_obj: W_Dynamic,

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -276,10 +276,10 @@ class W_Ptr(W_BasePtr):
         vm.add_global(w_ptr_to_bool.fqn, w_ptr_to_bool)
         return W_OpSpec(w_ptr_to_bool)
 
-    @builtin_method('__getattr__', color='blue', kind='metafunc')
+    @builtin_method('__getattribute__', color='blue', kind='metafunc')
     @staticmethod
-    def w_GETATTR(vm: 'SPyVM', wop_ptr: W_OpArg,
-                  wop_attr: W_OpArg) -> W_OpSpec:
+    def w_GETATTRIBUTE(vm: 'SPyVM', wop_ptr: W_OpArg,
+                       wop_attr: W_OpArg) -> W_OpSpec:
         return W_Ptr.op_ATTR('get', vm, wop_ptr, wop_attr, None)
 
     @builtin_method('__setattr__', color='blue', kind='metafunc')
@@ -292,7 +292,7 @@ class W_Ptr(W_BasePtr):
     def op_ATTR(opkind: str, vm: 'SPyVM', wop_ptr: W_OpArg, wop_attr: W_OpArg,
                 wop_v: Optional[W_OpArg]) -> W_OpSpec:
         """
-        Implement both w_GETATTR and w_SETATTR.
+        Implement both w_GETATTRIBUTE and w_SETATTR.
         """
         from .struct import W_StructType
         w_ptrtype = W_Ptr._get_ptrtype(wop_ptr)

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -279,17 +279,17 @@ class W_Ptr(W_BasePtr):
     @builtin_method('__getattribute__', color='blue', kind='metafunc')
     @staticmethod
     def w_GETATTRIBUTE(vm: 'SPyVM', wop_ptr: W_OpArg,
-                       wop_attr: W_OpArg) -> W_OpSpec:
-        return W_Ptr.op_ATTR('get', vm, wop_ptr, wop_attr, None)
+                       wop_name: W_OpArg) -> W_OpSpec:
+        return W_Ptr.op_ATTR('get', vm, wop_ptr, wop_name, None)
 
     @builtin_method('__setattr__', color='blue', kind='metafunc')
     @staticmethod
-    def w_SETATTR(vm: 'SPyVM', wop_ptr: W_OpArg, wop_attr: W_OpArg,
+    def w_SETATTR(vm: 'SPyVM', wop_ptr: W_OpArg, wop_name: W_OpArg,
                   wop_v: W_OpArg) -> W_OpSpec:
-        return W_Ptr.op_ATTR('set', vm, wop_ptr, wop_attr, wop_v)
+        return W_Ptr.op_ATTR('set', vm, wop_ptr, wop_name, wop_v)
 
     @staticmethod
-    def op_ATTR(opkind: str, vm: 'SPyVM', wop_ptr: W_OpArg, wop_attr: W_OpArg,
+    def op_ATTR(opkind: str, vm: 'SPyVM', wop_ptr: W_OpArg, wop_name: W_OpArg,
                 wop_v: Optional[W_OpArg]) -> W_OpSpec:
         """
         Implement both w_GETATTRIBUTE and w_SETATTR.
@@ -302,26 +302,26 @@ class W_Ptr(W_BasePtr):
             return W_OpSpec.NULL
 
         assert isinstance(w_T, W_StructType)
-        attr = wop_attr.blue_unwrap_str(vm)
-        if attr not in w_T.fields:
+        name = wop_name.blue_unwrap_str(vm)
+        if name not in w_T.fields:
             return W_OpSpec.NULL
 
-        w_field_T = w_T.fields[attr]
-        offset = w_T.offsets[attr]
+        w_field_T = w_T.fields[name]
+        offset = w_T.offsets[name]
         wop_offset = W_OpArg.from_w_obj(vm, vm.wrap(offset))
 
         if opkind == 'get':
-            # getfield[field_T](ptr, attr, offset)
+            # getfield[field_T](ptr, name, offset)
             assert wop_v is None
             w_func = vm.fast_call(UNSAFE.w_getfield, [w_field_T])
             assert isinstance(w_func, W_Func)
-            return W_OpSpec(w_func, [wop_ptr, wop_attr, wop_offset])
+            return W_OpSpec(w_func, [wop_ptr, wop_name, wop_offset])
         else:
-            # setfield[field_T](ptr, attr, offset, v)
+            # setfield[field_T](ptr, name, offset, v)
             assert wop_v is not None
             w_func = vm.fast_call(UNSAFE.w_setfield, [w_field_T])
             assert isinstance(w_func, W_Func)
-            return W_OpSpec(w_func, [wop_ptr, wop_attr, wop_offset, wop_v])
+            return W_OpSpec(w_func, [wop_ptr, wop_name, wop_offset, wop_v])
 
 
 
@@ -342,10 +342,10 @@ def w_getfield(vm: 'SPyVM', w_T: W_Type) -> W_Dynamic:
     # unsafe::getfield_byval[i32]
     # unsafe::getfield_byref[ptr[Point]]
     @builtin_func('unsafe', f'getfield_{by}', [w_T.fqn])
-    def w_getfield_T(vm: 'SPyVM', w_ptr: W_Ptr, w_attr: W_Str,
+    def w_getfield_T(vm: 'SPyVM', w_ptr: W_Ptr, w_name: W_Str,
                      w_offset: W_I32) -> T:
         """
-        NOTE: w_attr is ignored here, but it's used by the C backend
+        NOTE: w_name is ignored here, but it's used by the C backend
         """
         addr = w_ptr.addr + vm.unwrap_i32(w_offset)
         if by == 'byref':
@@ -365,10 +365,10 @@ def w_setfield(vm: 'SPyVM', w_T: W_Type) -> W_Dynamic:
     T = Annotated[W_Object, w_T]
 
     @builtin_func('unsafe', 'setfield', [w_T.fqn])  # unsafe::setfield[i32]
-    def w_setfield_T(vm: 'SPyVM', w_ptr: W_Ptr, w_attr: W_Str,
+    def w_setfield_T(vm: 'SPyVM', w_ptr: W_Ptr, w_name: W_Str,
                      w_offset: W_I32, w_val: T) -> None:
         """
-        NOTE: w_attr is ignored here, but it's used by the C backend
+        NOTE: w_name is ignored here, but it's used by the C backend
         """
         addr = w_ptr.addr + vm.unwrap_i32(w_offset)
         vm.call_generic(

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -158,7 +158,7 @@ class W_Object:
     #     a.b   ==> operator.getattr(a, "b")
     #
     # Types can implement each operator by implementing __special__ methods
-    # such as `__add__` or `__getattr__`.
+    # such as `__add__` or `__getattribute__`.
     #
     # __special__ methods can be defined as normal functions and executed as
     # expected.
@@ -177,7 +177,7 @@ class W_Object:
     # For example, consider the following expression:
     #     return obj.a
     #
-    # If __getattr__ is a metafunction, this is more or less what happens:
+    # If __getattribute__ is a metafunction, this is more or less what happens:
     #
     #     T = STATIC_TYPE(obj)
     #     v_obj = OpArg('red', T, ...)
@@ -199,15 +199,15 @@ class W_Object:
     #     def w_getitem(vm: 'SPyVM', w_self: 'W_MyClass', w_i: W_I32) -> W_I32:
     #         ...
     #
-    #     # implement __getattr__ as a metafunc
-    #     @builtin_method('__getattr__', color='blue', kind='metafunc')
-    #     def w_GETATTR(vm: 'SPyVM', wop_self: W_OpArg,
-    #                   wop_attr: W_OpArg) -> W_OpSpec:
+    #     # implement __getattribute__ as a metafunc
+    #     @builtin_method('__getattribute__', color='blue', kind='metafunc')
+    #     def w_GETATTRIBUTE(vm: 'SPyVM', wop_self: W_OpArg,
+    #                        wop_attr: W_OpArg) -> W_OpSpec:
     #         ...
     #
     # The naming convention at interp-level is the following:
-    #   - for normal functions, we use w_getitem, w_getattr, etc.
-    #   - for meta functions, we use w_GETITEM, w_GETATTR, etc.
+    #   - for normal functions, we use w_getitem, w_getattribute, etc.
+    #   - for meta functions, we use w_GETITEM, w_GETATTRIBUTE, etc.
     #
     # The following declarations are not strictly needed, but they are
     # provided so that in case a subclass decides to override them, mypy can
@@ -222,8 +222,8 @@ class W_Object:
         raise NotImplementedError('this should never be called')
 
     @staticmethod
-    def w_GETATTR(vm: 'SPyVM', wop_obj: 'W_OpArg',
-                  wop_attr: 'W_OpArg') -> 'W_OpSpec':
+    def w_GETATTRIBUTE(vm: 'SPyVM', wop_obj: 'W_OpArg',
+                       wop_attr: 'W_OpArg') -> 'W_OpSpec':
         raise NotImplementedError('this should never be called')
 
     @staticmethod
@@ -443,7 +443,6 @@ class W_Type(W_Object):
     def is_struct(self, vm: 'SPyVM') -> bool:
         return False
 
-
     def get_mro(self) -> Sequence['W_Type']:
         """
         Return a list of all the supertypes.
@@ -490,10 +489,10 @@ class W_Type(W_Object):
 
     # ======== app-level interface ========
 
-    @builtin_method('__getattr__', color='blue', kind='metafunc')
+    @builtin_method('__getattribute__', color='blue', kind='metafunc')
     @staticmethod
-    def w_GETATTR(vm: 'SPyVM', wop_self: 'W_OpArg',
-                  wop_attr: 'W_OpArg') -> 'W_OpSpec':
+    def w_GETATTRIBUTE(vm: 'SPyVM', wop_self: 'W_OpArg',
+                       wop_attr: 'W_OpArg') -> 'W_OpSpec':
         # type instances have a dict, so they can have arbitrary
         # attributes. If we are doing a getattr on a blue instance, we can
         # check whether the attribute exists, and return it in that case.

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -448,7 +448,7 @@ class W_Type(W_Object):
         Return a list of all the supertypes.
         """
         mro = []
-        w_T = self
+        w_T: Union['W_Type', 'W_NoneType'] = self
         while w_T is not B.w_None:
             assert isinstance(w_T, W_Type)
             mro.append(w_T)


### PR DESCRIPTION
Refactor things to follow CPython's conventions and logic more closely w.r.t. attribute lookup.
This makes it easier to follow SPy's rules, and to understand the differences.

- rename `__getattr__` into `__getattribute__` (the "proper" `__getattr__` is not supported yet)
- rename parameter `attr` into `name` (as in CPython)
- put SPy's default logic into `default_getattribute`: this mimics `PyObject_GenericGetAttr`, but it contains a long comment which explains what are the SPy-specific rules, and the rationale
- implement a much more complete `type.__getattribute__`, which follows closely CPython's equivalent `typeobject.c:type_getattro`.

