### PR TITLE
Make it possible to dump multiple modules after redshift

### DIFF
--- a/spy/cli/commands/redshift.py
+++ b/spy/cli/commands/redshift.py
@@ -48,9 +48,9 @@ class _redshift_mixin:
 class Redshift_Args(
     Base_Args, _redshift_mixin, _execute_flag, _execute_options, Filename_Required_Args
 ):
-    extra_files: Annotated[
+    extra_dump: Annotated[
         Optional[list[Path]],
-        Argument(help="Additional modules to dump"),
+        Option("--dump", help="Additional modules to dump"),
     ] = None
 
 
@@ -62,7 +62,7 @@ async def redshift(args: Redshift_Args) -> None:
     modname = args.filename.stem
     vm = await init_vm(args)
 
-    extra_files = args.extra_files or []
+    extra_files = args.extra_dump or []
     extra_modnames = [f.stem for f in extra_files]
 
     for extra_file in extra_files:


### PR DESCRIPTION
Imagine to have this example:
```python
# a.spy
from b import add

def main() -> None:
    x = add[int](1, 2)
    print(x)

# b.spy
@blue.generic
def add(T):
    def adder(x: T, y: T) -> T:
        return x + y
    return adder
```

The current version of `spy rs` takes a single module and there is no way to dump the content of `b.spy`:
```
❯ spy rs a.spy 

def main() -> None:
    x: i32
    x = `b::add[i32]::adder`(1, 2)
    print_i32(x)
```

This PR makes it possible to specify multiple filenames:
```
❯ spy rs a.spy b.spy 
# a.spy

def main() -> None:
    x: i32
    x = `b::add[i32]::adder`(1, 2)
    print_i32(x)



# b.spy

def `b::add[i32]::adder`(x: i32, y: i32) -> i32:
    return x + y
```

Note that this is very different to run just `spy rs b.spy`, because in that case the `add` blue function would never be instantiated.