### PR TITLE
Implement W_Module.__call_method__

### DIFF
--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -1119,8 +1119,7 @@ class TestBasic(CompilerTest):
         assert mod.test1() == 10
         assert mod.test2() == 'hello world'
 
-    @pytest.mark.skip(reason='implement me')
-    def test_getattr_call(self):
+    def test_call_module_attr(self):
         mod = self.compile("""
         import math
 

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -1118,3 +1118,13 @@ class TestBasic(CompilerTest):
         """)
         assert mod.test1() == 10
         assert mod.test2() == 'hello world'
+
+    @pytest.mark.skip(reason='implement me')
+    def test_getattr_call(self):
+        mod = self.compile("""
+        import math
+
+        def foo(x: f64) -> f64:
+            return math.fabs(x)
+        """)
+        assert mod.foo(-3.5) == 3.5

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -63,6 +63,7 @@ class W_Module(W_Object):
             raise WIP('__call_method__ on red modules')
 
         w_mod = wop_mod.w_blueval
+        assert isinstance(w_mod, W_Module)
         name = wop_name.blue_unwrap_str(vm)
         w_func = w_mod.getattr_maybe(name)
         if w_func is None:

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -98,12 +98,12 @@ class W_Module(W_Object):
 
     def keys(self) -> Iterable[FQN]:
         for fqn in self.vm.globals_w.keys():
-            if fqn.modname == self.name:
+            if fqn.modname == self.name and len(fqn.parts) > 1:
                 yield fqn
 
     def items_w(self) -> Iterable[ModItem]:
         for fqn, w_obj in self.vm.globals_w.items():
-            if fqn.modname == self.name:
+            if fqn.modname == self.name and len(fqn.parts) > 1:
                 yield fqn, w_obj
 
     def pp(self) -> None:

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -70,6 +70,7 @@ def w_CALL_METHOD(vm: 'SPyVM', wop_obj: W_OpArg, wop_method: W_OpArg,
     # else, the default implementation is to look into the type dict
     # XXX: is it correct here to assume that we get a blue string?
     meth = wop_method.blue_unwrap_str(vm)
+
     if w_func := w_type.dict_w.get(meth):
         # XXX: this should be turned into a proper exception, but for now we
         # cannot even write a test because we don't any way to inject

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -158,7 +158,9 @@ class SPyVM:
 
     def register_module(self, w_mod: W_Module) -> None:
         assert w_mod.name not in self.modules_w
+        assert w_mod.fqn not in self.globals_w
         self.modules_w[w_mod.name] = w_mod
+        self.globals_w[w_mod.fqn] = w_mod
 
     def make_module(self, reg: ModuleRegistry) -> None:
         w_mod = W_Module(self, reg.fqn.modname, None)


### PR DESCRIPTION
This PR makes it possible to call module-level functions using the dot notation, like this:
```
import math
print(math.fabs(x))
```

until now, the code above failed because Module didn't implement `__call_method__`.

This is a bit of a hack, though. Ideally, we would like a more generic logic like this:
1. if the type implements `__call_method__`, call it
2. else, fallback to the classic getattr()+call()

However, it's a bit tricky to implement (2) with the tools that we have now. In particular, `W_OpSpec` is not powerful enough to represent a combination of two calls.