### PR TITLE
Add support for decorators

### DIFF
--- a/spy/analyze/scope.py
+++ b/spy/analyze/scope.py
@@ -311,6 +311,9 @@ class ScopeAnalyzer:
         return node.visit('flatten', self)
 
     def flatten_FuncDef(self, funcdef: ast.FuncDef) -> None:
+        # decorators are evaluated in the outer scope
+        for decorator in funcdef.decorators:
+            self.flatten(decorator)
         # the TYPES of the arguments are evaluated in the outer scope
         self.flatten(funcdef.return_type)
         for arg in funcdef.args:

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -391,6 +391,7 @@ class FuncDef(Stmt):
     return_type: 'Expr'
     docstring: Optional[str]
     body: list['Stmt']
+    decorators: list['Expr']
     symtable: Any = field(repr=False, default=None)
 
     @property

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -76,7 +76,7 @@ class SPyBackend:
     def is_module_global(self, fqn: FQN) -> bool:
         return (len(fqn.parts) == 2 and
                 fqn.modname == self.modname
-                and fqn.parts[-1].suffix == 0)
+                and fqn.parts[-1].suffix == '')
 
     def dump_w_func(self, fqn: FQN, w_func: W_ASTFunc) -> None:
         if self.fqn_format == 'short' and self.is_module_global(fqn):

--- a/spy/cli.py
+++ b/spy/cli.py
@@ -387,6 +387,9 @@ async def inner_main(args: Arguments) -> None:
 
     outfile = backend.build()
     executable = outfile.relto(cwd)
+    if executable == '':
+        # outfile is not in a subdir of cwd, let's display the full path
+        executable = str(outfile)
     print(f"==> {executable}")
 
 

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -79,6 +79,7 @@ class DopplerFrame(ASTFrame):
         return True
 
     def redshift(self) -> W_ASTFunc:
+        assert not self.w_func.redshifted, 'cannot redshit twice'
         self.declare_arguments()
         funcdef = self.w_func.funcdef
         new_body = []
@@ -150,6 +151,16 @@ class DopplerFrame(ASTFrame):
         specialized = self.specialized_assigns[assign]
         newvalue = self.shifted_expr[assign.value]
         return [specialized.replace(value=newvalue)]
+
+    def shift_stmt_AssignLocal(self, assign: ast.AssignLocal) -> list[ast.Stmt]:
+        # specialized stmts such as AssignLocal and AssignCell are present
+        # ONLY inside redshifted ASTs, so we should never see them here
+        assert False, 'not supposed to happen'
+
+    def shift_stmt_AssignCell(self, assign: ast.AssignCell) -> list[ast.Stmt]:
+        # specialized stmts such as AssignLocal and AssignCell are present
+        # ONLY inside redshifted ASTs, so we should never see them here
+        assert False, 'not supposed to happen'
 
     def shift_stmt_AugAssign(self, node: ast.AugAssign) -> list[ast.Stmt]:
         assign = self._desugar_AugAssign(node)

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -98,9 +98,9 @@ def get_qualifiers(x: QUALIFIERS) -> tuple['FQN', ...]:
 class NSPart:
     name: str
     qualifiers: tuple['FQN', ...]
-    suffix: int = 0
+    suffix: str = ''
 
-    def __init__(self, name: str, quals: QUALIFIERS = None, suffix: int = 0) -> None:
+    def __init__(self, name: str, quals: QUALIFIERS = None, suffix: str = '') -> None:
         object.__setattr__(self, 'name', name)
         object.__setattr__(self, 'qualifiers', get_qualifiers(quals))
         object.__setattr__(self, 'suffix', suffix)
@@ -110,7 +110,7 @@ class NSPart:
         if len(self.qualifiers) > 0:
             quals = ', '.join(q.human_name for q in self.qualifiers)
             result = f'{result}[{quals}]'
-        if self.suffix != 0:
+        if self.suffix != '':
             result += f'#{self.suffix}'
         return result
 
@@ -121,7 +121,7 @@ class NSPart:
         if len(self.qualifiers) > 0:
             quals = '_'.join(fqn.c_name_plain for fqn in self.qualifiers)
             result = f'{result}__{quals}'
-        if self.suffix != 0:
+        if self.suffix != '':
             result += f'${self.suffix}'
         return result
 
@@ -143,7 +143,7 @@ class FQN:
             fqn.parts = get_parts(x)
             return fqn
 
-    def with_suffix(self, suffix: int) -> 'FQN':
+    def with_suffix(self, suffix: str) -> 'FQN':
         """
         Create a new FQN with the specified suffix on the last NSPart.
         """

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -69,9 +69,9 @@ import re
 import functools
 
 PARTS = Sequence[Union[str, 'NSPart']]
-QUALIFIERS = Optional[tuple[Union[str, 'FQN'], ...]]
+QUALIFIERS = Optional[Sequence[Union[str, 'FQN']]]
 
-def get_parts(x: PARTS) -> tuple['NSPart']:
+def get_parts(x: PARTS) -> tuple['NSPart', ...]:
     parts = []
     for part in x:
         if isinstance(part, str):
@@ -82,8 +82,8 @@ def get_parts(x: PARTS) -> tuple['NSPart']:
             assert False
     return tuple(parts)
 
-def get_qualifiers(x: QUALIFIERS) -> tuple['FQN']:
-    x = x or []
+def get_qualifiers(x: QUALIFIERS) -> tuple['FQN', ...]:
+    x = x or ()
     quals = []
     for item in x:
         if isinstance(item, str):
@@ -97,7 +97,7 @@ def get_qualifiers(x: QUALIFIERS) -> tuple['FQN']:
 @dataclass(frozen=True)
 class NSPart:
     name: str
-    qualifiers: tuple['FQN']
+    qualifiers: tuple['FQN', ...]
     suffix: int = 0
 
     def __init__(self, name: str, quals: QUALIFIERS = None, suffix: int = 0) -> None:
@@ -127,7 +127,7 @@ class NSPart:
 
 
 class FQN:
-    parts: tuple[NSPart]
+    parts: tuple[NSPart, ...]
 
     def __new__(cls, x: str | PARTS) -> 'FQN':
         """

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -143,6 +143,11 @@ class FQN:
             fqn.parts = get_parts(x)
             return fqn
 
+    # uncomment this to understand who creates a specific FQN
+    ## def __init__(self, *args) -> None:
+    ##     if str(self) == 'test::Point#0':
+    ##         breakpoint()
+
     def with_suffix(self, suffix: str) -> 'FQN':
         """
         Create a new FQN with the specified suffix on the last NSPart.

--- a/spy/fqn_parser.py
+++ b/spy/fqn_parser.py
@@ -101,7 +101,7 @@ class FQNParser:
         else:
             return NSPart(name, ())
 
-    def parse_qualifiers(self) -> list['FQN']:
+    def parse_qualifiers(self) -> tuple['FQN', ...]:
         qualifiers = []
         while True:
             qualifiers.append(self.parse_fqn())
@@ -111,7 +111,7 @@ class FQNParser:
                 self.expect(',')
             elif self.peek() == ']':
                 break
-        return qualifiers
+        return tuple(qualifiers)
 
     def parse_name(self) -> str:
         name = self.peek()

--- a/spy/fqn_parser.py
+++ b/spy/fqn_parser.py
@@ -83,8 +83,9 @@ class FQNParser:
             try:
                 # Convert suffix to int
                 suffix = int(suffix_str)
-                # Set suffix on the last part
-                parts[-1].suffix = suffix
+                # Create a new NSPart with the suffix for the last part
+                last_part = parts[-1]
+                parts[-1] = NSPart(last_part.name, last_part.qualifiers, suffix)
             except ValueError:
                 raise ValueError(f"Suffix must be numeric, got: {suffix_str}")
 
@@ -98,7 +99,7 @@ class FQNParser:
             self.expect(']')
             return NSPart(name, qualifiers)
         else:
-            return NSPart(name, [])
+            return NSPart(name, ())
 
     def parse_qualifiers(self) -> list['FQN']:
         qualifiers = []

--- a/spy/fqn_parser.py
+++ b/spy/fqn_parser.py
@@ -79,15 +79,10 @@ class FQNParser:
 
         if self.peek() == "#":
             self.expect("#")
-            suffix_str = self.parse_suffix()
-            try:
-                # Convert suffix to int
-                suffix = int(suffix_str)
-                # Create a new NSPart with the suffix for the last part
-                last_part = parts[-1]
-                parts[-1] = NSPart(last_part.name, last_part.qualifiers, suffix)
-            except ValueError:
-                raise ValueError(f"Suffix must be numeric, got: {suffix_str}")
+            suffix = self.parse_suffix()
+            # Create a new NSPart with the suffix for the last part
+            last_part = parts[-1]
+            parts[-1] = NSPart(last_part.name, last_part.qualifiers, suffix)
 
         return FQN(parts)
 

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -138,6 +138,8 @@ class Parser:
                                  ) -> spy.ast.FuncDef:
         color: spy.ast.Color = 'red'
         func_kind: spy.ast.FuncKind = 'plain'
+        decorators: list[spy.ast.Expr] = []
+
         for deco in py_funcdef.decorator_list:
             d = parse_special_decorator(deco)
             # @blue.* are special cased
@@ -150,9 +152,8 @@ class Parser:
                 color = 'blue'
                 func_kind = 'metafunc'
             else:
-                # other decorators are not supported:
-                self.error('decorators are not supported yet',
-                           'this is not supported', deco.loc)
+                # other decorators are stored as general decorators
+                decorators.append(self.from_py_expr(deco))
         #
         loc = py_funcdef.loc
         name = py_funcdef.name
@@ -202,6 +203,7 @@ class Parser:
             return_type = return_type,
             body = body,
             docstring = docstring,
+            decorators = decorators,
         )
 
     def from_py_arguments(self,

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -1125,7 +1125,6 @@ class TestBasic(CompilerTest):
         mod = self.compile(src)
         assert mod.foo() == 6
 
-    #@pytest.mark.skip('implement me')
     def test_decorator(self):
         src = """
         @blue
@@ -1144,3 +1143,25 @@ class TestBasic(CompilerTest):
         """
         mod = self.compile(src)
         assert mod.foo(5) == 12
+
+    def test_multiple_decorator(self):
+        src = """
+        @blue
+        def inc(fn):
+            def inner(x: i32) -> i32:
+                return fn(x) + 1
+            return inner
+
+        @blue
+        def double(fn):
+            def inner(x: i32) -> i32:
+                return fn(x) * 2
+            return inner
+
+        @inc
+        @double
+        def x2_plus_1(x: i32) -> i32:
+            return x
+        """
+        mod = self.compile(src)
+        assert mod.x2_plus_1(5) == 11

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -1124,3 +1124,23 @@ class TestBasic(CompilerTest):
         """
         mod = self.compile(src)
         assert mod.foo() == 6
+
+    @pytest.mark.skip('implement me')
+    def test_decorator(self):
+        src = """
+        @blue
+        def double(fn):
+            def inner(x: i32) -> i32:
+                res = fn(x)
+                return res * 2
+            return inner
+
+        @double
+        def inc(x: i32) -> i32:
+            return x + 1
+
+        def foo(x: i32):
+            return inc(x)
+        """
+        mod = self.compile(src)
+        assert mod.foo(5) == 12

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -1125,7 +1125,7 @@ class TestBasic(CompilerTest):
         mod = self.compile(src)
         assert mod.foo() == 6
 
-    @pytest.mark.skip('implement me')
+    #@pytest.mark.skip('implement me')
     def test_decorator(self):
         src = """
         @blue
@@ -1139,7 +1139,7 @@ class TestBasic(CompilerTest):
         def inc(x: i32) -> i32:
             return x + 1
 
-        def foo(x: i32):
+        def foo(x: i32) -> i32:
             return inc(x)
         """
         mod = self.compile(src)

--- a/spy/tests/test_backend_spy.py
+++ b/spy/tests/test_backend_spy.py
@@ -129,7 +129,7 @@ class TestSPyBackend(CompilerTest):
             pass
         """)
 
-    def test_dont_dump_func_references(self):
+    def test_func_aliases(self):
         mod = self.compile("""
         @blue.generic
         def add(T):
@@ -145,6 +145,9 @@ class TestSPyBackend(CompilerTest):
             add_f64(3.4, 5.6)
         """)
         self.assert_dump("""
+        add_i32 = `test::add[i32]::impl`
+        add_f64 = `test::add[f64]::impl`
+
         def `test::add[i32]::impl`(x: i32, y: i32) -> i32:
             return x + y
 

--- a/spy/tests/test_cli.py
+++ b/spy/tests/test_cli.py
@@ -99,7 +99,7 @@ class TestMain:
 
     def test_redshift_dump_spy(self):
         res, stdout = self.run('--redshift', self.main_spy)
-        assert stdout.startswith('def main() -> None:')
+        assert stdout.startswith('\ndef main() -> None:')
 
     def test_redshift_dump_ast(self):
         res, stdout = self.run('--redshift', '--parse', self.main_spy)

--- a/spy/tests/test_fqn.py
+++ b/spy/tests/test_fqn.py
@@ -17,7 +17,7 @@ def test_FQN_init_parts():
 def test_FQN_suffix():
     a = FQN("aaa::bbb#1")
     assert a.fullname == "aaa::bbb#1"
-    assert a.parts[-1].suffix == 1
+    assert a.parts[-1].suffix == '1'
 
 def test_many_FQNs():
     assert str(FQN("aaa")) == "aaa"
@@ -125,6 +125,6 @@ def test_FQN_match():
 
 def test_FQN_with_suffix():
     a = FQN("a::b")
-    a1 = a.with_suffix(1)
+    a1 = a.with_suffix('1')
     assert a.fullname == "a::b"
     assert a1.fullname == "a::b#1"

--- a/spy/tests/test_fqn.py
+++ b/spy/tests/test_fqn.py
@@ -4,10 +4,10 @@ def test_FQN_init_fullname():
     a = FQN("a.b.c::xxx")
     assert a.fullname == "a.b.c::xxx"
     assert a.modname == "a.b.c"
-    assert a.parts == [
-        NSPart("a.b.c", []),
-        NSPart("xxx", [])
-    ]
+    assert a.parts == (
+        NSPart("a.b.c", ()),
+        NSPart("xxx", ())
+    )
 
 def test_FQN_init_parts():
     a = FQN(['a.b.c', 'xxx'])
@@ -42,11 +42,11 @@ def test_qualifiers():
     a = FQN("a::b[x, y]::c")
     assert a.fullname == "a::b[x, y]::c"
     assert a.modname == "a"
-    assert a.parts == [
-        NSPart("a", []),
-        NSPart("b", [FQN("x"), FQN("y")]),
-        NSPart("c", [])
-    ]
+    assert a.parts == (
+        NSPart("a", ()),
+        NSPart("b", (FQN("x"), FQN("y"))),
+        NSPart("c", ())
+    )
 
 def test_nested_qualifiers():
     a = FQN("mod::dict[str, unsafe::ptr[mymod::Point]]")
@@ -122,3 +122,9 @@ def test_FQN_match():
     assert not a.match("mod::ptr[i32]::store")
     assert not a.match("mod::ptr[*]::store")
     assert not a.match("load")
+
+def test_FQN_with_suffix():
+    a = FQN("a::b")
+    a1 = a.with_suffix(1)
+    assert a.fullname == "a::b"
+    assert a1.fullname == "a::b#1"

--- a/spy/tests/test_fqn_parser.py
+++ b/spy/tests/test_fqn_parser.py
@@ -10,24 +10,24 @@ def test_single_unqualified_part():
     fqn = FQN("foo")
     assert len(fqn.parts) == 1
     assert fqn.parts[0].name == "foo"
-    assert fqn.parts[0].qualifiers == []
+    assert fqn.parts[0].qualifiers == ()
     assert fqn.parts[0].suffix == 0
 
 def test_two_parts():
     fqn = FQN("mod::foo")
     assert len(fqn.parts) == 2
     assert fqn.parts[0].name == "mod"
-    assert fqn.parts[0].qualifiers == []
+    assert fqn.parts[0].qualifiers == ()
     assert fqn.parts[1].name == "foo"
-    assert fqn.parts[1].qualifiers == []
+    assert fqn.parts[1].qualifiers == ()
 
 def test_dot_in_name():
     fqn = FQN("a.b.c::foo")
     assert len(fqn.parts) == 2
     assert fqn.parts[0].name == "a.b.c"
-    assert fqn.parts[0].qualifiers == []
+    assert fqn.parts[0].qualifiers == ()
     assert fqn.parts[1].name == "foo"
-    assert fqn.parts[1].qualifiers == []
+    assert fqn.parts[1].qualifiers == ()
 
 def test_single_part_with_qualifier():
     fqn = FQN("list[i32]")

--- a/spy/tests/test_fqn_parser.py
+++ b/spy/tests/test_fqn_parser.py
@@ -11,7 +11,7 @@ def test_single_unqualified_part():
     assert len(fqn.parts) == 1
     assert fqn.parts[0].name == "foo"
     assert fqn.parts[0].qualifiers == ()
-    assert fqn.parts[0].suffix == 0
+    assert fqn.parts[0].suffix == ''
 
 def test_two_parts():
     fqn = FQN("mod::foo")
@@ -51,5 +51,5 @@ def test_suffix():
     assert fqn.parts[0].name == "mod"
     assert fqn.parts[1].name == "foo"
     assert fqn.parts[1].qualifiers[0].parts[0].name == "i32"
-    assert fqn.parts[1].suffix == 1
+    assert fqn.parts[1].suffix == '1'
     assert str(fqn) == "mod::foo[i32]#1"

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -59,6 +59,7 @@ class TestParser:
                         body=[
                             Pass(),
                         ],
+                        decorators=[],
                     ),
                 ),
             ],
@@ -97,6 +98,7 @@ class TestParser:
                         body=[
                             Pass(),
                         ],
+                        decorators=[],
                     ),
                 ),
             ],
@@ -171,17 +173,100 @@ class TestParser:
             ("type is missing here", "a"),
         )
 
-    def test_FuncDef_errors_8(self):
-        src = """
+    def test_FuncDef_decorator(self):
+        mod = self.parse("""
         @mydecorator
         def foo() -> None:
             pass
-        """
-        self.expect_errors(
-            src,
-            "decorators are not supported yet",
-            ("this is not supported", "mydecorator"),
+        """)
+        funcdef = mod.get_funcdef('foo')
+        expected = """
+        FuncDef(
+            color='red',
+            kind='plain',
+            name='foo',
+            args=[],
+            vararg=None,
+            return_type=Constant(value=None),
+            docstring=None,
+            body=[
+                Pass(),
+            ],
+            decorators=[
+                Name(id='mydecorator'),
+            ],
         )
+        """
+        self.assert_dump(funcdef, expected)
+
+    def test_FuncDef_multiple_decorators(self):
+        mod = self.parse("""
+        @deco1
+        @deco2.attr
+        @deco3(arg)
+        def foo() -> None:
+            pass
+        """)
+        funcdef = mod.get_funcdef('foo')
+        expected = """
+        FuncDef(
+            color='red',
+            kind='plain',
+            name='foo',
+            args=[],
+            vararg=None,
+            return_type=Constant(value=None),
+            docstring=None,
+            body=[
+                Pass(),
+            ],
+            decorators=[
+                Name(id='deco1'),
+                GetAttr(
+                    value=Name(id='deco2'),
+                    attr=StrConst(value='attr'),
+                ),
+                Call(
+                    func=Name(id='deco3'),
+                    args=[
+                        Name(id='arg'),
+                    ],
+                ),
+            ],
+        )
+        """
+        self.assert_dump(funcdef, expected)
+
+    def test_FuncDef_mixed_decorators(self):
+        mod = self.parse("""
+        @mydecorator
+        @blue
+        @another_deco
+        def foo() -> i32:
+            return 42
+        """)
+        funcdef = mod.get_funcdef('foo')
+        expected = """
+        FuncDef(
+            color='blue',
+            kind='plain',
+            name='foo',
+            args=[],
+            vararg=None,
+            return_type=Name(id='i32'),
+            docstring=None,
+            body=[
+                Return(
+                    value=Constant(value=42),
+                ),
+            ],
+            decorators=[
+                Name(id='mydecorator'),
+                Name(id='another_deco'),
+            ],
+        )
+        """
+        self.assert_dump(funcdef, expected)
 
     def test_FuncDef_body(self):
         mod = self.parse("""
@@ -203,6 +288,7 @@ class TestParser:
                     value=Constant(value=42),
                 ),
             ],
+            decorators=[],
         )
         """
         self.assert_dump(funcdef, expected)
@@ -228,6 +314,7 @@ class TestParser:
                     value=Constant(value=42),
                 ),
             ],
+            decorators=[],
         )
         """
         self.assert_dump(funcdef, expected)
@@ -253,6 +340,7 @@ class TestParser:
                     value=Constant(value=42),
                 ),
             ],
+            decorators=[],
         )
         """
         self.assert_dump(funcdef, expected)
@@ -278,6 +366,7 @@ class TestParser:
                     value=Constant(value=42),
                 ),
             ],
+            decorators=[],
         )
         """
         self.assert_dump(funcdef, expected)
@@ -303,6 +392,7 @@ class TestParser:
                     value=Constant(value=42),
                 ),
             ],
+            decorators=[],
         )
         """
         self.assert_dump(funcdef, expected)
@@ -1002,8 +1092,10 @@ class TestParser:
                                 body=[
                                     Pass(),
                                 ],
+                                decorators=[],
                             ),
                         ],
+                        decorators=[],
                     ),
                 ),
             ],
@@ -1220,6 +1312,7 @@ class TestParser:
                     body=[
                         Pass(),
                     ],
+                    decorators=[],
                 ),
             ],
         )
@@ -1253,6 +1346,7 @@ class TestParser:
             body=[
                 Pass(),
             ],
+            decorators=[],
         )
         """
         self.assert_dump(funcdef, expected)

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -231,7 +231,7 @@ class AbstractFrame:
             # XXX explain
             fqn = fqn.with_suffix('__bare__')
 
-        w_func = W_ASTFunc(w_functype, fqn, funcdef, closure)
+        w_func: W_Object = W_ASTFunc(w_functype, fqn, funcdef, closure)
         self.vm.add_global(fqn, w_func)
 
         if funcdef.decorators:
@@ -252,7 +252,7 @@ class AbstractFrame:
                 w_func = wam_inner.w_blueval
 
         w_T = self.vm.dynamic_type(w_func)
-        self.declare_local(funcdef.name, w_T, funcdef.prototype_loc) # XXX loc?
+        self.declare_local(funcdef.name, w_T, funcdef.prototype_loc)
         self.store_local(funcdef.name, w_func)
 
 

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -235,7 +235,6 @@ class AbstractFrame:
         self.vm.add_global(fqn, w_func)
 
         if funcdef.decorators:
-            assert len(funcdef.decorators) == 1, 'fixme'
             for deco in reversed(funcdef.decorators):
                 # create a tmp Call node to evaluate
                 call_node = ast.Call(

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -227,8 +227,13 @@ class AbstractFrame:
         # XXX we should capture only the names actually used in the inner func
         closure = self.closure + (self._locals,)
 
+        # this is just a cosmetic nicety. In presence of decorators, "mod.foo"
+        # will NOT necessarily contain the function object which is being
+        # created. If we call the function FQN("mod::foo"), it might create
+        # confusion. The solution is that in presence of decorators, we use
+        # FQN("mod::foo#__bare__") as the name of the function, to make it
+        # clear is the undecorated version.
         if funcdef.decorators:
-            # XXX explain
             fqn = fqn.with_suffix('__bare__')
 
         w_func: W_Object = W_ASTFunc(w_functype, fqn, funcdef, closure)

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -196,7 +196,7 @@ class SPyVM:
         # XXX this is potentially quadratic if we create tons of
         # conflicting FQNs, but for now we don't care
         for n in itertools.count():
-            fqn2 = fqn.with_suffix(n)
+            fqn2 = fqn.with_suffix(str(n))
             if fqn2 not in self.globals_w:
                 return fqn2
         assert False, 'unreachable'

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -193,9 +193,15 @@ class SPyVM:
         """
         Get an unique variant of the given FQN, adding a suffix if necessary.
         """
+        if fqn not in self.globals_w:
+            # fqn not used yet, just return it
+            return fqn
+
+        # fqn already used, try to add an unique suffix.
+        #
         # XXX this is potentially quadratic if we create tons of
         # conflicting FQNs, but for now we don't care
-        for n in itertools.count():
+        for n in itertools.count(1):
             fqn2 = fqn.with_suffix(str(n))
             if fqn2 not in self.globals_w:
                 return fqn2


### PR DESCRIPTION
Decorators must be `@blue` functions, but otherwise they work very similarly to Python.

To make debugging easier, the "original" function is named e.g. `mod::foo#__bare__`, so that it's clear that it doesn't necessarily correspond to `mod.foo`.

Moreover, in this PR we modify the class FQN in two ways:
1. make sure it's immutable, and fix a bug which mutated the original FQN when calling `with_suffix`
2. change (again!) the type of `FQN.suffix` from int to str. This is needed to make it possible to use the `__bare__` suffix.