### PR TITLE
Introduce typed ASTs

### DIFF
--- a/spy/ast.py
+++ b/spy/ast.py
@@ -22,11 +22,24 @@ from spy.location import Loc
 from spy.util import extend
 
 if TYPE_CHECKING:
+    from spy.vm.object import W_Type
     from spy.vm.vm import SPyVM
 
 ClassKind = typing.Literal["class", "struct"]
 FuncKind = typing.Literal["plain", "generic", "metafunc"]
 FuncParamKind = typing.Literal["simple", "var_positional"]
+
+# ==== Typed vs untyped ASTs ====
+#
+# The Expr class has an optional field w_T which indicates the type of the expression.
+#
+# AST trees are said UNTYPED when all their Exprs have w_T == None.
+# AST trees are said TYPED when all their Exprs have w_T != None.
+#
+# It is a logical error to have AST trees which mix typed and untyped nodes.
+#
+# The parser produces UNTYPED ASTs. DopplerFrame produces TYPED ASTs.
+# ================================
 
 
 @extend(py_ast.AST)
@@ -225,6 +238,9 @@ class Expr(Node):
     # precedence must be overriden by subclasses. The weird type comment is
     # needed to make mypy happy
     precedence = "<Expr.precedence not set>"  # type: int # type: ignore
+
+    # the type of the expression: present only in TYPED ASTs.
+    w_T: Optional["W_Type"] = field(default=None, kw_only=True)
 
 
 @astnode

--- a/spy/ast_dump.py
+++ b/spy/ast_dump.py
@@ -121,6 +121,9 @@ class Dumper(TextBuilder):
             self.writeline("")
         with self.indent():
             for field, value in zip(fields, values):
+                # print the w_T only if it's not None
+                if field == "w_T" and value is None:
+                    continue
                 is_last = field is fields[-1]
                 self.write(f"{field}=")
                 self.dump_anything(value)

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -20,6 +20,7 @@ from spy.vm.opspec import W_MetaArg
 from spy.vm.tuple import W_Tuple
 
 if TYPE_CHECKING:
+    from spy.vm.object import W_Type
     from spy.vm.vm import SPyVM
 
 ErrorMode = Literal["eager", "lazy", "warn"]
@@ -44,16 +45,16 @@ def make_const(vm: "SPyVM", loc: Loc, w_val: W_Object) -> ast.Expr:
         value = vm.unwrap(w_val)
         if isinstance(value, FixedInt):  # type: ignore
             value = int(value)
-        return ast.Constant(loc, value)
+        return ast.Constant(loc, value, w_T=w_T)
 
     elif w_T is B.w_str:
         value = vm.unwrap_str(w_val)
-        return ast.StrConst(loc, value)
+        return ast.StrConst(loc, value, w_T=w_T)
 
     elif w_T is B.w_tuple:
         assert isinstance(w_val, W_Tuple)
         items = [make_const(vm, loc, w_item) for w_item in w_val.items_w]
-        return ast.Tuple(loc, items)
+        return ast.Tuple(loc, items, w_T=w_T)
 
     elif w_T is TYPES.w_Loc:
         # note that here we have two locs: 'loc' is as usual the location
@@ -61,11 +62,11 @@ def make_const(vm: "SPyVM", loc: Loc, w_val: W_Object) -> ast.Expr:
         # const, which happen to be of type Loc.
         assert isinstance(w_val, W_Loc)
         value = w_val.loc
-        return ast.LocConst(loc, value)
+        return ast.LocConst(loc, value, w_T=w_T)
 
     # this is a non-primitive prebuilt constant.
     fqn = vm.make_fqn_const(w_val)
-    return ast.FQNConst(loc, fqn)
+    return ast.FQNConst(loc, fqn, w_T=w_T)
 
 
 class DopplerFrame(ASTFrame):
@@ -345,6 +346,7 @@ class DopplerFrame(ASTFrame):
         assert self.redshifting
         wam = magic_dispatch(self, "eval_expr", expr)
         new_expr = self.shift_expr(expr, wam)
+        assert new_expr.w_T is not None, "shift_expr should return a typed ast.Expr"
 
         w_typeconv_opimpl = self.typecheck_maybe(wam, varname)
         if w_typeconv_opimpl:
@@ -382,7 +384,11 @@ class DopplerFrame(ASTFrame):
             return magic_dispatch(self, "shift_expr", expr, wam)
 
     def shift_opimpl(
-        self, op: ast.Node, w_opimpl: W_OpImpl, orig_args: list[ast.Expr]
+        self,
+        op: ast.Node,
+        w_opimpl: W_OpImpl,
+        orig_args: list[ast.Expr],
+        w_T: Optional["W_Type"] = None,
     ) -> ast.Expr:
         if w_opimpl.is_const():
             assert w_opimpl.w_const is not None
@@ -391,7 +397,7 @@ class DopplerFrame(ASTFrame):
         assert w_opimpl.is_func_call()
         func = make_const(self.vm, op.loc, w_opimpl.w_func)
         real_args = self._shift_opimpl_args(w_opimpl, orig_args)
-        return ast.Call(op.loc, func, real_args)
+        return ast.Call(op.loc, func, real_args, w_T=w_T)
 
     def _shift_opimpl_args(
         self, w_opimpl: W_OpImpl, orig_args: list[ast.Expr]
@@ -413,52 +419,52 @@ class DopplerFrame(ASTFrame):
         return real_args
 
     def shift_expr_Constant(self, const: ast.Constant, wam: W_MetaArg) -> ast.Expr:
-        return const
+        return const.replace(w_T=wam.w_static_T)
 
     def shift_expr_Name(self, name: ast.Name, wam: W_MetaArg) -> ast.Expr:
-        return self.specialized_names[name]
+        return self.specialized_names[name].replace(w_T=wam.w_static_T)
 
     def shift_expr_NameLocalDirect(
         self, name: ast.NameLocalDirect, wam: W_MetaArg
     ) -> ast.Expr:
-        return name
+        return name.replace(w_T=wam.w_static_T)
 
     def shift_expr_NameOuterDirect(
         self, name: ast.NameOuterDirect, wam: W_MetaArg
     ) -> ast.Expr:
-        return name
+        return name.replace(w_T=wam.w_static_T)
 
     def shift_expr_NameOuterCell(
         self, name: ast.NameOuterCell, wam: W_MetaArg
     ) -> ast.Expr:
-        return name
+        return name.replace(w_T=wam.w_static_T)
 
     def shift_expr_BinOp(self, binop: ast.BinOp, wam: W_MetaArg) -> ast.Expr:
         w_opimpl = self.opimpl[binop]
         l = self.shifted_expr[binop.left]
         r = self.shifted_expr[binop.right]
-        return self.shift_opimpl(binop, w_opimpl, [l, r])
+        return self.shift_opimpl(binop, w_opimpl, [l, r], w_T=wam.w_static_T)
 
     def shift_expr_CmpOp(self, op: ast.CmpOp, wam: W_MetaArg) -> ast.Expr:
         w_opimpl = self.opimpl[op]
         l = self.shifted_expr[op.left]
         r = self.shifted_expr[op.right]
-        return self.shift_opimpl(op, w_opimpl, [l, r])
+        return self.shift_opimpl(op, w_opimpl, [l, r], w_T=wam.w_static_T)
 
     def shift_expr_And(self, op: ast.And, wam: W_MetaArg) -> ast.Expr:
         l = self.shifted_expr[op.left]
         r = self.shifted_expr[op.right]
-        return ast.And(op.loc, l, r)
+        return ast.And(op.loc, l, r, w_T=wam.w_static_T)
 
     def shift_expr_Or(self, op: ast.Or, wam: W_MetaArg) -> ast.Expr:
         l = self.shifted_expr[op.left]
         r = self.shifted_expr[op.right]
-        return ast.Or(op.loc, l, r)
+        return ast.Or(op.loc, l, r, w_T=wam.w_static_T)
 
     def shift_expr_UnaryOp(self, unop: ast.UnaryOp, wam: W_MetaArg) -> ast.Expr:
         w_opimpl = self.opimpl[unop]
         v = self.shifted_expr[unop.value]
-        return self.shift_opimpl(unop, w_opimpl, [v])
+        return self.shift_opimpl(unop, w_opimpl, [v], w_T=wam.w_static_T)
 
     def shift_expr_List(self, lst: ast.List, wam: W_MetaArg) -> ast.Expr:
         # this logic is equivalent to what we have in eval_expr_List. Instead of
@@ -472,19 +478,21 @@ class DopplerFrame(ASTFrame):
         fqn_push = w_T.fqn.join("_push")
 
         # instantiate an empty list
-        newlst = ast.Call(
+        newlst: ast.Expr = ast.Call(
             loc=lst.loc,
             func=ast.FQNConst(loc=lst.loc, fqn=fqn_new),
             args=[],
         )
 
         # add a call to push() for each item
-        for item in lst.items:
+        for i, item in enumerate(lst.items):
             shifted_item = self.shifted_expr[item]
+            is_last = i == len(lst.items) - 1
             newlst = ast.Call(
                 item.loc,
                 func=ast.FQNConst(loc=item.loc, fqn=fqn_push),
                 args=[newlst, shifted_item],
+                w_T=w_T if is_last else None,
             )
         return newlst
 
@@ -493,7 +501,9 @@ class DopplerFrame(ASTFrame):
         v_start = self.shifted_expr[op.start]
         v_stop = self.shifted_expr[op.stop]
         v_step = self.shifted_expr[op.step]
-        return self.shift_opimpl(op, w_opimpl, [v_start, v_stop, v_step])
+        return self.shift_opimpl(
+            op, w_opimpl, [v_start, v_stop, v_step], w_T=wam.w_static_T
+        )
 
     def shift_expr_Dict(self, dict: ast.Dict, wam: W_MetaArg) -> ast.Expr:
         if len(dict.items) == 0:
@@ -505,20 +515,22 @@ class DopplerFrame(ASTFrame):
         fqn_new = w_T.fqn.join("__new__")
         fqn_push = w_T.fqn.join("_push")
 
-        newdict = ast.Call(
+        newdict: ast.Expr = ast.Call(
             loc=dict.loc,
             func=ast.FQNConst(loc=dict.loc, fqn=fqn_new),
             args=[],
         )
 
         # add a call to push() for each item (key, value)
-        for pair in dict.items:
+        for i, pair in enumerate(dict.items):
             shifted_key = self.shifted_expr[pair.key]
             shifted_val = self.shifted_expr[pair.value]
+            is_last = i == len(dict.items) - 1
             newdict = ast.Call(
                 loc=pair.loc,
                 func=ast.FQNConst(loc=pair.loc, fqn=fqn_push),
                 args=[newdict, shifted_key, shifted_val],
+                w_T=w_T if is_last else None,
             )
 
         return newdict
@@ -527,13 +539,13 @@ class DopplerFrame(ASTFrame):
         w_opimpl = self.opimpl[op]
         v = self.shifted_expr[op.value]
         args = [self.shifted_expr[arg] for arg in op.args]
-        return self.shift_opimpl(op, w_opimpl, [v] + args)
+        return self.shift_opimpl(op, w_opimpl, [v] + args, w_T=wam.w_static_T)
 
     def shift_expr_GetAttr(self, op: ast.GetAttr, wam: W_MetaArg) -> ast.Expr:
         w_opimpl = self.opimpl[op]
         v = self.shifted_expr[op.value]
         v_attr = self.shifted_expr[op.attr]
-        return self.shift_opimpl(op, w_opimpl, [v, v_attr])
+        return self.shift_opimpl(op, w_opimpl, [v, v_attr], w_T=wam.w_static_T)
 
     def shift_expr_Call(self, call: ast.Call, wam: W_MetaArg) -> ast.Expr:
         w_opimpl = self.opimpl[call]
@@ -542,21 +554,24 @@ class DopplerFrame(ASTFrame):
 
         if self.special_calls.get(call) in ("getattr", "setattr"):
             # see also the corresponding code in ASTFrame.eval_expr_Call.
-            newcall = self.shift_opimpl(call, w_opimpl, newargs)
+            return self.shift_opimpl(call, w_opimpl, newargs, w_T=wam.w_static_T)
         else:
-            newcall = self.shift_opimpl(call, w_opimpl, [newfunc] + newargs)
-        return newcall
+            return self.shift_opimpl(
+                call, w_opimpl, [newfunc] + newargs, w_T=wam.w_static_T
+            )
 
     def shift_expr_CallMethod(self, op: ast.CallMethod, wam: W_MetaArg) -> ast.Expr:
         w_opimpl = self.opimpl[op]
         v_obj = self.shifted_expr[op.target]
         v_meth = self.shifted_expr[op.method]
         newargs_v = [self.shifted_expr[arg] for arg in op.args]
-        return self.shift_opimpl(op, w_opimpl, [v_obj, v_meth] + newargs_v)
+        return self.shift_opimpl(
+            op, w_opimpl, [v_obj, v_meth] + newargs_v, w_T=wam.w_static_T
+        )
 
     def shift_expr_AssignExpr(
         self, assignexpr: ast.AssignExpr, wam: W_MetaArg
     ) -> ast.Expr:
         specialized = self.specialized_assignexprs[assignexpr]
         new_value = self.shifted_expr[assignexpr.value]
-        return specialized.replace(value=new_value)
+        return specialized.replace(value=new_value, w_T=wam.w_static_T)


### PR DESCRIPTION
From the comment in ast.py:
```
# The Expr class has an optional field w_T which indicates the type of the expression.
#
# AST trees are said UNTYPED when all their Exprs have w_T == None.
# AST trees are said TYPED when all their Exprs have w_T != None.
#
# It is a logical error to have AST trees which mix typed and untyped nodes.
#
# The parser produces UNTYPED ASTs. DopplerFrame produces TYPED ASTs.
```

This will be useful because the it allows the C backend to know the type of expressions.
In particular it's needed for tuple unpacking (PR #402) and "preserve left-to-right arg evaluation" (PR #386 which is now closed and will be redone in a different way).

@Jemeljanov this is probably what you will need for your PR :) 