### PR TITLE
Add break and continue statement support

### DIFF
--- a/spy/ast.py
+++ b/spy/ast.py
@@ -493,6 +493,14 @@ class Assert(Stmt):
     test: Expr
     msg: Optional[Expr]
 
+@dataclass(eq=False)
+class Break(Stmt):
+    pass
+
+@dataclass(eq=False)
+class Continue(Stmt):
+    pass
+
 
 # ====== IR-specific nodes ======
 #

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -133,6 +133,12 @@ class CFuncWriter:
     def emit_stmt_Pass(self, stmt: ast.Pass) -> None:
         pass
 
+    def emit_stmt_Break(self, stmt: ast.Break) -> None:
+        self.tbc.wl('break;')
+
+    def emit_stmt_Continue(self, stmt: ast.Continue) -> None:
+        self.tbc.wl('continue;')
+
     def emit_stmt_Return(self, ret: ast.Return) -> None:
         v = self.fmt_expr(ret.value)
         if v is C.Void():

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -198,6 +198,12 @@ class SPyBackend:
     def emit_stmt_Pass(self, stmt: ast.Pass) -> None:
         self.wl('pass')
 
+    def emit_stmt_Break(self, stmt: ast.Break) -> None:
+        self.wl('break')
+
+    def emit_stmt_Continue(self, stmt: ast.Continue) -> None:
+        self.wl('continue')
+
     def emit_stmt_Return(self, ret: ast.Return) -> None:
         v = self.fmt_expr(ret.value)
         self.wl(f'return {v}')

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -141,6 +141,12 @@ class DopplerFrame(ASTFrame):
     def shift_stmt_Pass(self, stmt: ast.Pass) -> list[ast.Stmt]:
         return [stmt]
 
+    def shift_stmt_Break(self, stmt: ast.Break) -> list[ast.Stmt]:
+        return [stmt]
+
+    def shift_stmt_Continue(self, stmt: ast.Continue) -> list[ast.Stmt]:
+        return [stmt]
+
     def shift_stmt_VarDef(self, vardef: ast.VarDef) -> list[ast.Stmt]:
         self.exec_stmt_VarDef(vardef)
         newtype = self.shifted_expr[vardef.type]

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -571,6 +571,12 @@ class Parser:
         msg = self.from_py_expr(py_node.msg) if py_node.msg else None
         return spy.ast.Assert(py_node.loc, test, msg)
 
+    def from_py_stmt_Break(self, py_node: py_ast.Break) -> spy.ast.Break:
+        return spy.ast.Break(py_node.loc)
+
+    def from_py_stmt_Continue(self, py_node: py_ast.Continue) -> spy.ast.Continue:
+        return spy.ast.Continue(py_node.loc)
+
     # ====== spy.ast.Expr ======
 
     def from_py_expr(self, py_node: py_ast.expr) -> spy.ast.Expr:

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -1178,3 +1178,80 @@ class TestBasic(CompilerTest):
         """
         mod = self.compile(src)
         assert mod.factorial(4) == 2 * 3 * 4
+
+    def test_break_in_while(self):
+        src = """
+        def foo() -> i32:
+            i = 0
+            while i < 10:
+                if i == 5:
+                    break
+                i += 1
+            return i
+        """
+        mod = self.compile(src)
+        assert mod.foo() == 5
+
+    def test_continue_in_while(self):
+        src = """
+        def foo() -> i32:
+            i = 0
+            count = 0
+            while i < 10:
+                i += 1
+                if i % 2 == 0:
+                    continue
+                count += 1
+            return count
+        """
+        mod = self.compile(src)
+        assert mod.foo() == 5  # counts odd numbers from 1 to 9
+
+    @pytest.mark.skip(reason="continue in for loops needs special handling for iterator advancement")
+    def test_break_in_for(self):
+        src = """
+        from _range import range
+
+        def foo() -> i32:
+            total = 0
+            for i in range(10):
+                if i == 5:
+                    break
+                total += i
+            return total
+        """
+        mod = self.compile(src)
+        assert mod.foo() == 0 + 1 + 2 + 3 + 4
+
+    @pytest.mark.skip(reason="continue in for loops needs special handling for iterator advancement")
+    def test_continue_in_for(self):
+        src = """
+        from _range import range
+
+        def foo() -> i32:
+            total = 0
+            for i in range(10):
+                if i % 2 == 0:
+                    continue
+                total += i
+            return total
+        """
+        mod = self.compile(src)
+        assert mod.foo() == 1 + 3 + 5 + 7 + 9
+
+    @pytest.mark.skip(reason="continue in for loops needs special handling for iterator advancement")
+    def test_nested_loops_with_break(self):
+        src = """
+        from _range import range
+
+        def foo() -> i32:
+            total = 0
+            for i in range(5):
+                for j in range(5):
+                    if j == 3:
+                        break
+                    total += 1
+            return total
+        """
+        mod = self.compile(src)
+        assert mod.foo() == 5 * 3  # 5 outer iterations, 3 inner iterations each

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -1207,7 +1207,6 @@ class TestBasic(CompilerTest):
         mod = self.compile(src)
         assert mod.foo() == 5  # counts odd numbers from 1 to 9
 
-    @pytest.mark.skip(reason="continue in for loops needs special handling for iterator advancement")
     def test_break_in_for(self):
         src = """
         from _range import range
@@ -1223,7 +1222,6 @@ class TestBasic(CompilerTest):
         mod = self.compile(src)
         assert mod.foo() == 0 + 1 + 2 + 3 + 4
 
-    @pytest.mark.skip(reason="continue in for loops needs special handling for iterator advancement")
     def test_continue_in_for(self):
         src = """
         from _range import range
@@ -1239,7 +1237,6 @@ class TestBasic(CompilerTest):
         mod = self.compile(src)
         assert mod.foo() == 1 + 3 + 5 + 7 + 9
 
-    @pytest.mark.skip(reason="continue in for loops needs special handling for iterator advancement")
     def test_nested_loops_with_break(self):
         src = """
         from _range import range

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -1447,3 +1447,107 @@ class TestParser:
         )
         """
         self.assert_dump(funcdef, expected)
+
+    def test_Break(self):
+        mod = self.parse("""
+        def foo() -> None:
+            while True:
+                break
+        """)
+        while_stmt = mod.get_funcdef('foo').body[0]
+        expected = """
+        While(
+            test=Constant(value=True),
+            body=[
+                Break(),
+            ],
+        )
+        """
+        self.assert_dump(while_stmt, expected)
+
+    def test_Continue(self):
+        mod = self.parse("""
+        def foo() -> None:
+            while True:
+                continue
+        """)
+        while_stmt = mod.get_funcdef('foo').body[0]
+        expected = """
+        While(
+            test=Constant(value=True),
+            body=[
+                Continue(),
+            ],
+        )
+        """
+        self.assert_dump(while_stmt, expected)
+
+    def test_Break_in_For(self):
+        mod = self.parse("""
+        def foo() -> None:
+            for i in range(10):
+                if i == 5:
+                    break
+        """)
+        for_stmt = mod.get_funcdef('foo').body[0]
+        expected = """
+        For(
+            seq=0,
+            target=StrConst(value='i'),
+            iter=Call(
+                func=Name(id='range'),
+                args=[
+                    Constant(value=10),
+                ],
+            ),
+            body=[
+                If(
+                    test=CmpOp(
+                        op='==',
+                        left=Name(id='i'),
+                        right=Constant(value=5),
+                    ),
+                    then_body=[
+                        Break(),
+                    ],
+                    else_body=[],
+                ),
+            ],
+        )
+        """
+        self.assert_dump(for_stmt, expected)
+
+    def test_Continue_in_For(self):
+        mod = self.parse("""
+        def foo() -> None:
+            for i in range(10):
+                if i == 5:
+                    continue
+        """)
+        for_stmt = mod.get_funcdef('foo').body[0]
+        expected = """
+        For(
+            seq=0,
+            target=StrConst(value='i'),
+            iter=Call(
+                func=Name(id='range'),
+                args=[
+                    Constant(value=10),
+                ],
+            ),
+            body=[
+                If(
+                    test=CmpOp(
+                        op='==',
+                        left=Name(id='i'),
+                        right=Constant(value=5),
+                    ),
+                    then_body=[
+                        Continue(),
+                    ],
+                    else_body=[],
+                ),
+            ],
+        )
+        """
+        self.assert_dump(for_stmt, expected)

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -33,6 +33,16 @@ class Return(Exception):
         self.w_value = w_value
 
 
+class Break(Exception):
+    """Exception to implement break statement"""
+    pass
+
+
+class Continue(Exception):
+    """Exception to implement continue statement"""
+    pass
+
+
 class AbstractFrame:
     """
     Frame which is able to run AST expressions/statements.
@@ -196,6 +206,12 @@ class AbstractFrame:
     def exec_stmt_Return(self, ret: ast.Return) -> None:
         wam = self.eval_expr(ret.value, varname='@return')
         raise Return(wam.w_val)
+
+    def exec_stmt_Break(self, brk: ast.Break) -> None:
+        raise Break()
+
+    def exec_stmt_Continue(self, cont: ast.Continue) -> None:
+        raise Continue()
 
     def exec_stmt_FuncDef(self, funcdef: ast.FuncDef) -> None:
         # evaluate the functype
@@ -476,8 +492,13 @@ class AbstractFrame:
             assert isinstance(wam_cond.w_val, W_Bool)
             if self.vm.is_False(wam_cond.w_val):
                 break
-            for stmt in while_node.body:
-                self.exec_stmt(stmt)
+            try:
+                for stmt in while_node.body:
+                    self.exec_stmt(stmt)
+            except Break:
+                break
+            except Continue:
+                continue
 
     def exec_stmt_For(self, for_node: ast.For) -> None:
         # see the comment in __init__ about desugared_fors

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -519,10 +519,13 @@ class AbstractFrame:
         #     it = X.__fastiter__()
         #     while it.__continue_iteration__():
         #         i = it.__item__()
-        #         body
         #         it = it.__next__()
+        #         body
         #
         # (instead of 'it' we use the special variable '_$iterN')
+        #
+        # Note that "body" is placed AFTER the call to it.__next__(). This
+        # way, 'continue' works out of the box.
         iter_name = f'_$iter{for_node.seq}'
         iter_sym = self.symtable.lookup(iter_name)
         iter_target = ast.StrConst(for_node.loc, iter_name)
@@ -569,7 +572,7 @@ class AbstractFrame:
                 method = ast.StrConst(for_node.loc, '__continue_iteration__'),
                 args = []
             ),
-            body = [assign_item] + for_node.body + [advance_iter]
+            body = [assign_item, advance_iter] + for_node.body
         )
         return init_iter, while_loop
 


### PR DESCRIPTION
## Summary
- Add `break` and `continue` statement support to parser, interpreter, doppler, C, and spy backends
- Refactor for-loop desugaring to call `__next__()` before the loop body, making `continue` work correctly
- Enable all break/continue tests in test_basic.py

## Implementation Details
For loops are desugared as:
```python
it = X.__fastiter__()
while it.__continue_iteration__():
    i = it.__item__()
    it = it.__next__()
    body  # placed after __next__() so continue works
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)