### PR TITLE
playground: Upgrade pyscript to 2026.1.1

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -6,9 +6,9 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <link rel="icon" href="favicon.ico" type="image/x-icon">
 
-    <link rel="stylesheet" href="https://pyscript.net/releases/2025.2.1/core.css">
-    <script type="module" src="https://pyscript.net/releases/2025.2.1/core.js"></script>
-    
+    <link rel="stylesheet" href="https://pyscript.net/releases/2026.1.1/core.css">
+    <script type="module" src="https://pyscript.net/releases/2026.1.1/core.js"></script>
+
     <script src="https://code.jquery.com/jquery-3.6.0.js"></script>
     <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.js"></script>
     <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">


### PR DESCRIPTION
Partial fix for #381 by updating pyscript to the latest version. It does fix the break and allows the playground to load correctly, but puts no protections in place to help detect or prevent this in the future.

I'll work on getting a micropip lockfile next. I'd like to upgrade pyodide to the latest as part of this, but there are many breaking changes since our current version (see https://pyodide.org/en/stable/project/changelog.html), so in the spirit of fixing the playground quickly I put up this quick PR first and will work on the micropip / pyodide part in a separate PR next.