### PR TITLE
For loops, range and iterators

### DIFF
--- a/spy/analyze/scope.py
+++ b/spy/analyze/scope.py
@@ -285,9 +285,15 @@ class ScopeAnalyzer:
             self.define_name(target.value, 'red', 'var', target.loc, type_loc)
 
     def declare_For(self, forstmt: ast.For) -> None:
-        # consider "for i in range(10)".  What is the "type_loc" of i? It's an
-        # implicit declaration, and its value depends on the iterator returned
-        # by range. So we use "range(10)" as the type_loc.
+        # Declare the hidden iterator variable @for_iter_N
+        iter_name = f'@for_iter_{forstmt.seq}'
+        self.define_name(iter_name, 'red', 'var',
+                         forstmt.iter.loc, forstmt.iter.loc)
+
+        # Declare the loop variable (e.g., "i" in "for i in range(10)")
+        # What is the "type_loc" of i? It's an implicit declaration, and its
+        # value depends on the iterator returned by range. So we use
+        # "range(10)" as the type_loc.
         self.define_name(forstmt.target.value, 'red', 'var',
                          forstmt.target.loc, forstmt.iter.loc)
         for stmt in forstmt.body:

--- a/spy/analyze/scope.py
+++ b/spy/analyze/scope.py
@@ -318,7 +318,7 @@ class ScopeAnalyzer:
 
         else:
             # the name was found but in an outer scope. Let's "capture" it.
-            level, sym = self.lookup_definition(varname)
+            level, sym = self.lookup_definition(varname)  # type: ignore
             assert sym
             assert not self.scope.has_definition(varname)
             new_sym = sym.replace(level=level)

--- a/spy/analyze/scope.py
+++ b/spy/analyze/scope.py
@@ -285,8 +285,8 @@ class ScopeAnalyzer:
             self.define_name(target.value, 'red', 'var', target.loc, type_loc)
 
     def declare_For(self, forstmt: ast.For) -> None:
-        # Declare the hidden iterator variable @for_iter_N
-        iter_name = f'@for_iter_{forstmt.seq}'
+        # Declare the hidden iterator variable _$iter0
+        iter_name = f'_$iter{forstmt.seq}'
         self.define_name(iter_name, 'red', 'var',
                          forstmt.iter.loc, forstmt.iter.loc)
 

--- a/spy/analyze/symtable.py
+++ b/spy/analyze/symtable.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 Color = Literal["red", "blue"]
 VarKind = Literal["var", "const"]
-VarStorage = Literal["direct", "cell"]
+VarStorage = Literal["direct", "cell", "NameError"]
 
 def maybe_blue(*colors: Color) -> Color:
     """
@@ -152,7 +152,13 @@ class SymTable:
         )
         for sym in symbols:
             sym_name = color.set(sym.color, f'{sym.name:10s}')
-            fqn = ''
+
+            if sym.storage == 'NameError':
+                # special formatting
+                print(f'    [ ] NameError  {sym_name}')
+                continue
+
+            impref = ''
             if sym.impref:
                 impref = f' => {sym.impref}'
             storage = ''

--- a/spy/analyze/symtable.py
+++ b/spy/analyze/symtable.py
@@ -152,7 +152,6 @@ class SymTable:
         )
         for sym in symbols:
             sym_name = color.set(sym.color, f'{sym.name:10s}')
-
             if sym.storage == 'NameError':
                 # special formatting
                 print(f'    [ ] NameError  {sym_name}')

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -479,6 +479,7 @@ class While(Stmt):
 
 @dataclass(eq=False)
 class For(Stmt):
+    seq: int  # unique id within a funcdef
     target: StrConst
     iter: Expr
     body: list[Stmt]

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -478,6 +478,12 @@ class While(Stmt):
     body: list[Stmt]
 
 @dataclass(eq=False)
+class For(Stmt):
+    target: StrConst
+    iter: Expr
+    body: list[Stmt]
+
+@dataclass(eq=False)
 class Raise(Stmt):
     exc: Expr
 

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -259,6 +259,14 @@ class SPyBackend:
             for stmt in while_node.body:
                 self.emit_stmt(stmt)
 
+    def emit_stmt_For(self, for_node: ast.For) -> None:
+        target = for_node.target.value
+        iter_expr = self.fmt_expr(for_node.iter)
+        self.wl(f'for {target} in {iter_expr}:')
+        with self.out.indent():
+            for stmt in for_node.body:
+                self.emit_stmt(stmt)
+
     def emit_stmt_If(self, if_node: ast.If) -> None:
         test = self.fmt_expr(if_node.test)
         self.wl(f'if {test}:')

--- a/spy/build/config.py
+++ b/spy/build/config.py
@@ -27,7 +27,7 @@ RELEASE_CFLAGS  = ['-DSPY_RELEASE', '-O3', '-flto']
 RELEASE_LDFLAGS = ['-flto']
 
 DEBUG_CFLAGS    = ['-DSPY_DEBUG',   '-O0', '-g']
-DEBUG_LDFLAGS   = []
+DEBUG_LDFLAGS: list[str] = []
 
 WASM_CFLAGS = [
     '-mmultivalue',

--- a/spy/build/config.py
+++ b/spy/build/config.py
@@ -23,8 +23,11 @@ CFLAGS = [
     '-fdiagnostics-color=always', # force colors
     '-I', str(spy.libspy.INCLUDE),
 ]
-RELEASE_CFLAGS = ['-DSPY_RELEASE', '-O3']
-DEBUG_CFLAGS   = ['-DSPY_DEBUG',   '-O0', '-g']
+RELEASE_CFLAGS  = ['-DSPY_RELEASE', '-O3', '-flto']
+RELEASE_LDFLAGS = ['-flto']
+
+DEBUG_CFLAGS    = ['-DSPY_DEBUG',   '-O0', '-g']
+DEBUG_LDFLAGS   = []
 
 WASM_CFLAGS = [
     '-mmultivalue',
@@ -44,10 +47,6 @@ class CompilerConfig:
         self.cflags += [
             f'-DSPY_TARGET_{config.target.upper()}'
         ]
-        if config.build_type == 'release':
-            self.cflags += RELEASE_CFLAGS
-        else:
-            self.cflags += DEBUG_CFLAGS
 
         # e.g. 'spy/libspy/build/native/release/'
         libdir = spy.libspy.BUILD.join(config.target, config.build_type)
@@ -55,6 +54,13 @@ class CompilerConfig:
             '-L', str(libdir),
             '-lspy'
         ]
+
+        if config.build_type == 'release':
+            self.cflags += RELEASE_CFLAGS
+            self.ldflags += RELEASE_LDFLAGS
+        else:
+            self.cflags += DEBUG_CFLAGS
+            self.ldflags += RELEASE_LDFLAGS
 
         # target specific flags
         if config.target == 'native':

--- a/spy/build/ninja.py
+++ b/spy/build/ninja.py
@@ -1,6 +1,7 @@
 from typing import Optional
 import shlex
 import py.path
+from spy.errors import WIP
 from spy.textbuilder import TextBuilder
 from spy.build.config import BuildConfig, CompilerConfig
 from spy.util import robust_run
@@ -35,7 +36,8 @@ class NinjaWriter:
     def __init__(self, config: BuildConfig, build_dir: py.path.local) -> None:
         # for now, we support only some combinations of target/kind
         if config.kind == 'lib':
-            assert config.target in ('wasi', 'emscripten')
+            if config.target not in ('wasi', 'emscripten'):
+                raise WIP('--output-kind=lib works only for wasi and emscripten targets')
         self.config = config
         self.build_dir = build_dir
         self.out = None

--- a/spy/cli.py
+++ b/spy/cli.py
@@ -404,7 +404,7 @@ async def inner_main(args: Arguments) -> None:
     if executable == '':
         # outfile is not in a subdir of cwd, let's display the full path
         executable = str(outfile)
-    print(f"==> {executable}")
+    print(f"[{config.build_type}] {executable} ")
 
 
 def execute_spy_main(args: Arguments, vm: SPyVM, w_mod: W_Module) -> None:

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -204,13 +204,17 @@ class DopplerFrame(ASTFrame):
             else_body = newelse
         )]
 
-    def shift_stmt_While(self, while_node: ast.While) -> list[ast.While]:
+    def shift_stmt_While(self, while_node: ast.While) -> list[ast.Stmt]:
         newtest = self.eval_and_shift(while_node.test, varname='@while')
         newbody = self.shift_body(while_node.body)
         return [while_node.replace(
             test = newtest,
             body = newbody
         )]
+
+    def shift_stmt_For(self, for_node: ast.For) -> list[ast.Stmt]:
+        init_iter, while_loop = self._desugar_For(for_node)
+        return self.shift_stmt(init_iter) + self.shift_stmt(while_loop)
 
     def shift_stmt_Raise(self, raise_node: ast.Raise) -> list[ast.Stmt]:
         self.exec_stmt(raise_node)

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -1165,3 +1165,16 @@ class TestBasic(CompilerTest):
         """
         mod = self.compile(src)
         assert mod.x2_plus_1(5) == 11
+
+    def test_for_loop(self):
+        src = """
+        from _range import range
+
+        def factorial(n: i32) -> i32:
+            res = 1
+            for i in range(n):
+                res *= (i+1)
+            return res
+        """
+        mod = self.compile(src)
+        assert mod.factorial(4) == 2 * 3 * 4

--- a/spy/tests/compiler/test_struct.py
+++ b/spy/tests/compiler/test_struct.py
@@ -46,6 +46,24 @@ class TestStructOnStack(CompilerTest):
         assert mod.foo(3, 4) == 7
         assert mod.bar(5, 6) == 11
 
+    def test_wrong_field(self):
+        src = """
+        @struct
+        class Point:
+            x: i32
+            y: i32
+
+        def foo() -> i32:
+            p = Point(0, 0)
+            return p.z
+        """
+        errors = expect_errors(
+            "type `test::Point` has no attribute 'z'",
+            ("this is `test::Point`", "p"),
+            ("`p` defined here", "p"),
+        )
+        self.compile_raises(src, "foo", errors)
+
     def test_spy_unwrap(self):
         src = """
         @struct

--- a/spy/tests/compiler/test_struct.py
+++ b/spy/tests/compiler/test_struct.py
@@ -55,10 +55,14 @@ class TestStructOnStack(CompilerTest):
 
         def make_point(x: i32, y: i32) -> Point:
             return Point(x, y)
+
+        def get_x(p: Point) -> i32:
+            return p.x
         """
         mod = self.compile(src)
         p = mod.make_point(1, 2)
         assert p == (1, 2)
+        assert mod.get_x(p) == 1
 
     def test_pass_and_return(self):
         src = """

--- a/spy/tests/stdlib/test__range.py
+++ b/spy/tests/stdlib/test__range.py
@@ -26,6 +26,9 @@ class TestRange(CompilerTest):
         def next(it: range_iterator) -> range_iterator:
             return it.__next__()
 
+        def item(it: range_iterator) -> int:
+            return it.__item__()
+
         def cont(it: range_iterator) -> bool:
             return it.__continue_iteration__()
         """
@@ -34,14 +37,17 @@ class TestRange(CompilerTest):
 
         assert it == (0, 3)
         assert mod.cont(it) == True
+        assert mod.item(it) == 0
         it = mod.next(it)
 
         assert it == (1, 3)
         assert mod.cont(it) == True
+        assert mod.item(it) == 1
         it = mod.next(it)
 
         assert it == (2, 3)
         assert mod.cont(it) == True
+        assert mod.item(it) == 2
         it = mod.next(it)
 
         assert it == (3, 3)

--- a/spy/tests/stdlib/test__range.py
+++ b/spy/tests/stdlib/test__range.py
@@ -52,3 +52,23 @@ class TestRange(CompilerTest):
 
         assert it == (3, 3)
         assert mod.cont(it) == False
+
+    def test_misc(self):
+        src = """
+        from _range import range
+
+        def tostr(r: range) -> str:
+            s = ''
+            for i in r:
+                s += str(i) + ' '
+            return s
+
+        def fmt1(n: int) -> str:
+            return tostr(range(n))
+
+        def fmt2(a: int, b: int) -> str:
+            return tostr(range(a, b))
+        """
+        mod = self.compile(src)
+        assert mod.fmt1(4) == '0 1 2 3 '
+        assert mod.fmt2(3, 7) == '3 4 5 6 '

--- a/spy/tests/stdlib/test__range.py
+++ b/spy/tests/stdlib/test__range.py
@@ -14,3 +14,35 @@ class TestRange(CompilerTest):
         r = mod.make_range()
         assert r.start == 0
         assert r.stop == 10
+
+    def test_fastiter(self):
+        src = """
+        from _range import range, range_iterator
+
+        def get_iter() -> range_iterator:
+            r = range(3)
+            return r.__fastiter__()
+
+        def next(it: range_iterator) -> range_iterator:
+            return it.__next__()
+
+        def cont(it: range_iterator) -> bool:
+            return it.__continue_iteration__()
+        """
+        mod = self.compile(src)
+        it = mod.get_iter()
+
+        assert it == (0, 3)
+        assert mod.cont(it) == True
+        it = mod.next(it)
+
+        assert it == (1, 3)
+        assert mod.cont(it) == True
+        it = mod.next(it)
+
+        assert it == (2, 3)
+        assert mod.cont(it) == True
+        it = mod.next(it)
+
+        assert it == (3, 3)
+        assert mod.cont(it) == False

--- a/spy/tests/stdlib/test__range.py
+++ b/spy/tests/stdlib/test__range.py
@@ -35,22 +35,22 @@ class TestRange(CompilerTest):
         mod = self.compile(src)
         it = mod.get_iter()
 
-        assert it == (0, 3)
+        assert it == (0, 3, 1)
         assert mod.cont(it) == True
         assert mod.item(it) == 0
         it = mod.next(it)
 
-        assert it == (1, 3)
+        assert it == (1, 3, 1)
         assert mod.cont(it) == True
         assert mod.item(it) == 1
         it = mod.next(it)
 
-        assert it == (2, 3)
+        assert it == (2, 3, 1)
         assert mod.cont(it) == True
         assert mod.item(it) == 2
         it = mod.next(it)
 
-        assert it == (3, 3)
+        assert it == (3, 3, 1)
         assert mod.cont(it) == False
 
     def test_misc(self):
@@ -68,7 +68,32 @@ class TestRange(CompilerTest):
 
         def fmt2(a: int, b: int) -> str:
             return tostr(range(a, b))
+
+        def fmt3(a: int, b: int, step: int) -> str:
+            return tostr(range(a, b, step))
         """
         mod = self.compile(src)
+        # Basic cases
         assert mod.fmt1(4) == '0 1 2 3 '
         assert mod.fmt2(3, 7) == '3 4 5 6 '
+
+        # Step parameter
+        assert mod.fmt3(0, 10, 2) == '0 2 4 6 8 '
+        assert mod.fmt3(1, 10, 3) == '1 4 7 '
+        assert mod.fmt3(5, 15, 4) == '5 9 13 '
+
+        # Negative step
+        assert mod.fmt3(10, 0, -1) == '10 9 8 7 6 5 4 3 2 1 '
+        assert mod.fmt3(10, 0, -2) == '10 8 6 4 2 '
+        assert mod.fmt3(5, -5, -3) == '5 2 -1 -4 '
+
+        # Negative stop (empty ranges)
+        assert mod.fmt1(-5) == ''
+        assert mod.fmt2(0, -10) == ''
+        assert mod.fmt2(5, 2) == ''
+
+        # Edge cases
+        assert mod.fmt1(0) == ''
+        assert mod.fmt2(5, 5) == ''
+        assert mod.fmt3(0, 0, 1) == ''
+        assert mod.fmt3(10, 10, -1) == ''

--- a/spy/tests/stdlib/test__range.py
+++ b/spy/tests/stdlib/test__range.py
@@ -1,0 +1,16 @@
+import pytest
+from spy.tests.support import CompilerTest
+
+class TestRange(CompilerTest):
+
+    def test_simple(self):
+        src = """
+        from _range import range
+
+        def make_range() -> range:
+            return range(10)
+        """
+        mod = self.compile(src)
+        r = mod.make_range()
+        assert r.start == 0
+        assert r.stop == 10

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -923,6 +923,55 @@ class TestParser:
         """
         self.assert_dump(stmt, expected)
 
+    def test_For(self):
+        mod = self.parse("""
+        def foo() -> None:
+            for i in range(10):
+                pass
+        """)
+        stmt = mod.get_funcdef('foo').body[0]
+        expected = """
+        For(
+            target=StrConst(value='i'),
+            iter=Call(
+                func=Name(id='range'),
+                args=[
+                    Constant(value=10),
+                ],
+            ),
+            body=[
+                Pass(),
+            ],
+        )
+        """
+        self.assert_dump(stmt, expected)
+
+    def test_For_else_unsupported(self):
+        src = """
+        def foo() -> None:
+            for i in range(10):
+                pass
+            else:
+                print("done")
+        """
+        self.expect_errors(
+            src,
+            "not implemented yet: `else` clause in `for` loops",
+            ("this is not supported", "for"),
+        )
+
+    def test_For_complex_target_unsupported(self):
+        src = """
+        def foo() -> None:
+            for i, j in pairs:
+                pass
+        """
+        self.expect_errors(
+            src,
+            "not implemented yet: complex for loop targets",
+            ("this is not supported", "i, j"),
+        )
+
     def test_Raise(self):
         mod = self.parse("""
         def foo() -> None:

--- a/spy/tests/test_scope.py
+++ b/spy/tests/test_scope.py
@@ -330,3 +330,16 @@ class TestScopeAnalyzer:
             '@return': MatchSymbol('@return', 'blue', 'var'),
             'deco': MatchSymbol('deco', 'blue', 'const', level=1),
         }
+
+    def test_symbol_not_found(self):
+        scopes = self.analyze("""
+        def foo() -> None:
+            x = y
+        """)
+        funcdef = self.mod.get_funcdef('foo')
+        scope = scopes.by_funcdef(funcdef)
+        assert scope._symbols == {
+            'x': MatchSymbol('x', 'red', 'var'),
+            '@return': MatchSymbol('@return', 'red', 'var'),
+            'y': MatchSymbol('y', 'red', 'var', level=-1, storage='NameError'),
+        }

--- a/spy/tests/test_scope.py
+++ b/spy/tests/test_scope.py
@@ -358,8 +358,35 @@ class TestScopeAnalyzer:
         funcdef = self.mod.get_funcdef('foo')
         scope = scopes.by_funcdef(funcdef)
         assert scope._symbols == {
+            '@for_iter_0': MatchSymbol('@for_iter_0', 'red', 'var'),
             'i': MatchSymbol('i', 'red', 'var'),
             'x': MatchSymbol('x', 'red', 'var'),
+            '@return': MatchSymbol('@return', 'red', 'var'),
+            'range': MatchSymbol('range', 'blue', 'const', level=1),
+            'i32': MatchSymbol('i32', 'blue', 'const', level=2),
+        }
+
+    def test_for_loop_multiple(self):
+        scopes = self.analyze("""
+        # XXX kill this when 'range' becomes a builtin
+        def range(n: i32) -> dynamic:
+            pass
+
+        def foo() -> None:
+            for i in range(10):
+                x: i32 = i * 2
+            for j in range(5):
+                y: i32 = j * 3
+        """)
+        funcdef = self.mod.get_funcdef('foo')
+        scope = scopes.by_funcdef(funcdef)
+        assert scope._symbols == {
+            '@for_iter_0': MatchSymbol('@for_iter_0', 'red', 'var'),
+            '@for_iter_1': MatchSymbol('@for_iter_1', 'red', 'var'),
+            'i': MatchSymbol('i', 'red', 'var'),
+            'j': MatchSymbol('j', 'red', 'var'),
+            'x': MatchSymbol('x', 'red', 'var'),
+            'y': MatchSymbol('y', 'red', 'var'),
             '@return': MatchSymbol('@return', 'red', 'var'),
             'range': MatchSymbol('range', 'blue', 'const', level=1),
             'i32': MatchSymbol('i32', 'blue', 'const', level=2),

--- a/spy/tests/test_scope.py
+++ b/spy/tests/test_scope.py
@@ -358,7 +358,7 @@ class TestScopeAnalyzer:
         funcdef = self.mod.get_funcdef('foo')
         scope = scopes.by_funcdef(funcdef)
         assert scope._symbols == {
-            '@for_iter_0': MatchSymbol('@for_iter_0', 'red', 'var'),
+            '_$iter0': MatchSymbol('_$iter0', 'red', 'var'),
             'i': MatchSymbol('i', 'red', 'var'),
             'x': MatchSymbol('x', 'red', 'var'),
             '@return': MatchSymbol('@return', 'red', 'var'),
@@ -381,8 +381,8 @@ class TestScopeAnalyzer:
         funcdef = self.mod.get_funcdef('foo')
         scope = scopes.by_funcdef(funcdef)
         assert scope._symbols == {
-            '@for_iter_0': MatchSymbol('@for_iter_0', 'red', 'var'),
-            '@for_iter_1': MatchSymbol('@for_iter_1', 'red', 'var'),
+            '_$iter0': MatchSymbol('_$iter0', 'red', 'var'),
+            '_$iter1': MatchSymbol('_$iter1', 'red', 'var'),
             'i': MatchSymbol('i', 'red', 'var'),
             'j': MatchSymbol('j', 'red', 'var'),
             'x': MatchSymbol('x', 'red', 'var'),

--- a/spy/tests/test_scope.py
+++ b/spy/tests/test_scope.py
@@ -347,6 +347,10 @@ class TestScopeAnalyzer:
 
     def test_for_loop(self):
         scopes = self.analyze("""
+        # XXX kill this when 'range' becomes a builtin
+        def range(n: i32) -> dynamic:
+            pass
+
         def foo() -> None:
             for i in range(10):
                 x: i32 = i * 2
@@ -357,7 +361,7 @@ class TestScopeAnalyzer:
             'i': MatchSymbol('i', 'red', 'var'),
             'x': MatchSymbol('x', 'red', 'var'),
             '@return': MatchSymbol('@return', 'red', 'var'),
-            'range': MatchSymbol('range', 'blue', 'const', level=2),
+            'range': MatchSymbol('range', 'blue', 'const', level=1),
             'i32': MatchSymbol('i32', 'blue', 'const', level=2),
         }
 

--- a/spy/tests/wasm_wrapper.py
+++ b/spy/tests/wasm_wrapper.py
@@ -97,6 +97,12 @@ class WasmFuncWrapper:
         elif isinstance(w_T, W_PtrType):
             assert isinstance(pyval, WasmPtr)
             return (pyval.addr, pyval.length)
+        elif isinstance(w_T, W_StructType):
+            # the function accepts a struct by value; wasmtime allows to pass
+            # a flat sequence of fields. This is the opposite of what we do in
+            # to_py_result. It works only for flat structs with simple types.
+            assert isinstance(pyval, UnwrappedStruct)
+            return tuple(pyval._fields.values())
         else:
             assert False, f'Unsupported type: {w_T}'
 

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -518,12 +518,7 @@ class AbstractFrame:
     def _specialize_Name(self, name: ast.Name) -> ast.Expr:
         varname = name.id
         sym = self.symtable.lookup_maybe(varname)
-        if sym is None:
-            msg = f"name `{name.id}` is not defined"
-            raise SPyError.simple(
-                "W_NameError", msg, "not found in this scope", name.loc,
-            )
-        elif sym.is_local:
+        if sym.is_local:
             assert sym.storage == 'direct'
             return ast.NameLocal(name.loc, sym)
         elif sym.storage == 'direct':
@@ -533,6 +528,11 @@ class AbstractFrame:
             w_cell = namespace[sym.name]
             assert isinstance(w_cell, W_Cell)
             return ast.NameOuterCell(name.loc, sym, w_cell.fqn)
+        elif sym.storage == 'NameError':
+            msg = f"name `{name.id}` is not defined"
+            raise SPyError.simple(
+                "W_NameError", msg, "not found in this scope", name.loc,
+            )
         else:
             assert False
 

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -502,8 +502,8 @@ class AbstractFrame:
         #         body
         #         it = it.__next__()
         #
-        # (instead of 'it' we use the special variable '@for_iter_N')
-        iter_name = f'@for_iter_{for_node.seq}'
+        # (instead of 'it' we use the special variable '_$iterN')
+        iter_name = f'_$iter{for_node.seq}'
         iter_sym = self.symtable.lookup(iter_name)
         iter_target = ast.StrConst(for_node.loc, iter_name)
 

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -593,6 +593,7 @@ class AbstractFrame:
     def _specialize_Name(self, name: ast.Name) -> ast.Expr:
         varname = name.id
         sym = self.symtable.lookup_maybe(varname)
+        assert sym is not None
         if sym.is_local:
             assert sym.storage == 'direct'
             return ast.NameLocal(name.loc, sym)

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -124,11 +124,6 @@ def w_len(vm: 'SPyVM', wam_obj: W_MetaArg) -> W_OpSpec:
         wam_obj.loc
     )
 
-@BUILTINS.builtin_func
-def w_range(vm: 'SPyVM') -> None:
-    raise NotImplementedError
-
-
 # add aliases for common types. For now we map:
 #   int -> i32
 #   float -> f64

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -124,6 +124,11 @@ def w_len(vm: 'SPyVM', wam_obj: W_MetaArg) -> W_OpSpec:
         wam_obj.loc
     )
 
+@BUILTINS.builtin_func
+def w_range(vm: 'SPyVM') -> None:
+    raise NotImplementedError
+
+
 # add aliases for common types. For now we map:
 #   int -> i32
 #   float -> f64

--- a/spy/vm/struct.py
+++ b/spy/vm/struct.py
@@ -149,6 +149,8 @@ class W_Struct(W_Object):
         w_structtype = wam_struct.w_static_T
         assert isinstance(w_structtype, W_StructType)
         name = wam_name.blue_unwrap_str(vm)
+        if name not in w_structtype.fields_w:
+            return W_OpSpec.NULL
 
         w_field = w_structtype.fields_w[name]
         T = Annotated[W_Object, w_field.w_T]

--- a/spy/vm/struct.py
+++ b/spy/vm/struct.py
@@ -185,6 +185,7 @@ class UnwrappedStruct:
     def spy_wrap(self, vm: 'SPyVM') -> W_Struct:
         "This is needed for tests, to use structs as function arguments"
         w_structT = vm.lookup_global(self.fqn)
+        assert isinstance(w_structT, W_StructType)
         assert set(self._fields.keys()) == set(w_structT.fields_w.keys())
         w_struct = W_Struct(w_structT)
         w_struct.values_w = {

--- a/spy/vm/struct.py
+++ b/spy/vm/struct.py
@@ -180,6 +180,17 @@ class UnwrappedStruct:
         self.fqn = fqn
         self._fields = fields
 
+    def spy_wrap(self, vm: 'SPyVM') -> W_Struct:
+        "This is needed for tests, to use structs as function arguments"
+        w_structT = vm.lookup_global(self.fqn)
+        assert set(self._fields.keys()) == set(w_structT.fields_w.keys())
+        w_struct = W_Struct(w_structT)
+        w_struct.values_w = {
+            key: vm.wrap(obj)
+            for key, obj in self._fields.items()
+        }
+        return w_struct
+
     def __getattr__(self, attr: str) -> Any:
         return self._fields[attr]
 

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -27,6 +27,7 @@ from spy.vm.opimpl import W_OpImpl
 from spy.vm.property import W_Property, W_StaticMethod, W_ClassMethod
 from spy.vm.member import W_Member
 from spy.vm.module import W_Module
+from spy.vm.struct import UnwrappedStruct
 from spy.vm.opspec import W_OpSpec, W_MetaArg
 from spy.vm.registry import ModuleRegistry
 from spy.vm.bluecache import BlueCache
@@ -547,6 +548,8 @@ class SPyVM:
             return W_Str(self, value)
         elif T is Loc:
             return W_Loc(value)
+        elif T is UnwrappedStruct:
+            return value.spy_wrap(self)
         elif isinstance(value, FunctionType):
             raise Exception(
                 f"Cannot wrap interp-level function {value.__name__}. "

--- a/stdlib/_range.spy
+++ b/stdlib/_range.spy
@@ -5,3 +5,18 @@ class range:
 
     def __new__(n: int) -> range:
         return range.__make__(0, n)
+
+    def __fastiter__(self: range) -> range_iterator:
+        return range_iterator(self.start, self.stop)
+
+@struct
+class range_iterator:
+    i: int
+    stop: int
+
+    def __next__(self: range_iterator) -> range_iterator:
+        return range_iterator(self.i+1, self.stop)
+
+    # the opposite of StopIteration :)
+    def __continue_iteration__(self: range_iterator) -> bool:
+        return self.i < self.stop

--- a/stdlib/_range.spy
+++ b/stdlib/_range.spy
@@ -1,10 +1,29 @@
+from operator import OpSpec, MetaArg
+
 @struct
 class range:
     start: int
     stop: int
 
-    def __new__(n: int) -> range:
-        return range.__make__(0, n)
+    @blue.metafunc
+    def __new__(m_cls, *args_m):
+        def impl1(n: int) -> range:
+            return range.__make__(0, n)
+
+        def impl2(a: int, b: int) -> range:
+            return range.__make__(a, b)
+
+        # we cannot do list(args_m), so we need to do it manually somehow :(
+        m0: MetaArg
+        m1: MetaArg
+        if len(args_m) == 1:
+            m0, = args_m
+            return OpSpec(impl1, [m0])
+        elif len(args_m) == 2:
+            m0, m1 = args_m
+            return OpSpec(impl2, [m0, m1])
+        else:
+            return OpSpec.NULL
 
     def __fastiter__(self: range) -> range_iterator:
         return range_iterator(self.start, self.stop)

--- a/stdlib/_range.spy
+++ b/stdlib/_range.spy
@@ -17,6 +17,9 @@ class range_iterator:
     def __next__(self: range_iterator) -> range_iterator:
         return range_iterator(self.i+1, self.stop)
 
+    def __item__(self: range_iterator) -> int:
+        return self.i
+
     # the opposite of StopIteration :)
     def __continue_iteration__(self: range_iterator) -> bool:
         return self.i < self.stop

--- a/stdlib/_range.spy
+++ b/stdlib/_range.spy
@@ -1,0 +1,7 @@
+@struct
+class range:
+    start: int
+    stop: int
+
+    def __new__(n: int) -> range:
+        return range.__make__(0, n)

--- a/stdlib/_range.spy
+++ b/stdlib/_range.spy
@@ -4,41 +4,53 @@ from operator import OpSpec, MetaArg
 class range:
     start: int
     stop: int
+    step: int
 
     @blue.metafunc
     def __new__(m_cls, *args_m):
         def impl1(n: int) -> range:
-            return range.__make__(0, n)
+            return range.__make__(0, n, 1)
 
         def impl2(a: int, b: int) -> range:
-            return range.__make__(a, b)
+            return range.__make__(a, b, 1)
+
+        def impl3(a: int, b: int, c: int) -> range:
+            return range.__make__(a, b, c)
 
         # we cannot do list(args_m), so we need to do it manually somehow :(
         m0: MetaArg
         m1: MetaArg
+        m2: MetaArg
         if len(args_m) == 1:
             m0, = args_m
             return OpSpec(impl1, [m0])
         elif len(args_m) == 2:
             m0, m1 = args_m
             return OpSpec(impl2, [m0, m1])
+        elif len(args_m) == 3:
+            m0, m1, m2 = args_m
+            return OpSpec(impl3, [m0, m1, m2])
         else:
             return OpSpec.NULL
 
     def __fastiter__(self: range) -> range_iterator:
-        return range_iterator(self.start, self.stop)
+        return range_iterator(self.start, self.stop, self.step)
 
 @struct
 class range_iterator:
     i: int
     stop: int
+    step: int
 
     def __next__(self: range_iterator) -> range_iterator:
-        return range_iterator(self.i+1, self.stop)
+        return range_iterator(self.i + self.step, self.stop, self.step)
 
     def __item__(self: range_iterator) -> int:
         return self.i
 
     # the opposite of StopIteration :)
     def __continue_iteration__(self: range_iterator) -> bool:
-        return self.i < self.stop
+        if self.step > 0:
+            return self.i < self.stop
+        else:
+            return self.i > self.stop


### PR DESCRIPTION
This PR implements support for `for` loops in the parser, ScopeAnalyzer and ASTFrame. For loops don't use the classical `__iter__` protocol as in Python. Instead, they use a new protocol called `__fastiter__`, which is stateless and thus easier to optimize for the compiler.

In ASTFrame, the `for` loop is desugared into the equivalent `while`: thanks to this, DopplerFrame and the C backend mostly work out of the box.

Moreover, this PR also introduces the `range` object, implemented in pure spy in `stdlib/_range.spy`. Currently it is not automatically available as a builtin because we don't have the machinery to import spy code as part of builtins.

Enable LTO when compiling in release mode: this is necessary to ensure that gcc is able to inline the methods of the `__fastiter__` protocol and produce optimal code.

Fix a bug in structs: emit a proper error if you try to get a non-existent field.

Make it possible to pass structs INTO wasm test functions: this makes it much easier to write certain kind of tests, like `test__range.py`.


