### PR TITLE
Increase ruff's target-version setting to match requires-python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ lint.select = [
 lint.ignore = ["C901"]
 line-length = 88
 indent-width = 4
-target-version = "py311"
+target-version = "py312"
 exclude = [".venv", "*.pyi", "*.c"]
 
 [tool.ruff.format]


### PR DESCRIPTION
The project says it supports Python `>=3.12`, but Ruff is configured with the minimum target version of `3.11`, this fixes the discrepancy by updating Ruff's target version to 3.12.