### PR TITLE
C: sequence expressions for deterministic eval order

### DIFF
--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -98,13 +98,8 @@ class CFuncWriter:
         """
         Emit a #line directive, but only if it's needed.
         """
-        desired_spy = loc.line_start
         # line numbers corresponding to the last emitted #line
         last_spy, last_c = self.last_emitted_linenos
-        # When sequenced lowering emits many synthetic statements for the same
-        # source line, avoid re-emitting identical #line directives.
-        if desired_spy == last_spy:
-            return
         #
         # line numbers as they are understood by the C compiler, i.e. what
         # goes to debuginfo if we don't emit a new #line
@@ -112,6 +107,7 @@ class CFuncWriter:
         cur_spy = last_spy + (cur_c - last_c) - 1
         #
         # desired spy line number, i.e. what we would like it to be
+        desired_spy = loc.line_start
         if desired_spy != cur_spy:
             # time to emit a new #line directive
             self.emit_lineno(desired_spy)

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -1,9 +1,11 @@
+import re
 from types import NoneType
 from typing import TYPE_CHECKING
 
 from spy import ast
 from spy.backend.c import c_ast as C
 from spy.backend.c.context import C_Ident, Context
+from spy.backend.c.expr_sequencer import expr_sequencer
 from spy.fqn import FQN
 from spy.location import Loc
 from spy.textbuilder import TextBuilder
@@ -15,6 +17,7 @@ from spy.vm.modules.unsafe.ptr import W_Ptr
 
 if TYPE_CHECKING:
     from spy.backend.c.cmodwriter import CModuleWriter
+    from spy.vm.object import W_Type
 
 
 class CFuncWriter:
@@ -24,6 +27,7 @@ class CFuncWriter:
     fqn: FQN
     w_func: W_ASTFunc
     last_emitted_linenos: tuple[int, int]
+    next_tmp_index: int
 
     def __init__(
         self, ctx: Context, cmodw: "CModuleWriter", fqn: FQN, w_func: W_ASTFunc
@@ -34,6 +38,7 @@ class CFuncWriter:
         self.fqn = fqn
         self.w_func = w_func
         self.last_emitted_linenos = (-1, -1)  # see emit_lineno_maybe
+        self.next_tmp_index = self._initial_tmp_index()
 
     def ppc(self) -> None:
         """
@@ -119,8 +124,39 @@ class CFuncWriter:
         self.last_emitted_linenos = (spyline, cline)
 
     def emit_stmt(self, stmt: ast.Stmt) -> None:
+        tmpvars, new_stmts, self.next_tmp_index = expr_sequencer(
+            stmt,
+            start_index=self.next_tmp_index,
+            is_pure_fqn=self._is_pure_fqn,
+        )
+        for varname, w_T in tmpvars:
+            self.declare_tmp_var(varname, w_T)
+        for new_stmt in new_stmts:
+            self.emit_stmt_unsequenced(new_stmt)
+
+    def emit_stmt_unsequenced(self, stmt: ast.Stmt) -> None:
         self.emit_lineno_maybe(stmt.loc)
         magic_dispatch(self, "emit_stmt", stmt)
+
+    def declare_tmp_var(self, varname: str, w_T: "W_Type") -> None:
+        c_type = self.ctx.w2c(w_T)
+        c_varname = C_Ident(varname)
+        self.tbc.wl(f"{c_type} {c_varname};")
+
+    def _initial_tmp_index(self) -> int:
+        # Make sure that the tmp variable names we generate here do not collide with local variables.
+        if self.w_func.locals_types_w is None:
+            return 0
+        max_index = -1
+        for name in self.w_func.locals_types_w:
+            match = re.fullmatch(r"spy_tmp(\d+)", name)
+            if match is not None:
+                max_index = max(max_index, int(match.group(1)))
+        return max_index + 1
+
+    def _is_pure_fqn(self, fqn: FQN) -> bool:
+        w_obj = self.ctx.vm.lookup_global_maybe(fqn)
+        return isinstance(w_obj, W_Func) and w_obj.is_pure()
 
     def fmt_expr(self, expr: ast.Expr) -> C.Expr:
         # XXX: here we should probably handle typeconv, if present.
@@ -183,13 +219,13 @@ class CFuncWriter:
         self.tbc.wl(f"if ({test})" + "{")
         with self.tbc.indent():
             for stmt in if_node.then_body:
-                self.emit_stmt(stmt)
+                self.emit_stmt_unsequenced(stmt)
         #
         if if_node.else_body:
             self.tbc.wl("} else {")
             with self.tbc.indent():
                 for stmt in if_node.else_body:
-                    self.emit_stmt(stmt)
+                    self.emit_stmt_unsequenced(stmt)
         #
         self.tbc.wl("}")
 
@@ -198,7 +234,7 @@ class CFuncWriter:
         self.tbc.wl(f"while ({test}) " + "{")
         with self.tbc.indent():
             for stmt in while_node.body:
-                self.emit_stmt(stmt)
+                self.emit_stmt_unsequenced(stmt)
         self.tbc.wl("}")
 
     def emit_stmt_Assert(self, assert_node: ast.Assert) -> None:

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -98,8 +98,13 @@ class CFuncWriter:
         """
         Emit a #line directive, but only if it's needed.
         """
+        desired_spy = loc.line_start
         # line numbers corresponding to the last emitted #line
         last_spy, last_c = self.last_emitted_linenos
+        # When sequenced lowering emits many synthetic statements for the same
+        # source line, avoid re-emitting identical #line directives.
+        if desired_spy == last_spy:
+            return
         #
         # line numbers as they are understood by the C compiler, i.e. what
         # goes to debuginfo if we don't emit a new #line
@@ -107,7 +112,6 @@ class CFuncWriter:
         cur_spy = last_spy + (cur_c - last_c) - 1
         #
         # desired spy line number, i.e. what we would like it to be
-        desired_spy = loc.line_start
         if desired_spy != cur_spy:
             # time to emit a new #line directive
             self.emit_lineno(desired_spy)

--- a/spy/backend/c/expr_sequencer.py
+++ b/spy/backend/c/expr_sequencer.py
@@ -29,6 +29,8 @@ Assumptions and heuristics:
   call-part sequence are not snapshotted;
 - assumption for that optimization: caller direct locals are frame-private, and
   only explicit local writes in the current expression can rebind them.
+- tmp index growth relies on Python's unbounded integers; fixed-width ports
+  should add an explicit overflow guard when advancing the tmp counter.
 
 The transform is backend-local:
 - it runs inside C emission right before nodes are lowered to C;
@@ -537,6 +539,8 @@ class _ExprSequencer:
         w_T = self._expr_type(expr)
         assert w_T is not TYPES.w_NoneType, "cannot materialize void expressions"
 
+        # Porting note: Python ints do not overflow. If this pass is reimplemented
+        # with fixed-width integers (e.g. in self-hosted SPy), guard this increment.
         tmp_name = f"{self.tmp_prefix}{self.next_tmp_index}"
         self.next_tmp_index += 1
         self.tmpvars.append((tmp_name, w_T))

--- a/spy/backend/c/expr_sequencer.py
+++ b/spy/backend/c/expr_sequencer.py
@@ -1,3 +1,40 @@
+"""
+Expression sequencing pass for the C backend.
+
+This module rewrites one typed `ast.Stmt` into an equivalent statement list
+whose expression evaluation order is explicit and safe to lower to C.
+
+Why this exists:
+- C leaves operand evaluation order unspecified in many contexts.
+- SPy semantics require left-to-right evaluation.
+- Some expressions (`and`/`or`, assignment expressions, effectful calls) need
+  statement-level rewrites to preserve those semantics.
+
+What this pass does:
+- emits pre-statements for subexpressions when ordering must be made explicit;
+- materializes selected subexpressions into compiler-generated temporaries;
+- lowers short-circuit expressions with RHS preludes into `if`-based control flow;
+- rewrites certain `while`/`assert` cases so preludes execute with correct timing.
+
+Assumptions and heuristics:
+- input is already typed (`expr.w_T` is expected to be set);
+- purity is FQN-based: known pure FQNs are treated as effect-free, while
+  unknown/non-FQN call targets are treated conservatively as effectful;
+- temporary insertion follows two rules:
+  1) preserve ordering when an effectful part precedes later
+     ordering-sensitive work;
+  2) snapshot unstable reads only when later effects could change observed
+     values;
+- optimization: direct mutable locals that are never written later in the same
+  call-part sequence are not snapshotted;
+- assumption for that optimization: caller direct locals are frame-private, and
+  only explicit local writes in the current expression can rebind them.
+
+The transform is backend-local:
+- it runs inside C emission right before nodes are lowered to C;
+- it returns rewritten nodes/tmp metadata instead of mutating earlier phases.
+"""
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable
 

--- a/spy/backend/c/expr_sequencer.py
+++ b/spy/backend/c/expr_sequencer.py
@@ -1,0 +1,413 @@
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable
+
+from spy import ast
+from spy.analyze.symtable import Symbol
+from spy.fqn import FQN
+from spy.location import Loc
+from spy.vm.b import TYPES, B
+
+if TYPE_CHECKING:
+    from spy.vm.object import W_Type
+
+TmpVar = tuple[str, "W_Type"]
+IsPureFQN = Callable[[FQN], bool]
+
+
+@dataclass
+class _ExprState:
+    expr: ast.Expr
+    pre_stmts: list[ast.Stmt]
+    has_side_effects: bool
+    is_stable: bool
+
+
+class _ExprSequencer:
+    tmp_prefix: str
+    next_tmp_index: int
+    tmpvars: list[TmpVar]
+    is_pure_fqn: IsPureFQN
+
+    def __init__(
+        self,
+        *,
+        start_index: int,
+        tmp_prefix: str,
+        is_pure_fqn: IsPureFQN,
+    ) -> None:
+        self.tmp_prefix = tmp_prefix
+        self.next_tmp_index = start_index
+        self.tmpvars = []
+        self.is_pure_fqn = is_pure_fqn
+
+    def _sequence_stmt(self, stmt: ast.Stmt) -> list[ast.Stmt]:
+        if isinstance(stmt, (ast.Pass, ast.Break, ast.Continue)):
+            return [stmt]
+
+        if isinstance(stmt, ast.Return):
+            value = self._sequence_expr(stmt.value)
+            return value.pre_stmts + [stmt.replace(value=value.expr)]
+
+        if isinstance(stmt, ast.VarDef):
+            if stmt.value is None:
+                return [stmt]
+            value = self._sequence_expr(stmt.value)
+            return value.pre_stmts + [stmt.replace(value=value.expr)]
+
+        if isinstance(stmt, ast.AssignLocal):
+            value = self._sequence_expr(stmt.value)
+            return value.pre_stmts + [stmt.replace(value=value.expr)]
+
+        if isinstance(stmt, ast.AssignCell):
+            value = self._sequence_expr(stmt.value)
+            return value.pre_stmts + [stmt.replace(value=value.expr)]
+
+        if isinstance(stmt, ast.StmtExpr):
+            value = self._sequence_expr(stmt.value)
+            return value.pre_stmts + [stmt.replace(value=value.expr)]
+
+        if isinstance(stmt, ast.If):
+            test = self._sequence_expr(stmt.test)
+            then_body = self._sequence_body(stmt.then_body)
+            else_body = self._sequence_body(stmt.else_body)
+            new_if = stmt.replace(
+                test=test.expr, then_body=then_body, else_body=else_body
+            )
+            return test.pre_stmts + [new_if]
+
+        if isinstance(stmt, ast.While):
+            test = self._sequence_expr(stmt.test)
+            body = self._sequence_body(stmt.body)
+            if not test.pre_stmts:
+                return [stmt.replace(test=test.expr, body=body)]
+
+            # Evaluate test preludes on every iteration, then decide whether
+            # to break. This preserves both sequencing and while semantics.
+            loop = ast.While(
+                loc=stmt.loc,
+                test=ast.Constant(loc=stmt.loc, value=True, w_T=B.w_bool),
+                body=test.pre_stmts
+                + [
+                    ast.If(
+                        loc=stmt.loc,
+                        test=test.expr,
+                        then_body=body,
+                        else_body=[ast.Break(loc=stmt.loc)],
+                    )
+                ],
+            )
+            return [loop]
+
+        if isinstance(stmt, ast.Assert):
+            test = self._sequence_expr(stmt.test)
+            if stmt.msg is None:
+                return test.pre_stmts + [stmt.replace(test=test.expr)]
+
+            # Keep message evaluation lazy: only when assertion fails.
+            msg = self._sequence_expr(stmt.msg)
+            if not msg.pre_stmts:
+                return test.pre_stmts + [stmt.replace(test=test.expr, msg=msg.expr)]
+
+            # If formatting the message needs preludes, evaluate them only on
+            # the failing branch.
+            fail_assert = ast.Assert(
+                loc=stmt.loc,
+                test=ast.Constant(loc=stmt.loc, value=False, w_T=B.w_bool),
+                msg=msg.expr,
+            )
+            lazy_assert = ast.If(
+                loc=stmt.loc,
+                test=test.expr,
+                then_body=[],
+                else_body=msg.pre_stmts + [fail_assert],
+            )
+            return test.pre_stmts + [lazy_assert]
+
+        return [stmt]
+
+    def _sequence_body(self, body: list[ast.Stmt]) -> list[ast.Stmt]:
+        out: list[ast.Stmt] = []
+        for stmt in body:
+            out.extend(self._sequence_stmt(stmt))
+        return out
+
+    def _sequence_expr(self, expr: ast.Expr) -> _ExprState:
+        if isinstance(expr, (ast.Constant, ast.StrConst, ast.FQNConst, ast.LocConst)):
+            return _ExprState(expr, [], False, True)
+
+        if isinstance(
+            expr, (ast.NameLocalDirect, ast.NameLocalCell, ast.NameOuterCell)
+        ):
+            is_stable = expr.sym.varkind == "const"
+            return _ExprState(expr, [], False, is_stable)
+
+        if isinstance(expr, (ast.NameOuterDirect, ast.NameImportRef)):
+            return _ExprState(expr, [], False, True)
+
+        if isinstance(expr, (ast.AssignExpr, ast.AssignExprLocal, ast.AssignExprCell)):
+            value = self._sequence_expr(expr.value)
+            return _ExprState(
+                expr=expr.replace(value=value.expr),
+                pre_stmts=value.pre_stmts,
+                has_side_effects=True,
+                is_stable=False,
+            )
+
+        if isinstance(expr, ast.And):
+            left = self._sequence_expr(expr.left)
+            right = self._sequence_expr(expr.right)
+            has_side_effects = left.has_side_effects or right.has_side_effects
+            is_stable = (not has_side_effects) and left.is_stable and right.is_stable
+            if not right.pre_stmts:
+                return _ExprState(
+                    expr=expr.replace(left=left.expr, right=right.expr),
+                    pre_stmts=left.pre_stmts,
+                    has_side_effects=has_side_effects,
+                    is_stable=is_stable,
+                )
+
+            left_ref, left_assign = self._make_tmp(left.expr)
+            target = ast.StrConst(loc=expr.loc, value=left_ref.sym.name)
+            then_body = right.pre_stmts + [
+                ast.AssignLocal(loc=expr.loc, target=target, value=right.expr)
+            ]
+            pre_stmts = left.pre_stmts + [
+                left_assign,
+                ast.If(
+                    loc=expr.loc,
+                    test=left_ref,
+                    then_body=then_body,
+                    else_body=[],
+                ),
+            ]
+            return _ExprState(
+                expr=left_ref,
+                pre_stmts=pre_stmts,
+                has_side_effects=has_side_effects,
+                is_stable=is_stable,
+            )
+
+        if isinstance(expr, ast.Or):
+            left = self._sequence_expr(expr.left)
+            right = self._sequence_expr(expr.right)
+            has_side_effects = left.has_side_effects or right.has_side_effects
+            is_stable = (not has_side_effects) and left.is_stable and right.is_stable
+            if not right.pre_stmts:
+                return _ExprState(
+                    expr=expr.replace(left=left.expr, right=right.expr),
+                    pre_stmts=left.pre_stmts,
+                    has_side_effects=has_side_effects,
+                    is_stable=is_stable,
+                )
+
+            left_ref, left_assign = self._make_tmp(left.expr)
+            target = ast.StrConst(loc=expr.loc, value=left_ref.sym.name)
+            else_body = right.pre_stmts + [
+                ast.AssignLocal(loc=expr.loc, target=target, value=right.expr)
+            ]
+            pre_stmts = left.pre_stmts + [
+                left_assign,
+                ast.If(
+                    loc=expr.loc,
+                    test=left_ref,
+                    then_body=[],
+                    else_body=else_body,
+                ),
+            ]
+            return _ExprState(
+                expr=left_ref,
+                pre_stmts=pre_stmts,
+                has_side_effects=has_side_effects,
+                is_stable=is_stable,
+            )
+
+        if isinstance(expr, ast.Call):
+            return self._sequence_call(expr)
+
+        raise NotImplementedError(
+            f"expr_sequencer does not support {type(expr).__name__}"
+        )
+
+    def _sequence_call(self, call: ast.Call) -> _ExprState:
+        states = [self._sequence_expr(call.func)] + [
+            self._sequence_expr(arg) for arg in call.args
+        ]
+        writes_per_state = [self._written_local_names_state(state) for state in states]
+        all_written_names: set[str] = set().union(*writes_per_state)
+
+        call_is_pure = self._is_pure_call(call.func)
+        has_side_effects = (not call_is_pure) or any(
+            state.has_side_effects for state in states
+        )
+        is_stable = (
+            call_is_pure
+            and (not has_side_effects)
+            and all(state.is_stable for state in states)
+        )
+
+        pre_stmts: list[ast.Stmt] = []
+        new_parts: list[ast.Expr] = []
+        has_effect_flags = [state.has_side_effects for state in states]
+        ordering_flags = []
+        for state in states:
+            ordering = state.has_side_effects or (not state.is_stable)
+            if (
+                isinstance(state.expr, ast.NameLocalDirect)
+                and state.expr.sym.varkind != "const"
+                and state.expr.sym.name not in all_written_names
+            ):
+                ordering = state.has_side_effects
+            ordering_flags.append(ordering)
+        suffix_has_effects = self._suffix_any(has_effect_flags)
+        suffix_ordering = self._suffix_any(ordering_flags)
+        suffix_written_names = self._suffix_union(writes_per_state)
+
+        for i, state in enumerate(states):
+            pre_stmts.extend(state.pre_stmts)
+            later_has_effects = suffix_has_effects[i + 1]
+            later_needs_ordering = suffix_ordering[i + 1]
+
+            need_tmp_for_effects = state.has_side_effects and later_needs_ordering
+            need_tmp_for_snapshot = (
+                (not state.has_side_effects)
+                and later_has_effects
+                and (not state.is_stable)
+            )
+            if (
+                need_tmp_for_snapshot
+                and isinstance(state.expr, ast.NameLocalDirect)
+                and state.expr.sym.varkind != "const"
+                and state.expr.sym.name not in suffix_written_names[i + 1]
+            ):
+                need_tmp_for_snapshot = False
+
+            if (
+                need_tmp_for_effects
+                and isinstance(state.expr, ast.AssignExprLocal)
+                and state.expr.target.value not in suffix_written_names[i + 1]
+            ):
+                # The assignment itself can be hoisted as a standalone stmt.
+                # We can then pass the assigned local by name and avoid a tmp.
+                pre_stmts.append(
+                    ast.AssignLocal(
+                        loc=state.expr.loc,
+                        target=state.expr.target,
+                        value=state.expr.value,
+                    )
+                )
+                new_parts.append(
+                    self._make_local_ref(
+                        name=state.expr.target.value,
+                        loc=state.expr.loc,
+                        w_T=self._expr_type(state.expr),
+                    )
+                )
+                continue
+
+            if need_tmp_for_effects or need_tmp_for_snapshot:
+                ref, assign = self._make_tmp(state.expr)
+                pre_stmts.append(assign)
+                new_parts.append(ref)
+            else:
+                new_parts.append(state.expr)
+
+        new_call = call.replace(func=new_parts[0], args=new_parts[1:])
+        return _ExprState(new_call, pre_stmts, has_side_effects, is_stable)
+
+    @staticmethod
+    def _suffix_any(flags: list[bool]) -> list[bool]:
+        out = [False] * (len(flags) + 1)
+        for i in range(len(flags) - 1, -1, -1):
+            out[i] = flags[i] or out[i + 1]
+        return out
+
+    @staticmethod
+    def _suffix_union(names: list[set[str]]) -> list[set[str]]:
+        out: list[set[str]] = [set() for _ in range(len(names) + 1)]
+        for i in range(len(names) - 1, -1, -1):
+            out[i] = set(out[i + 1])
+            out[i].update(names[i])
+        return out
+
+    def _make_tmp(self, expr: ast.Expr) -> tuple[ast.NameLocalDirect, ast.AssignLocal]:
+        w_T = self._expr_type(expr)
+        assert w_T is not TYPES.w_NoneType, "cannot materialize void expressions"
+
+        tmp_name = f"{self.tmp_prefix}{self.next_tmp_index}"
+        self.next_tmp_index += 1
+        self.tmpvars.append((tmp_name, w_T))
+
+        target = ast.StrConst(loc=expr.loc, value=tmp_name)
+        assign = ast.AssignLocal(loc=expr.loc, target=target, value=expr)
+        sym = Symbol(
+            name=tmp_name,
+            varkind="const",
+            varkind_origin="auto",
+            storage="direct",
+            loc=expr.loc,
+            type_loc=expr.loc,
+            level=0,
+        )
+        ref = ast.NameLocalDirect(loc=expr.loc, sym=sym, w_T=w_T)
+        return ref, assign
+
+    @staticmethod
+    def _make_local_ref(name: str, loc: Loc, w_T: "W_Type") -> ast.NameLocalDirect:
+        sym = Symbol(
+            name=name,
+            varkind="var",
+            varkind_origin="auto",
+            storage="direct",
+            loc=loc,
+            type_loc=loc,
+            level=0,
+        )
+        return ast.NameLocalDirect(loc=loc, sym=sym, w_T=w_T)
+
+    def _expr_type(self, expr: ast.Expr) -> "W_Type":
+        assert expr.w_T is not None, (
+            "expr_sequencer requires all expressions to have w_T set"
+        )
+        return expr.w_T
+
+    def _is_pure_call(self, func_expr: ast.Expr) -> bool:
+        if not isinstance(func_expr, ast.FQNConst):
+            return False
+        return self.is_pure_fqn(func_expr.fqn)
+
+    def _written_local_names_node(self, node: ast.Node) -> set[str]:
+        names: set[str] = set()
+        for cur in node.walk():
+            if isinstance(cur, ast.AssignLocal):
+                names.add(cur.target.value)
+            elif isinstance(cur, ast.VarDef):
+                names.add(cur.name.value)
+            elif isinstance(cur, (ast.AssignExpr, ast.AssignExprLocal)):
+                names.add(cur.target.value)
+        return names
+
+    def _written_local_names_state(self, state: _ExprState) -> set[str]:
+        names = self._written_local_names_node(state.expr)
+        for stmt in state.pre_stmts:
+            names.update(self._written_local_names_node(stmt))
+        return names
+
+
+def _default_is_pure_fqn(fqn: FQN) -> bool:
+    return fqn.modname == "operator" and fqn.symbol_name != "raise"
+
+
+def expr_sequencer(
+    stmt: ast.Stmt,
+    *,
+    start_index: int = 0,
+    tmp_prefix: str = "spy_tmp",
+    is_pure_fqn: IsPureFQN = _default_is_pure_fqn,
+) -> tuple[list[TmpVar], list[ast.Stmt], int]:
+    sequencer = _ExprSequencer(
+        start_index=start_index,
+        tmp_prefix=tmp_prefix,
+        is_pure_fqn=is_pure_fqn,
+    )
+    stmts = sequencer._sequence_stmt(stmt)
+    return sequencer.tmpvars, stmts, sequencer.next_tmp_index

--- a/spy/backend/c/expr_sequencer.py
+++ b/spy/backend/c/expr_sequencer.py
@@ -22,6 +22,12 @@ class _ExprState:
     is_stable: bool
 
 
+@dataclass(frozen=True)
+class _ExprEvalFacts:
+    has_side_effects: bool
+    is_stable: bool
+
+
 class _ExprSequencer:
     tmp_prefix: str
     next_tmp_index: int
@@ -234,6 +240,7 @@ class _ExprSequencer:
         ]
         writes_per_state = [self._written_local_names_state(state) for state in states]
         all_written_names: set[str] = set().union(*writes_per_state)
+        expr_eval_facts = [self._analyze_expr_eval(state.expr) for state in states]
 
         call_is_pure = self._is_pure_call(call.func)
         has_side_effects = (not call_is_pure) or any(
@@ -249,8 +256,8 @@ class _ExprSequencer:
         new_parts: list[ast.Expr] = []
         has_effect_flags = [state.has_side_effects for state in states]
         ordering_flags = []
-        for state in states:
-            ordering = state.has_side_effects or (not state.is_stable)
+        for i, state in enumerate(states):
+            ordering = state.has_side_effects or (not expr_eval_facts[i].is_stable)
             if (
                 isinstance(state.expr, ast.NameLocalDirect)
                 and state.expr.sym.varkind != "const"
@@ -266,12 +273,12 @@ class _ExprSequencer:
             pre_stmts.extend(state.pre_stmts)
             later_has_effects = suffix_has_effects[i + 1]
             later_needs_ordering = suffix_ordering[i + 1]
+            expr_has_effects = expr_eval_facts[i].has_side_effects
+            expr_is_stable = expr_eval_facts[i].is_stable
 
-            need_tmp_for_effects = state.has_side_effects and later_needs_ordering
+            need_tmp_for_effects = expr_has_effects and later_needs_ordering
             need_tmp_for_snapshot = (
-                (not state.has_side_effects)
-                and later_has_effects
-                and (not state.is_stable)
+                (not expr_has_effects) and later_has_effects and (not expr_is_stable)
             )
             if (
                 need_tmp_for_snapshot
@@ -313,6 +320,60 @@ class _ExprSequencer:
 
         new_call = call.replace(func=new_parts[0], args=new_parts[1:])
         return _ExprState(new_call, pre_stmts, has_side_effects, is_stable)
+
+    def _analyze_expr_eval(self, expr: ast.Expr) -> _ExprEvalFacts:
+        if isinstance(expr, (ast.Constant, ast.StrConst, ast.FQNConst, ast.LocConst)):
+            return _ExprEvalFacts(has_side_effects=False, is_stable=True)
+
+        if isinstance(
+            expr,
+            (
+                ast.NameLocalDirect,
+                ast.NameLocalCell,
+                ast.NameOuterCell,
+                ast.NameOuterDirect,
+                ast.NameImportRef,
+            ),
+        ):
+            is_stable = (
+                not isinstance(
+                    expr, (ast.NameLocalDirect, ast.NameLocalCell, ast.NameOuterCell)
+                )
+                or expr.sym.varkind == "const"
+            )
+            return _ExprEvalFacts(has_side_effects=False, is_stable=is_stable)
+
+        if isinstance(expr, (ast.AssignExpr, ast.AssignExprLocal, ast.AssignExprCell)):
+            return _ExprEvalFacts(has_side_effects=True, is_stable=False)
+
+        if isinstance(expr, (ast.And, ast.Or)):
+            left = self._analyze_expr_eval(expr.left)
+            right = self._analyze_expr_eval(expr.right)
+            has_side_effects = left.has_side_effects or right.has_side_effects
+            return _ExprEvalFacts(
+                has_side_effects=has_side_effects,
+                is_stable=(not has_side_effects) and left.is_stable and right.is_stable,
+            )
+
+        if isinstance(expr, ast.Call):
+            func = self._analyze_expr_eval(expr.func)
+            args = [self._analyze_expr_eval(arg) for arg in expr.args]
+            call_is_pure = self._is_pure_call(expr.func)
+            has_side_effects = (
+                func.has_side_effects
+                or any(arg.has_side_effects for arg in args)
+                or (not call_is_pure)
+            )
+            return _ExprEvalFacts(
+                has_side_effects=has_side_effects,
+                is_stable=(not has_side_effects)
+                and func.is_stable
+                and all(arg.is_stable for arg in args),
+            )
+
+        raise NotImplementedError(
+            f"expr_sequencer does not support {type(expr).__name__}"
+        )
 
     @staticmethod
     def _suffix_any(flags: list[bool]) -> list[bool]:

--- a/spy/backend/c/expr_sequencer.py
+++ b/spy/backend/c/expr_sequencer.py
@@ -186,60 +186,40 @@ class _ExprSequencer:
         pre_stmts: list[ast.Stmt] = []
         new_parts: list[ast.Expr] = []
         has_effect_flags = [state.has_side_effects for state in states]
-        ordering_flags = []
-        for i, state in enumerate(states):
-            ordering = state.has_side_effects or (not expr_eval_facts[i].is_stable)
-            if (
-                isinstance(state.expr, ast.NameLocalDirect)
-                and state.expr.sym.varkind != "const"
-                and state.expr.sym.name not in all_written_names
-            ):
-                ordering = state.has_side_effects
-            ordering_flags.append(ordering)
+        ordering_flags = [
+            self._needs_ordering(
+                state=state,
+                facts=expr_eval_facts[i],
+                all_written_names=all_written_names,
+            )
+            for i, state in enumerate(states)
+        ]
         suffix_has_effects = self._suffix_any(has_effect_flags)
         suffix_ordering = self._suffix_any(ordering_flags)
         suffix_written_names = self._suffix_union(writes_per_state)
 
         for i, state in enumerate(states):
             pre_stmts.extend(state.pre_stmts)
-            later_has_effects = suffix_has_effects[i + 1]
-            later_needs_ordering = suffix_ordering[i + 1]
-            expr_has_effects = expr_eval_facts[i].has_side_effects
-            expr_is_stable = expr_eval_facts[i].is_stable
-
-            need_tmp_for_effects = expr_has_effects and later_needs_ordering
-            need_tmp_for_snapshot = (
-                (not expr_has_effects) and later_has_effects and (not expr_is_stable)
+            later_written_names = suffix_written_names[i + 1]
+            need_tmp_for_effects, need_tmp_for_snapshot = self._tmp_requirements(
+                state=state,
+                facts=expr_eval_facts[i],
+                later_has_effects=suffix_has_effects[i + 1],
+                later_needs_ordering=suffix_ordering[i + 1],
+                later_written_names=later_written_names,
             )
-            if (
-                need_tmp_for_snapshot
-                and isinstance(state.expr, ast.NameLocalDirect)
-                and state.expr.sym.varkind != "const"
-                and state.expr.sym.name not in suffix_written_names[i + 1]
-            ):
-                need_tmp_for_snapshot = False
 
-            if (
-                need_tmp_for_effects
-                and isinstance(state.expr, ast.AssignExprLocal)
-                and state.expr.target.value not in suffix_written_names[i + 1]
+            if self._can_hoist_assignexpr_local(
+                expr=state.expr,
+                need_tmp_for_effects=need_tmp_for_effects,
+                later_written_names=later_written_names,
             ):
                 # The assignment itself can be hoisted as a standalone stmt.
                 # We can then pass the assigned local by name and avoid a tmp.
-                pre_stmts.append(
-                    ast.AssignLocal(
-                        loc=state.expr.loc,
-                        target=state.expr.target,
-                        value=state.expr.value,
-                    )
-                )
-                new_parts.append(
-                    self._make_local_ref(
-                        name=state.expr.target.value,
-                        loc=state.expr.loc,
-                        w_T=self._expr_type(state.expr),
-                    )
-                )
+                assert isinstance(state.expr, ast.AssignExprLocal)
+                assign, ref = self._hoist_assignexpr_local(state.expr)
+                pre_stmts.append(assign)
+                new_parts.append(ref)
                 continue
 
             if need_tmp_for_effects or need_tmp_for_snapshot:
@@ -251,6 +231,77 @@ class _ExprSequencer:
 
         new_call = call.replace(func=new_parts[0], args=new_parts[1:])
         return _ExprState(new_call, pre_stmts, has_side_effects, is_stable)
+
+    def _needs_ordering(
+        self,
+        *,
+        state: _ExprState,
+        facts: _ExprEvalFacts,
+        all_written_names: set[str],
+    ) -> bool:
+        ordering = state.has_side_effects or (not facts.is_stable)
+        if self._is_unwritten_mutable_local(
+            state.expr, written_names=all_written_names
+        ):
+            # If this local is never written by any part of the call, we only
+            # need ordering when reading it itself has side effects.
+            return state.has_side_effects
+        return ordering
+
+    def _tmp_requirements(
+        self,
+        *,
+        state: _ExprState,
+        facts: _ExprEvalFacts,
+        later_has_effects: bool,
+        later_needs_ordering: bool,
+        later_written_names: set[str],
+    ) -> tuple[bool, bool]:
+        need_tmp_for_effects = facts.has_side_effects and later_needs_ordering
+        need_tmp_for_snapshot = (
+            (not facts.has_side_effects) and later_has_effects and (not facts.is_stable)
+        )
+        if need_tmp_for_snapshot and self._is_unwritten_mutable_local(
+            state.expr, written_names=later_written_names
+        ):
+            need_tmp_for_snapshot = False
+        return need_tmp_for_effects, need_tmp_for_snapshot
+
+    @staticmethod
+    def _can_hoist_assignexpr_local(
+        *,
+        expr: ast.Expr,
+        need_tmp_for_effects: bool,
+        later_written_names: set[str],
+    ) -> bool:
+        return (
+            need_tmp_for_effects
+            and isinstance(expr, ast.AssignExprLocal)
+            and expr.target.value not in later_written_names
+        )
+
+    def _hoist_assignexpr_local(
+        self, expr: ast.AssignExprLocal
+    ) -> tuple[ast.AssignLocal, ast.NameLocalDirect]:
+        assign = ast.AssignLocal(
+            loc=expr.loc,
+            target=expr.target,
+            value=expr.value,
+        )
+        ref = self._make_local_ref(
+            name=expr.target.value,
+            loc=expr.loc,
+            w_T=self._expr_type(expr),
+        )
+        return assign, ref
+
+    @staticmethod
+    def _is_unwritten_mutable_local(expr: ast.Expr, *, written_names: set[str]) -> bool:
+        return (
+            isinstance(expr, ast.NameLocalDirect)
+            and expr.sym.varkind != "const"
+            and expr.sym.name not in written_names
+        )
 
     def _analyze_expr_eval(self, expr: ast.Expr) -> _ExprEvalFacts:
         leaf_facts = self._leaf_eval_facts(expr)

--- a/spy/backend/c/expr_sequencer.py
+++ b/spy/backend/c/expr_sequencer.py
@@ -140,108 +140,23 @@ class _ExprSequencer:
         return out
 
     def _sequence_expr(self, expr: ast.Expr) -> _ExprState:
-        if isinstance(expr, (ast.Constant, ast.StrConst, ast.FQNConst, ast.LocConst)):
-            return _ExprState(expr, [], False, True)
-
-        if isinstance(
-            expr, (ast.NameLocalDirect, ast.NameLocalCell, ast.NameOuterCell)
-        ):
-            is_stable = expr.sym.varkind == "const"
-            return _ExprState(expr, [], False, is_stable)
-
-        if isinstance(expr, (ast.NameOuterDirect, ast.NameImportRef)):
-            return _ExprState(expr, [], False, True)
+        leaf_facts = self._leaf_eval_facts(expr)
+        if leaf_facts is not None:
+            return self._state_from_facts(expr=expr, pre_stmts=[], facts=leaf_facts)
 
         if isinstance(expr, (ast.AssignExpr, ast.AssignExprLocal, ast.AssignExprCell)):
             value = self._sequence_expr(expr.value)
-            return _ExprState(
+            return self._state_from_facts(
                 expr=expr.replace(value=value.expr),
                 pre_stmts=value.pre_stmts,
-                has_side_effects=True,
-                is_stable=False,
+                facts=self._assign_expr_facts(),
             )
 
         if isinstance(expr, ast.And):
-            left = self._sequence_expr(expr.left)
-            right = self._sequence_expr(expr.right)
-            has_side_effects = left.has_side_effects or right.has_side_effects
-            is_stable = (not has_side_effects) and left.is_stable and right.is_stable
-            if not right.pre_stmts:
-                return _ExprState(
-                    expr=expr.replace(left=left.expr, right=right.expr),
-                    pre_stmts=left.pre_stmts,
-                    has_side_effects=has_side_effects,
-                    is_stable=is_stable,
-                )
-
-            left_ref, left_assign = self._short_circuit_carrier(left.expr)
-            target = ast.StrConst(loc=expr.loc, value=left_ref.sym.name)
-            rhs_stmts, rhs_expr, need_join_assign = self._coalesce_short_circuit_rhs(
-                carrier=left_ref, rhs=right
-            )
-            then_body = list(rhs_stmts)
-            if need_join_assign:
-                then_body.append(
-                    ast.AssignLocal(loc=expr.loc, target=target, value=rhs_expr)
-                )
-            pre_stmts = list(left.pre_stmts)
-            if left_assign is not None:
-                pre_stmts.append(left_assign)
-            pre_stmts.append(
-                ast.If(
-                    loc=expr.loc,
-                    test=left_ref,
-                    then_body=then_body,
-                    else_body=[],
-                )
-            )
-            return _ExprState(
-                expr=left_ref,
-                pre_stmts=pre_stmts,
-                has_side_effects=has_side_effects,
-                is_stable=is_stable,
-            )
+            return self._sequence_short_circuit(expr, rhs_when_test_true=True)
 
         if isinstance(expr, ast.Or):
-            left = self._sequence_expr(expr.left)
-            right = self._sequence_expr(expr.right)
-            has_side_effects = left.has_side_effects or right.has_side_effects
-            is_stable = (not has_side_effects) and left.is_stable and right.is_stable
-            if not right.pre_stmts:
-                return _ExprState(
-                    expr=expr.replace(left=left.expr, right=right.expr),
-                    pre_stmts=left.pre_stmts,
-                    has_side_effects=has_side_effects,
-                    is_stable=is_stable,
-                )
-
-            left_ref, left_assign = self._short_circuit_carrier(left.expr)
-            target = ast.StrConst(loc=expr.loc, value=left_ref.sym.name)
-            rhs_stmts, rhs_expr, need_join_assign = self._coalesce_short_circuit_rhs(
-                carrier=left_ref, rhs=right
-            )
-            else_body = list(rhs_stmts)
-            if need_join_assign:
-                else_body.append(
-                    ast.AssignLocal(loc=expr.loc, target=target, value=rhs_expr)
-                )
-            pre_stmts = list(left.pre_stmts)
-            if left_assign is not None:
-                pre_stmts.append(left_assign)
-            pre_stmts.append(
-                ast.If(
-                    loc=expr.loc,
-                    test=left_ref,
-                    then_body=[],
-                    else_body=else_body,
-                )
-            )
-            return _ExprState(
-                expr=left_ref,
-                pre_stmts=pre_stmts,
-                has_side_effects=has_side_effects,
-                is_stable=is_stable,
-            )
+            return self._sequence_short_circuit(expr, rhs_when_test_true=False)
 
         if isinstance(expr, ast.Call):
             return self._sequence_call(expr)
@@ -338,6 +253,116 @@ class _ExprSequencer:
         return _ExprState(new_call, pre_stmts, has_side_effects, is_stable)
 
     def _analyze_expr_eval(self, expr: ast.Expr) -> _ExprEvalFacts:
+        leaf_facts = self._leaf_eval_facts(expr)
+        if leaf_facts is not None:
+            return leaf_facts
+
+        if isinstance(expr, (ast.AssignExpr, ast.AssignExprLocal, ast.AssignExprCell)):
+            return self._assign_expr_facts()
+
+        if isinstance(expr, (ast.And, ast.Or)):
+            left = self._analyze_expr_eval(expr.left)
+            right = self._analyze_expr_eval(expr.right)
+            return self._merge_eval_facts(left, right)
+
+        if isinstance(expr, ast.Call):
+            func = self._analyze_expr_eval(expr.func)
+            args = [self._analyze_expr_eval(arg) for arg in expr.args]
+            call_is_pure = self._is_pure_call(expr.func)
+            has_side_effects = (
+                func.has_side_effects
+                or any(arg.has_side_effects for arg in args)
+                or (not call_is_pure)
+            )
+            return _ExprEvalFacts(
+                has_side_effects=has_side_effects,
+                is_stable=(not has_side_effects)
+                and func.is_stable
+                and all(arg.is_stable for arg in args),
+            )
+
+        raise NotImplementedError(
+            f"expr_sequencer does not support {type(expr).__name__}"
+        )
+
+    def _sequence_short_circuit(
+        self,
+        expr: ast.And | ast.Or,
+        *,
+        rhs_when_test_true: bool,
+    ) -> _ExprState:
+        left = self._sequence_expr(expr.left)
+        right = self._sequence_expr(expr.right)
+        facts = self._merge_eval_facts(
+            self._facts_from_state(left), self._facts_from_state(right)
+        )
+        if not right.pre_stmts:
+            return self._state_from_facts(
+                expr=expr.replace(left=left.expr, right=right.expr),
+                pre_stmts=left.pre_stmts,
+                facts=facts,
+            )
+
+        left_ref, left_assign = self._short_circuit_carrier(left.expr)
+        target = ast.StrConst(loc=expr.loc, value=left_ref.sym.name)
+        rhs_stmts, rhs_expr, need_join_assign = self._coalesce_short_circuit_rhs(
+            carrier=left_ref, rhs=right
+        )
+        rhs_body = list(rhs_stmts)
+        if need_join_assign:
+            rhs_body.append(
+                ast.AssignLocal(loc=expr.loc, target=target, value=rhs_expr)
+            )
+        then_body = rhs_body if rhs_when_test_true else []
+        else_body = [] if rhs_when_test_true else rhs_body
+
+        pre_stmts = list(left.pre_stmts)
+        if left_assign is not None:
+            pre_stmts.append(left_assign)
+        pre_stmts.append(
+            ast.If(
+                loc=expr.loc,
+                test=left_ref,
+                then_body=then_body,
+                else_body=else_body,
+            )
+        )
+        return self._state_from_facts(expr=left_ref, pre_stmts=pre_stmts, facts=facts)
+
+    @staticmethod
+    def _state_from_facts(
+        *, expr: ast.Expr, pre_stmts: list[ast.Stmt], facts: _ExprEvalFacts
+    ) -> _ExprState:
+        return _ExprState(
+            expr=expr,
+            pre_stmts=pre_stmts,
+            has_side_effects=facts.has_side_effects,
+            is_stable=facts.is_stable,
+        )
+
+    @staticmethod
+    def _facts_from_state(state: _ExprState) -> _ExprEvalFacts:
+        return _ExprEvalFacts(
+            has_side_effects=state.has_side_effects,
+            is_stable=state.is_stable,
+        )
+
+    @staticmethod
+    def _merge_eval_facts(
+        left: _ExprEvalFacts, right: _ExprEvalFacts
+    ) -> _ExprEvalFacts:
+        has_side_effects = left.has_side_effects or right.has_side_effects
+        return _ExprEvalFacts(
+            has_side_effects=has_side_effects,
+            is_stable=(not has_side_effects) and left.is_stable and right.is_stable,
+        )
+
+    @staticmethod
+    def _assign_expr_facts() -> _ExprEvalFacts:
+        return _ExprEvalFacts(has_side_effects=True, is_stable=False)
+
+    @staticmethod
+    def _leaf_eval_facts(expr: ast.Expr) -> _ExprEvalFacts | None:
         if isinstance(expr, (ast.Constant, ast.StrConst, ast.FQNConst, ast.LocConst)):
             return _ExprEvalFacts(has_side_effects=False, is_stable=True)
 
@@ -359,37 +384,7 @@ class _ExprSequencer:
             )
             return _ExprEvalFacts(has_side_effects=False, is_stable=is_stable)
 
-        if isinstance(expr, (ast.AssignExpr, ast.AssignExprLocal, ast.AssignExprCell)):
-            return _ExprEvalFacts(has_side_effects=True, is_stable=False)
-
-        if isinstance(expr, (ast.And, ast.Or)):
-            left = self._analyze_expr_eval(expr.left)
-            right = self._analyze_expr_eval(expr.right)
-            has_side_effects = left.has_side_effects or right.has_side_effects
-            return _ExprEvalFacts(
-                has_side_effects=has_side_effects,
-                is_stable=(not has_side_effects) and left.is_stable and right.is_stable,
-            )
-
-        if isinstance(expr, ast.Call):
-            func = self._analyze_expr_eval(expr.func)
-            args = [self._analyze_expr_eval(arg) for arg in expr.args]
-            call_is_pure = self._is_pure_call(expr.func)
-            has_side_effects = (
-                func.has_side_effects
-                or any(arg.has_side_effects for arg in args)
-                or (not call_is_pure)
-            )
-            return _ExprEvalFacts(
-                has_side_effects=has_side_effects,
-                is_stable=(not has_side_effects)
-                and func.is_stable
-                and all(arg.is_stable for arg in args),
-            )
-
-        raise NotImplementedError(
-            f"expr_sequencer does not support {type(expr).__name__}"
-        )
+        return None
 
     @staticmethod
     def _suffix_any(flags: list[bool]) -> list[bool]:

--- a/spy/backend/c/expr_sequencer.py
+++ b/spy/backend/c/expr_sequencer.py
@@ -32,6 +32,7 @@ class _ExprSequencer:
     tmp_prefix: str
     next_tmp_index: int
     tmpvars: list[TmpVar]
+    tmp_names: set[str]
     is_pure_fqn: IsPureFQN
 
     def __init__(
@@ -44,6 +45,7 @@ class _ExprSequencer:
         self.tmp_prefix = tmp_prefix
         self.next_tmp_index = start_index
         self.tmpvars = []
+        self.tmp_names = set()
         self.is_pure_fqn = is_pure_fqn
 
     def _sequence_stmt(self, stmt: ast.Stmt) -> list[ast.Stmt]:
@@ -172,20 +174,27 @@ class _ExprSequencer:
                     is_stable=is_stable,
                 )
 
-            left_ref, left_assign = self._make_tmp(left.expr)
+            left_ref, left_assign = self._short_circuit_carrier(left.expr)
             target = ast.StrConst(loc=expr.loc, value=left_ref.sym.name)
-            then_body = right.pre_stmts + [
-                ast.AssignLocal(loc=expr.loc, target=target, value=right.expr)
-            ]
-            pre_stmts = left.pre_stmts + [
-                left_assign,
+            rhs_stmts, rhs_expr, need_join_assign = self._coalesce_short_circuit_rhs(
+                carrier=left_ref, rhs=right
+            )
+            then_body = list(rhs_stmts)
+            if need_join_assign:
+                then_body.append(
+                    ast.AssignLocal(loc=expr.loc, target=target, value=rhs_expr)
+                )
+            pre_stmts = list(left.pre_stmts)
+            if left_assign is not None:
+                pre_stmts.append(left_assign)
+            pre_stmts.append(
                 ast.If(
                     loc=expr.loc,
                     test=left_ref,
                     then_body=then_body,
                     else_body=[],
-                ),
-            ]
+                )
+            )
             return _ExprState(
                 expr=left_ref,
                 pre_stmts=pre_stmts,
@@ -206,20 +215,27 @@ class _ExprSequencer:
                     is_stable=is_stable,
                 )
 
-            left_ref, left_assign = self._make_tmp(left.expr)
+            left_ref, left_assign = self._short_circuit_carrier(left.expr)
             target = ast.StrConst(loc=expr.loc, value=left_ref.sym.name)
-            else_body = right.pre_stmts + [
-                ast.AssignLocal(loc=expr.loc, target=target, value=right.expr)
-            ]
-            pre_stmts = left.pre_stmts + [
-                left_assign,
+            rhs_stmts, rhs_expr, need_join_assign = self._coalesce_short_circuit_rhs(
+                carrier=left_ref, rhs=right
+            )
+            else_body = list(rhs_stmts)
+            if need_join_assign:
+                else_body.append(
+                    ast.AssignLocal(loc=expr.loc, target=target, value=rhs_expr)
+                )
+            pre_stmts = list(left.pre_stmts)
+            if left_assign is not None:
+                pre_stmts.append(left_assign)
+            pre_stmts.append(
                 ast.If(
                     loc=expr.loc,
                     test=left_ref,
                     then_body=[],
                     else_body=else_body,
-                ),
-            ]
+                )
+            )
             return _ExprState(
                 expr=left_ref,
                 pre_stmts=pre_stmts,
@@ -397,6 +413,7 @@ class _ExprSequencer:
         tmp_name = f"{self.tmp_prefix}{self.next_tmp_index}"
         self.next_tmp_index += 1
         self.tmpvars.append((tmp_name, w_T))
+        self.tmp_names.add(tmp_name)
 
         target = ast.StrConst(loc=expr.loc, value=tmp_name)
         assign = ast.AssignLocal(loc=expr.loc, target=target, value=expr)
@@ -411,6 +428,126 @@ class _ExprSequencer:
         )
         ref = ast.NameLocalDirect(loc=expr.loc, sym=sym, w_T=w_T)
         return ref, assign
+
+    def _short_circuit_carrier(
+        self, expr: ast.Expr
+    ) -> tuple[ast.NameLocalDirect, ast.AssignLocal | None]:
+        # Nested short-circuit rewrites often feed an existing compiler-generated
+        # tmp into another And/Or. Reuse that tmp as carrier to avoid tmp-to-tmp
+        # copies such as `spy_tmpN = spy_tmpM`.
+        if isinstance(expr, ast.NameLocalDirect) and expr.sym.name in self.tmp_names:
+            return expr, None
+        ref, assign = self._make_tmp(expr)
+        return ref, assign
+
+    def _coalesce_short_circuit_rhs(
+        self,
+        *,
+        carrier: ast.NameLocalDirect,
+        rhs: _ExprState,
+    ) -> tuple[list[ast.Stmt], ast.Expr, bool]:
+        """
+        Try to rewrite RHS preludes to write directly into `carrier` when RHS
+        already ends in a compiler-generated tmp. This removes redundant
+        tmp-to-tmp joins such as `spy_tmpN = spy_tmpM`.
+        """
+        if not isinstance(rhs.expr, ast.NameLocalDirect):
+            return rhs.pre_stmts, rhs.expr, True
+
+        rhs_name = rhs.expr.sym.name
+        carrier_name = carrier.sym.name
+        if rhs_name == carrier_name:
+            return rhs.pre_stmts, rhs.expr, False
+        if rhs_name not in self.tmp_names or carrier_name not in self.tmp_names:
+            return rhs.pre_stmts, rhs.expr, True
+
+        renamed = [
+            self._rename_local_stmt(stmt, old_name=rhs_name, new_name=carrier_name)
+            for stmt in rhs.pre_stmts
+        ]
+        self._drop_tmp(rhs_name)
+        return renamed, carrier, False
+
+    def _drop_tmp(self, tmp_name: str) -> None:
+        if tmp_name not in self.tmp_names:
+            return
+        self.tmp_names.remove(tmp_name)
+        self.tmpvars = [(name, w_T) for name, w_T in self.tmpvars if name != tmp_name]
+
+    def _rename_local_stmt(
+        self, stmt: ast.Stmt, *, old_name: str, new_name: str
+    ) -> ast.Stmt:
+        if isinstance(stmt, ast.AssignLocal):
+            target = stmt.target
+            if target.value == old_name:
+                target = target.replace(value=new_name)
+            return stmt.replace(
+                target=target,
+                value=self._rename_local_expr(
+                    stmt.value, old_name=old_name, new_name=new_name
+                ),
+            )
+        if isinstance(stmt, ast.If):
+            return stmt.replace(
+                test=self._rename_local_expr(
+                    stmt.test, old_name=old_name, new_name=new_name
+                ),
+                then_body=[
+                    self._rename_local_stmt(s, old_name=old_name, new_name=new_name)
+                    for s in stmt.then_body
+                ],
+                else_body=[
+                    self._rename_local_stmt(s, old_name=old_name, new_name=new_name)
+                    for s in stmt.else_body
+                ],
+            )
+        return stmt
+
+    def _rename_local_expr(
+        self, expr: ast.Expr, *, old_name: str, new_name: str
+    ) -> ast.Expr:
+        if isinstance(expr, ast.NameLocalDirect) and expr.sym.name == old_name:
+            return self._make_local_ref(
+                name=new_name,
+                loc=expr.loc,
+                w_T=self._expr_type(expr),
+            )
+        if isinstance(expr, (ast.AssignExpr, ast.AssignExprLocal)):
+            target = expr.target
+            if target.value == old_name:
+                target = target.replace(value=new_name)
+            return expr.replace(
+                target=target,
+                value=self._rename_local_expr(
+                    expr.value, old_name=old_name, new_name=new_name
+                ),
+            )
+        if isinstance(expr, ast.AssignExprCell):
+            return expr.replace(
+                value=self._rename_local_expr(
+                    expr.value, old_name=old_name, new_name=new_name
+                )
+            )
+        if isinstance(expr, ast.Call):
+            return expr.replace(
+                func=self._rename_local_expr(
+                    expr.func, old_name=old_name, new_name=new_name
+                ),
+                args=[
+                    self._rename_local_expr(arg, old_name=old_name, new_name=new_name)
+                    for arg in expr.args
+                ],
+            )
+        if isinstance(expr, (ast.And, ast.Or)):
+            return expr.replace(
+                left=self._rename_local_expr(
+                    expr.left, old_name=old_name, new_name=new_name
+                ),
+                right=self._rename_local_expr(
+                    expr.right, old_name=old_name, new_name=new_name
+                ),
+            )
+        return expr
 
     @staticmethod
     def _make_local_ref(name: str, loc: Loc, w_T: "W_Type") -> ast.NameLocalDirect:

--- a/spy/backend/c/expr_sequencer.py
+++ b/spy/backend/c/expr_sequencer.py
@@ -29,6 +29,8 @@ class _ExprEvalFacts:
 
 
 class _ExprSequencer:
+    """Rewrite expressions into explicit, ordered statement form."""
+
     tmp_prefix: str
     next_tmp_index: int
     tmpvars: list[TmpVar]
@@ -42,6 +44,7 @@ class _ExprSequencer:
         tmp_prefix: str,
         is_pure_fqn: IsPureFQN,
     ) -> None:
+        """Initialize tmp naming and purity policy for one sequencing pass."""
         self.tmp_prefix = tmp_prefix
         self.next_tmp_index = start_index
         self.tmpvars = []
@@ -49,6 +52,7 @@ class _ExprSequencer:
         self.is_pure_fqn = is_pure_fqn
 
     def _sequence_stmt(self, stmt: ast.Stmt) -> list[ast.Stmt]:
+        """Sequence a statement and return replacement statements."""
         if isinstance(stmt, (ast.Pass, ast.Break, ast.Continue)):
             return [stmt]
 
@@ -134,12 +138,14 @@ class _ExprSequencer:
         return [stmt]
 
     def _sequence_body(self, body: list[ast.Stmt]) -> list[ast.Stmt]:
+        """Sequence each statement in a block and flatten the result."""
         out: list[ast.Stmt] = []
         for stmt in body:
             out.extend(self._sequence_stmt(stmt))
         return out
 
     def _sequence_expr(self, expr: ast.Expr) -> _ExprState:
+        """Sequence an expression and collect its required pre-statements."""
         leaf_facts = self._leaf_eval_facts(expr)
         if leaf_facts is not None:
             return self._state_from_facts(expr=expr, pre_stmts=[], facts=leaf_facts)
@@ -166,6 +172,9 @@ class _ExprSequencer:
         )
 
     def _sequence_call(self, call: ast.Call) -> _ExprState:
+        """Sequence call func/args left-to-right and insert tmps when needed."""
+        # `states[0]` corresponds to the call target expression, and `states[1:]`
+        # are the argument expressions in source order.
         states = [self._sequence_expr(call.func)] + [
             self._sequence_expr(arg) for arg in call.args
         ]
@@ -194,6 +203,11 @@ class _ExprSequencer:
             )
             for i, state in enumerate(states)
         ]
+        # Precompute right-to-left summaries so each part can query 'all later parts'
+        # with a single index lookup (i+1) instead of rescanning the suffix.
+        # - any later side effects
+        # - any later ordering-sensitive pieces
+        # - which local names are written later
         suffix_has_effects = self._suffix_any(has_effect_flags)
         suffix_ordering = self._suffix_any(ordering_flags)
         suffix_written_names = self._suffix_union(writes_per_state)
@@ -223,6 +237,7 @@ class _ExprSequencer:
                 continue
 
             if need_tmp_for_effects or need_tmp_for_snapshot:
+                # Materialize now to freeze ordering/value before later pieces run.
                 ref, assign = self._make_tmp(state.expr)
                 pre_stmts.append(assign)
                 new_parts.append(ref)
@@ -239,6 +254,7 @@ class _ExprSequencer:
         facts: _ExprEvalFacts,
         all_written_names: set[str],
     ) -> bool:
+        """Return whether this part must preserve evaluation position."""
         ordering = state.has_side_effects or (not facts.is_stable)
         if self._is_unwritten_mutable_local(
             state.expr, written_names=all_written_names
@@ -257,13 +273,22 @@ class _ExprSequencer:
         later_needs_ordering: bool,
         later_written_names: set[str],
     ) -> tuple[bool, bool]:
+        """Compute tmp needs for effects ordering and value snapshotting."""
+        # If evaluating this part can cause effects, we must materialize it before
+        # any later part that itself requires ordered evaluation.
         need_tmp_for_effects = facts.has_side_effects and later_needs_ordering
+        # If this part is a pure-but-unstable read, snapshot it only when later
+        # effects might change the observed value.
         need_tmp_for_snapshot = (
             (not facts.has_side_effects) and later_has_effects and (not facts.is_stable)
         )
         if need_tmp_for_snapshot and self._is_unwritten_mutable_local(
             state.expr, written_names=later_written_names
         ):
+            # Assumption: caller direct locals are frame-private and only explicit
+            # local writes can rebind them. Under that model, if this local name
+            # is never written later, we can skip snapshotting even when later
+            # expressions are effectful.
             need_tmp_for_snapshot = False
         return need_tmp_for_effects, need_tmp_for_snapshot
 
@@ -274,6 +299,7 @@ class _ExprSequencer:
         need_tmp_for_effects: bool,
         later_written_names: set[str],
     ) -> bool:
+        """Return whether assignexpr-local can be hoisted instead of tmp."""
         return (
             need_tmp_for_effects
             and isinstance(expr, ast.AssignExprLocal)
@@ -283,6 +309,7 @@ class _ExprSequencer:
     def _hoist_assignexpr_local(
         self, expr: ast.AssignExprLocal
     ) -> tuple[ast.AssignLocal, ast.NameLocalDirect]:
+        """Turn `x := value` into `x = value` plus direct local reference."""
         assign = ast.AssignLocal(
             loc=expr.loc,
             target=expr.target,
@@ -297,6 +324,7 @@ class _ExprSequencer:
 
     @staticmethod
     def _is_unwritten_mutable_local(expr: ast.Expr, *, written_names: set[str]) -> bool:
+        """Check for mutable direct local reads never written in the scope set."""
         return (
             isinstance(expr, ast.NameLocalDirect)
             and expr.sym.varkind != "const"
@@ -304,6 +332,7 @@ class _ExprSequencer:
         )
 
     def _analyze_expr_eval(self, expr: ast.Expr) -> _ExprEvalFacts:
+        """Summarize an expression's side-effects and value stability."""
         leaf_facts = self._leaf_eval_facts(expr)
         if leaf_facts is not None:
             return leaf_facts
@@ -342,6 +371,7 @@ class _ExprSequencer:
         *,
         rhs_when_test_true: bool,
     ) -> _ExprState:
+        """Lower short-circuit expressions with RHS preludes into explicit ifs."""
         left = self._sequence_expr(expr.left)
         right = self._sequence_expr(expr.right)
         facts = self._merge_eval_facts(
@@ -354,6 +384,12 @@ class _ExprSequencer:
                 facts=facts,
             )
 
+        # RHS has preludes, so expression-level `and/or` is not enough. Rewrite to:
+        #   carrier = left
+        #   if carrier (or not carrier for `or`):
+        #       <rhs preludes>
+        #       carrier = rhs
+        #   result = carrier
         left_ref, left_assign = self._short_circuit_carrier(left.expr)
         target = ast.StrConst(loc=expr.loc, value=left_ref.sym.name)
         rhs_stmts, rhs_expr, need_join_assign = self._coalesce_short_circuit_rhs(
@@ -384,6 +420,7 @@ class _ExprSequencer:
     def _state_from_facts(
         *, expr: ast.Expr, pre_stmts: list[ast.Stmt], facts: _ExprEvalFacts
     ) -> _ExprState:
+        """Build runtime state from expression facts and prelude statements."""
         return _ExprState(
             expr=expr,
             pre_stmts=pre_stmts,
@@ -393,6 +430,7 @@ class _ExprSequencer:
 
     @staticmethod
     def _facts_from_state(state: _ExprState) -> _ExprEvalFacts:
+        """Project evaluation facts from an `_ExprState`."""
         return _ExprEvalFacts(
             has_side_effects=state.has_side_effects,
             is_stable=state.is_stable,
@@ -402,6 +440,7 @@ class _ExprSequencer:
     def _merge_eval_facts(
         left: _ExprEvalFacts, right: _ExprEvalFacts
     ) -> _ExprEvalFacts:
+        """Combine eval facts for sequentially evaluated subexpressions."""
         has_side_effects = left.has_side_effects or right.has_side_effects
         return _ExprEvalFacts(
             has_side_effects=has_side_effects,
@@ -410,10 +449,12 @@ class _ExprSequencer:
 
     @staticmethod
     def _assign_expr_facts() -> _ExprEvalFacts:
+        """Facts for assignment expressions: effectful and unstable."""
         return _ExprEvalFacts(has_side_effects=True, is_stable=False)
 
     @staticmethod
     def _leaf_eval_facts(expr: ast.Expr) -> _ExprEvalFacts | None:
+        """Return eval facts for supported leaf expressions, else `None`."""
         if isinstance(expr, (ast.Constant, ast.StrConst, ast.FQNConst, ast.LocConst)):
             return _ExprEvalFacts(has_side_effects=False, is_stable=True)
 
@@ -439,6 +480,7 @@ class _ExprSequencer:
 
     @staticmethod
     def _suffix_any(flags: list[bool]) -> list[bool]:
+        """Compute suffix OR flags, including an empty-suffix sentinel slot."""
         out = [False] * (len(flags) + 1)
         for i in range(len(flags) - 1, -1, -1):
             out[i] = flags[i] or out[i + 1]
@@ -446,6 +488,7 @@ class _ExprSequencer:
 
     @staticmethod
     def _suffix_union(names: list[set[str]]) -> list[set[str]]:
+        """Compute suffix unions of name sets with an empty-suffix sentinel."""
         out: list[set[str]] = [set() for _ in range(len(names) + 1)]
         for i in range(len(names) - 1, -1, -1):
             out[i] = set(out[i + 1])
@@ -453,6 +496,7 @@ class _ExprSequencer:
         return out
 
     def _make_tmp(self, expr: ast.Expr) -> tuple[ast.NameLocalDirect, ast.AssignLocal]:
+        """Materialize an expression into a fresh compiler-generated local tmp."""
         w_T = self._expr_type(expr)
         assert w_T is not TYPES.w_NoneType, "cannot materialize void expressions"
 
@@ -478,6 +522,7 @@ class _ExprSequencer:
     def _short_circuit_carrier(
         self, expr: ast.Expr
     ) -> tuple[ast.NameLocalDirect, ast.AssignLocal | None]:
+        """Return carrier local for short-circuit result, reusing existing tmps."""
         # Nested short-circuit rewrites often feed an existing compiler-generated
         # tmp into another And/Or. Reuse that tmp as carrier to avoid tmp-to-tmp
         # copies such as `spy_tmpN = spy_tmpM`.
@@ -507,6 +552,8 @@ class _ExprSequencer:
         if rhs_name not in self.tmp_names or carrier_name not in self.tmp_names:
             return rhs.pre_stmts, rhs.expr, True
 
+        # Both sides are compiler tmps. Rewrite RHS preludes to write into
+        # `carrier` directly and drop the redundant RHS tmp.
         renamed = [
             self._rename_local_stmt(stmt, old_name=rhs_name, new_name=carrier_name)
             for stmt in rhs.pre_stmts
@@ -515,6 +562,7 @@ class _ExprSequencer:
         return renamed, carrier, False
 
     def _drop_tmp(self, tmp_name: str) -> None:
+        """Forget a tmp variable after coalescing away its final use."""
         if tmp_name not in self.tmp_names:
             return
         self.tmp_names.remove(tmp_name)
@@ -523,6 +571,7 @@ class _ExprSequencer:
     def _rename_local_stmt(
         self, stmt: ast.Stmt, *, old_name: str, new_name: str
     ) -> ast.Stmt:
+        """Rename direct local occurrences in a sequenced statement tree."""
         if isinstance(stmt, ast.AssignLocal):
             target = stmt.target
             if target.value == old_name:
@@ -552,6 +601,7 @@ class _ExprSequencer:
     def _rename_local_expr(
         self, expr: ast.Expr, *, old_name: str, new_name: str
     ) -> ast.Expr:
+        """Rename direct local occurrences inside supported expression nodes."""
         if isinstance(expr, ast.NameLocalDirect) and expr.sym.name == old_name:
             return self._make_local_ref(
                 name=new_name,
@@ -597,6 +647,7 @@ class _ExprSequencer:
 
     @staticmethod
     def _make_local_ref(name: str, loc: Loc, w_T: "W_Type") -> ast.NameLocalDirect:
+        """Create a synthetic direct-local reference with the provided type."""
         sym = Symbol(
             name=name,
             varkind="var",
@@ -609,17 +660,20 @@ class _ExprSequencer:
         return ast.NameLocalDirect(loc=loc, sym=sym, w_T=w_T)
 
     def _expr_type(self, expr: ast.Expr) -> "W_Type":
+        """Return expression type, requiring it to be already resolved."""
         assert expr.w_T is not None, (
             "expr_sequencer requires all expressions to have w_T set"
         )
         return expr.w_T
 
     def _is_pure_call(self, func_expr: ast.Expr) -> bool:
+        """Return whether a call target is known pure by FQN classification."""
         if not isinstance(func_expr, ast.FQNConst):
             return False
         return self.is_pure_fqn(func_expr.fqn)
 
     def _written_local_names_node(self, node: ast.Node) -> set[str]:
+        """Collect direct-local names written by a node subtree."""
         names: set[str] = set()
         for cur in node.walk():
             if isinstance(cur, ast.AssignLocal):
@@ -631,6 +685,7 @@ class _ExprSequencer:
         return names
 
     def _written_local_names_state(self, state: _ExprState) -> set[str]:
+        """Collect local names written by expression and its prelude stmts."""
         names = self._written_local_names_node(state.expr)
         for stmt in state.pre_stmts:
             names.update(self._written_local_names_node(stmt))
@@ -638,6 +693,7 @@ class _ExprSequencer:
 
 
 def _default_is_pure_fqn(fqn: FQN) -> bool:
+    """Default purity policy: pure operator calls except `operator::raise`."""
     return fqn.modname == "operator" and fqn.symbol_name != "raise"
 
 
@@ -648,6 +704,7 @@ def expr_sequencer(
     tmp_prefix: str = "spy_tmp",
     is_pure_fqn: IsPureFQN = _default_is_pure_fqn,
 ) -> tuple[list[TmpVar], list[ast.Stmt], int]:
+    """Sequence one statement into ordered form and return emitted tmp metadata."""
     sequencer = _ExprSequencer(
         start_index=start_index,
         tmp_prefix=tmp_prefix,

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -355,8 +355,10 @@ class DopplerFrame(ASTFrame):
             expT = make_const(self.vm, lv.decl_loc, lv.w_T)
             gotT = make_const(self.vm, wam.loc, wam.w_static_T)
             new_expr = self.shift_opimpl(
-                expr, w_typeconv_opimpl, [expT, gotT, new_expr]
+                expr, w_typeconv_opimpl, [expT, gotT, new_expr], w_T=lv.w_T
             )
+
+        assert new_expr.w_T is not None, "eval_expr should produce a typed ast.Expr"
 
         self.shifted_expr[expr] = new_expr
         self.record_node_color(expr, wam.color)
@@ -395,6 +397,8 @@ class DopplerFrame(ASTFrame):
             return make_const(self.vm, op.loc, w_opimpl.w_const)
 
         assert w_opimpl.is_func_call()
+        if w_T is None:
+            w_T = w_opimpl.w_functype.w_restype
         func = make_const(self.vm, op.loc, w_opimpl.w_func)
         real_args = self._shift_opimpl_args(w_opimpl, orig_args)
         return ast.Call(op.loc, func, real_args, w_T=w_T)
@@ -482,17 +486,17 @@ class DopplerFrame(ASTFrame):
             loc=lst.loc,
             func=ast.FQNConst(loc=lst.loc, fqn=fqn_new),
             args=[],
+            w_T=w_T,
         )
 
         # add a call to push() for each item
-        for i, item in enumerate(lst.items):
+        for item in lst.items:
             shifted_item = self.shifted_expr[item]
-            is_last = i == len(lst.items) - 1
             newlst = ast.Call(
                 item.loc,
                 func=ast.FQNConst(loc=item.loc, fqn=fqn_push),
                 args=[newlst, shifted_item],
-                w_T=w_T if is_last else None,
+                w_T=w_T,
             )
         return newlst
 
@@ -519,18 +523,18 @@ class DopplerFrame(ASTFrame):
             loc=dict.loc,
             func=ast.FQNConst(loc=dict.loc, fqn=fqn_new),
             args=[],
+            w_T=w_T,
         )
 
         # add a call to push() for each item (key, value)
-        for i, pair in enumerate(dict.items):
+        for pair in dict.items:
             shifted_key = self.shifted_expr[pair.key]
             shifted_val = self.shifted_expr[pair.value]
-            is_last = i == len(dict.items) - 1
             newdict = ast.Call(
                 loc=pair.loc,
                 func=ast.FQNConst(loc=pair.loc, fqn=fqn_push),
                 args=[newdict, shifted_key, shifted_val],
-                w_T=w_T if is_last else None,
+                w_T=w_T,
             )
 
         return newdict

--- a/spy/tests/backend/c/test_expr_sequencer.py
+++ b/spy/tests/backend/c/test_expr_sequencer.py
@@ -1,0 +1,667 @@
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from spy import ast
+from spy.analyze.symtable import ImportRef, Symbol, VarKind, VarStorage
+from spy.backend.c.expr_sequencer import expr_sequencer
+from spy.fqn import FQN
+from spy.location import Loc
+
+LOC = Loc.fake()
+
+if TYPE_CHECKING:
+    from spy.vm.object import W_Type
+
+
+def _fake_w_type() -> "W_Type":
+    return cast("W_Type", object())
+
+
+W_I32 = _fake_w_type()
+W_BOOL = _fake_w_type()
+W_STR = _fake_w_type()
+W_LOC = _fake_w_type()
+
+
+def mk_sym(
+    name: str,
+    *,
+    varkind: VarKind = "var",
+    storage: VarStorage = "direct",
+    level: int = 0,
+    impref: ImportRef | None = None,
+) -> Symbol:
+    return Symbol(
+        name=name,
+        varkind=varkind,
+        varkind_origin="auto",
+        storage=storage,
+        loc=LOC,
+        type_loc=LOC,
+        level=level,
+        impref=impref,
+    )
+
+
+def i32(value: int) -> ast.Constant:
+    return ast.Constant(loc=LOC, value=value, w_T=W_I32)
+
+
+def bconst(value: bool) -> ast.Constant:
+    return ast.Constant(loc=LOC, value=value, w_T=W_BOOL)
+
+
+def name_local(
+    name: str,
+    *,
+    varkind: VarKind = "var",
+    storage: VarStorage = "direct",
+    w_T: "W_Type" = W_I32,
+) -> ast.NameLocalDirect:
+    assert storage == "direct", "name_local helper only supports direct locals"
+    return ast.NameLocalDirect(loc=LOC, sym=mk_sym(name, varkind=varkind), w_T=w_T)
+
+
+def assignexpr_local(name: str, value: ast.Expr) -> ast.AssignExprLocal:
+    return ast.AssignExprLocal(
+        loc=LOC,
+        target=ast.StrConst(loc=LOC, value=name),
+        value=value,
+        w_T=value.w_T,
+    )
+
+
+def call_fqn(fullname: str, args: list[ast.Expr], *, w_T: "W_Type") -> ast.Call:
+    return ast.Call(
+        loc=LOC,
+        func=ast.FQNConst(loc=LOC, fqn=FQN(fullname), w_T=w_T),
+        args=args,
+        w_T=w_T,
+    )
+
+
+def sequence_stmt(
+    stmt: ast.Stmt,
+    *,
+    start_index: int = 0,
+    pure_fqns: set[tuple[str, str]] | None = None,
+):
+    extra_pure = pure_fqns or set()
+
+    def is_pure_fqn(fqn: FQN) -> bool:
+        return (fqn.modname == "operator" and fqn.symbol_name != "raise") or (
+            fqn.modname,
+            fqn.symbol_name,
+        ) in extra_pure
+
+    return expr_sequencer(stmt, start_index=start_index, is_pure_fqn=is_pure_fqn)
+
+
+def add_with_assign(value: int = 1) -> ast.Call:
+    return call_fqn(
+        "test::add",
+        [name_local("x"), assignexpr_local("x", i32(value))],
+        w_T=W_I32,
+    )
+
+
+def pred_with_assign(value: int) -> ast.Call:
+    return call_fqn(
+        "test::pred",
+        [name_local("x"), assignexpr_local("x", i32(value))],
+        w_T=W_BOOL,
+    )
+
+
+class TestExprSequencer:
+    @staticmethod
+    def assert_no_tmp_to_tmp_forwarders(stmts: list[ast.Stmt]) -> None:
+        for root in stmts:
+            for node in root.walk():
+                if isinstance(node, ast.AssignLocal) and isinstance(
+                    node.value, ast.NameLocalDirect
+                ):
+                    assert not (
+                        node.target.value.startswith("spy_tmp")
+                        and node.value.sym.name.startswith("spy_tmp")
+                    )
+
+    @pytest.mark.parametrize(
+        "stmt",
+        [
+            ast.Pass(loc=LOC),
+            ast.Break(loc=LOC),
+            ast.Continue(loc=LOC),
+            ast.VarDef(
+                loc=LOC,
+                kind="var",
+                name=ast.StrConst(loc=LOC, value="x"),
+                type=ast.FQNConst(loc=LOC, fqn=FQN("builtins::i32")),
+                value=None,
+            ),
+            ast.Raise(
+                loc=LOC,
+                exc=ast.FQNConst(loc=LOC, fqn=FQN("builtins::ValueError")),
+            ),
+        ],
+        ids=["pass", "break", "continue", "vardef_none", "default_passthrough_raise"],
+    )
+    def test_passthrough_stmt_cases(self, stmt: ast.Stmt):
+        # Snippet: statement kinds that expr_sequencer should pass through unchanged.
+        tmpvars, new_stmts, next_idx = expr_sequencer(stmt)
+        assert tmpvars == []
+        assert next_idx == 0
+        assert len(new_stmts) == 1
+        assert new_stmts[0] is stmt
+
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            ast.Constant(loc=LOC, value=1, w_T=W_I32),
+            ast.StrConst(loc=LOC, value="s", w_T=W_STR),
+            ast.FQNConst(loc=LOC, fqn=FQN("operator::i32_add"), w_T=W_I32),
+            ast.LocConst(loc=LOC, value=LOC, w_T=W_LOC),
+            ast.NameLocalDirect(loc=LOC, sym=mk_sym("x", varkind="var"), w_T=W_I32),
+            ast.NameLocalCell(
+                loc=LOC,
+                sym=mk_sym("x_cell", varkind="const", storage="cell"),
+                w_T=W_I32,
+            ),
+            ast.NameOuterCell(
+                loc=LOC,
+                sym=mk_sym("outer", varkind="var", storage="cell", level=1),
+                fqn=FQN("test::outer"),
+                w_T=W_I32,
+            ),
+            ast.NameOuterDirect(
+                loc=LOC, sym=mk_sym("outer2", varkind="const", level=1), w_T=W_I32
+            ),
+            ast.NameImportRef(
+                loc=LOC,
+                sym=mk_sym(
+                    "print_i32",
+                    varkind="const",
+                    level=1,
+                    impref=ImportRef("builtins", "print_i32"),
+                ),
+                w_T=W_I32,
+            ),
+        ],
+        ids=[
+            "const",
+            "strconst",
+            "fqnconst",
+            "locconst",
+            "name_local_direct",
+            "name_local_cell",
+            "name_outer_cell",
+            "name_outer_direct",
+            "name_import_ref",
+        ],
+    )
+    def test_leaf_exprs_stay_inline(self, expr: ast.Expr):
+        # Snippet: return of a leaf expression (constant/name/fqn/import ref, etc.).
+        stmt = ast.Return(loc=LOC, value=expr)
+        tmpvars, new_stmts, next_idx = expr_sequencer(stmt)
+        assert tmpvars == []
+        assert next_idx == 0
+        assert len(new_stmts) == 1
+        assert isinstance(new_stmts[0], ast.Return)
+        assert new_stmts[0].value is expr
+
+    @pytest.mark.parametrize(
+        "stmt_kind",
+        ["vardef", "assign_local", "assign_cell", "stmt_expr"],
+        ids=["vardef", "assign_local", "assign_cell", "stmt_expr"],
+    )
+    def test_stmt_kinds_sequence_value_expr(self, stmt_kind: str):
+        # Snippet: each statement form wraps the same order-sensitive call `add(x, x := 1)`.
+        stmt: ast.Stmt
+        if stmt_kind == "vardef":
+            stmt = ast.VarDef(
+                loc=LOC,
+                kind="var",
+                name=ast.StrConst(loc=LOC, value="y"),
+                type=ast.FQNConst(loc=LOC, fqn=FQN("builtins::i32")),
+                value=add_with_assign(),
+            )
+        elif stmt_kind == "assign_local":
+            stmt = ast.AssignLocal(
+                loc=LOC,
+                target=ast.StrConst(loc=LOC, value="y"),
+                value=add_with_assign(),
+            )
+        elif stmt_kind == "assign_cell":
+            stmt = ast.AssignCell(
+                loc=LOC,
+                target=ast.StrConst(loc=LOC, value="cell"),
+                target_fqn=FQN("test::cell"),
+                value=add_with_assign(),
+            )
+        else:
+            stmt = ast.StmtExpr(loc=LOC, value=add_with_assign())
+
+        tmpvars, new_stmts, next_idx = sequence_stmt(
+            stmt,
+            pure_fqns={("test", "add")},
+        )
+
+        assert len(tmpvars) == 1
+        tmp_name, _ = tmpvars[0]
+        assert next_idx == 1
+        assert len(new_stmts) == 2
+        assert isinstance(new_stmts[0], ast.AssignLocal)
+        assert new_stmts[0].target.value == tmp_name
+
+        seq_stmt = new_stmts[1]
+        if isinstance(seq_stmt, ast.VarDef):
+            value = seq_stmt.value
+        elif isinstance(seq_stmt, ast.AssignLocal):
+            value = seq_stmt.value
+        elif isinstance(seq_stmt, ast.AssignCell):
+            value = seq_stmt.value
+        else:
+            assert isinstance(seq_stmt, ast.StmtExpr)
+            value = seq_stmt.value
+        assert isinstance(value, ast.Call)
+        assert isinstance(value.args[0], ast.NameLocalDirect)
+        assert value.args[0].sym.name == tmp_name
+
+    def test_if_sequences_test_and_bodies(self):
+        # Snippet: `if add(x, x := 1): y = add(...); else: add(...)` sequences test and both bodies.
+        stmt = ast.If(
+            loc=LOC,
+            test=add_with_assign(),
+            then_body=[
+                ast.AssignLocal(
+                    loc=LOC,
+                    target=ast.StrConst(loc=LOC, value="y"),
+                    value=add_with_assign(),
+                )
+            ],
+            else_body=[ast.StmtExpr(loc=LOC, value=add_with_assign())],
+        )
+
+        tmpvars, new_stmts, _ = sequence_stmt(stmt, pure_fqns={("test", "add")})
+
+        assert len(tmpvars) == 3
+        assert len(new_stmts) == 2
+        assert isinstance(new_stmts[0], ast.AssignLocal)
+        assert isinstance(new_stmts[1], ast.If)
+
+        new_if = new_stmts[1]
+        assert any(isinstance(s, ast.AssignLocal) for s in new_if.then_body)
+        assert any(isinstance(s, ast.AssignLocal) for s in new_if.else_body)
+        assert any(isinstance(s, ast.StmtExpr) for s in new_if.else_body)
+
+    def test_while_without_test_preludes_keeps_structure(self):
+        # Snippet: `while cond:` with a plain test should remain a normal while.
+        stmt = ast.While(
+            loc=LOC,
+            test=name_local("cond", w_T=W_BOOL),
+            body=[
+                ast.AssignLocal(
+                    loc=LOC,
+                    target=ast.StrConst(loc=LOC, value="x"),
+                    value=i32(0),
+                )
+            ],
+        )
+
+        tmpvars, new_stmts, next_idx = sequence_stmt(stmt)
+
+        assert tmpvars == []
+        assert next_idx == 0
+        assert len(new_stmts) == 1
+        assert isinstance(new_stmts[0], ast.While)
+        assert not (
+            isinstance(new_stmts[0].test, ast.Constant)
+            and new_stmts[0].test.value is True
+        )
+
+    def test_while_with_test_preludes_rewrites_to_loop_with_break(self):
+        # Snippet under test:
+        #   while add(x, x := 1):
+        #       return x
+        # Expected shape:
+        #   while True:
+        #       <prelude for add(...)>
+        #       if <sequenced test>:
+        #           return x
+        #       else:
+        #           break
+        stmt = ast.While(
+            loc=LOC,
+            test=add_with_assign(),
+            body=[ast.Return(loc=LOC, value=name_local("x"))],
+        )
+
+        _, new_stmts, _ = sequence_stmt(stmt, pure_fqns={("test", "add")})
+
+        assert len(new_stmts) == 1
+        assert isinstance(new_stmts[0], ast.While)
+        new_loop = new_stmts[0]
+        assert isinstance(new_loop.test, ast.Constant)
+        assert new_loop.test.value is True
+        assert isinstance(new_loop.body[-1], ast.If)
+        branch = new_loop.body[-1]
+        assert isinstance(branch.else_body[-1], ast.Break)
+
+    def test_assert_without_msg_sequences_only_test(self):
+        # Snippet: `assert add(x, x := 1)` should sequence only the test expression.
+        stmt = ast.Assert(loc=LOC, test=add_with_assign(), msg=None)
+
+        tmpvars, new_stmts, _ = sequence_stmt(stmt, pure_fqns={("test", "add")})
+
+        assert len(tmpvars) == 1
+        assert len(new_stmts) == 2
+        assert isinstance(new_stmts[0], ast.AssignLocal)
+        assert isinstance(new_stmts[1], ast.Assert)
+        seq_assert = new_stmts[1]
+        assert seq_assert.msg is None
+
+    def test_assert_message_preludes_remain_lazy(self):
+        # Snippet under test:
+        #   assert True, fmt(x, x := 1)
+        # `fmt(...)` has a prelude (`x := 1`) so the rewrite must keep it lazy:
+        # it should appear only in the `else` branch of an `if test` guard.
+        stmt = ast.Assert(
+            loc=LOC,
+            test=bconst(True),
+            msg=call_fqn(
+                "test::fmt",
+                [name_local("x"), assignexpr_local("x", i32(1))],
+                w_T=W_STR,
+            ),
+        )
+
+        _, new_stmts, _ = sequence_stmt(stmt, pure_fqns={("test", "fmt")})
+
+        assert len(new_stmts) == 1
+        assert isinstance(new_stmts[0], ast.If)
+        lazy_if = new_stmts[0]
+        assert lazy_if.then_body == []
+        assert lazy_if.else_body
+        assert isinstance(lazy_if.else_body[-1], ast.Assert)
+        fail_assert = lazy_if.else_body[-1]
+        assert isinstance(fail_assert.test, ast.Constant)
+        assert fail_assert.test.value is False
+        assert fail_assert.msg is not None
+
+    @pytest.mark.parametrize(
+        ("bool_expr", "branch_with_assignment"),
+        [
+            (
+                ast.And(
+                    loc=LOC,
+                    left=bconst(True),
+                    right=pred_with_assign(1),
+                    w_T=W_BOOL,
+                ),
+                "then_body",
+            ),
+            (
+                ast.Or(
+                    loc=LOC,
+                    left=bconst(False),
+                    right=pred_with_assign(1),
+                    w_T=W_BOOL,
+                ),
+                "else_body",
+            ),
+        ],
+        ids=["and_with_rhs_preludes", "or_with_rhs_preludes"],
+    )
+    def test_short_circuit_rewrite_with_rhs_preludes(
+        self, bool_expr: ast.Expr, branch_with_assignment: str
+    ):
+        # Snippet under test (parametrized):
+        #   return True and pred(x, x := 1)
+        #   return False or pred(x, x := 1)
+        # RHS has preludes, so short-circuit must rewrite to:
+        #   tmp = left
+        #   if <short-circuit condition>:
+        #       <RHS preludes>
+        #       tmp = <rhs value>
+        #   return tmp
+        stmt = ast.Return(loc=LOC, value=bool_expr)
+        _, new_stmts, _ = sequence_stmt(stmt, pure_fqns={("test", "pred")})
+
+        assert isinstance(new_stmts[-1], ast.Return)
+        ret = new_stmts[-1]
+        assert isinstance(ret.value, ast.NameLocalDirect)
+        if_stmt = next(s for s in new_stmts if isinstance(s, ast.If))
+        branch = getattr(if_stmt, branch_with_assignment)
+        assignments = [s for s in branch if isinstance(s, ast.AssignLocal)]
+        assert assignments
+        assert any(assign.target.value == ret.value.sym.name for assign in assignments)
+
+    def test_nested_short_circuit_reuses_existing_carrier_tmps(self):
+        # Snippet under test:
+        #   b = ((True and pred(x, x := 1)) and (pred(x, x := 2) or (True and pred(x, x := 3)))) \
+        #       or (False and pred(x, x := 4))
+        # This stresses nested short-circuit rewrites. We validate that rewrites
+        # avoid redundant forwarding like `spy_tmpN = spy_tmpM`.
+        expr = ast.Or(
+            loc=LOC,
+            left=ast.And(
+                loc=LOC,
+                left=ast.And(
+                    loc=LOC,
+                    left=bconst(True),
+                    right=pred_with_assign(1),
+                    w_T=W_BOOL,
+                ),
+                right=ast.Or(
+                    loc=LOC,
+                    left=pred_with_assign(2),
+                    right=ast.And(
+                        loc=LOC,
+                        left=bconst(True),
+                        right=pred_with_assign(3),
+                        w_T=W_BOOL,
+                    ),
+                    w_T=W_BOOL,
+                ),
+                w_T=W_BOOL,
+            ),
+            right=ast.And(
+                loc=LOC,
+                left=bconst(False),
+                right=pred_with_assign(4),
+                w_T=W_BOOL,
+            ),
+            w_T=W_BOOL,
+        )
+        stmt = ast.AssignLocal(
+            loc=LOC,
+            target=ast.StrConst(loc=LOC, value="b"),
+            value=expr,
+        )
+
+        tmpvars, new_stmts, _ = sequence_stmt(stmt, pure_fqns={("test", "pred")})
+
+        assert len(tmpvars) >= 4
+        self.assert_no_tmp_to_tmp_forwarders(new_stmts)
+
+    def test_assignexpr_local_is_hoisted_without_tmp(self):
+        # Snippet under test:
+        #   return pack(x := bump_a(), y := bump_b())
+        # First argument has effects and must be sequenced before later args.
+        # For local targets, sequencer should hoist to a direct assignment:
+        #   x = bump_a()
+        #   return pack(x, y := bump_b())
+        stmt = ast.Return(
+            loc=LOC,
+            value=call_fqn(
+                "test::pack",
+                [
+                    assignexpr_local(
+                        "x",
+                        call_fqn("test::bump_a", [], w_T=W_I32),
+                    ),
+                    assignexpr_local(
+                        "y",
+                        call_fqn("test::bump_b", [], w_T=W_I32),
+                    ),
+                ],
+                w_T=W_I32,
+            ),
+        )
+
+        tmpvars, new_stmts, _ = sequence_stmt(stmt)
+
+        assert tmpvars == []
+        assert len(new_stmts) == 2
+        assert isinstance(new_stmts[0], ast.AssignLocal)
+        assert isinstance(new_stmts[1], ast.Return)
+        ret = new_stmts[1]
+        assert isinstance(ret, ast.Return)
+        assert isinstance(ret.value, ast.Call)
+        assert isinstance(ret.value.args[0], ast.NameLocalDirect)
+        assert ret.value.args[0].sym.name == "x"
+        assert isinstance(ret.value.args[1], ast.AssignExprLocal)
+        assert ret.value.args[1].target.value == "y"
+
+    def test_assignexpr_cell_is_materialized_when_later_arg_needs_ordering(self):
+        # Snippet under test:
+        #   return op(x_cell := 1, x_cell := 2)
+        # Cell assignment cannot be hoisted like a local assignexpr, so when
+        # ordering is required the first arg should be materialized into a tmp.
+        call = ast.Call(
+            loc=LOC,
+            func=ast.FQNConst(loc=LOC, fqn=FQN("operator::i32_add"), w_T=W_I32),
+            args=[
+                ast.AssignExprCell(
+                    loc=LOC,
+                    target=ast.StrConst(loc=LOC, value="x"),
+                    target_fqn=FQN("test::x"),
+                    value=ast.Constant(loc=LOC, value=1, w_T=W_I32),
+                    w_T=W_I32,
+                ),
+                ast.AssignExprCell(
+                    loc=LOC,
+                    target=ast.StrConst(loc=LOC, value="x"),
+                    target_fqn=FQN("test::x"),
+                    value=ast.Constant(loc=LOC, value=2, w_T=W_I32),
+                    w_T=W_I32,
+                ),
+            ],
+            w_T=W_I32,
+        )
+        stmt = ast.Return(loc=LOC, value=call)
+        tmpvars, new_stmts, _ = expr_sequencer(stmt)
+
+        assert len(tmpvars) == 1
+        assert len(new_stmts) == 2
+        assert isinstance(new_stmts[0], ast.AssignLocal)
+        assert isinstance(new_stmts[1], ast.Return)
+
+        first = new_stmts[0]
+        assert isinstance(first, ast.AssignLocal)
+        assert isinstance(first.value, ast.AssignExprCell)
+        tmp_name = first.target.value
+
+        ret = new_stmts[1]
+        assert isinstance(ret, ast.Return)
+        assert isinstance(ret.value, ast.Call)
+        assert isinstance(ret.value.args[0], ast.NameLocalDirect)
+        assert ret.value.args[0].sym.name == tmp_name
+        assert isinstance(ret.value.args[1], ast.AssignExprCell)
+
+    def test_skips_snapshot_for_unwritten_local_with_later_effects(self):
+        # Snippet under test:
+        #   return add(x, bump())
+        # Even though `bump()` is effectful, `x` is an unwritten mutable local in
+        # this call, so snapshotting `x` into a tmp would be unnecessary.
+        stmt = ast.Return(
+            loc=LOC,
+            value=call_fqn(
+                "test::add",
+                [
+                    name_local("x"),
+                    call_fqn("test::bump", [], w_T=W_I32),
+                ],
+                w_T=W_I32,
+            ),
+        )
+
+        tmpvars, new_stmts, next_idx = sequence_stmt(
+            stmt,
+            pure_fqns={("test", "add")},
+        )
+
+        assert tmpvars == []
+        assert next_idx == 0
+        assert len(new_stmts) == 1
+        assert isinstance(new_stmts[0], ast.Return)
+        assert isinstance(new_stmts[0].value, ast.Call)
+        assert isinstance(new_stmts[0].value.args[0], ast.NameLocalDirect)
+        assert new_stmts[0].value.args[0].sym.name == "x"
+
+    def test_materializes_side_effect_arg_when_followed_by_order_sensitive_arg(self):
+        # Snippet under test:
+        #   return add(bump(), x := 1)
+        # First arg has effects and later arg is order-sensitive, so sequencer
+        # should materialize first arg into a tmp to preserve left-to-right eval.
+        stmt = ast.Return(
+            loc=LOC,
+            value=call_fqn(
+                "test::add",
+                [
+                    call_fqn("test::bump", [], w_T=W_I32),
+                    assignexpr_local("x", i32(1)),
+                ],
+                w_T=W_I32,
+            ),
+        )
+
+        tmpvars, new_stmts, _ = sequence_stmt(
+            stmt,
+            pure_fqns={("test", "add")},
+        )
+
+        assert len(tmpvars) == 1
+        assert len(new_stmts) == 2
+        assert isinstance(new_stmts[0], ast.AssignLocal)
+        assert isinstance(new_stmts[1], ast.Return)
+        first = new_stmts[0]
+        assert isinstance(first, ast.AssignLocal)
+        assert isinstance(first.value, ast.Call)
+        tmp_name = first.target.value
+        ret = new_stmts[1]
+        assert isinstance(ret, ast.Return)
+        assert isinstance(ret.value, ast.Call)
+        assert isinstance(ret.value.args[0], ast.NameLocalDirect)
+        assert ret.value.args[0].sym.name == tmp_name
+
+    def test_start_index_is_respected_for_tmp_names(self):
+        # Snippet: `start_index=7` should produce first tmp named `spy_tmp7`.
+        stmt = ast.Return(loc=LOC, value=add_with_assign())
+        tmpvars, _, next_idx = sequence_stmt(
+            stmt,
+            start_index=7,
+            pure_fqns={("test", "add")},
+        )
+
+        assert [name for name, _ in tmpvars] == ["spy_tmp7"]
+        assert next_idx == 8
+
+    def test_non_fqn_call_stays_inline_without_ordering_pressure(self):
+        # Snippet: `return fn(1)` uses a non-FQN callee, but with no later ordering pressure.
+        call = ast.Call(
+            loc=LOC,
+            func=ast.NameLocalDirect(loc=LOC, sym=mk_sym("fn"), w_T=W_I32),
+            args=[ast.Constant(loc=LOC, value=1, w_T=W_I32)],
+            w_T=W_I32,
+        )
+        stmt = ast.Return(loc=LOC, value=call)
+        tmpvars, new_stmts, next_idx = expr_sequencer(stmt)
+
+        assert tmpvars == []
+        assert next_idx == 0
+        assert len(new_stmts) == 1
+        assert isinstance(new_stmts[0], ast.Return)
+        assert isinstance(new_stmts[0].value, ast.Call)
+        assert isinstance(new_stmts[0].value.func, ast.NameLocalDirect)

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any
 
 import pytest
@@ -8,6 +9,7 @@ from spy.tests.support import (
     CompilerTest,
     expect_errors,
     no_C,
+    only_C,
     only_interp,
     skip_backends,
 )
@@ -187,6 +189,98 @@ class TestBasic(CompilerTest):
             return x + result
         """)
         assert mod.foo() == 2
+
+    def test_call_argument_order_left_to_right_nested_calls(self):
+        mod = self.compile("""
+        var g: i32 = 0
+
+        def side() -> i32:
+            g = g + 1
+            return g
+
+        def h(a: i32, b: i32) -> i32:
+            return a * 10 + b
+
+        def f(a: i32, b: i32) -> i32:
+            return a * 100 + b
+
+        def foo() -> i32:
+            g = 0
+            x = 5
+            return f(x, h(x := 1, side()))
+        """)
+        # left-to-right:
+        #   f arg0: x = 5
+        #   then arg1: h(x := 1, side()) = 11
+        # 5*100 + (1*10 + 1) = 511
+        assert mod.foo() == 511
+
+    @only_C
+    def test_binop_operand_order_left_to_right(self):
+        mod = self.compile("""
+        var state: i32 = 0
+
+        def fa() -> i32:
+            state = 1
+            return 10
+
+        def fb() -> i32:
+            state = state + 10
+            return 20
+
+        def foo() -> i32:
+            state = 0
+            return fa() + fb() + state
+        """)
+        # left-to-right:
+        #   fa() sets state = 1
+        #   fb() sets state = 11
+        #   trailing + state reads 11
+        # 10 + 20 + (1+10) = 41
+        assert mod.foo() == 41
+        cfile = self.builddir.join("src", "test.c")
+        if not cfile.exists():
+            cfile = self.builddir.join("test.c")
+        csrc = cfile.read()
+        # C leaves operand evaluation order for `+` unspecified,
+        # so we should never emit direct `fa(...) + ... + fb(...)` in one expression.
+        # Match with flexible whitespace and intervening tokens up to `;`
+        assert re.search(r"\$fa\s*\(\s*\)\s*\+\s*[^;]*\$fb\s*\(\s*\)", csrc) is None
+
+    def test_call_argument_order_left_to_right_temp_name_collision(self):
+        mod = self.compile("""
+        def add(a: i32, b: i32) -> i32:
+            return a * 10 + b
+
+        def foo() -> i32:
+            spy_tmp0 = 40
+            return add(spy_tmp0, spy_tmp0 := 2)
+        """)
+        # left-to-right:
+        #   first arg snapshots 40, then second arg assigns 2
+        assert mod.foo() == 402
+
+    @only_C
+    def test_call_argument_order_left_to_right_short_circuit_rhs(self):
+        mod = self.compile("""
+        def add(a: i32, b: i32) -> i32:
+            return a * 10 + b
+
+        def foo() -> i32:
+            x = 0
+            if True and add(x, x := 1) == 1:
+                return x
+            return 100
+        """)
+        assert mod.foo() == 1
+        cfile = self.builddir.join("src", "test.c")
+        if not cfile.exists():
+            cfile = self.builddir.join("test.c")
+        csrc = cfile.read()
+        # Calls embedded in lazy boolean contexts still need explicit sequencing:
+        # C argument order is unspecified for patterns like `f(x, x = 1)`.
+        # This regex matches any `(x, x = 1)` argument pair form.
+        assert re.search(r"\(\s*x\s*,\s*\(?\s*x\s*=\s*1\s*\)?\s*\)", csrc) is None
 
     @only_interp
     def test_blue_cannot_redeclare(self):

--- a/spy/tests/compiler/unsafe/test_ptr.py
+++ b/spy/tests/compiler/unsafe/test_ptr.py
@@ -125,6 +125,37 @@ class TestUnsafePtr(CompilerTest):
         assert mod.with_ptr(3, 4.5) == 7.5
         assert mod.with_ref(6, 7.8) == 13.8
 
+    def test_ptr_setfield_eval_order_left_to_right(self, memkind):
+        k = memkind
+        mod = self.compile(f"""
+        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr
+
+        var state: i32 = 0
+
+        @struct
+        class Point:
+            x: i32
+
+        def make_point(v: i32) -> k_ptr[Point]:
+            state = v
+            p = k_alloc[Point](1)
+            p.x = 0
+            return p
+
+        def bump() -> i32:
+            state = state + 1
+            return state
+
+        def foo() -> i32:
+            state = 0
+            make_point(10).x = bump()
+            return state
+        """)
+        # LTR order:
+        #   1) make_point(10) sets state=10
+        #   2) bump() sets state=11
+        assert mod.foo() == 11
+
     def test_ptr_to_string(self, memkind):
         # XXX: support for raw_alloc[str] was added by 30ffdb9a, but doesn't make sense
         # now. We should support ONLY gc_alloc[str]


### PR DESCRIPTION
C does not guarantee operand evaluation order, but SPy requires left-to-right semantics.
This PR adds a backend-local expression sequencer that rewrites typed C-backend AST statements so evaluation order is explicit.

The pass introduces temporaries only when required for correctness:
- materialize effectful parts when later parts are ordering-sensitive;
- snapshot unstable reads only when later effects could change the observed value;
- hoist local assignment expressions when that preserves order without creating a tmp.

It also performs control-flow rewrites needed to preserve lazy semantics:
- short-circuit expressions with RHS preludes are lowered into explicit `if` flow;
- `while`/`assert` cases with preludes are rewritten so preludes execute at the correct time.

Added module-level and function docs in `expr_sequencer.py`.
