### PR TITLE
Add posix module with get_terminal_size function

### DIFF
--- a/spy/backend/c/context.py
+++ b/spy/backend/c/context.py
@@ -8,6 +8,7 @@ from spy.vm.function import W_Func, W_ASTFunc
 from spy.vm.modules.types import W_LiftedType
 from spy.vm.modules.rawbuffer import RB
 from spy.vm.modules.jsffi import JSFFI
+from spy.vm.modules.posix import POSIX
 from spy.vm.modules.unsafe.ptr import W_PtrType
 from spy.vm.struct import W_StructType
 from spy.textbuilder import TextBuilder
@@ -82,6 +83,7 @@ class Context:
         self._d[B.w_str] = C_Type('spy_Str *')
         self._d[RB.w_RawBuffer] = C_Type('spy_RawBuffer *')
         self._d[JSFFI.w_JsRef] = C_Type('JsRef')
+        self._d[POSIX.w_TerminalSize] = C_Type('spy_TerminalSize')
 
     def w2c(self, w_T: W_Type) -> C_Type:
         if w_T in self._d:

--- a/spy/libspy/include/spy.h
+++ b/spy/libspy/include/spy.h
@@ -34,6 +34,7 @@
 #include "spy/gc.h"
 #include "spy/unsafe.h"
 #include "spy/rawbuffer.h"
+#include "spy/posix.h"
 #include "spy/debug.h"
 
 #ifdef SPY_TARGET_EMSCRIPTEN

--- a/spy/libspy/include/spy/posix.h
+++ b/spy/libspy/include/spy/posix.h
@@ -1,0 +1,46 @@
+#ifndef SPY_POSIX_H
+#define SPY_POSIX_H
+
+#ifndef SPY_TARGET_WASI
+#include <sys/ioctl.h>
+#endif
+#include <unistd.h>
+
+typedef struct {
+    int32_t columns;
+    int32_t lines;
+} spy_TerminalSize;
+
+static inline spy_TerminalSize
+spy_posix$get_terminal_size(void) {
+    spy_TerminalSize result;
+
+#ifndef SPY_TARGET_WASI
+    struct winsize w;
+    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) == 0) {
+        result.columns = w.ws_col;
+        result.lines = w.ws_row;
+    } else {
+        result.columns = 80;
+        result.lines = 24;
+    }
+#else
+    // Fallback to default values on WASI (no terminal support)
+    result.columns = 80;
+    result.lines = 24;
+#endif
+
+    return result;
+}
+
+static inline int32_t
+spy_posix$TerminalSize$__get_columns__(spy_TerminalSize self) {
+    return self.columns;
+}
+
+static inline int32_t
+spy_posix$TerminalSize$__get_lines__(spy_TerminalSize self) {
+    return self.lines;
+}
+
+#endif /* SPY_POSIX_H */

--- a/spy/tests/compiler/test_posix.py
+++ b/spy/tests/compiler/test_posix.py
@@ -1,0 +1,23 @@
+#-*- encoding: utf-8 -*-
+
+from spy.tests.support import CompilerTest
+
+class TestPosix(CompilerTest):
+
+    def test_get_terminal_size(self):
+        mod = self.compile(
+        """
+        from posix import TerminalSize, get_terminal_size
+
+        def foo() -> str:
+            size: TerminalSize = get_terminal_size()
+            return str(size.lines) + " " + str(size.columns)
+        """)
+        result = mod.foo()
+        parts = result.split()
+        assert len(parts) == 2
+        lines = int(parts[0])
+        columns = int(parts[1])
+        # When running in pytest without a terminal, we get fallback values
+        assert columns >= 80
+        assert lines >= 24

--- a/spy/vm/modules/posix.py
+++ b/spy/vm/modules/posix.py
@@ -1,0 +1,38 @@
+"""
+SPy `posix` module.
+"""
+
+from typing import TYPE_CHECKING, Annotated
+from spy.vm.primitive import W_I32
+from spy.vm.object import W_Type
+from spy.vm.w import W_Object
+from spy.vm.registry import ModuleRegistry
+from spy.vm.member import Member
+if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
+
+POSIX = ModuleRegistry('posix')
+
+@POSIX.builtin_type('TerminalSize')
+class W_TerminalSize(W_Object):
+    __spy_storage_category__ = 'value'
+
+    w_columns: Annotated[W_I32, Member('columns')]
+    w_lines: Annotated[W_I32, Member('lines')]
+
+    def __init__(self, columns: int, lines: int) -> None:
+        self.w_columns = W_I32(columns)
+        self.w_lines = W_I32(lines)
+
+    def spy_key(self, vm: 'SPyVM') -> tuple:
+        return ('TerminalSize', self.w_columns.value, self.w_lines.value)
+
+@POSIX.builtin_func
+def w_get_terminal_size(vm: 'SPyVM') -> W_TerminalSize:
+    import os
+    try:
+        size = os.get_terminal_size()
+        return W_TerminalSize(size.columns, size.lines)
+    except OSError:
+        # Fallback when no terminal is available (e.g., in tests)
+        return W_TerminalSize(80, 24)

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -39,6 +39,7 @@ from spy.vm.modules.math import MATH
 from spy.vm.modules.unsafe import UNSAFE
 from spy.vm.modules.rawbuffer import RAW_BUFFER
 from spy.vm.modules.jsffi import JSFFI
+from spy.vm.modules.posix import POSIX
 from spy.vm.modules._testing_helpers import _TESTING_HELPERS
 
 # lazy definition of some some core types. See the docstring of W_Type.
@@ -100,6 +101,7 @@ class SPyVM:
         self.make_module(UNSAFE)
         self.make_module(RAW_BUFFER)
         self.make_module(JSFFI)
+        self.make_module(POSIX)
         self.make_module(_TESTING_HELPERS)
         self.call_INITs()
 

--- a/stdlib/os.spy
+++ b/stdlib/os.spy
@@ -1,0 +1,1 @@
+from posix import get_terminal_size


### PR DESCRIPTION
## Summary
- Adds a new `posix` module to SPy
- Implements `get_terminal_size()` function that returns a `TerminalSize` struct with `columns` and `lines` fields
- Works across all three backends: interpreter, doppler, and C

## Implementation Details
- **Python backend**: Uses `os.get_terminal_size()` with fallback to 80x24 for non-terminal environments
- **C backend**: Uses `ioctl(TIOCGWINSZ)` on native platforms, falls back to 80x24 on WASI (which lacks terminal support)
- `TerminalSize` is a value type with two `i32` fields accessible via member accessors

## Test plan
- [x] Added `test_posix.py` with `test_get_terminal_size`
- [x] Tests pass on all three backends (interp, doppler, C)
- [x] Handles missing terminal gracefully (pytest environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)