### PR TITLE
Add __spy__ module with is_compiled() function

### DIFF
--- a/spy/libspy/include/spy.h
+++ b/spy/libspy/include/spy.h
@@ -42,6 +42,7 @@
 #include "spy/rawbuffer.h"
 #include "spy/posix.h"
 #include "spy/time.h"
+#include "spy/__spy__.h"
 #include "spy/debug.h"
 
 #ifdef SPY_TARGET_EMSCRIPTEN

--- a/spy/libspy/include/spy/__spy__.h
+++ b/spy/libspy/include/spy/__spy__.h
@@ -1,0 +1,11 @@
+#ifndef SPY___SPY___H
+#define SPY___SPY___H
+
+#include <stdbool.h>
+
+static inline bool
+spy___spy__$is_compiled(void) {
+    return true;
+}
+
+#endif /* SPY___SPY___H */

--- a/spy/tests/compiler/test_dunder_spy.py
+++ b/spy/tests/compiler/test_dunder_spy.py
@@ -1,0 +1,16 @@
+from spy.tests.support import CompilerTest
+
+class TestDunderSpy(CompilerTest):
+
+    def test_is_compiled(self):
+        mod = self.compile(
+        """
+        from __spy__ import is_compiled
+
+        def foo() -> bool:
+            return is_compiled()
+        """)
+        if self.backend in ('interp', 'doppler'):
+            assert mod.foo() == False
+        else:
+            assert mod.foo() == True

--- a/spy/vm/modules/spy.py
+++ b/spy/vm/modules/spy.py
@@ -1,0 +1,15 @@
+"""
+SPy `__spy__` module.
+"""
+from typing import TYPE_CHECKING
+from spy.vm.primitive import W_Bool
+from spy.vm.registry import ModuleRegistry
+from spy.vm.b import B
+if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
+
+SPY = ModuleRegistry('__spy__')
+
+@SPY.builtin_func
+def w_is_compiled(vm: 'SPyVM') -> W_Bool:
+    return B.w_False

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -41,6 +41,7 @@ from spy.vm.modules.rawbuffer import RAW_BUFFER
 from spy.vm.modules.jsffi import JSFFI
 from spy.vm.modules.posix import POSIX
 from spy.vm.modules.time import TIME
+from spy.vm.modules.spy import SPY
 from spy.vm.modules._testing_helpers import _TESTING_HELPERS
 
 # lazy definition of some some core types. See the docstring of W_Type.
@@ -104,6 +105,7 @@ class SPyVM:
         self.make_module(JSFFI)
         self.make_module(POSIX)
         self.make_module(TIME)
+        self.make_module(SPY)
         self.make_module(_TESTING_HELPERS)
         self.call_INITs()
 


### PR DESCRIPTION
## Summary
- Introduces a new `__spy__` module containing `is_compiled()` function
- Returns `False` in interpreter and doppler modes
- Returns `True` when compiled to C backend
- Includes comprehensive tests for all backends

## Test plan
- [x] Tests pass for interp backend
- [x] Tests pass for doppler backend  
- [x] Tests pass for C backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)