### PR TITLE
Revert "Enable ruff formatting for .spy files"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      # - name: Install wasi-sdk
+      #   run: |
+      #     cd
+      #     WASI_OS=linux
+      #     WASI_ARCH=x86_64
+      #     WASI_VERSION=24
+      #     WASI_VERSION_FULL=${WASI_VERSION}.0
+      #     WASI_FILENAME=wasi-sdk-${WASI_VERSION_FULL}-${WASI_ARCH}-${WASI_OS}
+      #     wget -q https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/${WASI_FILENAME}.tar.gz
+      #     tar xf ${WASI_FILENAME}.tar.gz
+      #     $PWD/${WASI_FILENAME}/bin/clang --version
+      #     echo "$PWD/${WASI_FILENAME}/bin" >> $GITHUB_PATH
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -65,7 +78,7 @@ jobs:
 
       - name: Format check
         run: |
-          ruff format --check . --extension py,spy  # Added .spy support
+          ruff format --check .
 
       - name: Build libspy
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,6 @@ repos:
       - id: check-toml # checks toml files for parseable syntax.
       - id: check-xml # checks xml files for parseable syntax.
       - id: check-yaml # checks yaml files for parseable syntax.
-
   # 🧹 Ruff for linting, import sorting, and formatting
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.0
@@ -15,8 +14,6 @@ repos:
         args:
           - --fix
       - id: ruff-format
-        args: ["--extension", "py,spy"]  # Added .spy support
-
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v21.1.5
     hooks:


### PR DESCRIPTION
Reverts spylang/spy#388

The following is the investigation done by Claude: 

Root Cause
PR #388 added --extension py,spy to the ruff format command in both .github/workflows/tests.yml and .pre-commit-config.yaml. This syntax is invalid — ruff's --extension flag requires the format <Extension>:<LanguageCode> (e.g., spy:python), not a comma-separated list.
