### PR TITLE
Add support for List[str]

### DIFF
--- a/spy/tests/compiler/unsafe/test_ptr.py
+++ b/spy/tests/compiler/unsafe/test_ptr.py
@@ -97,6 +97,21 @@ class TestUnsafePtr(CompilerTest):
         """)
         assert mod.foo(3, 4.5) == 7.5
 
+    def test_ptr_to_string(self):
+        mod = self.compile("""
+        from unsafe import gc_alloc, ptr
+
+        def make_str_ptr(s: str) -> ptr[str]:
+            p = gc_alloc(str)(1)
+            p[0] = s
+            return p
+
+        def foo() -> str:
+            p = make_str_ptr("hello")
+            return p[0]
+        """)
+        assert mod.foo() == "hello"
+
     @only_interp
     def test_dir_ptr(self):
         mod = self.compile("""

--- a/spy/tests/stdlib/test__list.py
+++ b/spy/tests/stdlib/test__list.py
@@ -24,6 +24,19 @@ class TestList(CompilerTest):
         assert mod.test_empty() == 0
         assert mod.test_append() == 3
 
+    def test_list_of_string(self):
+        src = """
+        from _list import List
+
+        def foo() -> str:
+            lst = List[str]()
+            lst.append("hello ")
+            lst.append("world")
+            return lst[0] + lst[1]
+        """
+        mod = self.compile(src)
+        assert mod.foo() == "hello world"
+
     def test_getitem(self):
         src = """
         from _list import List

--- a/spy/vm/modules/unsafe/misc.py
+++ b/spy/vm/modules/unsafe/misc.py
@@ -15,7 +15,9 @@ def sizeof(w_T: W_Type) -> int:
         return 8
     elif isinstance(w_T, W_StructType):
         return w_T.size
-    elif isinstance(w_T, W_PtrType):
+    elif isinstance(w_T, W_PtrType) or w_T is B.w_str:
+        # w_str is a "spy_Str *" in C, so it's a pointer.
+        #
         # XXX what is the right size of pointers? For wasm32 is 4 of course,
         # but for native it might be 8. Does it mean that we need to
         # preemptively choose the target platform BEFORE redshifting?


### PR DESCRIPTION
- teach the `unsafe` module how to deal with `ptr[str]`
- this automatically makes `_list.List[str]` working.