### PR TITLE
Defer wasmtime Engine creation to avoid signal handler conflicts

### DIFF
--- a/spy/tests/conftest.py
+++ b/spy/tests/conftest.py
@@ -1,25 +1,12 @@
 # type: ignore
 
 import shutil
-import sys
 
 import py
 import pytest
 from pytest_pyodide import get_global_config
 
 from spy.util import cleanup_spyc_files
-
-# this is a VERY WEIRD sanity check!
-# If we import spy.llwasm very early, we trigger the line "ENGINE = wt.Engine". I don't
-# know why, but if we create the ENGINE so early, then calls to spy_panic crashes with
-# "Illegal instruction" instead of correctly raising WasmTrap.
-#
-# I have no idea why it happens.
-if "spy.llwasm" in sys.modules:
-    raise Exception("""
-    You shouldn't import spy.llwasm so early in the conftest, else spy_panic crashes
-    during tests. See PR #378.
-    """)
 
 ROOT = py.path.local(__file__).dirpath()
 HAVE_EMCC = shutil.which("emcc") is not None


### PR DESCRIPTION
This replaces #378 with a different workaround.
It turns out that the problem originates from the fact that both pytest and wasmtime try to install a `faulthandler`, and wasmtime should do it later in order to "win".

The most proper fix is make the instantiation of `wt.Engine` lazy.

The following is the description generated by claude.

---


## Summary
Changed wasmtime Engine initialization from import-time to lazy initialization to prevent signal handler conflicts with pytest's faulthandler.

## Changes
- Replaced module-level `ENGINE = wt.Engine()` with a lazy-initialized `_ENGINE` global variable
- Added `get_engine()` function that creates the Engine on first use
- Updated all Engine references in `LLWasmModule.__init__()` and `LLWasmInstance.__init__()` to use `get_engine()`

## Details
The wasmtime Engine installs signal handlers for WebAssembly trap handling at creation time. When the Engine was created at import time, pytest's `faulthandler.enable()` could overwrite these handlers during test initialization, causing WASM traps to crash with "Illegal instruction" errors instead of being properly caught.

By deferring Engine creation until first use (typically during test execution), the signal handlers are installed after pytest's faulthandler setup, ensuring proper trap handling throughout test execution.
