### PR TITLE
Increase minimum Ruff version to match pre-commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 dev = [
     "pdbpp>=0.11.7",
     "pytest==8.3.4",
-    "ruff>=0.12.8,<1",
+    "ruff~=0.14.0",
     "mypy==1.15.0",
     # the followings are needed for "tests/compiler/test_cffi.py"
     "cffi",


### PR DESCRIPTION
The `pre-commit` config lists Ruff v0.14, but the `pyproject.toml` file allows Ruff v0.12 to be used, this could lead to different output from the `ruff` CLI and `pre-commit`, so I've bumped the version of Ruff used in the `pyproject.toml` to match `pre-commit`.