### PR TITLE
Fix for loops in nested functions

### DIFF
--- a/spy/parser.py
+++ b/spy/parser.py
@@ -206,8 +206,12 @@ class Parser:
             return_type = spy.ast.Auto(retloc)
 
         docstring, py_body = self.get_docstring_maybe(py_funcdef.body)
-        self.for_loop_seq = 0  # reset counter for this function
+        # by doing this "saved_seq" dance, we ensure that nested functions "continue"
+        # the numbering from the their parent, but sibling functions reset the
+        # numbering. See test_scope::test_for_loop_nested_funcs
+        saved_seq = self.for_loop_seq
         body = self.from_py_body(py_body)
+        self.for_loop_seq = saved_seq
 
         return spy.ast.FuncDef(
             loc=py_funcdef.loc,

--- a/spy/tests/test_scope.py
+++ b/spy/tests/test_scope.py
@@ -582,6 +582,38 @@ class TestScopeAnalyzer:
             "i32": MatchSymbol("i32", "const", "explicit", level=2),
         }
 
+    def test_for_loop_nested_funcs(self):
+        scopes = self.analyze("""
+        def foo() -> None:
+            for i in range(10):
+                x: i32 = i * 2
+
+            def bar() -> None:
+                for j in range(5):
+                    y: i32 = j * 3
+        """)
+        foo_scope = scopes.by_funcdef(self.mod.get_funcdef("foo"))
+        assert foo_scope._symbols == {
+            "_$iter0": MatchSymbol("_$iter0", "var", "auto"),
+            "i": MatchSymbol("i", "var", "auto"),
+            "x": MatchSymbol("x", "var", "auto"),
+            "bar": MatchSymbol("bar", "const", "funcdef"),
+            "@return": MatchSymbol("@return", "var", "auto"),
+            "range": MatchSymbol("range", "const", "explicit", level=2),
+            "i32": MatchSymbol("i32", "const", "explicit", level=2),
+        }
+        foo_funcdef = self.mod.get_funcdef("foo")
+        bar_funcdef = foo_funcdef.body[1]  # type: ignore[assignment]
+        bar_scope = scopes.by_funcdef(bar_funcdef)
+        assert bar_scope._symbols == {
+            "_$iter1": MatchSymbol("_$iter1", "var", "auto"),
+            "j": MatchSymbol("j", "var", "auto"),
+            "y": MatchSymbol("y", "var", "auto"),
+            "@return": MatchSymbol("@return", "var", "auto"),
+            "range": MatchSymbol("range", "const", "explicit", level=3),
+            "i32": MatchSymbol("i32", "const", "explicit", level=3),
+        }
+
     def test_for_loop_no_shadowing(self):
         src = """
         i: i32 = 0


### PR DESCRIPTION
This PR fixes this bug:
```python
@blue
def foo():
    for i in range(10):
        pass

    def bar():
        for j in range(10):
            pass

def main() -> None:
    foo()
```

```
Traceback (most recent call last):

ScopeError: variable `_$iter0` shadows a name declared in an outer scope
  | /tmp/x.spy:7
  |         for j in range(10):
  |                  |_______| this is the new declaration

  | /tmp/x.spy:3
  |     for i in range(10):
  |              |_______| this is the previous declaration
```