### PR TITLE
cli: add -h short option for --help

### DIFF
--- a/spy/cli/spy_typer.py
+++ b/spy/cli/spy_typer.py
@@ -116,6 +116,7 @@ class SpyTyper(typer.Typer):
         kwargs["add_completion"] = (
             False  # Hide the default --install-completion and --show-completion options for cleanliness
         )
+        kwargs["context_settings"] = {"help_option_names": ["-h", "--help"]}
         super().__init__(*args, **kwargs)
 
     def _command_with_default_option(


### PR DESCRIPTION
It seems to me that it's very common and convenient to be able to get help with just `spy -h`, `spy execute -h` or `spy build -h`.

I recently discovered that this behavior can be obtained with Typer like this so here is a simple PR.