### PR TITLE
playground: myarray.spy, fix gc_alloc + blue.generic

### DIFF
--- a/playground/myarray.spy
+++ b/playground/myarray.spy
@@ -8,7 +8,7 @@ from operator import OpSpec, MetaArg
 from unsafe import gc_alloc, gc_ptr
 
 
-@blue
+@blue.generic
 def ArrayData(DTYPE):
     @struct
     class _ArrayData:
@@ -29,10 +29,10 @@ def ndarray1(DTYPE):
 
     @struct
     class ndarray:
-        __ll__: gc_ptr[ArrayData(DTYPE)]
+        __ll__: gc_ptr[ArrayData[DTYPE]]
 
         def __new__(length: i32) -> ndarray:
-            data = gc_alloc(ArrayData(DTYPE))(1)
+            data = gc_alloc[ArrayData[DTYPE]](1)
             data.length = length
             data.capacity = length
             data.items = gc_alloc[DTYPE](length)


### PR DESCRIPTION
Related to #416 

A question: in myarray.spy, I was a bit surprised to have a while loop at the end. Wouldn't it be more natural (and I think as fast) with a `for`?