### PR TITLE
Restore effect of `--no-spyc` in several subcommands

### DIFF
--- a/spy/cli/commands/build.py
+++ b/spy/cli/commands/build.py
@@ -96,7 +96,7 @@ async def build(args: Build_Args) -> None:
     modname = args.filename.stem
     vm = await init_vm(args)
 
-    importer = ImportAnalyzer(vm, modname)
+    importer = ImportAnalyzer(vm, modname, use_spyc=not args.no_spyc)
     importer.parse_all()
     importer.import_all()
 

--- a/spy/cli/commands/execute.py
+++ b/spy/cli/commands/execute.py
@@ -18,7 +18,7 @@ async def execute(args: Execute_Args) -> None:
     modname = args.filename.stem
     vm = await init_vm(args)
 
-    importer = ImportAnalyzer(vm, modname)
+    importer = ImportAnalyzer(vm, modname, use_spyc=not args.no_spyc)
     importer.parse_all()
     importer.import_all()
     w_mod = vm.modules_w[modname]

--- a/spy/cli/commands/imports.py
+++ b/spy/cli/commands/imports.py
@@ -8,6 +8,6 @@ async def imports(args: Base_Args_With_Filename) -> None:
     modname = args.filename.stem
     vm = await init_vm(args)
 
-    importer = ImportAnalyzer(vm, modname)
+    importer = ImportAnalyzer(vm, modname, use_spyc=not args.no_spyc)
     importer.parse_all()
     importer.pp()

--- a/spy/cli/commands/parse.py
+++ b/spy/cli/commands/parse.py
@@ -17,7 +17,7 @@ async def parse(args: Parse_Args) -> None:
     modname = args.filename.stem
     vm = await init_vm(args)
 
-    importer = ImportAnalyzer(vm, modname)
+    importer = ImportAnalyzer(vm, modname, use_spyc=not args.no_spyc)
     importer.parse_all()
 
     orig_mod = importer.getmod(modname)

--- a/spy/cli/commands/redshift.py
+++ b/spy/cli/commands/redshift.py
@@ -41,7 +41,7 @@ async def redshift(args: Redshift_Args) -> None:
     modname = args.filename.stem
     vm = await init_vm(args)
 
-    importer = ImportAnalyzer(vm, modname)
+    importer = ImportAnalyzer(vm, modname, use_spyc=not args.no_spyc)
     importer.parse_all()
     importer.import_all()
 


### PR DESCRIPTION
In the CLI rework #332, a bunch of the new subcommands didn't pass `--no-spyc` along to the ImportAnalyzer, meaning that flag has no effect in those subcommands. This PR rectifies that. 

Fixes #361 