### PR TITLE
Improve metafunc error reporting and make STATIC_TYPE a normal builtin

### DIFF
--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -970,61 +970,6 @@ class TestBasic(CompilerTest):
         assert mod.ne_dynamic(1, 2) == True
         assert mod.ne_dynamic(1, 'str') == True
 
-    @no_C
-    def test_STATIC_TYPE(self):
-        mod = self.compile("""
-        def foo() -> type:
-            x = 42
-            return STATIC_TYPE(x)
-        """)
-        w_T = mod.foo(unwrap=False)
-        assert w_T is B.w_i32
-
-    @no_C
-    def test_STATIC_TYPE_wrong_argcount(self):
-        src = """
-        def foo() -> type:
-            x = 42
-            return STATIC_TYPE(x, 1, 2)
-        """
-        errors = expect_errors(
-            'this function takes 1 argument but 3 arguments were supplied',
-            ('2 extra arguments', '1, 2')
-        )
-        self.compile_raises(src, 'foo', errors)
-
-    @no_C
-    def test_STATIC_TYPE_side_effects(self):
-        # Ideally, we sould like to allow STATIC_TYPE on arbitrary
-        # expressions: this is easy to implement for interp, but tricky for
-        # doppler. For now, we declare that we support only simple expressions
-        # as argument of STATIC_TYPE, to avoid side effects
-        src = """
-        var x: i32 = 0
-
-        def get_x() -> i32:
-            return x
-
-        def inc() -> i32:
-            x = x + 1
-            return x
-
-        def foo() -> type:
-            return STATIC_TYPE(inc())
-        """
-        # this is what we would like, eventually
-        ## assert mod.get_x() == 0
-        ## pyclass = mod.foo()
-        ## assert pyclass is self.vm.unwrap(B.w_i32)
-        ## assert mod.get_x() == 1
-        #
-        # this is what we have now
-        errors = expect_errors(
-            'STATIC_TYPE works only on simple expressions',
-            ('Call not allowed here', 'inc()')
-        )
-        self.compile_raises(src, 'foo', errors)
-
     @only_interp
     def test_automatic_forward_declaration(self):
         mod = self.compile("""

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -1094,31 +1094,6 @@ class TestBasic(CompilerTest):
         """)
         assert mod.foo(3) == 4
 
-    def test_blue_metafunc(self):
-        mod = self.compile("""
-        from operator import OpSpec
-
-        @blue.metafunc
-        def foo(v_x):
-            if v_x.static_type == i32:
-               def impl_i32(x: i32) -> i32:
-                   return x * 2
-               return OpSpec(impl_i32)
-            elif v_x.static_type == str:
-               def impl_str(x: str) -> str:
-                   return x + ' world'
-               return OpSpec(impl_str)
-            raise StaticError("unsupported type")
-
-        def test1() -> i32:
-            return foo(5)
-
-        def test2() -> str:
-            return foo('hello')
-        """)
-        assert mod.test1() == 10
-        assert mod.test2() == 'hello world'
-
     def test_call_module_attr(self):
         mod = self.compile("""
         import math

--- a/spy/tests/compiler/test_metafunc.py
+++ b/spy/tests/compiler/test_metafunc.py
@@ -74,11 +74,11 @@ class TestMetaFunc(CompilerTest):
         w_T = mod.foo(unwrap=False)
         assert w_T is B.w_i32
 
-    @pytest.mark.skip(reason='fix me')
     @no_C
     def test_STATIC_TYPE_side_effects(self):
-        # ideally, you should be able to call STATIC_TYPE(expr) *and have the
-        # expression evaluated*. However, this is broken.
+        if self.backend == 'doppler':
+            pytest.skip('fixme: side effects of arguments which are redshifted away')
+
         src = """
         var x: i32 = 0
 

--- a/spy/tests/compiler/test_metafunc.py
+++ b/spy/tests/compiler/test_metafunc.py
@@ -74,25 +74,11 @@ class TestMetaFunc(CompilerTest):
         w_T = mod.foo(unwrap=False)
         assert w_T is B.w_i32
 
-    @no_C
-    def test_STATIC_TYPE_wrong_argcount(self):
-        src = """
-        def foo() -> type:
-            x = 42
-            return STATIC_TYPE(x, 1, 2)
-        """
-        errors = expect_errors(
-            'this function takes 1 argument but 3 arguments were supplied',
-            ('2 extra arguments', '1, 2')
-        )
-        self.compile_raises(src, 'foo', errors)
-
+    @pytest.mark.skip(reason='fix me')
     @no_C
     def test_STATIC_TYPE_side_effects(self):
-        # Ideally, we sould like to allow STATIC_TYPE on arbitrary
-        # expressions: this is easy to implement for interp, but tricky for
-        # doppler. For now, we declare that we support only simple expressions
-        # as argument of STATIC_TYPE, to avoid side effects
+        # ideally, you should be able to call STATIC_TYPE(expr) *and have the
+        # expression evaluated*. However, this is broken.
         src = """
         var x: i32 = 0
 
@@ -106,15 +92,8 @@ class TestMetaFunc(CompilerTest):
         def foo() -> type:
             return STATIC_TYPE(inc())
         """
-        # this is what we would like, eventually
-        ## assert mod.get_x() == 0
-        ## pyclass = mod.foo()
-        ## assert pyclass is self.vm.unwrap(B.w_i32)
-        ## assert mod.get_x() == 1
-        #
-        # this is what we have now
-        errors = expect_errors(
-            'STATIC_TYPE works only on simple expressions',
-            ('Call not allowed here', 'inc()')
-        )
-        self.compile_raises(src, 'foo', errors)
+        mod = self.compile(src)
+        assert mod.get_x() == 0
+        w_T = mod.foo(unwrap=False)
+        assert w_T is B.w_i32
+        assert mod.get_x() == 1

--- a/spy/tests/compiler/test_metafunc.py
+++ b/spy/tests/compiler/test_metafunc.py
@@ -1,0 +1,49 @@
+import pytest
+from spy.fqn import FQN
+from spy.errors import SPyError
+from spy.vm.b import B
+from spy.fqn import FQN
+from spy.tests.support import (CompilerTest, skip_backends, expect_errors, only_interp, no_C)
+
+class TestMetaFunc(CompilerTest):
+
+    def test_simple(self):
+        mod = self.compile("""
+        from operator import OpSpec
+
+        @blue.metafunc
+        def foo(v_x):
+            if v_x.static_type == i32:
+               def impl_i32(x: i32) -> i32:
+                   return x * 2
+               return OpSpec(impl_i32)
+            elif v_x.static_type == str:
+               def impl_str(x: str) -> str:
+                   return x + ' world'
+               return OpSpec(impl_str)
+            raise StaticError("unsupported type")
+
+        def test1() -> i32:
+            return foo(5)
+
+        def test2() -> str:
+            return foo('hello')
+        """)
+        assert mod.test1() == 10
+        assert mod.test2() == 'hello world'
+
+    @pytest.mark.skip(reason='implement me')
+    def test_wrong_args(self):
+        mod = self.compile("""
+        from operator import OpSpec
+
+        @blue.metafunc
+        def m(v_x):
+           def impl_i32(x: i32) -> i32:
+               return x * 2
+           return OpSpec(impl_i32)
+
+        def foo() -> i32:
+            return m()
+        """)
+        mod.foo()

--- a/spy/tests/compiler/test_metafunc.py
+++ b/spy/tests/compiler/test_metafunc.py
@@ -34,8 +34,6 @@ class TestMetaFunc(CompilerTest):
 
     def test_wrong_argcount(self):
         src = """
-        from operator import OpSpec
-
         @blue.metafunc
         def m(v_x):
             pass
@@ -46,5 +44,22 @@ class TestMetaFunc(CompilerTest):
         errors = expect_errors(
             'this function takes 1 argument but 0 arguments were supplied',
             ('function defined here', 'def m(v_x):'),
+        )
+        self.compile_raises(src, "foo", errors)
+
+    def test_wrong_restype(self):
+        src = """
+        @blue.metafunc
+        def m():
+            # the metacall protocol expects an OpSpec, not an int
+            return 42
+
+        def foo() -> i32:
+            return m()
+        """
+        errors = expect_errors(
+            'wrong metafunc return type: expected `operator::OpSpec`, got `i32`',
+            ('this is a metafunc', 'm'),
+            ('metafunc defined here', 'def m():'),
         )
         self.compile_raises(src, "foo", errors)

--- a/spy/tests/compiler/test_metafunc.py
+++ b/spy/tests/compiler/test_metafunc.py
@@ -32,18 +32,19 @@ class TestMetaFunc(CompilerTest):
         assert mod.test1() == 10
         assert mod.test2() == 'hello world'
 
-    @pytest.mark.skip(reason='implement me')
-    def test_wrong_args(self):
-        mod = self.compile("""
+    def test_wrong_argcount(self):
+        src = """
         from operator import OpSpec
 
         @blue.metafunc
         def m(v_x):
-           def impl_i32(x: i32) -> i32:
-               return x * 2
-           return OpSpec(impl_i32)
+            pass
 
         def foo() -> i32:
             return m()
-        """)
-        mod.foo()
+        """
+        errors = expect_errors(
+            'this function takes 1 argument but 0 arguments were supplied',
+            ('function defined here', 'def m(v_x):'),
+        )
+        self.compile_raises(src, "foo", errors)

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -512,9 +512,6 @@ class AbstractFrame:
 
     def eval_expr_Call(self, call: ast.Call) -> W_OpArg:
         wop_func = self.eval_expr(call.func)
-        # STATIC_TYPE is special
-        if wop_func.color == 'blue' and wop_func.w_val is B.w_STATIC_TYPE:
-            return self._eval_STATIC_TYPE(wop_func, call)
         args_wop = [self.eval_expr(arg) for arg in call.args]
         w_opimpl = self.vm.call_OP(
             call.loc,
@@ -522,22 +519,6 @@ class AbstractFrame:
             [wop_func]+args_wop
         )
         return self.eval_opimpl(call, w_opimpl, [wop_func]+args_wop)
-
-    def _eval_STATIC_TYPE(self, wop_func: W_OpArg, call: ast.Call) -> W_OpArg:
-        for arg in call.args:
-            if not isinstance(arg, (ast.Name, ast.Constant, ast.StrConst)):
-                msg = 'STATIC_TYPE works only on simple expressions'
-                E = arg.__class__.__name__
-                raise SPyError.simple(
-                    "W_TypeError",
-                    msg, f'{E} not allowed here', arg.loc,
-                )
-
-        args_wop = [self.eval_expr(arg) for arg in call.args]
-        w_opimpl = self.vm.call_OP(call.loc, OP.w_CALL, [wop_func]+args_wop)
-        assert len(call.args) == 1
-        w_argtype = args_wop[0].w_static_T
-        return W_OpArg.from_w_obj(self.vm, w_argtype)
 
     def eval_expr_CallMethod(self, op: ast.CallMethod) -> W_Object:
         wop_obj = self.eval_expr(op.target)

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -25,6 +25,10 @@ def w_STATIC_TYPE(vm: 'SPyVM', w_expr: W_Object) -> W_Type:
            "It's special-cased by ASTFrame")
     raise NotImplementedError(msg)
 
+## @BUILTINS.builtin_func(color='blue', kind='metafunc')
+## def w_STATIC_TYPE(vm: 'SPyVM', wop_obj: W_OpArg) -> W_OpSpec:
+##     return W_OpSpec.const(wop_obj.w_static_T)
+
 @BUILTINS.builtin_func
 def w_abs(vm: 'SPyVM', w_x: W_I32) -> W_I32:
     x = vm.unwrap_i32(w_x)

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -19,15 +19,9 @@ if TYPE_CHECKING:
 
 PY_PRINT = print  # type: ignore
 
-@BUILTINS.builtin_func(color='blue')
-def w_STATIC_TYPE(vm: 'SPyVM', w_expr: W_Object) -> W_Type:
-    msg = ("STATIC_TYPE should never be called at runtime. "
-           "It's special-cased by ASTFrame")
-    raise NotImplementedError(msg)
-
-## @BUILTINS.builtin_func(color='blue', kind='metafunc')
-## def w_STATIC_TYPE(vm: 'SPyVM', wop_obj: W_OpArg) -> W_OpSpec:
-##     return W_OpSpec.const(wop_obj.w_static_T)
+@BUILTINS.builtin_func(color='blue', kind='metafunc')
+def w_STATIC_TYPE(vm: 'SPyVM', wop_obj: W_OpArg) -> W_OpSpec:
+    return W_OpSpec.const(wop_obj.w_static_T)
 
 @BUILTINS.builtin_func
 def w_abs(vm: 'SPyVM', w_x: W_I32) -> W_I32:

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -22,20 +22,12 @@ def w_CALL(vm: 'SPyVM', wop_obj: W_OpArg, *args_wop: W_OpArg) -> W_OpImpl:
         # W_Func is a special case, as it can't have a w_CALL for bootstrapping
         # reasons. Moreover, while we are at it, we can produce a better error
         # message in case we try to call a plain function with [].
+        assert w_T.pyclass is W_Func
         if w_T.kind == 'plain':
-            assert w_T.pyclass is W_Func
             w_opspec = W_Func.op_CALL(vm, wop_obj, *args_wop) # type: ignore
-
         elif w_T.kind == 'metafunc':
             assert w_T.pyclass is W_Func
-            w_opspec = W_Func.op_CALL(vm, wop_obj, *args_wop) # type: ignore
-            # this is a bit of a hack: without this, by default we call the
-            # w_opspec with ALL the newargs_wop, including the function object
-            # itself. But for metafunc it makes more sense that the default
-            # calling convention is to pass only the rest of the wops
-            if w_opspec.is_simple():
-                w_opspec._args_wop = list(args_wop)
-
+            w_opspec = W_Func.op_METACALL(vm, wop_obj, *args_wop) # type: ignore
         elif w_T.kind == 'generic':
             errmsg = 'generic functions must be called via `[...]`'
         else:

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -93,7 +93,7 @@ def typecheck_opspec(
     # build the argspec for the W_OpImpl
     args = []
     for param, wop_out_arg in zip(w_out_functype.all_params(), out_args_wop):
-        # add a converter if needed (this might raise SPyTypeError)
+        # add a converter if needed (this might raise W_TypeError)
         w_conv = get_w_conv(vm, param.w_T, wop_out_arg, def_loc)
         arg: ArgSpec
         if wop_out_arg.is_blue():


### PR DESCRIPTION
- make sure to generate the correct TypeErrors in case you call a metafunc with wrong arguments or it returns a wrong type
- thanks to metafunc we can remove the special case for STATIC_TYPE and implement it as a normal builtin