### PR TITLE
Move types-pexpect to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "py==1.11.0",
     "typer==0.15.1",
     "pexpect==4.9.0; sys_platform != 'emscripten'",
-    "types-pexpect==4.9.0.20250516; sys_platform != 'emscripten'",
     "wasmtime==8.0.1; sys_platform != 'emscripten'",
     "ziglang==0.13.0; sys_platform != 'emscripten'",
 ]
@@ -24,6 +23,7 @@ dev = [
     "pytest==8.3.4",
     "ruff>=0.12.8,<1",
     "mypy==1.15.0",
+    "types-pexpect==4.9.0.20250516; sys_platform != 'emscripten'",
     # the followings are needed for "tests/compiler/test_cffi.py"
     "cffi",
     "setuptools",


### PR DESCRIPTION
This package is only used for type checking and is not needed at runtime :)