### PR TITLE
format dict expression in compiler backend

### DIFF
--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -513,3 +513,9 @@ class SPyBackend:
         itemlist = [self.fmt_expr(it) for it in node.items]
         items = ", ".join(itemlist)
         return f"({items})"
+
+    def fmt_expr_Dict(self, node: ast.Dict) -> str:
+        pairs = [
+            f"{self.fmt_expr(kv.key)}: {self.fmt_expr(kv.value)}" for kv in node.items
+        ]
+        return "{" + ", ".join(pairs) + "}"

--- a/spy/tests/test_backend_spy.py
+++ b/spy/tests/test_backend_spy.py
@@ -350,6 +350,14 @@ class TestSPyBackend(CompilerTest):
         self.compile(src)
         self.assert_dump(src)
 
+    def test_dict_literal(self):
+        src = """
+        def foo() -> None:
+            x = {10: 50, 60: 40}
+        """
+        self.compile(src)
+        self.assert_dump(src)
+
     def test_zz_sanity_check(self):
         """
         This is a hack.


### PR DESCRIPTION
Fixed error pipeline for backend lacking of dict expression formatter. 