### PR TITLE
Fix "Illegal instruction" crash

### DIFF
--- a/spy/tests/conftest.py
+++ b/spy/tests/conftest.py
@@ -7,13 +7,18 @@ import py
 import pytest
 from pytest_pyodide import get_global_config
 
-from spy.tests.test_backend_spy import run_sanity_check_fixture
 from spy.util import cleanup_spyc_files
 
+# this is a VERY WEIRD sanity check!
+# If we import spy.llwasm very early, we trigger the line "ENGINE = wt.Engine". I don't
+# know why, but if we create the ENGINE so early, then calls to spy_panic crashes with
+# "Illegal instruction" instead of correctly raising WasmTrap.
+#
+# I have no idea why it happens.
 if "spy.llwasm" in sys.modules:
     raise Exception("""
     You shouldn't import spy.llwasm so early in the conftest, else spy_panic crashes
-    during tests. See PR #...
+    during tests. See PR #378.
     """)
 
 ROOT = py.path.local(__file__).dirpath()
@@ -106,6 +111,8 @@ def spy_backend_sanity_check_fixture(tmpdir_factory):
     This ensures that the SPy backend can format all AST nodes that were
     compiled during the test run. This runs on every xdist worker.
     """
+    from spy.tests.test_backend_spy import run_sanity_check_fixture
+
     yield
     run_sanity_check_fixture(tmpdir_factory)
 


### PR DESCRIPTION
I really don't know how to explain this.
After commit 6bd42afa, `spy/tests/compiler/test_float.py::TestFloat::test_zero_division_error` started to crash with an `Illegal instruction` error:
```
spy/tests/compiler/test_float.py::TestFloat::test_zero_division_error[f32-interp] Fatal Python error: Illegal instruction

Current thread 0x00007945d3cc3080 (most recent call first):
  File "/home/antocuni/anaconda/spy/venv/lib/python3.12/site-packages/wasmtime/_bindings.py", line 3006 in wasmtime_func_call
  File "/home/antocuni/anaconda/spy/venv/lib/python3.12/site-packages/wasmtime/_func.py", line 94 in __call__
  File "/home/antocuni/anaconda/spy/spy/llwasm/wasmtime.py", line 165 in call
  File "/home/antocuni/anaconda/spy/spy/libspy/__init__.py", line 101 in call
  File "/home/antocuni/anaconda/spy/spy/vm/modules/operator/opimpl_f32.py", line 16 in _f32_op_f32
  [...]
Illegal instruction
```

It turns out that this is ultimately triggered by creating `wt.Engine` very early in the conftest, which was ultimately triggered by `from spy.tests.test_backend_spy import run_sanity_check_fixture`:
https://github.com/spylang/spy/blob/45325ab3af81623c24622c360dc80f061f5bf862/spy/llwasm/wasmtime.py#L15


I even tried a different workaround to do the early import but a delayed instantiation of `wt.Engine`, and I confirm it also solves the issue. It seems a bug in wasmtime, but now I'd be curious to know what's happening.