### PR TITLE
io: implement posix.open/read/write.close + _io.FileIO + open

### DIFF
--- a/docs/src/api_reference/python_builtins.md
+++ b/docs/src/api_reference/python_builtins.md
@@ -73,6 +73,10 @@ The following built-in functions work similarly to their equivalents in CPython;
 
 :   `object` is implemented as a type, and can be used as a parameter or return type. "Plain" objects (i.e. `x = object()`) are not supported.
 
+### __open__(file: str, mode: str) { data-toc-label='open()' }
+
+:    Open file and return a `_io.FileIO`.  Raise OSError upon failure.
+
 ### __print__(obj) { data-toc-label='print()' }
 
 :   The print function is currently not variadic, in the sense that it only accepts a single argument. The built-in types are special-cased, and SPy can always print blue objects by pre-computing their string representation
@@ -151,4 +155,4 @@ Many of these types are not implemented yet; others are in active development.
 
 The I/O story is currently a high priority and is in active development.
 
-:   input(), open()
+:   input()

--- a/docs/src/api_reference/python_builtins.md
+++ b/docs/src/api_reference/python_builtins.md
@@ -7,7 +7,7 @@ h3 {
 }
 </style>
 
-## Implemented CPython-Like Built-ins 
+## Implemented CPython-Like Built-ins
 
 The following built-in functions work similarly to their equivalents in CPython; see the specific functions below for notes
 
@@ -43,7 +43,7 @@ The following built-in functions work similarly to their equivalents in CPython;
 ### __hash__(object) { data-toc-label='hash()' }
 :   Currently implemented for types: `i8`,`i32`, `u8`, `bool`, `str`.
 
-:   By default, instances of SPy structs are not hashable. As a planned future feature, structs will have auto-generated `__hash__` by default, but this is awaiting implementation. Currently, users can implement the `__hash__` function to permit hashing. 
+:   By default, instances of SPy structs are not hashable. As a planned future feature, structs will have auto-generated `__hash__` by default, but this is awaiting implementation. Currently, users can implement the `__hash__` function to permit hashing.
 
 ### __int__(object) { data-toc-label='int()' }
 
@@ -57,7 +57,7 @@ The following built-in functions work similarly to their equivalents in CPython;
 
 ### __list__\[type\]() { data-toc-label='list()' }
 
-:   The syntax `list[type]()` can be used to create a new empty list of the given type. The simpler syntax `l: list[membertype] = []` can also be used. Unlike CPython, this does not (currently) accept an Iterable to create a new list from. 
+:   The syntax `list[type]()` can be used to create a new empty list of the given type. The simpler syntax `l: list[membertype] = []` can also be used. Unlike CPython, this does not (currently) accept an Iterable to create a new list from.
 
 :   The implementation (in SPy) of `list` can be [viewed here](https://github.com/spylang/spy/blob/main/stdlib/_list.spy).
 
@@ -103,7 +103,7 @@ The following built-in functions work similarly to their equivalents in CPython;
 
 ### __tuple__()
 
-:   The syntax `tuple[t1, t2, ...](val1, val2 ...)` can be used to create a new tuple, with `t1` as the type of `val1`, etc. unlike CPython, this does not (currently) accept an Iterable to create a new tuple from. 
+:   The syntax `tuple[t1, t2, ...](val1, val2 ...)` can be used to create a new tuple, with `t1` as the type of `val1`, etc. unlike CPython, this does not (currently) accept an Iterable to create a new tuple from.
 
 :   The implementation (in SPy) of `tuple` can be [viewed here](https://github.com/spylang/spy/blob/main/stdlib/_tuple.spy).
 
@@ -111,7 +111,7 @@ The following built-in functions work similarly to their equivalents in CPython;
 
 :   Returns the type (i.e. the dynamic type at runtime) of an object
 
-## Not-Implemented CPython Built-ins 
+## Not-Implemented CPython Built-ins
 
 The following CPython built-ins are not currently implemented in SPy. Each category has a brief note about the current state of that category of object or function - some require additional internal mechanics, others are simply lower priority that other facets of the language to this point.
 

--- a/examples/io_low_level.spy
+++ b/examples/io_low_level.spy
@@ -1,0 +1,21 @@
+from posix import open, write, read, close, O_WRONLY, O_CREAT, O_TRUNC, O_RDONLY
+
+
+def write_file(path: str, data: str) -> i32:
+    fd: i32 = open(path, O_WRONLY | O_CREAT | O_TRUNC)
+    n: i32 = write(fd, data)
+    close(fd)
+    return n
+
+
+def read_file(path: str, n: i32) -> str:
+    fd: i32 = open(path, O_RDONLY)
+    result = read(fd, n)
+    close(fd)
+    return result
+
+
+def main() -> None:
+    path = "/tmp/spy-io_low_level.txt"
+    write_file(path, "hello world")
+    print(read_file(path, 64))

--- a/examples/io_open.spy
+++ b/examples/io_open.spy
@@ -1,0 +1,17 @@
+def write(path: str, data: str, mode: str) -> None:
+    file = open(path, mode)
+    file.write(data)
+    file.close()
+
+
+def main() -> None:
+    path = "/tmp/spy-io_open.txt"
+
+    write(path, "Like Python", "w")
+    write(path, ", but static\n", "a")
+
+    file = open(path, "r")
+    txt = file.read(11)
+    file.close()
+
+    assert txt == "Like Python"

--- a/spy/analyze/symtable.py
+++ b/spy/analyze/symtable.py
@@ -195,6 +195,7 @@ class SymTable:
         add_sym("tuple", ImportRef("_tuple", "tuple"))
         add_sym("slice", ImportRef("_slice", "Slice"))
         add_sym("dict", ImportRef("_dict", "dict"))
+        add_sym("open", ImportRef("_io", "open"))
         return scope
 
     def __repr__(self) -> str:

--- a/spy/libspy/include/spy/posix.h
+++ b/spy/libspy/include/spy/posix.h
@@ -48,7 +48,7 @@ spy_posix$open(spy_Str *path, int32_t flags) {
     int fd = open(cpath, flags);
     free(cpath);
     if (fd == -1) {
-        spy_panic("ValueError", strerror(errno), __FILE__, __LINE__);
+        spy_panic("OSError", strerror(errno), __FILE__, __LINE__);
     }
     return (int32_t)fd;
 }
@@ -58,7 +58,7 @@ spy_posix$read(int32_t fd, int32_t count) {
     spy_Str *result = spy_str_alloc((size_t)count);
     ssize_t n = read(fd, (void *)result->utf8, (size_t)count);
     if (n == -1) {
-        spy_panic("ValueError", strerror(errno), __FILE__, __LINE__);
+        spy_panic("OSError", strerror(errno), __FILE__, __LINE__);
     }
     // Adjust the length to what was actually read
     result->length = (size_t)n;
@@ -70,7 +70,7 @@ static inline int32_t
 spy_posix$write(int32_t fd, spy_Str *data) {
     ssize_t n = write(fd, data->utf8, data->length);
     if (n == -1) {
-        spy_panic("ValueError", strerror(errno), __FILE__, __LINE__);
+        spy_panic("OSError", strerror(errno), __FILE__, __LINE__);
     }
     return (int32_t)n;
 }
@@ -78,7 +78,7 @@ spy_posix$write(int32_t fd, spy_Str *data) {
 static inline void
 spy_posix$close(int32_t fd) {
     if (close(fd) == -1) {
-        spy_panic("ValueError", strerror(errno), __FILE__, __LINE__);
+        spy_panic("OSError", strerror(errno), __FILE__, __LINE__);
     }
 }
 

--- a/spy/libspy/include/spy/posix.h
+++ b/spy/libspy/include/spy/posix.h
@@ -4,6 +4,9 @@
 #ifndef SPY_TARGET_WASI
 #  include <sys/ioctl.h>
 #endif
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
 #include <unistd.h>
 
 // NOTE: this struct is also defined in vm/modules/posix.py, the two definitions must be
@@ -34,6 +37,49 @@ spy_posix$get_terminal_size(void) {
 #endif
 
     return result;
+}
+
+static inline int32_t
+spy_posix$open(spy_Str *path, int32_t flags) {
+    // path->utf8 is NOT null-terminated, so we need a temporary copy
+    char *cpath = (char *)malloc(path->length + 1);
+    memcpy(cpath, path->utf8, path->length);
+    cpath[path->length] = '\0';
+    int fd = open(cpath, flags);
+    free(cpath);
+    if (fd == -1) {
+        spy_panic("ValueError", strerror(errno), __FILE__, __LINE__);
+    }
+    return (int32_t)fd;
+}
+
+static inline spy_Str *
+spy_posix$read(int32_t fd, int32_t count) {
+    spy_Str *result = spy_str_alloc((size_t)count);
+    ssize_t n = read(fd, (void *)result->utf8, (size_t)count);
+    if (n == -1) {
+        spy_panic("ValueError", strerror(errno), __FILE__, __LINE__);
+    }
+    // Adjust the length to what was actually read
+    result->length = (size_t)n;
+    result->hash = -1;
+    return result;
+}
+
+static inline int32_t
+spy_posix$write(int32_t fd, spy_Str *data) {
+    ssize_t n = write(fd, data->utf8, data->length);
+    if (n == -1) {
+        spy_panic("ValueError", strerror(errno), __FILE__, __LINE__);
+    }
+    return (int32_t)n;
+}
+
+static inline void
+spy_posix$close(int32_t fd) {
+    if (close(fd) == -1) {
+        spy_panic("ValueError", strerror(errno), __FILE__, __LINE__);
+    }
 }
 
 #endif /* SPY_POSIX_H */

--- a/spy/tests/compiler/test_posix.py
+++ b/spy/tests/compiler/test_posix.py
@@ -1,4 +1,9 @@
-from spy.tests.support import CompilerTest
+import os
+
+import pytest
+
+from spy.errors import SPyError
+from spy.tests.support import CompilerTest, skip_backends
 
 
 class TestPosix(CompilerTest):
@@ -18,3 +23,96 @@ class TestPosix(CompilerTest):
         # When running in pytest without a terminal, we get fallback values
         assert columns >= 80
         assert lines >= 24
+
+    @skip_backends("C", reason="WASI sandbox cannot access host filesystem paths")
+    def test_open_read(self, tmp_path):
+        fpath = tmp_path / "hello.txt"
+        fpath.write_text("hello world", encoding="utf-8")
+        mod = self.compile("""
+        from posix import open, read, close, O_RDONLY
+
+        def read_file(path: str, n: i32) -> str:
+            fd: i32 = open(path, O_RDONLY)
+            result: str = read(fd, n)
+            close(fd)
+            return result
+        """)
+        assert mod.read_file(str(fpath), 11) == "hello world"
+        # Requesting fewer bytes than available
+        assert mod.read_file(str(fpath), 5) == "hello"
+
+    @skip_backends("C", reason="WASI sandbox cannot access host filesystem paths")
+    def test_open_write(self, tmp_path):
+        fpath = tmp_path / "out.txt"
+        mod = self.compile("""
+        from posix import open, write, close, O_WRONLY, O_CREAT, O_TRUNC
+
+        def write_file(path: str, data: str) -> i32:
+            fd: i32 = open(path, O_WRONLY | O_CREAT | O_TRUNC)
+            n: i32 = write(fd, data)
+            close(fd)
+            return n
+        """)
+        n = mod.write_file(str(fpath), "spy rocks")
+        assert n == 9
+        assert fpath.read_text(encoding="utf-8") == "spy rocks"
+
+    def test_o_flags_constants(self):
+        mod = self.compile("""
+        from posix import O_RDONLY, O_WRONLY, O_RDWR, O_CREAT, O_TRUNC, O_APPEND, O_EXCL
+
+        def get_rdonly() -> i32: return O_RDONLY
+        def get_wronly() -> i32: return O_WRONLY
+        def get_rdwr()   -> i32: return O_RDWR
+        def get_creat()  -> i32: return O_CREAT
+        def get_trunc()  -> i32: return O_TRUNC
+        def get_append() -> i32: return O_APPEND
+        def get_excl()   -> i32: return O_EXCL
+        """)
+        assert mod.get_rdonly() == os.O_RDONLY
+        assert mod.get_wronly() == os.O_WRONLY
+        assert mod.get_rdwr() == os.O_RDWR
+        assert mod.get_creat() == os.O_CREAT
+        assert mod.get_trunc() == os.O_TRUNC
+        assert mod.get_append() == os.O_APPEND
+        assert mod.get_excl() == os.O_EXCL
+
+    def test_open_nonexistent(self, tmp_path):
+        mod = self.compile("""
+        from posix import open, O_RDONLY
+
+        def foo(path: str) -> i32:
+            return open(path, O_RDONLY)
+        """)
+        with SPyError.raises("W_ValueError", match="No such file or directory"):
+            mod.foo(str(tmp_path / "nonexistent.txt"))
+
+    def test_read_invalid_fd(self):
+        mod = self.compile("""
+        from posix import read
+
+        def foo() -> str:
+            return read(-1, 64)
+        """)
+        with SPyError.raises("W_ValueError", match="Bad file descriptor"):
+            mod.foo()
+
+    def test_write_invalid_fd(self):
+        mod = self.compile("""
+        from posix import write
+
+        def foo() -> i32:
+            return write(-1, "data")
+        """)
+        with SPyError.raises("W_ValueError", match="Bad file descriptor"):
+            mod.foo()
+
+    def test_close_invalid_fd(self):
+        mod = self.compile("""
+        from posix import close
+
+        def foo() -> None:
+            close(-1)
+        """)
+        with SPyError.raises("W_ValueError", match="Bad file descriptor"):
+            mod.foo()

--- a/spy/tests/compiler/test_posix.py
+++ b/spy/tests/compiler/test_posix.py
@@ -1,7 +1,5 @@
 import os
 
-import pytest
-
 from spy.errors import SPyError
 from spy.tests.support import CompilerTest, skip_backends
 
@@ -84,7 +82,7 @@ class TestPosix(CompilerTest):
         def foo(path: str) -> i32:
             return open(path, O_RDONLY)
         """)
-        with SPyError.raises("W_ValueError", match="No such file or directory"):
+        with SPyError.raises("W_OSError", match="No such file or directory"):
             mod.foo(str(tmp_path / "nonexistent.txt"))
 
     def test_read_invalid_fd(self):
@@ -94,7 +92,7 @@ class TestPosix(CompilerTest):
         def foo() -> str:
             return read(-1, 64)
         """)
-        with SPyError.raises("W_ValueError", match="Bad file descriptor"):
+        with SPyError.raises("W_OSError", match="Bad file descriptor"):
             mod.foo()
 
     def test_write_invalid_fd(self):
@@ -104,7 +102,7 @@ class TestPosix(CompilerTest):
         def foo() -> i32:
             return write(-1, "data")
         """)
-        with SPyError.raises("W_ValueError", match="Bad file descriptor"):
+        with SPyError.raises("W_OSError", match="Bad file descriptor"):
             mod.foo()
 
     def test_close_invalid_fd(self):
@@ -114,5 +112,5 @@ class TestPosix(CompilerTest):
         def foo() -> None:
             close(-1)
         """)
-        with SPyError.raises("W_ValueError", match="Bad file descriptor"):
+        with SPyError.raises("W_OSError", match="Bad file descriptor"):
             mod.foo()

--- a/spy/tests/stdlib/test__io.py
+++ b/spy/tests/stdlib/test__io.py
@@ -83,3 +83,19 @@ class TestIO(CompilerTest):
         """)
         with SPyError.raises("W_ValueError", match="invalid mode"):
             mod.open_file(str(fpath))
+
+
+@skip_backends("C", reason="WASI sandbox cannot access host filesystem paths")
+class TestOpen(CompilerTest):
+    def test_read(self, tmp_path):
+        fpath = tmp_path / "hello.txt"
+        fpath.write_text("hello world", encoding="utf-8")
+        mod = self.compile("""
+        def read_file(path: str, n: i32) -> str:
+            f = open(path, "r")
+            result: str = f.read(n)
+            f.close()
+            return result
+        """)
+        assert mod.read_file(str(fpath), 11) == "hello world"
+        assert mod.read_file(str(fpath), 5) == "hello"

--- a/spy/tests/stdlib/test__io.py
+++ b/spy/tests/stdlib/test__io.py
@@ -1,0 +1,85 @@
+from spy.errors import SPyError
+from spy.tests.support import CompilerTest, skip_backends
+
+
+@skip_backends("C", reason="WASI sandbox cannot access host filesystem paths")
+class TestIO(CompilerTest):
+    def test_read(self, tmp_path):
+        fpath = tmp_path / "hello.txt"
+        fpath.write_text("hello world", encoding="utf-8")
+        mod = self.compile("""
+        from _io import FileIO
+
+        def read_file(path: str, n: i32) -> str:
+            f = FileIO(path, "r")
+            result: str = f.read(n)
+            f.close()
+            return result
+        """)
+        assert mod.read_file(str(fpath), 11) == "hello world"
+        assert mod.read_file(str(fpath), 5) == "hello"
+
+    def test_write(self, tmp_path):
+        fpath = tmp_path / "out.txt"
+        mod = self.compile("""
+        from _io import FileIO
+
+        def write_file(path: str, data: str) -> i32:
+            f = FileIO(path, "w")
+            n: i32 = f.write(data)
+            f.close()
+            return n
+        """)
+        n = mod.write_file(str(fpath), "spy rocks")
+        assert n == 9
+        assert fpath.read_text(encoding="utf-8") == "spy rocks"
+
+    def test_write_truncates(self, tmp_path):
+        fpath = tmp_path / "out.txt"
+        fpath.write_text("old content here", encoding="utf-8")
+        mod = self.compile("""
+        from _io import FileIO
+
+        def write_file(path: str, data: str) -> None:
+            f = FileIO(path, "w")
+            f.write(data)
+            f.close()
+        """)
+        mod.write_file(str(fpath), "new")
+        assert fpath.read_text(encoding="utf-8") == "new"
+
+    def test_append(self, tmp_path):
+        fpath = tmp_path / "out.txt"
+        fpath.write_text("hello ", encoding="utf-8")
+        mod = self.compile("""
+        from _io import FileIO
+
+        def append_file(path: str, data: str) -> None:
+            f = FileIO(path, "a")
+            f.write(data)
+            f.close()
+        """)
+        mod.append_file(str(fpath), "world")
+        assert fpath.read_text(encoding="utf-8") == "hello world"
+
+    def test_open_nonexistent(self, tmp_path):
+        mod = self.compile("""
+        from _io import FileIO
+
+        def open_file(path: str) -> FileIO:
+            return FileIO(path, "r")
+        """)
+        with SPyError.raises("W_OSError", match="No such file or directory"):
+            mod.open_file(str(tmp_path / "nonexistent.txt"))
+
+    def test_invalid_mode(self, tmp_path):
+        fpath = tmp_path / "f.txt"
+        fpath.write_text("x", encoding="utf-8")
+        mod = self.compile("""
+        from _io import FileIO
+
+        def open_file(path: str) -> FileIO:
+            return FileIO(path, "x")
+        """)
+        with SPyError.raises("W_ValueError", match="invalid mode"):
+            mod.open_file(str(fpath))

--- a/spy/vm/exc.py
+++ b/spy/vm/exc.py
@@ -321,6 +321,11 @@ class W_KeyError(W_Exception):
     pass
 
 
+@BUILTINS.builtin_type("OSError")
+class W_OSError(W_Exception):
+    pass
+
+
 @BUILTINS.builtin_type("WIP")
 class W_WIP(W_Exception):
     """

--- a/spy/vm/modules/posix.py
+++ b/spy/vm/modules/posix.py
@@ -72,7 +72,7 @@ def w_open(vm: "SPyVM", w_path: W_Str, w_flags: W_I32) -> W_I32:
     try:
         fd = os.open(path, flags)
     except OSError as e:
-        raise SPyError("W_ValueError", e.strerror)
+        raise SPyError("W_OSError", e.strerror)
     return W_I32(fd)
 
 
@@ -85,7 +85,7 @@ def w_read(vm: "SPyVM", w_fd: W_I32, w_count: W_I32) -> W_Str:
     try:
         data = os.read(fd, count)
     except OSError as e:
-        raise SPyError("W_ValueError", e.strerror)
+        raise SPyError("W_OSError", e.strerror)
     return W_Str(vm, data.decode("utf-8"))
 
 
@@ -98,7 +98,7 @@ def w_write(vm: "SPyVM", w_fd: W_I32, w_data: W_Str) -> W_I32:
     try:
         n = os.write(fd, data)
     except OSError as e:
-        raise SPyError("W_ValueError", e.strerror)
+        raise SPyError("W_OSError", e.strerror)
     return W_I32(n)
 
 
@@ -110,4 +110,4 @@ def w_close(vm: "SPyVM", w_fd: W_I32) -> None:
     try:
         os.close(fd)
     except OSError as e:
-        raise SPyError("W_ValueError", e.strerror)
+        raise SPyError("W_OSError", e.strerror)

--- a/spy/vm/modules/posix.py
+++ b/spy/vm/modules/posix.py
@@ -4,9 +4,11 @@ SPy `posix` module.
 
 from typing import TYPE_CHECKING, Annotated
 
+from spy.errors import SPyError
 from spy.vm.b import B
 from spy.vm.primitive import W_I32
 from spy.vm.registry import ModuleRegistry
+from spy.vm.str import W_Str
 from spy.vm.struct import W_Struct
 
 if TYPE_CHECKING:
@@ -27,6 +29,25 @@ POSIX.struct_type(
 W_TerminalSize = Annotated[W_Struct, POSIX.w_TerminalSize]
 
 
+@POSIX.builtin_func("__INIT__", color="blue")
+def w_INIT(vm: "SPyVM") -> None:
+    import os
+
+    w_mod = vm.modules_w["posix"]
+    # Expose the most common O_* flags as module-level constants
+    for name in (
+        "O_RDONLY",
+        "O_WRONLY",
+        "O_RDWR",
+        "O_APPEND",
+        "O_CREAT",
+        "O_TRUNC",
+        "O_EXCL",
+    ):
+        if hasattr(os, name):
+            w_mod.setattr(name, W_I32(getattr(os, name)))
+
+
 @POSIX.builtin_func
 def w_get_terminal_size(vm: "SPyVM") -> W_TerminalSize:
     import os
@@ -40,3 +61,53 @@ def w_get_terminal_size(vm: "SPyVM") -> W_TerminalSize:
     w_st = W_Struct(POSIX.w_TerminalSize)
     w_st.values_w = {"columns": W_I32(columns), "lines": W_I32(lines)}
     return w_st
+
+
+@POSIX.builtin_func
+def w_open(vm: "SPyVM", w_path: W_Str, w_flags: W_I32) -> W_I32:
+    import os
+
+    path = vm.unwrap_str(w_path)
+    flags = w_flags.value
+    try:
+        fd = os.open(path, flags)
+    except OSError as e:
+        raise SPyError("W_ValueError", e.strerror)
+    return W_I32(fd)
+
+
+@POSIX.builtin_func
+def w_read(vm: "SPyVM", w_fd: W_I32, w_count: W_I32) -> W_Str:
+    import os
+
+    fd = w_fd.value
+    count = w_count.value
+    try:
+        data = os.read(fd, count)
+    except OSError as e:
+        raise SPyError("W_ValueError", e.strerror)
+    return W_Str(vm, data.decode("utf-8"))
+
+
+@POSIX.builtin_func
+def w_write(vm: "SPyVM", w_fd: W_I32, w_data: W_Str) -> W_I32:
+    import os
+
+    fd = w_fd.value
+    data = vm.unwrap_str(w_data).encode("utf-8")
+    try:
+        n = os.write(fd, data)
+    except OSError as e:
+        raise SPyError("W_ValueError", e.strerror)
+    return W_I32(n)
+
+
+@POSIX.builtin_func
+def w_close(vm: "SPyVM", w_fd: W_I32) -> None:
+    import os
+
+    fd = w_fd.value
+    try:
+        os.close(fd)
+    except OSError as e:
+        raise SPyError("W_ValueError", e.strerror)

--- a/spy/vm/modules/posix.py
+++ b/spy/vm/modules/posix.py
@@ -72,7 +72,7 @@ def w_open(vm: "SPyVM", w_path: W_Str, w_flags: W_I32) -> W_I32:
     try:
         fd = os.open(path, flags)
     except OSError as e:
-        raise SPyError("W_OSError", e.strerror)
+        raise SPyError("W_OSError", e.strerror or "unknown error")
     return W_I32(fd)
 
 
@@ -85,7 +85,7 @@ def w_read(vm: "SPyVM", w_fd: W_I32, w_count: W_I32) -> W_Str:
     try:
         data = os.read(fd, count)
     except OSError as e:
-        raise SPyError("W_OSError", e.strerror)
+        raise SPyError("W_OSError", e.strerror or "unknown error")
     return W_Str(vm, data.decode("utf-8"))
 
 
@@ -98,7 +98,7 @@ def w_write(vm: "SPyVM", w_fd: W_I32, w_data: W_Str) -> W_I32:
     try:
         n = os.write(fd, data)
     except OSError as e:
-        raise SPyError("W_OSError", e.strerror)
+        raise SPyError("W_OSError", e.strerror or "unknown error")
     return W_I32(n)
 
 
@@ -110,4 +110,4 @@ def w_close(vm: "SPyVM", w_fd: W_I32) -> None:
     try:
         os.close(fd)
     except OSError as e:
-        raise SPyError("W_OSError", e.strerror)
+        raise SPyError("W_OSError", e.strerror or "unknown error")

--- a/stdlib/_io.spy
+++ b/stdlib/_io.spy
@@ -1,0 +1,52 @@
+"""
+SPy `_io` module.
+
+Provides a `FileIO` type for basic UTF-8 file I/O built on top of the
+low-level posix syscalls.  Only UTF-8 encoding is supported for now, since
+that is what SPy's `str` type uses internally.
+
+Supported modes (same meanings as Python's built-in open()):
+  "r"  - read-only (default)
+  "w"  - write, truncate
+  "a"  - write, append
+"""
+
+import posix
+
+from posix import O_RDONLY, O_WRONLY, O_CREAT, O_TRUNC, O_APPEND
+from unsafe import gc_alloc, gc_ptr
+
+
+@struct
+class _FileData:
+    fd: i32
+
+
+@struct
+class FileIO:
+    __ll__: gc_ptr[_FileData]
+
+    def __new__(path: str, mode: str) -> FileIO:
+        flags: i32 = 0
+        if mode == "r":
+            flags = O_RDONLY
+        elif mode == "w":
+            flags = O_WRONLY | O_CREAT | O_TRUNC
+        elif mode == "a":
+            flags = O_WRONLY | O_CREAT | O_APPEND
+        else:
+            raise ValueError("invalid mode")
+
+        fd: i32 = posix.open(path, flags)
+        data = gc_alloc[_FileData](1)
+        data.fd = fd
+        return FileIO.__make__(data)
+
+    def read(self, count: i32) -> str:
+        return posix.read(self.__ll__.fd, count)
+
+    def write(self, data: str) -> i32:
+        return posix.write(self.__ll__.fd, data)
+
+    def close(self) -> None:
+        posix.close(self.__ll__.fd)

--- a/stdlib/_io.spy
+++ b/stdlib/_io.spy
@@ -14,17 +14,11 @@ Supported modes (same meanings as Python's built-in open()):
 import posix
 
 from posix import O_RDONLY, O_WRONLY, O_CREAT, O_TRUNC, O_APPEND
-from unsafe import gc_alloc, gc_ptr
-
-
-@struct
-class _FileData:
-    fd: i32
 
 
 @struct
 class FileIO:
-    __ll__: gc_ptr[_FileData]
+    fd: i32
 
     def __new__(path: str, mode: str) -> FileIO:
         flags: i32 = 0
@@ -38,18 +32,16 @@ class FileIO:
             raise ValueError("invalid mode")
 
         fd: i32 = posix.open(path, flags)
-        data = gc_alloc[_FileData](1)
-        data.fd = fd
-        return FileIO.__make__(data)
+        return FileIO.__make__(fd)
 
     def read(self, count: i32) -> str:
-        return posix.read(self.__ll__.fd, count)
+        return posix.read(self.fd, count)
 
     def write(self, data: str) -> i32:
-        return posix.write(self.__ll__.fd, data)
+        return posix.write(self.fd, data)
 
     def close(self) -> None:
-        posix.close(self.__ll__.fd)
+        posix.close(self.fd)
 
 
 def open(file: str, mode: str) -> FileIO:

--- a/stdlib/_io.spy
+++ b/stdlib/_io.spy
@@ -50,3 +50,8 @@ class FileIO:
 
     def close(self) -> None:
         posix.close(self.__ll__.fd)
+
+
+def open(file: str, mode: str) -> FileIO:
+    """Open file and return a `_io.FileIO`.  Raise OSError upon failure."""
+    return FileIO(file, mode)


### PR DESCRIPTION
- Fixes #355
- Fixes #356
- ~~Fixes~~ related to #357 
- ~~Fixes~~ related to #354

I was helped by Claude, which in particular wrote the C code! It seems reasonable but I'm quite unable to judge if it is really correct.

The most important tests (`test_open_read` and `test_open_write`) raises an error for the C backend.

```
>               raise SPyError.simple(etype, message, "", loc)
E               spy.errors.SPyError: Traceback (most recent call last):
E               
E               ValueError: No such file or directory
E                 | /home/pierre/dev/spy/spy/libspy/include/spy/posix.h:51
E                 |         spy_panic("ValueError", strerror(errno), __FILE__, __LINE__);
E                 |  |__________________________________________________________________|
```

Claude told me that it is due to the WASI sandbox and that the test can be skipped with

```
@skip_backends("C", reason="WASI sandbox cannot access host filesystem paths")
```

Nevertheless a good news is that this works fine:

```
cd examples
spy build io_low_level.spy
./build/io_low_level
```