### PR TITLE
Add `redshift --format` option

### DIFF
--- a/spy/cli/commands/redshift.py
+++ b/spy/cli/commands/redshift.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Annotated
 
+import click
 from typer import Option
 
 from spy.analyze.importing import ImportAnalyzer
@@ -21,10 +22,14 @@ class _redshift_mixin:
         Option("--full-fqn", help="Show full FQNs in redshifted modules"),
     ] = False
 
-    human_readable: Annotated[
-        bool,
-        Option("--human-readable", help="Show full FQNs in redshifted modules"),
-    ] = False
+    format: Annotated[
+        str,
+        Option(
+            "--format",
+            help="Output format (ast or spy [source])",
+            click_type=click.Choice(["ast", "spy"]),
+        ),
+    ] = "spy"
 
 
 @dataclass
@@ -52,7 +57,9 @@ async def redshift(args: Redshift_Args) -> None:
         w_mod = vm.modules_w[modname]
         execute_spy_main(vm, w_mod, redshift=True, _timeit=args.timeit)
     else:
-        if args.human_readable:
+        if args.format == "spy":
             dump_spy_mod(vm, modname, args.full_fqn)
-        else:  # not args.human_readable
+        elif args.format == "ast":
             dump_spy_mod_ast(vm, modname)
+        else:
+            assert False, f"Invalid redshift format `{args.format}`"

--- a/spy/tests/test_cli.py
+++ b/spy/tests/test_cli.py
@@ -152,15 +152,15 @@ class TestMain:
         assert stdout == "hello world\n"
 
     def test_redshift_dump_ast(self):
-        _, stdout = self.run("redshift", self.main_spy)
+        _, stdout = self.run("redshift", "--format", "ast", self.main_spy)
         assert stdout.startswith("`main::main` = FuncDef(")
 
     def test_redshift_full_fqn(self):
         _, stdout = self.run("redshift", "--full-fqn", self.main_spy)
-        assert "FQN('builtins::print_str')" in stdout
+        assert "builtins::print_str" in stdout
 
-    def test_redshift_human_readable(self):
-        _, stdout = self.run("redshift", "--human-readable", self.main_spy)
+    def test_redshift_spy_output(self):
+        _, stdout = self.run("redshift", self.main_spy)
         assert stdout.startswith("\ndef main() -> None:")
 
     def test_colorize_ast(self):


### PR DESCRIPTION
Changes the redshift flag "`--human-readable" into the more flexible `--format` option, to make it clearer what the option does and to make it easier to add further output formats.

Closes #362