### PR TITLE
Remove unused encoding comments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ lint.select = [
     "I",  # isort
     "Q000", # double quotes
     "C",  # flake8-comprehensions
+    "UP009",  # Remove unnecessary UTF-8 encoding declarations
 ]
 lint.ignore = ["C901"]
 line-length = 88

--- a/spy/tests/compiler/test_debug.py
+++ b/spy/tests/compiler/test_debug.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 import re
 
 import pytest

--- a/spy/tests/compiler/test_float.py
+++ b/spy/tests/compiler/test_float.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 from spy.errors import SPyError
 from spy.tests.support import CompilerTest
 

--- a/spy/tests/compiler/test_jsffi.py
+++ b/spy/tests/compiler/test_jsffi.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 from spy.tests.support import CompilerTest, only_emscripten
 
 

--- a/spy/tests/compiler/test_list.py
+++ b/spy/tests/compiler/test_list.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 import pytest
 
 from spy.fqn import FQN

--- a/spy/tests/compiler/test_opspec.py
+++ b/spy/tests/compiler/test_opspec.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 from spy.tests.support import CompilerTest, expect_errors, only_interp
 from spy.vm.b import B
 from spy.vm.opimpl import W_OpImpl

--- a/spy/tests/compiler/test_posix.py
+++ b/spy/tests/compiler/test_posix.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 from spy.tests.support import CompilerTest
 
 

--- a/spy/tests/compiler/test_rawbuffer.py
+++ b/spy/tests/compiler/test_rawbuffer.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 import struct
 
 from spy.tests.support import CompilerTest

--- a/spy/tests/compiler/test_spdb.py
+++ b/spy/tests/compiler/test_spdb.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 import re
 import textwrap
 from io import StringIO

--- a/spy/tests/compiler/test_str.py
+++ b/spy/tests/compiler/test_str.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 import re
 
 from spy.errors import SPyError

--- a/spy/tests/compiler/test_struct.py
+++ b/spy/tests/compiler/test_struct.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 from spy.errors import SPyError
 from spy.fqn import FQN
 from spy.tests.support import CompilerTest, expect_errors, only_interp

--- a/spy/tests/compiler/test_time.py
+++ b/spy/tests/compiler/test_time.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 import time
 
 from spy.tests.support import CompilerTest

--- a/spy/tests/compiler/unsafe/test_ptr.py
+++ b/spy/tests/compiler/unsafe/test_ptr.py
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 from spy.errors import SPyError
 from spy.tests.support import CompilerTest, expect_errors, only_C, only_interp
 from spy.tests.wasm_wrapper import WasmPtr

--- a/spy/util.py
+++ b/spy/util.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 import difflib
 import inspect
 import itertools


### PR DESCRIPTION
These comments are unused in modern Python, I also added a Ruff rule to disallow them in the future.

See [the Ruff documentation](https://docs.astral.sh/ruff/rules/utf8-encoding-declaration/) for more info.