### PR TITLE
Replace py.path with pathlib

### DIFF
--- a/playground/main.py
+++ b/playground/main.py
@@ -75,8 +75,7 @@ example_tabs = ltk.Tabs(
 def run_click(event):
     __terminal__.clear()
     text = editor.text()
-    with open("test.spy", "w") as f:
-        f.write(text)
+    Path("test.spy").write_text(text)
 
     element = ltk.find(event.target)
     t = element.text().lower()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ dependencies = [
     "click==8.1.8",
     "fixedint==0.2.0",
     "ninja==1.11.1.4; sys_platform != 'emscripten'",
-    "py==1.11.0",
     "typer==0.15.1",
     "pexpect==4.9.0; sys_platform != 'emscripten'",
     "wasmtime==8.0.1; sys_platform != 'emscripten'",

--- a/spy/__init__.py
+++ b/spy/__init__.py
@@ -1,4 +1,3 @@
-import py.path
+from pathlib import Path
 
-ROOT: py.path.local = py.path.local(__file__).dirpath()
-del py
+ROOT = Path(__file__).parent

--- a/spy/analyze/importing.py
+++ b/spy/analyze/importing.py
@@ -1,8 +1,6 @@
 from collections import deque
 from typing import TYPE_CHECKING, Optional, Union
 
-import py.path
-
 from spy import ast
 from spy.analyze.scope import ScopeAnalyzer
 from spy.fqn import FQN
@@ -206,7 +204,7 @@ class ImportAnalyzer:
         paths = {}
         if self.vm.path:
             for i, path in enumerate(self.vm.path):
-                paths[path + "/"] = f"$p{i}"
+                paths[str(path) + "/"] = f"$p{i}"
 
         def shorten_path(path: str) -> str:
             if not path:

--- a/spy/backend/c/cmodwriter.py
+++ b/spy/backend/c/cmodwriter.py
@@ -1,8 +1,7 @@
 import itertools
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
-
-import py.path
 
 from spy.backend.c.cffiwriter import CFFIWriter
 from spy.backend.c.context import C_Type, Context
@@ -23,9 +22,9 @@ from spy.vm.vm import SPyVM
 @dataclass
 class CModule:
     modname: str
-    spyfile: py.path.local
-    hfile: py.path.local
-    cfile: py.path.local
+    spyfile: Path
+    hfile: Path
+    cfile: Path
     content: list[tuple[FQN, W_Object]]
 
     def __repr__(self) -> str:
@@ -71,8 +70,8 @@ class CModuleWriter:
 
     def write_c_source(self) -> None:
         self.emit_content()
-        self.c_mod.hfile.write(self.tbh.build())
-        self.c_mod.cfile.write(self.tbc.build())
+        self.c_mod.hfile.write_text(self.tbh.build())
+        self.c_mod.cfile.write_text(self.tbc.build())
 
     def new_global_var(self, prefix: str) -> str:
         """
@@ -87,7 +86,7 @@ class CModuleWriter:
         return varname
 
     def init_h(self) -> None:
-        GUARD = self.c_mod.hfile.purebasename.upper()
+        GUARD = self.c_mod.hfile.stem.upper()
         self.tbh.wb(f"""
         #ifndef SPY_{GUARD}_H
         #define SPY_{GUARD}_H
@@ -127,7 +126,7 @@ class CModuleWriter:
         """)
 
     def init_c(self) -> None:
-        header_name = self.c_mod.hfile.basename
+        header_name = self.c_mod.hfile.name
         self.cffi.emit_include(header_name)
         self.tbc.wb(f"""
         #include "{header_name}"

--- a/spy/backend/c/cstructwriter.py
+++ b/spy/backend/c/cstructwriter.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
-
-import py.path
 
 from spy.backend.c.cffiwriter import CFFIWriter
 from spy.backend.c.context import C_Type, Context
@@ -16,7 +15,7 @@ from spy.vm.vm import SPyVM
 
 @dataclass
 class CStructDefs:
-    hfile: py.path.local
+    hfile: Path
     content: list[tuple[FQN, W_Type]]
 
 
@@ -51,10 +50,10 @@ class CStructWriter:
         Write the structdefs header
         """
         self.emit_content()
-        self.c_structdefs.hfile.write(self.tbh.build())
+        self.c_structdefs.hfile.write_text(self.tbh.build())
 
     def init_h(self) -> None:
-        GUARD = self.c_structdefs.hfile.purebasename.upper()
+        GUARD = self.c_structdefs.hfile.stem.upper()
         self.tbh.wb(f"""
         #ifndef SPY_{GUARD}_H
         #define SPY_{GUARD}_H

--- a/spy/build/cffi.py
+++ b/spy/build/cffi.py
@@ -1,15 +1,14 @@
 import contextlib
 import os
 import sys
+from pathlib import Path
 from typing import Any
-
-import py.path
 
 from spy.util import robust_run
 
 
 @contextlib.contextmanager
-def chdir(path: str | py.path.local) -> Any:
+def chdir(path: str | Path) -> Any:
     """Context manager to temporarily change directory."""
     old_dir = os.getcwd()
     try:
@@ -19,17 +18,17 @@ def chdir(path: str | py.path.local) -> Any:
         os.chdir(old_dir)
 
 
-def cffi_build(build_script: py.path.local) -> py.path.local:
+def cffi_build(build_script: Path) -> Path:
     """
     Generate a CPython extension module by running the cffi-build.py
     script produced by spy.backend.c.cffiwriter.
     """
     cmdline = [sys.executable, str(build_script)]
-    d = build_script.dirpath()
+    d = build_script.parent
     with chdir(d):
         proc = robust_run(cmdline)
     # The generated .so file is expected to be in the stdout of the build script
     out = proc.stdout.decode("utf-8")
-    sofile = py.path.local(out.strip())
+    sofile = Path(out.strip())
     assert sofile.exists()
     return sofile

--- a/spy/build/config.py
+++ b/spy/build/config.py
@@ -56,7 +56,7 @@ class CompilerConfig:
 
         # e.g. 'spy/libspy/build/native/release/'
         self.ldflags += LDFLAGS
-        libdir = spy.libspy.BUILD.join(config.target, config.build_type)
+        libdir = spy.libspy.BUILD / config.target / config.build_type
         self.ldflags += [
             "-L", str(libdir),
             "-lspy",
@@ -87,7 +87,7 @@ class CompilerConfig:
         elif config.target == "emscripten":
             self.CC = "emcc"
             self.ext = ".mjs"
-            post_js = spy.libspy.SRC.join("emscripten_extern_post.js")
+            post_js = spy.libspy.SRC / "emscripten_extern_post.js"
             self.cflags += WASM_CFLAGS
             self.ldflags += [
                 "-sWASM_BIGINT",

--- a/spy/interop.py
+++ b/spy/interop.py
@@ -18,7 +18,7 @@ def redshift(filename: str | Path) -> tuple[SPyVM, W_Module]:
     modname = filename.stem
     builddir = filename.parent
     vm = SPyVM()
-    vm.path.append(str(builddir))
+    vm.path.append(builddir)
     w_mod = vm.import_(modname)
     vm.redshift(error_mode="eager")
     return vm, w_mod

--- a/spy/libspy/__init__.py
+++ b/spy/libspy/__init__.py
@@ -6,13 +6,13 @@ from spy.llwasm import HostModule, LLWasmInstance, LLWasmModule, WasmTrap
 from spy.location import Loc
 from spy.platform import IS_BROWSER, IS_NODE, IS_PYODIDE
 
-SRC = spy.ROOT.join("libspy", "src")
-INCLUDE = spy.ROOT.join("libspy", "include")
-BUILD = spy.ROOT.join("libspy", "build")
+SRC = spy.ROOT / "libspy" / "src"
+INCLUDE = spy.ROOT / "libspy" / "include"
+BUILD = spy.ROOT / "libspy" / "build"
 
 
 if IS_NODE:
-    LIBSPY_WASM = BUILD.join("emscripten", "debug", "libspy.mjs")
+    LIBSPY_WASM = BUILD / "emscripten" / "debug" / "libspy.mjs"
     LLMOD = None
 elif IS_BROWSER:
     LIBSPY_WASM = None  # type: ignore    # needs to be set by the embedder
@@ -20,7 +20,7 @@ elif IS_BROWSER:
 else:
     assert not IS_PYODIDE
     # "normal" python, we can preload LLMOD
-    LIBSPY_WASM = BUILD.join("wasi", "debug", "libspy.wasm")
+    LIBSPY_WASM = BUILD / "wasi" / "debug" / "libspy.wasm"
     LLMOD = LLWasmModule(LIBSPY_WASM)  # type: ignore
 
 # XXX ^^^^

--- a/spy/llwasm/base.py
+++ b/spy/llwasm/base.py
@@ -1,7 +1,6 @@
 import struct
+from pathlib import Path
 from typing import Any, Literal, Self
-
-import py.path
 
 LLWasmType = Literal[None, "void *", "int32_t", "int16_t"]
 
@@ -30,7 +29,7 @@ class LLWasmInstanceBase:
         raise NotImplementedError
 
     @classmethod
-    def from_file(cls, f: py.path.local, hostmods: list[HostModule] = []) -> Self:
+    def from_file(cls, f: Path, hostmods: list[HostModule] = []) -> Self:
         raise NotImplementedError
 
     def call(self, name: str, *args: Any) -> Any:

--- a/spy/llwasm/emscripten.py
+++ b/spy/llwasm/emscripten.py
@@ -3,9 +3,9 @@ A pythonic way to instantiate Emscripten binaries.
 """
 
 from asyncio import Future
+from pathlib import Path
 from typing import Any, Callable, Optional
 
-import py.path
 from pyodide.code import run_js
 from pyodide.ffi import JsProxy, run_sync
 from typing_extensions import Self
@@ -100,7 +100,7 @@ class LLWasmInstance(LLWasmInstanceBase):
         return llmod.instance_factory(adjustWasmImports=adjust_imports)
 
     @classmethod
-    def from_file(cls, f: py.path.local, hostmods: list[HostModule] = []) -> Self:
+    def from_file(cls, f: Path, hostmods: list[HostModule] = []) -> Self:
         llmod = LLWasmModule(str(f))
         return cls(llmod, hostmods)
 

--- a/spy/llwasm/wasmtime.py
+++ b/spy/llwasm/wasmtime.py
@@ -2,9 +2,9 @@
 A pythonic wrapper around wasmtime.
 """
 
+from pathlib import Path
 from typing import Any, Optional
 
-import py.path
 import wasmtime as wt
 from typing_extensions import Self
 
@@ -103,7 +103,7 @@ def get_wasi_config() -> wt.WasiConfig:
 
 
 class LLWasmInstance(LLWasmInstanceBase):
-    f: py.path.local
+    f: Path
     store: wt.Store
     instance: wt.Instance
     mem: "LLWasmMemory"
@@ -137,7 +137,7 @@ class LLWasmInstance(LLWasmInstanceBase):
         return cls(llmod, hostmods)
 
     @classmethod
-    def from_file(cls, f: py.path.local, hostmods: list[HostModule] = []) -> Self:
+    def from_file(cls, f: Path, hostmods: list[HostModule] = []) -> Self:
         llmod = LLWasmModule(str(f))
         return cls(llmod, hostmods)
 

--- a/spy/tests/cffi_wrapper.py
+++ b/spy/tests/cffi_wrapper.py
@@ -1,12 +1,11 @@
 import sys
+from pathlib import Path
 from typing import Any
-
-import py.path
 
 from spy.vm.vm import SPyVM
 
 
-def isolated_import(modname: str, sofile: py.path.local):
+def isolated_import(modname: str, sofile: Path):
     """
     Import the given modules in isolation, without leaving trace in
     sys.modules
@@ -14,7 +13,7 @@ def isolated_import(modname: str, sofile: py.path.local):
     assert modname not in sys.modules
     before_mods = set(sys.modules.keys())
 
-    d = sofile.dirpath()
+    d = sofile.parent
     sys.path.insert(0, str(d))
     try:
         mod = __import__(modname)
@@ -30,5 +29,5 @@ def isolated_import(modname: str, sofile: py.path.local):
     return mod
 
 
-def load_cffi_module(vm: SPyVM, modname: str, sofile: py.path.local) -> Any:
+def load_cffi_module(vm: SPyVM, modname: str, sofile: Path) -> Any:
     return isolated_import(modname, sofile)

--- a/spy/tests/compiler/test_00_bluemod.py
+++ b/spy/tests/compiler/test_00_bluemod.py
@@ -1,4 +1,5 @@
 import textwrap
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -11,11 +12,13 @@ from spy.vm.vm import SPyVM
 
 @pytest.mark.usefixtures("init")
 class TestBlueMod:
+    tmpdir: Path
+
     @pytest.fixture
-    def init(self, tmpdir):
-        self.tmpdir = tmpdir
+    def init(self, tmp_path):
+        self.tmpdir = tmp_path
         self.vm = SPyVM()
-        self.vm.path.append(str(tmpdir))
+        self.vm.path.append(tmp_path)
 
     def write_file(self, filename: str, src: str) -> Any:
         """
@@ -24,8 +27,8 @@ class TestBlueMod:
         The source code is automatically dedented.
         """
         src = textwrap.dedent(src)
-        srcfile = self.tmpdir.join(filename)
-        srcfile.write(src)
+        srcfile = self.tmpdir / filename
+        srcfile.write_text(src)
         return srcfile
 
     def import_(self, src: str) -> Any:

--- a/spy/tests/compiler/test_debug.py
+++ b/spy/tests/compiler/test_debug.py
@@ -28,7 +28,7 @@ class TestDebug(CompilerTest):
         # C code:
         #   1. that SPY_LINE(spy, c) contains the correct C line number
         #   2. that we emit only the SPY_LINE which are marked by the arrows
-        csrc = self.builddir.join("test.c").read()
+        csrc = (self.builddir / "test.c").read_text()
         spylines = []
         for lineno, line in enumerate(csrc.splitlines(), start=1):
             m = self.RE_SPY_LINE.search(line)

--- a/spy/tests/compiler/test_spdb.py
+++ b/spy/tests/compiler/test_spdb.py
@@ -99,7 +99,7 @@ class TestSPdb(CompilerTest):
 
     @property
     def filename(self) -> str:
-        return str(self.tmpdir.join("test.spy"))
+        return str(self.tmpdir / "test.spy")
 
     def test_simple(self):
         src = """

--- a/spy/tests/conftest.py
+++ b/spy/tests/conftest.py
@@ -1,12 +1,13 @@
 # type: ignore
 
 import shutil
+from pathlib import Path
+from typing import cast
 
-import py
 import pytest
 from pytest_pyodide import get_global_config
 
-ROOT = py.path.local(__file__).dirpath()
+ROOT = Path(__file__).parent
 HAVE_EMCC = shutil.which("emcc") is not None
 
 
@@ -26,7 +27,7 @@ def pytest_collection_modifyitems(session, config, items):
     yield
 
     def key(item):
-        filename = item.fspath.relto(ROOT)
+        filename = Path(item.fspath).relative_to(ROOT)
         if filename == "test_zz_mypy.py":
             return 100  # last
         elif filename == "test_backend_spy.py":
@@ -70,7 +71,7 @@ def call_immediately(f):
 
 @call_immediately
 def configure_pyodide():
-    SPY_ROOT = ROOT.join("..", "..")  # the root of the repo
+    SPY_ROOT = ROOT.parent.parent  # the root of the repo
 
     pytest_pyodide_config = get_global_config()
     pytest_pyodide_config.set_flags(

--- a/spy/tests/exe_wrapper.py
+++ b/spy/tests/exe_wrapper.py
@@ -1,17 +1,16 @@
 import subprocess
-
-import py.path
+from pathlib import Path
 
 from spy.vm.vm import SPyVM
 
 
 class ExeWrapper:
-    def __init__(self, vm: SPyVM, modname: str, f: py.path.local) -> None:
+    def __init__(self, vm: SPyVM, modname: str, f: Path) -> None:
         # vm and modname are ignored
         self.f = f
 
     def run(self, *args: str) -> str:
-        if self.f.ext == ".mjs":
+        if self.f.suffix == ".mjs":
             # run with node
             cmdline = ["node", str(self.f)]
             cmdline += list(args)

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -1,4 +1,5 @@
 import textwrap
+from pathlib import Path
 
 import pytest
 
@@ -9,17 +10,19 @@ from spy.vm.vm import SPyVM
 
 @pytest.mark.usefixtures("init")
 class TestDoppler:
+    tmpdir: Path
+
     @pytest.fixture
-    def init(self, tmpdir):
+    def init(self, tmp_path: Path):
         # XXX there is a lot of code duplication with CompilerTest
-        self.tmpdir = tmpdir
+        self.tmpdir = tmp_path
         self.vm = SPyVM()
-        self.vm.path.append(str(self.tmpdir))
+        self.vm.path.append(self.tmpdir)
 
     def redshift(self, src: str) -> None:
-        f = self.tmpdir.join("test.spy")
+        f = self.tmpdir / "test.spy"
         src = textwrap.dedent(src)
-        f.write(src)
+        f.write_text(src)
         self.vm.import_("test")
         self.vm.redshift(error_mode="eager")
 
@@ -288,7 +291,7 @@ class TestDoppler:
         """)
 
     def test_format_prebuilt_exception(self):
-        fname = str(self.tmpdir.join("test.spy"))
+        fname = str(self.tmpdir / "test.spy")
         self.redshift("""
         def foo() -> None:
             raise TypeError('foo')

--- a/spy/tests/test_interop.py
+++ b/spy/tests/test_interop.py
@@ -1,4 +1,5 @@
 import textwrap
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -9,17 +10,17 @@ from spy.vm.function import W_ASTFunc
 
 @pytest.mark.usefixtures("init")
 class TestInterop:
-    tmpdir: Any
+    tmpdir: Path
 
     @pytest.fixture
-    def init(self, tmpdir):
-        self.tmpdir = tmpdir
-        self.foo_spy = tmpdir.join("foo.spy")
+    def init(self, tmp_path: Path):
+        self.tmpdir = tmp_path
+        self.foo_spy = tmp_path / "foo.spy"
         src = """
         def add(x: i32, y: i32) -> i32:
             return x + y
         """
-        self.foo_spy.write(textwrap.dedent(src))
+        self.foo_spy.write_text(textwrap.dedent(src))
 
     def test_redshift(self):
         vm, w_mod = interop.redshift(str(self.foo_spy))

--- a/spy/tests/test_llwasm.py
+++ b/spy/tests/test_llwasm.py
@@ -4,8 +4,8 @@ from pytest_pyodide import run_in_pyodide  # type: ignore
 from spy import ROOT
 from spy.tests.support import CTest
 
-PYODIDE = ROOT.join("..", "pyodide", "node_modules", "pyodide")
-HAS_PYODIDE = PYODIDE.check(exists=True)
+PYODIDE = ROOT.parent / "pyodide" / "node_modules" / "pyodide"
+HAS_PYODIDE = PYODIDE.exists()
 
 
 @pytest.mark.usefixtures("init_llwasm")

--- a/spy/tests/test_magic_py_parse.py
+++ b/spy/tests/test_magic_py_parse.py
@@ -1,4 +1,5 @@
 import textwrap
+from pathlib import Path
 
 from spy.ast_dump import dump
 from spy.magic_py_parse import magic_py_parse, preprocess
@@ -81,13 +82,13 @@ def test_magic_py_parse():
     assert dumped.strip() == expected.strip()
 
 
-def test_magic_py_parse_error(tmpdir):
+def test_magic_py_parse_error(tmp_path: Path):
     src = textwrap.dedent("""
     def main() -> void:
         if 1:
     """)
-    f = tmpdir.join("test.spy")
-    f.write(src)
+    f = tmp_path / "test.spy"
+    f.write_text(src)
     parser = Parser(src, str(f))
     errors = expect_errors(
         "expected an indented block after 'if' statement on line 3", ("", "    if 1:")
@@ -96,14 +97,14 @@ def test_magic_py_parse_error(tmpdir):
         parser.parse()
 
 
-def test_magic_py_parse_tabs(tmpdir):
+def test_magic_py_parse_tabs(tmp_path: Path):
     src = textwrap.dedent("""
     def main() -> void:
         print('hello')
     \tprint('world')
     """)
-    f = tmpdir.join("test.spy")
-    f.write(src)
+    f = tmp_path / "test.spy"
+    f.write_text(src)
     parser = Parser(src, str(f))
     errors = expect_errors(
         "inconsistent use of tabs and spaces in indentation (<string>, line 4)",
@@ -113,13 +114,13 @@ def test_magic_py_parse_tabs(tmpdir):
         parser.parse()
 
 
-def test_magic_py_parse_token_error(tmpdir):
+def test_magic_py_parse_token_error(tmp_path: Path):
     src = textwrap.dedent("""
     def main() -> void:
         '''
     """)
-    f = tmpdir.join("test.spy")
-    f.write(src)
+    f = tmp_path / "test.spy"
+    f.write_text(src)
     parser = Parser(src, str(f))
     errors = expect_errors("('EOF in multi-line string', (3, 5))", ("", "    '''"))
     with errors:

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -1,4 +1,5 @@
 import textwrap
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -12,14 +13,16 @@ from spy.util import print_diff
 
 @pytest.mark.usefixtures("init")
 class TestParser:
+    tmpdir: Path
+
     @pytest.fixture
-    def init(self, tmpdir):
-        self.tmpdir = tmpdir
+    def init(self, tmp_path: Path):
+        self.tmpdir = tmp_path
 
     def parse(self, src: str) -> ast.Module:
-        f = self.tmpdir.join("test.spy")
+        f = self.tmpdir / "test.spy"
         src = textwrap.dedent(src)
-        f.write(src)
+        f.write_text(src)
         parser = Parser(src, str(f))
         self.mod = parser.parse()
         return self.mod

--- a/spy/tests/test_scope.py
+++ b/spy/tests/test_scope.py
@@ -1,4 +1,5 @@
 import textwrap
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -59,15 +60,17 @@ class MatchSymbol:
 
 @pytest.mark.usefixtures("init")
 class TestScopeAnalyzer:
+    tmpdir: Path
+
     @pytest.fixture
-    def init(self, tmpdir):
+    def init(self, tmp_path: Path):
         self.vm = SPyVM()
-        self.tmpdir = tmpdir
+        self.tmpdir = tmp_path
 
     def analyze(self, src: str):
-        f = self.tmpdir.join("test.spy")
+        f = self.tmpdir / "test.spy"
         src = textwrap.dedent(src)
-        f.write(src)
+        f.write_text(src)
         parser = Parser(src, str(f))
         self.mod = parser.parse()
         scopes = ScopeAnalyzer(self.vm, "test", self.mod)
@@ -340,10 +343,10 @@ class TestScopeAnalyzer:
 
     def test_import_wrong_py_module(self):
         # Create a .py file that would match the import
-        py_file = self.tmpdir.join("mymodule.py")
-        py_file.write("x = 42\n")
+        py_file = self.tmpdir / "mymodule.py"
+        py_file.write_text("x = 42\n")
 
-        self.vm.path.append(str(self.tmpdir))
+        self.vm.path.append(self.tmpdir)
         src = "from mymodule import x"
         self.expect_errors(
             src,

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import fixedint
 import pytest
 
@@ -260,16 +262,16 @@ class TestVM:
         with pytest.raises(ValueError, match="'builtins::x' already exists"):
             vm.add_global(fqn, vm.wrap(43))
 
-    def test_get_filename(self, tmpdir):
+    def test_get_filename(self, tmp_path: Path):
         vm = SPyVM()
-        vm.path = [str(tmpdir)]
-        spy_file = tmpdir.join("main.spy")
-        spy_file.write("x: i32 = 42\n")
+        vm.path = [tmp_path]
+        spy_file = tmp_path / "main.spy"
+        spy_file.write_text("x: i32 = 42\n")
 
         filename = vm.find_file_on_path("main")
-        assert filename == tmpdir.join("main.spy")
+        assert filename == tmp_path / "main.spy"
         assert vm.find_file_on_path("nonexistent") is None
-        py_file = tmpdir.join("py.py")
-        py_file.write("i = 42\n")
+        py_file = tmp_path / "py.py"
+        py_file.write_text("i = 42\n")
         assert vm.find_file_on_path("py") is None
-        assert vm.find_file_on_path("py", allow_py_files=True) == tmpdir.join("py.py")
+        assert vm.find_file_on_path("py", allow_py_files=True) == tmp_path / "py.py"

--- a/spy/tests/wasm_wrapper.py
+++ b/spy/tests/wasm_wrapper.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
-import py.path
 import wasmtime
 
 from spy.fqn import FQN
@@ -30,7 +30,7 @@ class WasmModuleWrapper:
     modname: str
     ll: LLSPyInstance
 
-    def __init__(self, vm: SPyVM, modname: str, f: py.path.local) -> None:
+    def __init__(self, vm: SPyVM, modname: str, f: Path) -> None:
         self.vm = vm
         self.modname = modname
         self.w_mod = vm.modules_w[modname]

--- a/spy/util.py
+++ b/spy/util.py
@@ -7,9 +7,8 @@ import re
 import subprocess
 import typing
 from collections import defaultdict
-from typing import Callable, Literal, Sequence
-
-import py.path
+from pathlib import Path
+from typing import Callable, List, Literal, Sequence
 
 from spy.textbuilder import Color
 
@@ -174,7 +173,7 @@ def unbuffer_run(cmdline_s: Sequence[str]) -> subprocess.CompletedProcess:
 
 
 def robust_run(
-    cmdline: Sequence[str | py.path.local], unbuffer: bool = False
+    cmdline: list[str], unbuffer: bool = False
 ) -> subprocess.CompletedProcess:
     """
     Similar to subprocess.run, but raise an Exception with the content of

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -1,9 +1,9 @@
 import itertools
+from pathlib import Path
 from types import FunctionType
 from typing import Any, Callable, Iterable, Optional, Sequence, Union, overload
 
 import fixedint
-import py.path
 
 from spy import ROOT, ast, libspy
 from spy.analyze.symtable import ImportRef
@@ -83,7 +83,7 @@ W_Str._w.define(W_Str)
 w_DynamicType.define(W_Object)
 
 
-STDLIB = ROOT.join("..", "stdlib")
+STDLIB = ROOT.parent / "stdlib"
 
 
 class SPyVM:
@@ -99,7 +99,7 @@ class SPyVM:
     irtags: dict[FQN, IRTag]
     modules_w: dict[str, W_Module]
     builtins_closure: CLOSURE
-    path: list[str]
+    path: list[Path]
     bluecache: BlueCache
     emit_warning: Callable[[SPyError], None]
     # For use by --colorize to remember the red/blue color of each expr
@@ -115,7 +115,7 @@ class SPyVM:
         self.globals_w = {}
         self.irtags = {}
         self.modules_w = {}
-        self.path = [str(STDLIB)]
+        self.path = [STDLIB]
         self.bluecache = BlueCache(self)
         self.emit_warning = lambda err: None
         self.ast_color_map = None  # By default, don't keep track of expr colors.
@@ -158,18 +158,18 @@ class SPyVM:
 
     def find_file_on_path(
         self, modname: str, allow_py_files: bool = False
-    ) -> Optional[py.path.local]:
+    ) -> Optional[Path]:
         # XXX for now we assume that we find the module as a single file in
         # the only vm.path entry. Eventually we will need a proper import
         # mechanism and support for packages
         assert self.path, "vm.path not set"
         for d in self.path:
             # XXX write test for this
-            f = py.path.local(d).join(f"{modname}.spy")
+            f = Path(d) / f"{modname}.spy"
             if f.exists():
                 return f
             if allow_py_files:
-                py_f = f.new(ext=".py")
+                py_f = f.parent / f"{f.stem}.py"
                 if py_f.exists():
                     return py_f
 


### PR DESCRIPTION
Sorry for submitting such a big PR without checking first! 😅 I thought this would just be a small change, but by the time I was halfway through I realised it was going to be much bigger. Let me know if this is too much and I can try splitting it up or dialling it back, or just close the PR 😅 

According to [the `py` documentation](https://py.readthedocs.io/en/latest/path.html):

> The ‘py’ library is in “maintenance mode” and so is not recommended for new projects. Please check out [pathlib](https://docs.python.org/3/library/pathlib.html) or [pathlib2](https://pypi.org/project/pathlib2/) for path operations.

This PR replaces the `py.path.local` type with the `pathlib.Path` type, and makes the following changes:

- `with open(p, "w") as f: f.write(...)` -> `p.write_text(...)`
- `p.dirpath()` -> `p.parent`
- `p.join("dir")` -> `p / "dir"`
- `p.ensure(dir=True)` -> `p.mkdir(exist_ok=True)`
- `p.purebasename` -> `p.stem`
- `p.basename` -> `p.name`
- `p.read()` -> `p.read_text()`
- `p.relto(other_p)` -> `p.relative_to(other_p)` (the `pathlib` API raises a `ValueError` if the relative path cannot be found, as opposed to `py.path` returning an empty string)
- `p.new(ext=".ext")` -> `p.parent / f"{p.stem}.ext"`
- The `pytest` fixture `tmpdir` which is a `py.path.local` has been replaced with the fixture `tmp_path` which is a `pthlib.Path`
- `p.check(exists=True)` -> `p.exists()`