### PR TITLE
Fix misspelling ImportAnalizyer to ImportAnalyzer

### DIFF
--- a/spy/analyze/importing.py
+++ b/spy/analyze/importing.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 MODULE = Union[ast.Module, 'W_Module', None]
 
 
-class ImportAnalizyer:
+class ImportAnalyzer:
     """
     The set of modules needed and loaded by a SPy program is statically
     determined ahead of time.

--- a/spy/cli.py
+++ b/spy/cli.py
@@ -12,7 +12,7 @@ import py.path
 import pdb as stdlib_pdb # to distinguish from the "--pdb" option
 from spy.vendored.dataclass_typer import dataclass_typer
 from spy.magic_py_parse import magic_py_parse
-from spy.analyze.importing import ImportAnalizyer
+from spy.analyze.importing import ImportAnalyzer
 from spy.errors import SPyError
 from spy.backend.spy import SPyBackend, FQN_FORMAT
 from spy.doppler import ErrorMode
@@ -328,7 +328,7 @@ async def inner_main(args: Arguments) -> None:
         args.error_mode = 'lazy'
         vm.emit_warning = emit_warning
 
-    importer = ImportAnalizyer(vm, modname)
+    importer = ImportAnalyzer(vm, modname)
     importer.parse_all()
 
     orig_mod = importer.getmod(modname)

--- a/spy/tests/test_importing.py
+++ b/spy/tests/test_importing.py
@@ -2,12 +2,12 @@ import textwrap
 import pytest
 import py.path
 from spy import ast
-from spy.analyze.importing import ImportAnalizyer
+from spy.analyze.importing import ImportAnalyzer
 from spy.vm.vm import SPyVM
 
 
 @pytest.mark.usefixtures('init')
-class TestImportAnalizyer:
+class TestImportAnalyzer:
 
     @pytest.fixture
     def init(self, tmpdir):
@@ -29,7 +29,7 @@ class TestImportAnalizyer:
         self.write("main.spy", """
         import mod1
         """)
-        analyzer = ImportAnalizyer(self.vm, 'main')
+        analyzer = ImportAnalyzer(self.vm, 'main')
         analyzer.parse_all()
 
         assert list(analyzer.mods) == ['main', 'mod1']
@@ -63,7 +63,7 @@ class TestImportAnalizyer:
         x = 'b2'
         """)
 
-        analyzer = ImportAnalizyer(self.vm, 'main')
+        analyzer = ImportAnalyzer(self.vm, 'main')
         analyzer.parse_all()
         mods = analyzer.get_import_list()
         assert mods == ['a1', 'a2', 'aaa', 'b1', 'b2', 'bbb', 'main']
@@ -77,7 +77,7 @@ class TestImportAnalizyer:
         self.write("mod1.spy", """
         x: i32 = 42
         """)
-        analyzer = ImportAnalizyer(self.vm, 'main')
+        analyzer = ImportAnalyzer(self.vm, 'main')
         analyzer.parse_all()
         assert list(analyzer.mods) == ['main', 'mod1']
 
@@ -86,7 +86,7 @@ class TestImportAnalizyer:
         import nonexistent
         """)
 
-        analyzer = ImportAnalizyer(self.vm, 'main')
+        analyzer = ImportAnalyzer(self.vm, 'main')
         analyzer.parse_all()
         assert list(analyzer.mods) == ['main', 'nonexistent']
         assert isinstance(analyzer.mods['main'], ast.Module)
@@ -104,7 +104,7 @@ class TestImportAnalizyer:
         dummy_module = object()
         self.vm.modules_w['mod1'] = dummy_module  # type: ignore
 
-        analyzer = ImportAnalizyer(self.vm, 'main')
+        analyzer = ImportAnalyzer(self.vm, 'main')
         analyzer.parse_all()
         assert list(analyzer.mods) == ['main', 'mod1']
         assert analyzer.mods['mod1'] is dummy_module
@@ -113,7 +113,7 @@ class TestImportAnalizyer:
         self.write("main.spy", """
         x: i32 = 42
         """)
-        analyzer = ImportAnalizyer(self.vm, 'main')
+        analyzer = ImportAnalyzer(self.vm, 'main')
         analyzer.parse_all()
         scopes = analyzer.analyze_scopes('main')
         assert scopes.by_module().name == 'main'
@@ -128,7 +128,7 @@ class TestImportAnalizyer:
         """)
 
         self.vm.path.append(self.tmpdir.join('mylib'))
-        analyzer = ImportAnalizyer(self.vm, 'main')
+        analyzer = ImportAnalyzer(self.vm, 'main')
         analyzer.parse_all()
         assert list(analyzer.mods) == ['main', 'mod1']
         assert analyzer.mods['mod1'] is not None # check that we found it

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -114,11 +114,11 @@ class SPyVM:
         return SPyVM(ll=ll)
 
     def import_(self, modname: str) -> W_Module:
-        from spy.analyze.importing import ImportAnalizyer
+        from spy.analyze.importing import ImportAnalyzer
         if modname in self.modules_w:
             return self.modules_w[modname]
 
-        importer = ImportAnalizyer(self, modname)
+        importer = ImportAnalyzer(self, modname)
         importer.parse_all()
         #importer.pp()
         importer.import_all()


### PR DESCRIPTION
Reading through the code, I encountered a misspelled variable name `ImportAnalizyer`. It was tugging on my brain enough that I thought I'd put up a PR to fix it. 😄  