### PR TITLE
Add a loading indicator before pyodide initialization.

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -56,6 +56,7 @@ jobs:
           cp spy/libspy/build/emscripten/release/libspy.mjs playground/
           cp spy/libspy/build/emscripten/release/libspy.wasm playground/
           cp dist/spylang-*.whl playground/
+          cp -r assets playground/
 
       - name: Remove build files from playground
         run: rm -f playground/Makefile

--- a/playground/Makefile
+++ b/playground/Makefile
@@ -38,8 +38,12 @@ local:
 	cp $(BUILD_DIR)/libspy.wasm .
 	cp $(DIST_DIR)/spylang-*.whl .
 
+	@echo "Copying assets..."
+	cp -rv $(ROOT_DIR)/assets .
+
 	@echo "✓ Playground built successfully!"
 	@echo "Run 'python -m http.server' in this directory to test locally"
 
 clean:
 	rm -f libspy.mjs libspy.wasm spylang-*.whl
+	rm -rf assets

--- a/playground/index.html
+++ b/playground/index.html
@@ -21,8 +21,48 @@
     <!-- Custom playground styles -->
     <link rel="stylesheet" href="style.css">
 
+    <!-- PyScript lifecycle event logging -->
+    <script>
+        console.log('[PyScript] Page loaded, waiting for PyScript initialization...');
+
+        // Fired when PyScript finds a script/element and interpreter is ready
+        addEventListener("py:ready", (event) => {
+            console.log('[PyScript] py:ready - Interpreter bootstrapped, about to execute:', event.target);
+            console.time('[PyScript] Execution time');
+
+            // Remove loading indicator when PyScript is ready
+            const loadingIndicator = document.getElementById('loading-indicator');
+            if (loadingIndicator) {
+                loadingIndicator.remove();
+            }
+        });
+
+        // Fired when a specific script/element finishes executing
+        addEventListener("py:done", (event) => {
+            console.timeEnd('[PyScript] Execution time');
+            console.log('[PyScript] py:done - Script execution completed:', event.target);
+        });
+
+        // Fired when ALL scripts on the page are done
+        addEventListener("py:all-done", () => {
+            console.log('[PyScript] py:all-done - All scripts finished, app ready!');
+        });
+
+        // Error event
+        addEventListener("py:error", (event) => {
+            console.error('[PyScript] py:error - Error occurred:', event.detail);
+        });
+    </script>
+
 </head>
 <body>
+    <!-- Loading indicator - shown until PyScript is ready -->
+    <div id="loading-indicator">
+        <img src="assets/disguised-face.svg" alt="Loading...">
+        <h2>Loading SPy Playground</h2>
+        <p>Initializing PyScript and SPy compiler...</p>
+    </div>
+
     <script type="py" src="main.py" config="pyscript.toml" terminal>
     </script>
 

--- a/playground/main.py
+++ b/playground/main.py
@@ -4,20 +4,28 @@ import tomllib
 from pathlib import Path
 
 import ltk
+from js import console
+
+console.log("[Python] main.py started executing")
 
 # ========== SPy code ==========
 
+console.log("[Python] Installing spy package...")
 print("Installing spy... ", end="")
 sys.stdout.flush()
 import micropip
 
 await micropip.install("./spylang-0.1.0-py3-none-any.whl")
 print("DONE")
+console.log("[Python] SPy package installed successfully")
 
 from js import URL, document
 
+console.log("[Python] Importing spy.cli and libspy...")
 import spy.cli
 from spy import libspy
+
+console.log("[Python] SPy imports complete")
 
 libspy.LIBSPY_WASM = str(URL.new("./libspy.mjs", document.baseURI))
 
@@ -64,6 +72,7 @@ class Editor(ltk.Div):
 
 
 # Auto-discover example files from pyscript.toml
+console.log("[Python] Loading example files from pyscript.toml...")
 with open("pyscript.toml", "rb") as f:
     config = tomllib.load(f)
 EXAMPLE_FILES = [
@@ -72,7 +81,9 @@ EXAMPLE_FILES = [
     if dest == "examples/"
 ]
 
+console.log(f"[Python] Creating editor with initial file: {EXAMPLE_FILES[0]}")
 editor = Editor(Path(EXAMPLE_FILES[0]).read_text())
+console.log("[Python] Editor created")
 
 display_filename = "test.spy"
 command_leader = "$"
@@ -173,6 +184,8 @@ def tab_activated(event, ui=None):
 
 
 def main():
+    console.log("[Python] main() function started - building GUI...")
+
     # Register tab activation callback
     example_tabs.on("tabsactivate", tab_activated)
 
@@ -209,6 +222,8 @@ def main():
     )
 
     ltk.find("#terminal").append(ltk.find("py-terminal"))
+    console.log("[Python] GUI construction complete - playground ready!")
 
 
+console.log("[Python] Calling main()...")
 main()

--- a/playground/style.css
+++ b/playground/style.css
@@ -7,6 +7,45 @@ body {
     background-color: #f5f5f5;
 }
 
+/* Loading indicator */
+#loading-indicator {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(255, 255, 255, 0.95);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    z-index: 9999;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+#loading-indicator img {
+    width: 80px;
+    height: 80px;
+    animation: spin 2s linear infinite;
+    margin-bottom: 20px;
+    transform-style: preserve-3d;
+}
+
+@keyframes spin {
+    0% { transform: perspective(400px) rotateY(0deg); }
+    100% { transform: perspective(400px) rotateY(360deg); }
+}
+
+#loading-indicator h2 {
+    margin: 10px 0;
+    color: #333;
+}
+
+#loading-indicator p {
+    color: #666;
+    font-size: 14px;
+}
+
 h1 {
     text-align: center;
     margin: 20px 0;


### PR DESCRIPTION
This is a quick PR for some easy playground wins. See: #297 

# Add a loading indicator before pyodide runs

It can take a couple of seconds before you see the initial terminal that tells you that SPy is loading. To signal to the user that the page is working, I added a small animated loading screen:
<img width="166" height="110" alt="image" src="https://github.com/user-attachments/assets/9e80e889-4658-4277-9670-42299530999b" />

# Add some console.log statements to indicate when pyscript events happen

To give more insight into what the page is doing, I added some `console.log` statements (in both .js and .py) to signal when particular lifetime events are happening. It might be a little useful in debugging if things break. 
<img width="1153" height="369" alt="image" src="https://github.com/user-attachments/assets/9b1c2c37-7bd0-449a-95e6-0c20c3b1df7a" />
