### PR TITLE
Rename all local variables w_type into w_T 

### DIFF
--- a/spy/backend/c/cmodwriter.py
+++ b/spy/backend/c/cmodwriter.py
@@ -198,7 +198,7 @@ class CModuleWriter:
             self.emit_obj(fqn, w_obj)
 
     def emit_obj(self, fqn: FQN, w_obj: W_Object) -> None:
-        w_type = self.ctx.vm.dynamic_type(w_obj)
+        w_T = self.ctx.vm.dynamic_type(w_obj)
 
         if hasattr(w_obj, 'fqn') and w_obj.fqn != fqn:
             # just a reference to a function/type defined elsewhere, we can
@@ -228,19 +228,19 @@ class CModuleWriter:
         # ==== vars/consts ====
         elif isinstance(w_obj, W_I32):
             intval = self.ctx.vm.unwrap(w_obj)
-            c_type = self.ctx.w2c(w_type)
+            c_type = self.ctx.w2c(w_T)
             self.tbh_globals.wl(f'extern {c_type} {fqn.c_name};')
             self.tbc_globals.wl(f'{c_type} {fqn.c_name} = {intval};')
 
-        elif isinstance(w_type, W_PtrType):
+        elif isinstance(w_T, W_PtrType):
             # for now, we only support NULL constnts
             assert isinstance(w_obj, W_Ptr)
             assert w_obj.addr == 0, 'only NULL pointers can be stored in constants for now'
-            c_type = self.ctx.w2c(w_type)
+            c_type = self.ctx.w2c(w_T)
             self.tbh_globals.wl(f'extern {c_type} {fqn.c_name};')
             self.tbc_globals.wl(f'{c_type} {fqn.c_name} = {{0}};')
 
-        elif isinstance(w_type, W_Type) and w_type.fqn.modname == 'builtins':
+        elif isinstance(w_T, W_Type) and w_T.fqn.modname == 'builtins':
             # this is an ad-hoc hack to support things like this at
             # module-level:
             #    T = i32

--- a/spy/backend/c/context.py
+++ b/spy/backend/c/context.py
@@ -104,7 +104,7 @@ class Context:
         argnames = [arg.name for arg in w_func.funcdef.args]
         c_restype = self.w2c(w_functype.w_restype)
         c_params = [
-            C_FuncParam(name=name, c_type=self.w2c(p.w_type))
+            C_FuncParam(name=name, c_type=self.w2c(p.w_T))
             for name, p in zip(argnames, w_functype.params, strict=True)
         ]
         return C_Function(name, c_params, c_restype)

--- a/spy/backend/c/context.py
+++ b/spy/backend/c/context.py
@@ -82,16 +82,16 @@ class Context:
         self._d[RB.w_RawBuffer] = C_Type('spy_RawBuffer *')
         self._d[JSFFI.w_JsRef] = C_Type('JsRef')
 
-    def w2c(self, w_type: W_Type) -> C_Type:
-        if w_type in self._d:
-            return self._d[w_type]
-        elif isinstance(w_type, W_PtrType):
-            return self.new_ptr_type(w_type)
-        elif isinstance(w_type, W_StructType):
-            return self.new_struct_type(w_type)
-        elif isinstance(w_type, W_LiftedType):
-            return self.new_lifted_type(w_type)
-        raise NotImplementedError(f'Cannot translate type {w_type} to C')
+    def w2c(self, w_T: W_Type) -> C_Type:
+        if w_T in self._d:
+            return self._d[w_T]
+        elif isinstance(w_T, W_PtrType):
+            return self.new_ptr_type(w_T)
+        elif isinstance(w_T, W_StructType):
+            return self.new_struct_type(w_T)
+        elif isinstance(w_T, W_LiftedType):
+            return self.new_lifted_type(w_T)
+        raise NotImplementedError(f'Cannot translate type {w_T} to C')
 
     def c_restype_by_fqn(self, fqn: FQN) -> C_Type:
         w_func = self.vm.lookup_global(fqn)

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -78,8 +78,8 @@ class CFuncWriter:
         """
         assert self.w_func.locals_types_w is not None
         param_names = [arg.name for arg in self.w_func.funcdef.args]
-        for varname, w_type in self.w_func.locals_types_w.items():
-            c_type = self.ctx.w2c(w_type)
+        for varname, w_T in self.w_func.locals_types_w.items():
+            c_type = self.ctx.w2c(w_T)
             if (varname not in ('@return', '@if', '@while') and
                 varname not in param_names):
                 self.tbc.wl(f'{c_type} {varname};')

--- a/spy/backend/interp.py
+++ b/spy/backend/interp.py
@@ -56,7 +56,7 @@ class InterpFuncWrapper:
         # *and to call the func, and unwrap the result
         args_w = []
         for arg, param in zip(args, self.w_functype.params, strict=True):
-            w_T = param.w_type
+            w_T = param.w_T
             if w_T is B.w_i8:
                 arg = fixedint.Int8(arg)
             elif w_T is B.w_u8:

--- a/spy/backend/interp.py
+++ b/spy/backend/interp.py
@@ -56,10 +56,10 @@ class InterpFuncWrapper:
         # *and to call the func, and unwrap the result
         args_w = []
         for arg, param in zip(args, self.w_functype.params, strict=True):
-            w_type = param.w_type
-            if w_type is B.w_i8:
+            w_T = param.w_type
+            if w_T is B.w_i8:
                 arg = fixedint.Int8(arg)
-            elif w_type is B.w_u8:
+            elif w_T is B.w_u8:
                 arg = fixedint.UInt8(arg)
             w_arg = self.vm.wrap(arg)
             args_w.append(w_arg)

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -78,7 +78,7 @@ class SPyBackend:
         params = w_func.w_functype.params
         l = []
         for argname, p in zip(argnames, params, strict=True):
-            t = self.fmt_w_obj(p.w_type)
+            t = self.fmt_w_obj(p.w_T)
             l.append(f'{argname}: {t}')
         return ', '.join(l)
 

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -129,8 +129,8 @@ class SPyBackend:
         sym = symtable.lookup(varname)
         if self.w_func.redshifted and sym.level == 0 and varname not in self.vars_declared:
             assert self.w_func.locals_types_w is not None
-            w_type = self.w_func.locals_types_w[varname]
-            t = self.fmt_w_obj(w_type)
+            w_T = self.w_func.locals_types_w[varname]
+            t = self.fmt_w_obj(w_T)
             self.wl(f'{varname}: {t}')
             self.vars_declared.add(varname)
 

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -32,14 +32,14 @@ def make_const(vm: 'SPyVM', loc: Loc, w_val: W_Object) -> ast.Expr:
     For non primitive types, we assign an unique FQN to the w_val, and we
     return ast.FQNConst.
     """
-    w_type = vm.dynamic_type(w_val)
-    if w_type in (B.w_i32, B.w_f64, B.w_bool, B.w_NoneType):
+    w_T = vm.dynamic_type(w_val)
+    if w_T in (B.w_i32, B.w_f64, B.w_bool, B.w_NoneType):
         # this is a primitive, we can just use ast.Constant
         value = vm.unwrap(w_val)
         if isinstance(value, FixedInt): # type: ignore
             value = int(value)
         return ast.Constant(loc, value)
-    elif w_type is B.w_str:
+    elif w_T is B.w_str:
         value = vm.unwrap_str(w_val)
         return ast.StrConst(loc, value)
 

--- a/spy/interop.py
+++ b/spy/interop.py
@@ -35,8 +35,8 @@ def main(argv: list[str]) -> None:
             print('functype:', w_obj.w_functype)
             print('locals:')
             assert w_obj.locals_types_w is not None
-            for varname, w_type in w_obj.locals_types_w.items():
-                print('   ', varname, w_type)
+            for varname, w_T in w_obj.locals_types_w.items():
+                print('   ', varname, w_T)
             print('AST:')
             w_obj.funcdef.pp()
             print()

--- a/spy/tests/compiler/operator/test_attrop.py
+++ b/spy/tests/compiler/operator/test_attrop.py
@@ -178,7 +178,7 @@ class TestAttrOp(CompilerTest):
                 This exist just to test that we can have a metafunc as a
                 @builtin_property
                 """
-                w_t = wop_self.w_static_type
+                w_t = wop_self.w_static_T
                 assert W_MyClass._w is w_t
                 @builtin_func(w_t.fqn, 'get_y')
                 def w_get_x2(vm: 'SPyVM', w_self: W_MyClass) -> W_I32:

--- a/spy/tests/compiler/operator/test_convop.py
+++ b/spy/tests/compiler/operator/test_convop.py
@@ -28,7 +28,7 @@ class W_MyClass(W_Object):
             wop_target_type: W_OpArg,
             wop_self: W_OpArg
     ) -> W_OpSpec:
-        w_target_type = wop_target_type.w_blueval
+        w_target_T = wop_target_type.w_blueval
 
         @builtin_func('ext')
         def w_to_i32(vm: 'SPyVM', w_self: W_MyClass) -> W_I32:
@@ -39,10 +39,10 @@ class W_MyClass(W_Object):
             x = vm.unwrap_i32(w_self.w_x)
             return vm.wrap(str(x))
 
-        if w_target_type is B.w_i32:
+        if w_target_T is B.w_i32:
             vm.add_global(w_to_i32.fqn, w_to_i32)
             return W_OpSpec(w_to_i32)
-        elif w_target_type is B.w_str:
+        elif w_target_T is B.w_str:
             vm.add_global(w_to_str.fqn, w_to_str)
             return W_OpSpec(w_to_str)
         return W_OpSpec.NULL
@@ -54,7 +54,7 @@ class W_MyClass(W_Object):
             wop_source_type: W_OpArg,
             wop_val: W_OpArg
     ) -> W_OpSpec:
-        w_source_type = wop_source_type.w_blueval
+        w_src_T = wop_source_type.w_blueval
 
         @builtin_func('ext')
         def w_from_str(vm: 'SPyVM', w_val: W_Str) -> W_MyClass:
@@ -62,7 +62,7 @@ class W_MyClass(W_Object):
             w_x = vm.wrap(int(s))
             return W_MyClass(w_x)
 
-        if w_source_type is B.w_str:
+        if w_src_T is B.w_str:
             vm.add_global(w_from_str.fqn, w_from_str)
             return W_OpSpec(w_from_str)
         return W_OpSpec.NULL

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -1051,8 +1051,8 @@ class TestBasic(CompilerTest):
         expected_sig = 'def(test::S, unsafe::ptr[test::S]) -> None'
         assert w_foo.w_functype.fqn.human_name == expected_sig
         params = w_foo.w_functype.params
-        assert params[0].w_type is w_S
-        assert params[1].w_type is w_ptr_S1 is w_ptr_S2
+        assert params[0].w_T is w_S
+        assert params[1].w_T is w_ptr_S1 is w_ptr_S2
 
     @only_interp
     def test_forward_declaration_in_funcdef(self):

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -977,8 +977,8 @@ class TestBasic(CompilerTest):
             x = 42
             return STATIC_TYPE(x)
         """)
-        w_type = mod.foo(unwrap=False)
-        assert w_type is B.w_i32
+        w_T = mod.foo(unwrap=False)
+        assert w_T is B.w_i32
 
     @no_C
     def test_STATIC_TYPE_wrong_argcount(self):
@@ -1084,8 +1084,8 @@ class TestBasic(CompilerTest):
             x = bar()
             return STATIC_TYPE(x)
         """)
-        w_type = mod.foo(unwrap=False)
-        assert w_type is B.w_i32
+        w_T = mod.foo(unwrap=False)
+        assert w_T is B.w_i32
 
     def test_cls_as_param_name(self):
         mod = self.compile("""

--- a/spy/tests/compiler/test_opspec.py
+++ b/spy/tests/compiler/test_opspec.py
@@ -49,7 +49,7 @@ class TestOpSpec(CompilerTest):
         wop = w_opspec._args_wop[0]
         assert isinstance(wop, W_OpArg)
         assert wop.color == 'blue'
-        assert wop.w_static_type is B.w_i32
+        assert wop.w_static_T is B.w_i32
         assert wop.is_blue()
         assert wop._w_val is not None
         assert self.vm.unwrap_i32(wop._w_val) == 42
@@ -72,14 +72,14 @@ class TestOpSpec(CompilerTest):
         w_blue_oparg = mod.create_blue_oparg(42, unwrap=False)
         assert isinstance(w_blue_oparg, W_OpArg)
         assert w_blue_oparg.color == 'blue'
-        assert w_blue_oparg.w_static_type is B.w_i32
+        assert w_blue_oparg.w_static_T is B.w_i32
         assert w_blue_oparg._w_val is not None
 
         # Test red OpArg creation
         w_red_oparg = mod.create_red_oparg(unwrap=False)
         assert isinstance(w_red_oparg, W_OpArg)
         assert w_red_oparg.color == 'red'
-        assert w_red_oparg.w_static_type is B.w_i32
+        assert w_red_oparg.w_static_T is B.w_i32
         assert w_red_oparg._w_val is None
 
     def test_oparg_properties(self):
@@ -122,7 +122,7 @@ class TestOpSpec(CompilerTest):
         """)
         wop_x = mod.foo(unwrap=False)
         assert wop_x.color == 'red'
-        assert wop_x.w_static_type is B.w_i32
+        assert wop_x.w_static_T is B.w_i32
         assert wop_x._w_val is None
 
         errors = expect_errors(

--- a/spy/tests/wasm_wrapper.py
+++ b/spy/tests/wasm_wrapper.py
@@ -95,7 +95,7 @@ class WasmFuncWrapper:
         #
         wasm_args: list[Any] = []
         for py_arg, param in zip(py_args, self.w_functype.params):
-            wasm_arg = self.py2wasm(py_arg, param.w_type)
+            wasm_arg = self.py2wasm(py_arg, param.w_T)
             if type(wasm_arg) is tuple:
                 # special case for multivalue
                 wasm_args += wasm_arg

--- a/spy/tests/wasm_wrapper.py
+++ b/spy/tests/wasm_wrapper.py
@@ -52,12 +52,12 @@ class WasmModuleWrapper:
     def read_global(self, fqn: FQN) -> Any:
         w_val = self.vm.lookup_global(fqn)
         assert w_val is not None
-        w_type = self.vm.dynamic_type(w_val)
+        w_T = self.vm.dynamic_type(w_val)
         t: LLWasmType
-        if w_type is B.w_i32:
+        if w_T is B.w_i32:
             t = 'int32_t'
         else:
-            assert False, f'Unknown type: {w_type}'
+            assert False, f'Unknown type: {w_T}'
 
         return self.ll.read_global(fqn.c_name, deref=t)
 
@@ -75,17 +75,17 @@ class WasmFuncWrapper:
         self.c_name = c_name
         self.w_functype = w_functype
 
-    def py2wasm(self, pyval: Any, w_type: W_Type) -> Any:
-        if w_type in (B.w_i32, B.w_i8, B.w_u8, B.w_f64, B.w_bool):
+    def py2wasm(self, pyval: Any, w_T: W_Type) -> Any:
+        if w_T in (B.w_i32, B.w_i8, B.w_u8, B.w_f64, B.w_bool):
             return pyval
-        elif w_type is B.w_str:
+        elif w_T is B.w_str:
             # XXX: with the GC, we need to think how to keep this alive
             return ll_spy_Str_new(self.ll, pyval)
-        elif isinstance(w_type, W_PtrType):
+        elif isinstance(w_T, W_PtrType):
             assert isinstance(pyval, WasmPtr)
             return (pyval.addr, pyval.length)
         else:
-            assert False, f'Unsupported type: {w_type}'
+            assert False, f'Unsupported type: {w_T}'
 
     def from_py_args(self, py_args: Any) -> Any:
         a = len(py_args)
@@ -103,44 +103,44 @@ class WasmFuncWrapper:
                 wasm_args.append(wasm_arg)
         return wasm_args
 
-    def to_py_result(self, w_type: W_Type, res: Any) -> Any:
-        if w_type is B.w_NoneType:
+    def to_py_result(self, w_T: W_Type, res: Any) -> Any:
+        if w_T is B.w_NoneType:
             assert res is None
             return None
-        elif w_type in (B.w_i8, B.w_i32, B.w_f64, B.w_u8):
+        elif w_T in (B.w_i8, B.w_i32, B.w_f64, B.w_u8):
             return res
-        elif w_type is B.w_bool:
+        elif w_T is B.w_bool:
             return bool(res)
-        elif w_type is B.w_str:
+        elif w_T is B.w_str:
             # res is a  spy_Str*
             addr = res
             length = self.ll.mem.read_i32(addr)
             utf8 = self.ll.mem.read(addr + 4, length)
             return utf8.decode('utf-8')
-        elif w_type is RB.w_RawBuffer:
+        elif w_T is RB.w_RawBuffer:
             # res is a  spy_RawBuffer*
             addr = res
             length = self.ll.mem.read_i32(addr)
             buf = self.ll.mem.read(addr + 4, length)
             return buf
-        elif isinstance(w_type, W_PtrType):
+        elif isinstance(w_T, W_PtrType):
             # this assumes that we compiled libspy with SPY_DEBUG:
             #   - checked ptrs are represented as a struct { addr; length }
             #   - res contains a a list [addr, length] (because of WASM
             #     multivalue)
             addr, length = res
             return WasmPtr(addr, length)
-        elif isinstance(w_type, W_LiftedType):
-            w_hltype = w_type
+        elif isinstance(w_T, W_LiftedType):
+            w_hltype = w_T
             llval = self.to_py_result(w_hltype.w_lltype, res)
             return UnwrappedLiftedObject(w_hltype, llval)
         else:
-            assert False, f"Don't know how to read {w_type} from WASM"
+            assert False, f"Don't know how to read {w_T} from WASM"
 
 
     def __call__(self, *py_args: Any, unwrap: bool = True) -> Any:
         assert unwrap, 'unwrap=False is not supported by the C backend'
         wasm_args = self.from_py_args(py_args)
         res = self.ll.call(self.c_name, *wasm_args)
-        w_type = self.w_functype.w_restype
-        return self.to_py_result(w_type, res)
+        w_T = self.w_functype.w_restype
+        return self.to_py_result(w_T, res)

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -271,7 +271,7 @@ class AbstractFrame:
         else:
             # first assignment, implicit declaration
             wop = self.eval_expr(expr)
-            self.declare_local(varname, wop.w_static_type, target.loc)
+            self.declare_local(varname, wop.w_static_T, target.loc)
 
         if not self.redshifting:
             self.store_local(varname, wop.w_val)
@@ -297,8 +297,8 @@ class AbstractFrame:
 
     def exec_stmt_UnpackAssign(self, unpack: ast.UnpackAssign) -> None:
         wop_tup = self.eval_expr(unpack.value)
-        if wop_tup.w_static_type is not B.w_tuple:
-            t = wop_tup.w_static_type.fqn.human_name
+        if wop_tup.w_static_T is not B.w_tuple:
+            t = wop_tup.w_static_T.fqn.human_name
             err = SPyError(
                 'W_TypeError',
                 f'`{t}` does not support unpacking',
@@ -536,7 +536,7 @@ class AbstractFrame:
         args_wop = [self.eval_expr(arg) for arg in call.args]
         w_opimpl = self.vm.call_OP(call.loc, OP.w_CALL, [wop_func]+args_wop)
         assert len(call.args) == 1
-        w_argtype = args_wop[0].w_static_type
+        w_argtype = args_wop[0].w_static_T
         return W_OpArg.from_w_obj(self.vm, w_argtype)
 
     def eval_expr_CallMethod(self, op: ast.CallMethod) -> W_Object:
@@ -575,8 +575,8 @@ class AbstractFrame:
             items_wop.append(wop_item)
             color = maybe_blue(color, wop_item.color)
             if w_itemtype is None:
-                w_itemtype = wop_item.w_static_type
-            w_itemtype = self.vm.union_type(w_itemtype, wop_item.w_static_type)
+                w_itemtype = wop_item.w_static_T
+            w_itemtype = self.vm.union_type(w_itemtype, wop_item.w_static_T)
         #
         # XXX we need to handle empty lists
         assert w_itemtype is not None

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -100,13 +100,13 @@ class AbstractFrame:
                         varname: Optional[str]) -> Optional[W_Func]:
         if varname is None:
             return None # no typecheck needed
-        w_exp_type = self.locals_types_w[varname]
+        w_exp_T = self.locals_types_w[varname]
         try:
-            w_typeconv = CONVERT_maybe(self.vm, w_exp_type, wop)
+            w_typeconv = CONVERT_maybe(self.vm, w_exp_T, wop)
         except SPyError as err:
             if not err.match(W_TypeError):
                 raise
-            exp = w_exp_type.fqn.human_name
+            exp = w_exp_T.fqn.human_name
             exp_loc = self.symtable.lookup(varname).type_loc
             if varname == '@return':
                 because = ' because of return type'

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -184,7 +184,7 @@ class AbstractFrame:
         for arg in funcdef.args:
             w_param_type = self.eval_expr_type(arg.type)
             param = FuncParam(
-                w_type = w_param_type,
+                w_T = w_param_type,
                 kind = 'simple'
             )
             params.append(param)
@@ -709,7 +709,7 @@ class ASTFrame(AbstractFrame):
         self.declare_local('@while', B.w_bool, Loc.fake())
         self.declare_local('@return', w_ft.w_restype, funcdef.return_type.loc)
         for arg, param in zip(self.funcdef.args, w_ft.params, strict=True):
-            self.declare_local(arg.name, param.w_type, arg.loc)
+            self.declare_local(arg.name, param.w_T, arg.loc)
 
     def init_arguments(self, args_w: Sequence[W_Object]) -> None:
         """
@@ -719,5 +719,5 @@ class ASTFrame(AbstractFrame):
         args = self.funcdef.args
         params = w_ft.params
         for arg, param, w_arg in zip(args, params, args_w, strict=True):
-            assert self.vm.isinstance(w_arg, param.w_type)
+            assert self.vm.isinstance(w_arg, param.w_T)
             self.store_local(arg.name, w_arg)

--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -50,7 +50,7 @@ def to_spy_type(ann: Any, *, allow_None: bool = False) -> W_Type:
 
 def to_spy_FuncParam(p: Any, extra_types: TYPES_DICT) -> FuncParam:
     annotation = extra_types.get(p.annotation, p.annotation)
-    w_type = to_spy_type(annotation)
+    w_T = to_spy_type(annotation)
     kind: FuncParamKind
     if p.kind == p.POSITIONAL_OR_KEYWORD:
         kind = 'simple'
@@ -58,7 +58,7 @@ def to_spy_FuncParam(p: Any, extra_types: TYPES_DICT) -> FuncParam:
         kind = 'varargs'
     else:
         assert False
-    return FuncParam(w_type, kind)
+    return FuncParam(w_T, kind)
 
 
 def functype_from_sig(fn: Callable, color: Color, kind: FuncKind, *,
@@ -154,9 +154,9 @@ def builtin_type(namespace: FQN|str,
 
     def decorator(pyclass: Type[W_Object]) -> Type[W_Object]:
         assert issubclass(pyclass, W_Object)
-        w_type = W_MetaClass.declare(fqn)
+        w_T = W_MetaClass.declare(fqn)
         if not lazy_definition:
-            w_type.define(pyclass)
-        pyclass._w = w_type
+            w_T.define(pyclass)
+        pyclass._w = w_T
         return pyclass
     return decorator

--- a/spy/vm/exc.py
+++ b/spy/vm/exc.py
@@ -77,8 +77,8 @@ class W_Exception(W_Object):
     def w_EQ(vm: 'SPyVM', wop_a: W_OpArg, wop_b: W_OpArg) -> W_OpSpec:
         from spy.vm.opspec import W_OpSpec
 
-        w_atype = wop_a.w_static_type
-        w_btype = wop_b.w_static_type
+        w_atype = wop_a.w_static_T
+        w_btype = wop_b.w_static_T
 
         # If different exception types, return null implementation
         if w_atype is not w_btype:
@@ -97,8 +97,8 @@ class W_Exception(W_Object):
     def w_NE(vm: 'SPyVM', wop_a: W_OpArg, wop_b: W_OpArg) -> W_OpSpec:
         from spy.vm.opspec import W_OpSpec
 
-        w_atype = wop_a.w_static_type
-        w_btype = wop_b.w_static_type
+        w_atype = wop_a.w_static_T
+        w_btype = wop_b.w_static_T
 
         # If different exception types, return null implementation
         if w_atype is not w_btype:

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -64,7 +64,7 @@ class W_FuncType(W_Type):
     def w_EQ(vm: 'SPyVM', wop_l: 'W_OpArg', wop_r: 'W_OpArg') -> 'W_OpSpec':
         from spy.vm.opspec import W_OpSpec
         from spy.vm.modules.builtins import w_functype_eq
-        if wop_l.w_static_type is wop_r.w_static_type:
+        if wop_l.w_static_T is wop_r.w_static_T:
             return W_OpSpec(w_functype_eq)
         else:
             return W_OpSpec.NULL

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -19,7 +19,7 @@ FuncParamKind = Literal['simple', 'varargs']
 
 @dataclass(frozen=True, eq=True)
 class FuncParam:
-    w_type: W_Type
+    w_T: W_Type
     kind: FuncParamKind
 
 
@@ -36,7 +36,7 @@ class W_FuncType(W_Type):
         # build an artificial FQN for the functype.
         # E.g. for 'def(i32, i32) -> bool', the FQN looks like this:
         #    builtins::def[i32, i32, bool]
-        qualifiers = [p.w_type.fqn for p in params] + [w_restype.fqn]
+        qualifiers = [p.w_T.fqn for p in params] + [w_restype.fqn]
         if color == 'red' and kind == 'plain':
             t = 'def'
         elif color == 'blue' and kind == 'plain':

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -93,8 +93,8 @@ class W_FuncType(W_Type):
         for argtype in arglist:
             if argtype == '':
                 continue
-            w_type = parse_type(argtype.strip())
-            params.append(FuncParam(w_type, 'simple'))
+            w_T = parse_type(argtype.strip())
+            params.append(FuncParam(w_T, 'simple'))
         #
         w_restype = parse_type(res)
         if w_restype is B.w_None:

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -19,9 +19,9 @@ class W_ListType(W_Type):
 
     @classmethod
     def from_itemtype(cls, fqn: FQN, w_itemtype: W_Type) -> Self:
-        w_type = cls.from_pyclass(fqn, W_List)
-        w_type.w_itemtype = w_itemtype
-        return w_type
+        w_T = cls.from_pyclass(fqn, W_List)
+        w_T.w_itemtype = w_itemtype
+        return w_T
 
 
 # PREBUILT list types are instantiated the end of the file

--- a/spy/vm/list.py
+++ b/spy/vm/list.py
@@ -104,7 +104,7 @@ class W_List(W_BaseList, Generic[T]):
 
     @staticmethod
     def _get_listtype(wop_list: W_OpArg) -> W_ListType:
-        w_listtype = wop_list.w_static_type
+        w_listtype = wop_list.w_static_T
         if isinstance(w_listtype, W_ListType):
             return w_listtype
         else:
@@ -149,8 +149,8 @@ class W_List(W_BaseList, Generic[T]):
     @staticmethod
     def w_EQ(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpSpec:
         from spy.vm.opspec import W_OpSpec
-        w_ltype = wop_l.w_static_type
-        w_rtype = wop_r.w_static_type
+        w_ltype = wop_l.w_static_T
+        w_rtype = wop_r.w_static_T
         if w_ltype is not w_rtype:
             return W_OpSpec.NULL
         w_listtype = W_List._get_listtype(wop_l)

--- a/spy/vm/member.py
+++ b/spy/vm/member.py
@@ -68,7 +68,7 @@ class W_Member(W_Object):
         from spy.vm.opspec import W_OpSpec
         w_self = wop_self.w_blueval
         assert isinstance(w_self, W_Member)
-        w_T = wop_obj.w_static_type
+        w_T = wop_obj.w_static_T
         field = w_self.field # the interp-level name of the attr (e.g, 'w_x')
         T = Annotated[W_Object, w_T]           # type of the object
         V = Annotated[W_Object, w_self.w_type] # type of the attribute
@@ -89,7 +89,7 @@ class W_Member(W_Object):
         from spy.vm.builtin import builtin_func
         w_self = wop_self.w_blueval
         assert isinstance(w_self, W_Member)
-        w_T = wop_obj.w_static_type
+        w_T = wop_obj.w_static_T
         field = w_self.field # the interp-level name of the attr (e.g, 'w_x')
         T = Annotated[W_Object, w_T]           # type of the object
         V = Annotated[W_Object, w_self.w_type] # type of the attribute

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -48,24 +48,24 @@ def w_min(vm: 'SPyVM', w_x: W_I32, w_y: W_I32) -> W_I32:
 
 @BUILTINS.builtin_func(color='blue', kind='metafunc')
 def w_print(vm: 'SPyVM', wop_obj: W_OpArg) -> W_OpSpec:
-    w_type = wop_obj.w_static_type
-    if w_type is B.w_i32:
+    w_T = wop_obj.w_static_type
+    if w_T is B.w_i32:
         return W_OpSpec(B.w_print_i32)
-    elif w_type is B.w_f64:
+    elif w_T is B.w_f64:
         return W_OpSpec(B.w_print_f64)
-    elif w_type is B.w_bool:
+    elif w_T is B.w_bool:
         return W_OpSpec(B.w_print_bool)
-    elif w_type is B.w_NoneType:
+    elif w_T is B.w_NoneType:
         return W_OpSpec(B.w_print_NoneType)
-    elif w_type is B.w_str:
+    elif w_T is B.w_str:
         return W_OpSpec(B.w_print_str)
-    elif w_type is B.w_dynamic:
+    elif w_T is B.w_dynamic:
         return W_OpSpec(B.w_print_dynamic)
     else:
         # NOTE: this doesn't work in the C backend
         return W_OpSpec(B.w_print_object)
 
-    t = w_type.fqn.human_name
+    t = w_T.fqn.human_name
     raise SPyError.simple(
         'W_TypeError',
         f'cannot call print(`{t}`)',
@@ -104,12 +104,12 @@ def w_print_object(vm: 'SPyVM', w_x: W_Object) -> None:
 
 @BUILTINS.builtin_func(color='blue', kind='metafunc')
 def w_len(vm: 'SPyVM', wop_obj: W_OpArg) -> W_OpSpec:
-    w_type = wop_obj.w_static_type
-    if w_fn := w_type.lookup_func('__len__'):
+    w_T = wop_obj.w_static_type
+    if w_fn := w_T.lookup_func('__len__'):
         w_opspec = vm.fast_metacall(w_fn, [wop_obj])
         return w_opspec
 
-    t = w_type.fqn.human_name
+    t = w_T.fqn.human_name
     raise SPyError.simple(
         'W_TypeError',
         f'cannot call len(`{t}`)',

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -48,7 +48,7 @@ def w_min(vm: 'SPyVM', w_x: W_I32, w_y: W_I32) -> W_I32:
 
 @BUILTINS.builtin_func(color='blue', kind='metafunc')
 def w_print(vm: 'SPyVM', wop_obj: W_OpArg) -> W_OpSpec:
-    w_T = wop_obj.w_static_type
+    w_T = wop_obj.w_static_T
     if w_T is B.w_i32:
         return W_OpSpec(B.w_print_i32)
     elif w_T is B.w_f64:
@@ -104,7 +104,7 @@ def w_print_object(vm: 'SPyVM', w_x: W_Object) -> None:
 
 @BUILTINS.builtin_func(color='blue', kind='metafunc')
 def w_len(vm: 'SPyVM', wop_obj: W_OpArg) -> W_OpSpec:
-    w_T = wop_obj.w_static_type
+    w_T = wop_obj.w_static_T
     if w_fn := w_T.lookup_func('__len__'):
         w_opspec = vm.fast_metacall(w_fn, [wop_obj])
         return w_opspec

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -115,13 +115,13 @@ def w_SETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_name: W_OpArg,
 
 def _get_SETATTR_opspec(vm: 'SPyVM', wop_obj: W_OpArg, wop_name: W_OpArg,
                         wop_v: W_OpArg, name: str) -> W_OpSpec:
-    w_type = wop_obj.w_static_type
+    w_T = wop_obj.w_static_type
 
-    if w_type is B.w_dynamic:
+    if w_T is B.w_dynamic:
         return W_OpSpec(OP.w_dynamic_setattr)
 
     # try to find a descriptor with a __set__ method
-    elif w_member := w_type.lookup(name):
+    elif w_member := w_T.lookup(name):
         w_member_type = vm.dynamic_type(w_member)
         w_set = w_member_type.lookup_func('__set__')
         if w_set:
@@ -129,7 +129,7 @@ def _get_SETATTR_opspec(vm: 'SPyVM', wop_obj: W_OpArg, wop_name: W_OpArg,
             wop_member = W_OpArg.from_w_obj(vm, w_member)
             return vm.fast_metacall(w_set, [wop_member, wop_obj, wop_v])
 
-    elif w_setattr := w_type.lookup_func('__setattr__'):
+    elif w_setattr := w_T.lookup_func('__setattr__'):
         return vm.fast_metacall(w_setattr, [wop_obj, wop_name, wop_v])
 
     return W_OpSpec.NULL

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -122,8 +122,8 @@ def _get_SETATTR_opspec(vm: 'SPyVM', wop_obj: W_OpArg, wop_name: W_OpArg,
 
     # try to find a descriptor with a __set__ method
     elif w_member := w_T.lookup(name):
-        w_member_type = vm.dynamic_type(w_member)
-        w_set = w_member_type.lookup_func('__set__')
+        w_member_T = vm.dynamic_type(w_member)
+        w_set = w_member_T.lookup_func('__set__')
         if w_set:
             # w_member is a descriptor! We can call its __set__
             wop_member = W_OpArg.from_w_obj(vm, w_member)

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 OpKind = Literal['get', 'set']
 
 def unwrap_name_maybe(vm: 'SPyVM', wop_name: W_OpArg) -> str:
-    if wop_name.is_blue() and wop_name.w_static_type is B.w_str:
+    if wop_name.is_blue() and wop_name.w_static_T is B.w_str:
         return vm.unwrap_str(wop_name.w_blueval)
     else:
         return '<unknown>'
@@ -24,7 +24,7 @@ def w_GETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_name: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
     name = unwrap_name_maybe(vm, wop_name)
 
-    w_T = wop_obj.w_static_type
+    w_T = wop_obj.w_static_T
     if w_T is B.w_dynamic:
         w_opspec = W_OpSpec(OP.w_dynamic_getattr)
     elif w_getattribute := w_T.lookup_func(f'__getattribute__'):
@@ -81,7 +81,7 @@ def default_getattribute(
     # Also note that contrarily to Python, in SPy instances don't have a
     # __dict__ by default. (__dict__ support not implemented yet ATM).
 
-    w_T = wop_obj.w_static_type
+    w_T = wop_obj.w_static_T
     if w_attr := w_T.lookup(name):
         if w_get := vm.dynamic_type(w_attr).lookup_func('__get__'):
             # 1. found a descriptor on the type
@@ -115,7 +115,7 @@ def w_SETATTR(vm: 'SPyVM', wop_obj: W_OpArg, wop_name: W_OpArg,
 
 def _get_SETATTR_opspec(vm: 'SPyVM', wop_obj: W_OpArg, wop_name: W_OpArg,
                         wop_v: W_OpArg, name: str) -> W_OpSpec:
-    w_T = wop_obj.w_static_type
+    w_T = wop_obj.w_static_T
 
     if w_T is B.w_dynamic:
         return W_OpSpec(OP.w_dynamic_setattr)

--- a/spy/vm/modules/operator/binop.py
+++ b/spy/vm/modules/operator/binop.py
@@ -136,7 +136,7 @@ MM.register_partial('>=', 'dynamic', OP.w_dynamic_ge)
 @OP.builtin_func(color='blue')
 def w_ADD(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
-    w_ltype = wop_l.w_static_type
+    w_ltype = wop_l.w_static_T
     if w_add := w_ltype.lookup_func('__add__'):
         w_opspec = vm.fast_metacall(w_add, [wop_l, wop_r])
         return typecheck_opspec(vm, w_opspec, [wop_l, wop_r],
@@ -147,7 +147,7 @@ def w_ADD(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
 @OP.builtin_func(color='blue')
 def w_SUB(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
-    w_ltype = wop_l.w_static_type
+    w_ltype = wop_l.w_static_T
     if w_sub := w_ltype.lookup_func('__sub__'):
         w_opspec = vm.fast_metacall(w_sub, [wop_l, wop_r])
         return typecheck_opspec(vm, w_opspec, [wop_l, wop_r],
@@ -158,7 +158,7 @@ def w_SUB(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
 @OP.builtin_func(color='blue')
 def w_MUL(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
-    w_ltype = wop_l.w_static_type
+    w_ltype = wop_l.w_static_T
     if w_mul := w_ltype.lookup_func('__mul__'):
         w_opspec = vm.fast_metacall(w_mul, [wop_l, wop_r])
         return typecheck_opspec(vm, w_opspec, [wop_l, wop_r],
@@ -169,7 +169,7 @@ def w_MUL(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
 @OP.builtin_func(color='blue')
 def w_DIV(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
-    w_ltype = wop_l.w_static_type
+    w_ltype = wop_l.w_static_T
     if w_div := w_ltype.lookup_func('__div__'):
         w_opspec = vm.fast_metacall(w_div, [wop_l, wop_r])
         return typecheck_opspec(vm, w_opspec, [wop_l, wop_r],
@@ -180,7 +180,7 @@ def w_DIV(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
 @OP.builtin_func(color='blue')
 def w_FLOORDIV(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
-    w_ltype = wop_l.w_static_type
+    w_ltype = wop_l.w_static_T
     if w_floordiv := w_ltype.lookup_func('__floordiv__'):
         w_opspec = vm.fast_metacall(w_floordiv, [wop_l, wop_r])
         return typecheck_opspec(vm, w_opspec, [wop_l, wop_r],
@@ -192,7 +192,7 @@ def w_FLOORDIV(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
 @OP.builtin_func(color='blue')
 def w_MOD(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
-    w_ltype = wop_l.w_static_type
+    w_ltype = wop_l.w_static_T
     if w_mod := w_ltype.lookup_func('__mod__'):
         w_opspec = vm.fast_metacall(w_mod, [wop_l, wop_r])
         return typecheck_opspec(vm, w_opspec, [wop_l, wop_r],
@@ -203,7 +203,7 @@ def w_MOD(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
 @OP.builtin_func(color='blue')
 def w_LSHIFT(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
-    w_ltype = wop_l.w_static_type
+    w_ltype = wop_l.w_static_T
     if w_lshift := w_ltype.lookup_func('__lshift__'):
         w_opspec = vm.fast_metacall(w_lshift, [wop_l, wop_r])
         return typecheck_opspec(vm, w_opspec, [wop_l, wop_r],
@@ -214,7 +214,7 @@ def w_LSHIFT(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
 @OP.builtin_func(color='blue')
 def w_RSHIFT(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
-    w_ltype = wop_l.w_static_type
+    w_ltype = wop_l.w_static_T
     if w_rshift := w_ltype.lookup_func('__rshift__'):
         w_opspec = vm.fast_metacall(w_rshift, [wop_l, wop_r])
         return typecheck_opspec(vm, w_opspec, [wop_l, wop_r],
@@ -225,7 +225,7 @@ def w_RSHIFT(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
 @OP.builtin_func(color='blue')
 def w_AND(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
-    w_ltype = wop_l.w_static_type
+    w_ltype = wop_l.w_static_T
     if w_and := w_ltype.lookup_func('__and__'):
         w_opspec = vm.fast_metacall(w_and, [wop_l, wop_r])
         return typecheck_opspec(vm, w_opspec, [wop_l, wop_r],
@@ -236,7 +236,7 @@ def w_AND(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
 @OP.builtin_func(color='blue')
 def w_OR(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
-    w_ltype = wop_l.w_static_type
+    w_ltype = wop_l.w_static_T
     if w_or := w_ltype.lookup_func('__or__'):
         w_opspec = vm.fast_metacall(w_or, [wop_l, wop_r])
         return typecheck_opspec(vm, w_opspec, [wop_l, wop_r],
@@ -247,7 +247,7 @@ def w_OR(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
 @OP.builtin_func(color='blue')
 def w_XOR(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
-    w_ltype = wop_l.w_static_type
+    w_ltype = wop_l.w_static_T
     if w_xor := w_ltype.lookup_func('__xor__'):
         w_opspec = vm.fast_metacall(w_xor, [wop_l, wop_r])
         return typecheck_opspec(vm, w_opspec, [wop_l, wop_r],
@@ -267,8 +267,8 @@ def can_use_reference_eq(vm: 'SPyVM', w_ltype: W_Type, w_rtype: W_Type) -> bool:
 @OP.builtin_func(color='blue')
 def w_EQ(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
-    w_ltype = wop_l.w_static_type
-    w_rtype = wop_r.w_static_type
+    w_ltype = wop_l.w_static_T
+    w_rtype = wop_r.w_static_T
     if w_eq := w_ltype.lookup_func('__eq__'):
         w_opspec = vm.fast_metacall(w_eq, [wop_l, wop_r])
         return typecheck_opspec(vm, w_opspec, [wop_l, wop_r],
@@ -285,8 +285,8 @@ def w_EQ(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
 @OP.builtin_func(color='blue')
 def w_NE(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
-    w_ltype = wop_l.w_static_type
-    w_rtype = wop_r.w_static_type
+    w_ltype = wop_l.w_static_T
+    w_rtype = wop_r.w_static_T
     if w_ne := w_ltype.lookup_func('__ne__'):
         w_opspec = vm.fast_metacall(w_ne, [wop_l, wop_r])
         return typecheck_opspec(vm, w_opspec, [wop_l, wop_r],
@@ -323,7 +323,7 @@ def w_UNIVERSAL_NE(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
 @OP.builtin_func(color='blue')
 def w_LT(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
-    w_ltype = wop_l.w_static_type
+    w_ltype = wop_l.w_static_T
     if w_lt := w_ltype.lookup_func('__lt__'):
         w_opspec = vm.fast_metacall(w_lt, [wop_l, wop_r])
         return typecheck_opspec(vm, w_opspec, [wop_l, wop_r],
@@ -334,7 +334,7 @@ def w_LT(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
 @OP.builtin_func(color='blue')
 def w_LE(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
-    w_ltype = wop_l.w_static_type
+    w_ltype = wop_l.w_static_T
     if w_le := w_ltype.lookup_func('__le__'):
         w_opspec = vm.fast_metacall(w_le, [wop_l, wop_r])
         return typecheck_opspec(vm, w_opspec, [wop_l, wop_r],
@@ -345,7 +345,7 @@ def w_LE(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
 @OP.builtin_func(color='blue')
 def w_GT(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
-    w_ltype = wop_l.w_static_type
+    w_ltype = wop_l.w_static_T
     if w_gt := w_ltype.lookup_func('__gt__'):
         w_opspec = vm.fast_metacall(w_gt, [wop_l, wop_r])
         return typecheck_opspec(vm, w_opspec, [wop_l, wop_r],
@@ -356,7 +356,7 @@ def w_GT(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
 @OP.builtin_func(color='blue')
 def w_GE(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
-    w_ltype = wop_l.w_static_type
+    w_ltype = wop_l.w_static_T
     if w_ge := w_ltype.lookup_func('__ge__'):
         w_opspec = vm.fast_metacall(w_ge, [wop_l, wop_r])
         return typecheck_opspec(vm, w_opspec, [wop_l, wop_r],

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 def w_CALL(vm: 'SPyVM', wop_obj: W_OpArg, *args_wop: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
     w_opspec = W_OpSpec.NULL
-    w_T = wop_obj.w_static_type
+    w_T = wop_obj.w_static_T
 
     newargs_wop = [wop_obj] + list(args_wop)
     errmsg = 'cannot call objects of type `{0}`'
@@ -60,7 +60,7 @@ def w_CALL_METHOD(vm: 'SPyVM', wop_obj: W_OpArg, wop_method: W_OpArg,
                   *args_wop: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
     w_opspec = W_OpSpec.NULL
-    w_T = wop_obj.w_static_type
+    w_T = wop_obj.w_static_T
 
     # if the type provides __call_method__, use it
     if w_call_method := w_T.lookup_func('__call_method__'):

--- a/spy/vm/modules/operator/convop.py
+++ b/spy/vm/modules/operator/convop.py
@@ -29,7 +29,7 @@ def w_CONVERT(vm: 'SPyVM', w_exp: W_Type, wop_x: W_OpArg) -> W_Func:
 
     # mismatched types
     err = SPyError('W_TypeError', 'mismatched types')
-    got = wop_x.w_static_type.fqn.human_name
+    got = wop_x.w_static_T.fqn.human_name
     exp = w_exp.fqn.human_name
     err.add('error', f'expected `{exp}`, got `{got}`', loc=wop_x.loc)
     raise err
@@ -39,7 +39,7 @@ def get_opspec(vm: 'SPyVM', w_exp: W_Type, wop_x: W_OpArg) -> W_OpSpec:
     # this condition is checked by CONVERT_maybe. If we want this function to
     # become more generally usable, we might want to return an identity func
     # here.
-    w_got = wop_x.w_static_type
+    w_got = wop_x.w_static_T
     assert not vm.issubclass(w_got, w_exp)
 
     if vm.issubclass(w_exp, w_got):
@@ -75,7 +75,7 @@ def CONVERT_maybe(
     """
     Same as w_CONVERT, but return None if the types are already compatible.
     """
-    w_got = wop_x.w_static_type
+    w_got = wop_x.w_static_T
     if vm.issubclass(w_got, w_exp):
         # nothing to do
         return None

--- a/spy/vm/modules/operator/itemop.py
+++ b/spy/vm/modules/operator/itemop.py
@@ -12,13 +12,13 @@ if TYPE_CHECKING:
 def w_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg, *args_wop: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
     w_opspec = W_OpSpec.NULL
-    w_type = wop_obj.w_static_type
+    w_T = wop_obj.w_static_type
 
     newargs_wop = [wop_obj] + list(args_wop)
-    if isinstance(w_type, W_FuncType) and w_type.kind == 'generic':
+    if isinstance(w_T, W_FuncType) and w_T.kind == 'generic':
         # special case: for generic W_Funcs, "[]" means "call"
-        w_opspec = w_type.pyclass.op_CALL(vm, wop_obj, *args_wop) # type: ignore
-    elif w_getitem := w_type.lookup_func('__getitem__'):
+        w_opspec = w_T.pyclass.op_CALL(vm, wop_obj, *args_wop) # type: ignore
+    elif w_getitem := w_T.lookup_func('__getitem__'):
         w_opspec = vm.fast_metacall(w_getitem, newargs_wop)
 
     return typecheck_opspec(
@@ -34,10 +34,10 @@ def w_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg, *args_wop: W_OpArg) -> W_OpImpl:
 def w_SETITEM(vm: 'SPyVM', wop_obj: W_OpArg, *args_wop: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
     w_opspec = W_OpSpec.NULL
-    w_type = wop_obj.w_static_type
+    w_T = wop_obj.w_static_type
 
     newargs_wop = [wop_obj] + list(args_wop)
-    if w_setitem := w_type.lookup_func('__setitem__'):
+    if w_setitem := w_T.lookup_func('__setitem__'):
         w_opspec = vm.fast_metacall(w_setitem, newargs_wop)
 
     return typecheck_opspec(

--- a/spy/vm/modules/operator/itemop.py
+++ b/spy/vm/modules/operator/itemop.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 def w_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg, *args_wop: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
     w_opspec = W_OpSpec.NULL
-    w_T = wop_obj.w_static_type
+    w_T = wop_obj.w_static_T
 
     newargs_wop = [wop_obj] + list(args_wop)
     if isinstance(w_T, W_FuncType) and w_T.kind == 'generic':
@@ -34,7 +34,7 @@ def w_GETITEM(vm: 'SPyVM', wop_obj: W_OpArg, *args_wop: W_OpArg) -> W_OpImpl:
 def w_SETITEM(vm: 'SPyVM', wop_obj: W_OpArg, *args_wop: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
     w_opspec = W_OpSpec.NULL
-    w_T = wop_obj.w_static_type
+    w_T = wop_obj.w_static_T
 
     newargs_wop = [wop_obj] + list(args_wop)
     if w_setitem := w_T.lookup_func('__setitem__'):

--- a/spy/vm/modules/operator/multimethod.py
+++ b/spy/vm/modules/operator/multimethod.py
@@ -75,8 +75,8 @@ class MultiMethodTable:
     def get_opimpl(self, vm: 'SPyVM', op: str,
                    wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpImpl:
         from spy.vm.typechecker import typecheck_opspec
-        w_ltype = wop_l.w_static_type
-        w_rtype = wop_r.w_static_type
+        w_ltype = wop_l.w_static_T
+        w_rtype = wop_r.w_static_T
         w_opspec = self.lookup(op, w_ltype, w_rtype)
         return typecheck_opspec(
             vm,
@@ -89,7 +89,7 @@ class MultiMethodTable:
     def get_unary_opimpl(self, vm: 'SPyVM', op: str,
                          wop_v: W_OpArg) -> W_OpImpl:
         from spy.vm.typechecker import typecheck_opspec
-        w_vtype = wop_v.w_static_type
+        w_vtype = wop_v.w_static_T
         w_opspec = self.lookup(op, w_vtype, None)
         return typecheck_opspec(
             vm,

--- a/spy/vm/modules/operator/opimpl_int.py
+++ b/spy/vm/modules/operator/opimpl_int.py
@@ -10,8 +10,8 @@ class W_IntLike(Protocol):
     value: Any
 
 def make_ops(T: str, pyclass: type[W_Object]) -> None:
-    w_type = pyclass._w  # e.g. B.w_i32
-    WT = Annotated[W_IntLike, w_type]
+    w_T = pyclass._w  # e.g. B.w_i32
+    WT = Annotated[W_IntLike, w_T]
 
     def _binop(vm: 'SPyVM', w_a: WT, w_b: WT, fn: Any) -> Any:
         a = w_a.value

--- a/spy/vm/modules/operator/unaryop.py
+++ b/spy/vm/modules/operator/unaryop.py
@@ -11,7 +11,7 @@ MM = MultiMethodTable()
 @OP.builtin_func(color='blue')
 def w_NEG(vm: 'SPyVM', wop_v: W_OpArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
-    w_vtype = wop_v.w_static_type
+    w_vtype = wop_v.w_static_T
     if w_neg := w_vtype.lookup_func('__neg__'):
         w_opspec = vm.fast_metacall(w_neg, [wop_v])
         return typecheck_opspec(vm, w_opspec, [wop_v],

--- a/spy/vm/modules/types.py
+++ b/spy/vm/modules/types.py
@@ -94,7 +94,7 @@ class W_LiftedObject(W_Object):
     @builtin_property('__ll__', color='blue', kind='metafunc')
     @staticmethod
     def w_GET_ll(vm: 'SPyVM', wop_hl: W_OpArg) -> W_OpSpec:
-        w_hltype = wop_hl.w_static_type
+        w_hltype = wop_hl.w_static_T
         HL = Annotated[W_LiftedObject, w_hltype]
         LL = Annotated[W_Object, w_hltype.w_lltype]
 

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -56,9 +56,9 @@ class W_PtrType(W_Type):
 
     @classmethod
     def from_itemtype(cls, fqn: FQN, w_itemtype: W_Type) -> Self:
-        w_type = cls.from_pyclass(fqn, W_Ptr)
-        w_type.w_itemtype = w_itemtype
-        return w_type
+        w_T = cls.from_pyclass(fqn, W_Ptr)
+        w_T.w_itemtype = w_itemtype
+        return w_T
 
     @builtin_property('NULL', color='blue', kind='metafunc')
     @staticmethod

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -141,7 +141,7 @@ class W_Ptr(W_BasePtr):
 
     @staticmethod
     def _get_ptrtype(wop_ptr: W_OpArg) -> W_PtrType:
-        w_ptrtype = wop_ptr.w_static_type
+        w_ptrtype = wop_ptr.w_static_T
         if isinstance(w_ptrtype, W_PtrType):
             return w_ptrtype
         else:
@@ -224,8 +224,8 @@ class W_Ptr(W_BasePtr):
     @builtin_method('__eq__', color='blue', kind='metafunc')
     @staticmethod
     def w_EQ(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpSpec:
-        w_ltype = wop_l.w_static_type
-        w_rtype = wop_r.w_static_type
+        w_ltype = wop_l.w_static_T
+        w_rtype = wop_r.w_static_T
         if w_ltype is not w_rtype:
             return W_OpSpec.NULL
         w_ptrtype = W_Ptr._get_ptrtype(wop_l)
@@ -242,8 +242,8 @@ class W_Ptr(W_BasePtr):
     @builtin_method('__ne__', color='blue', kind='metafunc')
     @staticmethod
     def w_NE(vm: 'SPyVM', wop_l: W_OpArg, wop_r: W_OpArg) -> W_OpSpec:
-        w_ltype = wop_l.w_static_type
-        w_rtype = wop_r.w_static_type
+        w_ltype = wop_l.w_static_T
+        w_rtype = wop_r.w_static_T
         if w_ltype is not w_rtype:
             return W_OpSpec.NULL
         w_ptrtype = W_Ptr._get_ptrtype(wop_l)

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -325,20 +325,20 @@ class W_Type(W_Object):
         """
         Create a new type in the "forward declaration" state
         """
-        w_type = super().__new__(cls)
-        w_type.fqn = fqn
-        w_type._pyclass = None
-        w_type._dict_w = None
-        return w_type
+        w_T = super().__new__(cls)
+        w_T.fqn = fqn
+        w_T._pyclass = None
+        w_T._dict_w = None
+        return w_T
 
     @classmethod
     def from_pyclass(cls, fqn: FQN, pyclass: Type[W_Object]) -> Self:
         """
         Declare AND define a new builtin type.
         """
-        w_type = cls.declare(fqn)
-        w_type.define(pyclass)
-        return w_type
+        w_T = cls.declare(fqn)
+        w_T.define(pyclass)
+        return w_T
 
     def define(self, pyclass: Type[W_Object]) -> None:
         """
@@ -549,11 +549,11 @@ class W_Type(W_Object):
             err.add('error', f"this is red", loc=wop_t.loc)
             raise err
 
-        w_type = wop_t.w_blueval
-        assert isinstance(w_type, W_Type)
+        w_T = wop_t.w_blueval
+        assert isinstance(w_T, W_Type)
 
         # try to call __new__
-        if w_new := w_type.lookup_func('__new__'):
+        if w_new := w_T.lookup_func('__new__'):
             # this is a bit of ad-hoc logic around normal __new__ vs metafunc
             # __new__: when it's a metafunc we also want to pass the OpArg of
             # the type itself (so that the function can reach
@@ -568,7 +568,7 @@ class W_Type(W_Object):
             return w_opspec
 
         # no __new__, error out
-        clsname = w_type.fqn.human_name
+        clsname = w_T.fqn.human_name
         err = SPyError('W_TypeError', f"cannot instantiate `{clsname}`")
         err.add('error', f"`{clsname}` does not have a method `__new__`",
                 loc=wop_t.loc)

--- a/spy/vm/opimpl.py
+++ b/spy/vm/opimpl.py
@@ -172,7 +172,7 @@ class W_OpImpl(W_Object):
     def func_signature(self) -> str:
         w_ft = self.w_functype
         params = [
-            f'v{i}: {p.w_type.fqn.human_name}'
+            f'v{i}: {p.w_T.fqn.human_name}'
             for i, p in enumerate(w_ft.params)
         ]
         str_params = ', '.join(params)

--- a/spy/vm/opspec.py
+++ b/spy/vm/opspec.py
@@ -123,11 +123,11 @@ class W_OpArg(W_Object):
         - val: the value (optional for red OpArg, required for blue)
         """
         # Check that w_color is a string
-        w_type = vm.dynamic_type(w_color)
-        if w_type is not B.w_str:
+        w_T = vm.dynamic_type(w_color)
+        if w_T is not B.w_str:
             raise SPyError(
                 'W_TypeError',
-                f"OpArg color must be a string, got {w_type.fqn.human_name}",
+                f"OpArg color must be a string, got {w_T.fqn.human_name}",
             )
 
         color: Color = vm.unwrap_str(w_color)  # type: ignore
@@ -151,8 +151,8 @@ class W_OpArg(W_Object):
 
     @classmethod
     def from_w_obj(cls, vm: 'SPyVM', w_obj: W_Object) -> 'W_OpArg':
-        w_type = vm.dynamic_type(w_obj)
-        return W_OpArg(vm, 'blue', w_type, w_obj, Loc.here(-2))
+        w_T = vm.dynamic_type(w_obj)
+        return W_OpArg(vm, 'blue', w_T, w_obj, Loc.here(-2))
 
     def __repr__(self) -> str:
         if self.is_blue():
@@ -373,19 +373,19 @@ class W_OpSpec(W_Object):
         from spy.vm.function import W_Func
         from spy.vm.list import W_OpArgList
 
-        w_type = wop_cls.w_blueval
-        assert isinstance(w_type, W_Type)
+        w_T = wop_cls.w_blueval
+        assert isinstance(w_T, W_Type)
 
         if len(args_wop) == 1:
             # Simple case: OpSpec(func)
-            @builtin_func(w_type.fqn, 'new1')
+            @builtin_func(w_T.fqn, 'new1')
             def w_new1(vm: 'SPyVM', w_cls: W_Type, w_func: W_Func) -> W_OpSpec:
                 return W_OpSpec(w_func)
             return W_OpSpec(w_new1)
 
         elif len(args_wop) == 2:
             # OpSpec(func, args) case
-            @builtin_func(w_type.fqn, 'new2')
+            @builtin_func(w_T.fqn, 'new2')
             def w_new2(vm: 'SPyVM', w_cls: W_Type,
                        w_func: W_Func, w_args: W_OpArgList) -> W_OpSpec:
                 # Convert from applevel w_args into interp-level args_w

--- a/spy/vm/opspec.py
+++ b/spy/vm/opspec.py
@@ -182,7 +182,7 @@ class W_OpArg(W_Object):
         assert self._w_val is not None
         return self._w_val
 
-    def blue_ensure(self, vm: 'SPyVM', w_expected_type: W_Type) -> W_Object:
+    def blue_ensure(self, vm: 'SPyVM', w_expected_T: W_Type) -> W_Object:
         """
         Ensure that the W_OpArg is blue and of the expected type.
         Raise SPyError(W_TypeError) if not.
@@ -199,16 +199,16 @@ class W_OpArg(W_Object):
         # check that the blueval has the expected type. If not, we should
         # probably raise a better error, but for now we just fail with
         # AssertionError.
-        w_func = CONVERT_maybe(vm, w_expected_type, self)
+        w_func = CONVERT_maybe(vm, w_expected_T, self)
         assert w_func is None
         assert self.w_val is not None
         return self.w_val
 
-    def blue_unwrap(self, vm: 'SPyVM', w_expected_type: W_Type) -> Any:
+    def blue_unwrap(self, vm: 'SPyVM', w_expected_T: W_Type) -> Any:
         """
         Like ensure_blue, but also unwrap.
         """
-        w_obj = self.blue_ensure(vm, w_expected_type)
+        w_obj = self.blue_ensure(vm, w_expected_T)
         return vm.unwrap(w_obj)
 
     def blue_unwrap_str(self, vm: 'SPyVM') -> str:

--- a/spy/vm/opspec.py
+++ b/spy/vm/opspec.py
@@ -81,7 +81,7 @@ class W_OpArg(W_Object):
     Blue OpArg always have an associated value.
     """
     color: Color
-    w_static_type: Annotated[W_Type, Member('static_type')]
+    w_static_T: Annotated[W_Type, Member('static_type')]
     loc: Loc
     _w_val: Optional[W_Object]
     sym: Optional[Symbol]
@@ -89,7 +89,7 @@ class W_OpArg(W_Object):
     def __init__(self,
                  vm: 'SPyVM',
                  color: Color,
-                 w_static_type: W_Type,
+                 w_static_T: W_Type,
                  w_val: Optional[W_Object],
                  loc: Loc,
                  *,
@@ -97,13 +97,13 @@ class W_OpArg(W_Object):
                  ) -> None:
         if color == 'blue':
             assert w_val is not None
-            if w_static_type is B.w_dynamic:
+            if w_static_T is B.w_dynamic:
                 # "dynamic blue" doesn't make sense: if it's blue, we
                 # precisely know its type, and we can eagerly evaluate it.
                 # See test_basic::test_eager_blue_eval
-                w_static_type = vm.dynamic_type(w_val)
+                w_static_T = vm.dynamic_type(w_val)
         self.color = color
-        self.w_static_type = w_static_type
+        self.w_static_T = w_static_T
         self._w_val = w_val
         self.loc = loc
         self.sym = sym
@@ -113,7 +113,7 @@ class W_OpArg(W_Object):
     def w_new(
             vm: 'SPyVM',
             w_color: W_Object,
-            w_static_type: W_Type,
+            w_static_T: W_Type,
             w_val: W_Object
     ) -> 'W_OpArg':
         """
@@ -147,7 +147,7 @@ class W_OpArg(W_Object):
             raise SPyError("Blue OpArg requires a value", etype='W_TypeError')
 
         loc = Loc.here(-2)  # approximate source location
-        return W_OpArg(vm, color, w_static_type, w_val2, loc)
+        return W_OpArg(vm, color, w_static_T, w_val2, loc)
 
     @classmethod
     def from_w_obj(cls, vm: 'SPyVM', w_obj: W_Object) -> 'W_OpArg':
@@ -159,7 +159,7 @@ class W_OpArg(W_Object):
             extra = f' = {self.w_val}'
         else:
             extra = ''
-        t = self.w_static_type.fqn.human_name
+        t = self.w_static_T.fqn.human_name
         return f'<W_OpArg {self.color} {t}{extra}>'
 
     def is_blue(self) -> bool:
@@ -168,7 +168,7 @@ class W_OpArg(W_Object):
     def as_red(self, vm: 'SPyVM') -> 'W_OpArg':
         if self.color == 'red':
             return self
-        return W_OpArg(vm, 'red', self.w_static_type, self._w_val, self.loc,
+        return W_OpArg(vm, 'red', self.w_static_T, self._w_val, self.loc,
                        sym=self.sym)
 
     @property
@@ -229,7 +229,7 @@ class W_OpArg(W_Object):
                 return W_OpArg(
                     vm,
                     color='red',
-                    w_static_type=w_type,
+                    w_static_T=w_type,
                     w_val=None,
                     loc=Loc.here()  # w_from_type
                 )
@@ -239,8 +239,8 @@ class W_OpArg(W_Object):
     @builtin_method('__eq__', color='blue', kind='metafunc')
     @staticmethod
     def w_EQ(vm: 'SPyVM', wop_l: 'W_OpArg', wop_r: 'W_OpArg') -> 'W_OpSpec':
-        w_ltype = wop_l.w_static_type
-        w_rtype = wop_r.w_static_type
+        w_ltype = wop_l.w_static_T
+        w_rtype = wop_r.w_static_T
         assert w_ltype.pyclass is W_OpArg
 
         if w_ltype is w_rtype:
@@ -281,7 +281,7 @@ def w_oparg_eq(vm: 'SPyVM', wop1: W_OpArg, wop2: W_OpArg) -> W_Bool:
     from spy.vm.b import B
     # note that the prefix is NOT considered for equality, is purely for
     # description
-    if wop1.w_static_type is not wop2.w_static_type:
+    if wop1.w_static_T is not wop2.w_static_T:
         return B.w_False
     # we need to think what to do in this case
     ## if wop1.is_blue() != wop2.is_blue():

--- a/spy/vm/primitive.py
+++ b/spy/vm/primitive.py
@@ -51,7 +51,7 @@ class W_I32(W_Object):
         if len(args_wop) != 1:
             return W_OpSpec.NULL
         wop_arg = args_wop[0]
-        if wop_arg.w_static_type == B.w_f64:
+        if wop_arg.w_static_T == B.w_f64:
             return W_OpSpec(OP.w_f64_to_i32, [wop_arg])
         return W_OpSpec.NULL
 
@@ -106,7 +106,7 @@ class W_F64(W_Object):
         if len(args_wop) != 1:
             return W_OpSpec.NULL
         wop_arg = args_wop[0]
-        if wop_arg.w_static_type == B.w_i32:
+        if wop_arg.w_static_T == B.w_i32:
             return W_OpSpec(OP.w_i32_to_f64, [wop_arg])
         return W_OpSpec.NULL
 

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -72,7 +72,7 @@ class W_Str(W_Object):
     @staticmethod
     def w_NEW(vm: 'SPyVM', wop_cls: W_OpArg, *args_wop: W_OpArg) -> 'W_OpSpec':
         from spy.vm.b import B
-        if len(args_wop) == 1 and args_wop[0].w_static_type is B.w_i32:
+        if len(args_wop) == 1 and args_wop[0].w_static_T is B.w_i32:
             wop_i = args_wop[0]
             return W_OpSpec(w_int2str, [wop_i])
         else:

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -114,7 +114,7 @@ def typecheck_opspec(
 
 def functype_from_opargs(args_wop: list[W_OpArg], w_restype: W_Type,
                          color: Color) -> W_FuncType:
-    params = [FuncParam(wop.w_static_type, 'simple') for wop in args_wop]
+    params = [FuncParam(wop.w_static_T, 'simple') for wop in args_wop]
     return W_FuncType.new(params, w_restype, color=color)
 
 
@@ -149,12 +149,12 @@ def _opspec_null_error(
        determining whether an operation is supported, so we report all
        of them
     """
-    typenames = [wop.w_static_type.fqn.human_name for wop in in_args_wop]
+    typenames = [wop.w_static_T.fqn.human_name for wop in in_args_wop]
     errmsg = errmsg.format(*typenames)
     err = SPyError('W_TypeError', errmsg)
     if dispatch == 'single':
         wop_target = in_args_wop[0]
-        t = wop_target.w_static_type.fqn.human_name
+        t = wop_target.w_static_T.fqn.human_name
         if wop_target.loc:
             err.add('error', f'this is `{t}`', wop_target.loc)
         if wop_target.sym:
@@ -162,7 +162,7 @@ def _opspec_null_error(
             err.add('note', f'`{sym.name}` defined here', sym.loc)
     else:
         for wop_arg in in_args_wop:
-            t = wop_arg.w_static_type.fqn.human_name
+            t = wop_arg.w_static_T.fqn.human_name
             err.add('error', f'this is `{t}`', wop_arg.loc)
     raise err
 

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -94,7 +94,7 @@ def typecheck_opspec(
     args = []
     for param, wop_out_arg in zip(w_out_functype.all_params(), out_args_wop):
         # add a converter if needed (this might raise SPyTypeError)
-        w_conv = get_w_conv(vm, param.w_type, wop_out_arg, def_loc)
+        w_conv = get_w_conv(vm, param.w_T, wop_out_arg, def_loc)
         arg: ArgSpec
         if wop_out_arg.is_blue():
             arg = ArgSpec.Const(wop_out_arg.w_blueval, wop_out_arg.loc)

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -644,8 +644,8 @@ class SPyVM:
                 raise
             # sanity check: EQ between objects of the same type should always
             # be possible. If it's not, it means that we forgot to implement it
-            w_ta = wop_a.w_static_type
-            w_tb = wop_b.w_static_type
+            w_ta = wop_a.w_static_T
+            w_tb = wop_b.w_static_T
             assert w_ta is not w_tb, f'EQ missing on type `{w_ta.fqn}`'
             return B.w_False
 

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -558,7 +558,7 @@ class SPyVM:
         w_functype = w_func.w_functype
         assert w_functype.is_argcount_ok(len(args_w))
         for param, w_arg in zip(w_functype.all_params(), args_w):
-            assert self.isinstance(w_arg, param.w_type)
+            assert self.isinstance(w_arg, param.w_T)
         return w_func.raw_call(self, args_w)
 
     def _w_oparg(self, w_x: W_Dynamic) -> W_OpArg:

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -256,12 +256,12 @@ class SPyVM:
             # the argument to "raise" must be blue for now (see also
             # W_Exception.w_NEW). Eventually, we will have proper support
             # for prebuilt constants, but for now we special case W_Exception.
-            w_type = self.dynamic_type(w_val)
-            fqn = w_type.fqn.join('prebuilt')
+            w_T = self.dynamic_type(w_val)
+            fqn = w_T.fqn.join('prebuilt')
             fqn = self.get_unique_FQN(fqn)
         else:
-            w_type = self.dynamic_type(w_val)
-            T = w_type.fqn.human_name
+            w_T = self.dynamic_type(w_val)
+            T = w_T.fqn.human_name
             msg = f"This prebuilt constant cannot be redshifted (yet): {w_val}"
             raise WIP(msg)
             assert False, 'implement me'


### PR DESCRIPTION
we already have `W_Type` and `B.w_type`, so all local var names `w_type` makes things very confusing.
Rename those into `w_T`, and follow the same pattern for e.g. `w_member_type` -> `w_member_T` etc.