### PR TITLE
Support --format=json output with colorization

### DIFF
--- a/spy/cli.py
+++ b/spy/cli.py
@@ -21,7 +21,12 @@ from spy.doppler import ErrorMode
 from spy.errors import SPyError
 from spy.magic_py_parse import magic_py_parse
 from spy.textbuilder import Color
-from spy.util import cleanup_spyc_files, colors_coordinates, highlight_src_maybe
+from spy.util import (
+    cleanup_spyc_files,
+    colors_coordinates,
+    format_colors_as_json,
+    highlight_src_maybe,
+)
 from spy.vendored.dataclass_typer import dataclass_typer
 from spy.vm.b import B
 from spy.vm.debugger.spdb import SPdb
@@ -66,6 +71,15 @@ class Arguments:
             help="Output the pre-redshifted AST with blue / red text colors.",
         ),
     ] = False
+
+    format: Annotated[
+        str,
+        Option(
+            "--format",
+            help="Output format for --colorize (ansi or json)",
+            click_type=click.Choice(["ansi", "json"]),
+        ),
+    ] = "ansi"
 
     imports: Annotated[
         bool,
@@ -439,7 +453,10 @@ async def inner_main(args: Arguments) -> None:
                 orig_mod.pp(vm=vm)
             else:
                 coords = colors_coordinates(orig_mod, vm.ast_color_map)
-                print(highlight_sourcecode(args.filename, coords))
+                if args.format == "json":
+                    print(format_colors_as_json(coords))
+                else:
+                    print(highlight_sourcecode(args.filename, coords))
         elif args.parse:
             dump_spy_mod_ast(vm, modname)
         else:

--- a/spy/util.py
+++ b/spy/util.py
@@ -279,6 +279,39 @@ def colors_coordinates(ast_module, ast_color_map) -> dict[int, list[tuple[str, s
     return dict(coords)
 
 
+def format_colors_as_json(coords_dict: dict[int, list[tuple[str, str]]]) -> str:
+    """
+    Convert color coordinates to JSON format for editor integration.
+
+    Args:
+        coords_dict: Dictionary mapping line numbers to list of (col_range, color) tuples,
+                     as returned by colors_coordinates()
+
+    Returns:
+        JSON string with format: [{"line": 10, "col": 5, "length": 3, "type": "blue"}, ...]
+
+    Example:
+        >>> coords = {3: [("4:9", "red"), ("10:15", "blue")]}
+        >>> format_colors_as_json(coords)
+        '[{"line": 3, "col": 4, "length": 6, "type": "red"}, ...]'
+    """
+    import json
+
+    highlights = []
+    for line_num, spans in coords_dict.items():
+        for col_range, color in spans:
+            start_str, end_str = col_range.split(":")
+            start = int(start_str)
+            end = int(end_str)
+            length = end - start + 1
+
+            highlights.append(
+                {"line": line_num, "col": start, "length": length, "type": color}
+            )
+
+    return json.dumps(highlights, indent=2)
+
+
 _record_src_counter = itertools.count()
 
 


### PR DESCRIPTION
Add a JSON format option to `--colorize`, like so:

```
spy --colorize example.spy
```

Which will output JSON like so:
```
[
  {
    "line": 21,
    "col": 4,
    "length": 22,
    "type": "red"
  },
  {
    "line": 21,
    "col": 8,
    "length": 18,
    "type": "red"
  },
...
```

The intent of this PR is to make colorize output readable by other tools so they can also add colorization support. For an early example of this, see: https://github.com/aisipos/spy-mode.el
<img width="492" height="336" alt="image" src="https://github.com/user-attachments/assets/7dd4b5d6-1af9-4ca6-a31d-2c5a98962566" />

Eventually I think this sort of functionality belongs in an LSP server. But since we don't have one yet, adding JSON support to SPy cli outputs seemed like a quick win.
