### PR TITLE
parser: simple implementation of PEP 695 for functions

### DIFF
--- a/spy/parser.py
+++ b/spy/parser.py
@@ -165,6 +165,8 @@ class Parser:
     def from_py_stmt_FunctionDef(
         self, py_funcdef: py_ast.FunctionDef
     ) -> spy.ast.FuncDef:
+        if py_funcdef.type_params:
+            return self.desugar_pep695_FunctionDef(py_funcdef)
         color: spy.ast.Color = "red"
         func_kind: spy.ast.FuncKind = "plain"
         decorators: list[spy.ast.Expr] = []
@@ -227,6 +229,95 @@ class Parser:
             body=body,
             docstring=docstring,
             decorators=decorators,
+        )
+
+    def desugar_pep695_FunctionDef(
+        self, py_funcdef: py_ast.FunctionDef
+    ) -> spy.ast.FuncDef:
+        """
+        Desugar PEP 695 generic function syntax into the equivalent @blue form.
+
+        This transforms:
+            def my_func[T](a0: T, a1: T) -> T:
+                return a0 + a1
+
+        Into the SPy AST equivalent of:
+            @blue.generic
+            def my_func(T):
+                def _my_func(a0: T, a1: T) -> T:
+                    return a0 + a1
+                return _my_func
+        """
+        loc = py_funcdef.loc
+        inner_name = f"_{py_funcdef.name}"
+
+        # Build one outer FuncArg per type_param (all unannotated, i.e. Auto).
+        # Only py_ast.TypeVar is supported for now; ParamSpec / TypeVarTuple
+        # are rejected with a clear error.
+        outer_args: list[spy.ast.FuncArg] = []
+        for tp in py_funcdef.type_params:
+            if not isinstance(tp, py_ast.TypeVar):
+                self.unsupported(tp, "only TypeVar type parameters are supported")
+            outer_args.append(
+                spy.ast.FuncArg(
+                    loc=tp.loc,
+                    name=tp.name,
+                    type=spy.ast.Auto(tp.loc),
+                    kind="simple",
+                )
+            )
+
+        # Build the inner (red) function, identical to what was written but
+        # without type_params (those became the outer args).
+        inner_args = self.from_py_arguments("red", py_funcdef.args)
+        py_returns = py_funcdef.returns
+        if py_returns:
+            inner_return_type = self.from_py_expr(py_returns)
+        else:
+            if inner_args:
+                l = inner_args[-1].loc
+                retloc = l.replace(col_end=-1)
+            else:
+                retloc = loc.replace(line_end=loc.line_start, col_end=-1)
+            inner_return_type = spy.ast.Auto(retloc)
+
+        docstring, py_body = self.get_docstring_maybe(py_funcdef.body)
+        saved_seq = self.for_loop_seq
+        inner_body = self.from_py_body(py_body)
+        self.for_loop_seq = saved_seq
+
+        inner_funcdef = spy.ast.FuncDef(
+            loc=loc,
+            color="red",
+            kind="plain",
+            name=inner_name,
+            args=inner_args,
+            return_type=inner_return_type,
+            body=inner_body,
+            docstring=docstring,
+            decorators=[],
+        )
+
+        # The outer (blue) function body: define the inner function then
+        # return it.
+        return_inner = spy.ast.Return(
+            loc=loc,
+            value=spy.ast.Name(loc, inner_name),
+        )
+        outer_body: list[spy.ast.Stmt] = [inner_funcdef, return_inner]
+
+        outer_return_type = spy.ast.Auto(loc)
+
+        return spy.ast.FuncDef(
+            loc=loc,
+            color="blue",
+            kind="generic",
+            name=py_funcdef.name,
+            args=outer_args,
+            return_type=outer_return_type,
+            body=outer_body,
+            docstring=None,
+            decorators=[],
         )
 
     def from_py_arguments(

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -369,6 +369,132 @@ class TestParser:
         """
         self.assert_dump(funcdef, expected)
 
+    def test_pep695_single_typevar(self):
+        """
+        PEP 695 syntax `def f[T](...)` is desugared into the @blue.generic wrapper
+        pattern at parse time.
+        """
+        mod = self.parse("""
+        def my_func[T](a0: T, a1: T) -> T:
+            return a0 + a1
+        """)
+        funcdef = mod.get_funcdef("my_func")
+        expected = """
+        FuncDef(
+            color='blue',
+            kind='generic',
+            name='my_func',
+            args=[
+                FuncArg(
+                    name='T',
+                    type=Auto(),
+                    kind='simple',
+                ),
+            ],
+            return_type=Auto(),
+            docstring=None,
+            body=[
+                FuncDef(
+                    color='red',
+                    kind='plain',
+                    name='_my_func',
+                    args=[
+                        FuncArg(
+                            name='a0',
+                            type=Name(id='T'),
+                            kind='simple',
+                        ),
+                        FuncArg(
+                            name='a1',
+                            type=Name(id='T'),
+                            kind='simple',
+                        ),
+                    ],
+                    return_type=Name(id='T'),
+                    docstring=None,
+                    body=[
+                        Return(
+                            value=BinOp(
+                                op='+',
+                                left=Name(id='a0'),
+                                right=Name(id='a1'),
+                            ),
+                        ),
+                    ],
+                    decorators=[],
+                ),
+                Return(
+                    value=Name(id='_my_func'),
+                ),
+            ],
+            decorators=[],
+        )
+        """
+        self.assert_dump(funcdef, expected)
+
+    def test_pep695_multiple_typevars(self):
+        """
+        Multiple type parameters each become an arg of the outer blue function.
+        """
+        mod = self.parse("""
+        def my_func[T, U](a: T, b: U) -> T:
+            return a
+        """)
+        funcdef = mod.get_funcdef("my_func")
+        expected = """
+        FuncDef(
+            color='blue',
+            kind='generic',
+            name='my_func',
+            args=[
+                FuncArg(
+                    name='T',
+                    type=Auto(),
+                    kind='simple',
+                ),
+                FuncArg(
+                    name='U',
+                    type=Auto(),
+                    kind='simple',
+                ),
+            ],
+            return_type=Auto(),
+            docstring=None,
+            body=[
+                FuncDef(
+                    color='red',
+                    kind='plain',
+                    name='_my_func',
+                    args=[
+                        FuncArg(
+                            name='a',
+                            type=Name(id='T'),
+                            kind='simple',
+                        ),
+                        FuncArg(
+                            name='b',
+                            type=Name(id='U'),
+                            kind='simple',
+                        ),
+                    ],
+                    return_type=Name(id='T'),
+                    docstring=None,
+                    body=[
+                        Return(
+                            value=Name(id='a'),
+                        ),
+                    ],
+                    decorators=[],
+                ),
+                Return(
+                    value=Name(id='_my_func'),
+                ),
+            ],
+            decorators=[],
+        )
+        """
+        self.assert_dump(funcdef, expected)
+
     def test_FuncDef_prototype_loc(self):
         # blue functions without return type, are parsed as if they had a
         # synthetic '-> dynamic' annotation. We also need to generate a


### PR DESCRIPTION
Related to #417

With it, this works

```
def my_func[T](a0: T, a1: T) -> T:
    return a0 + a1

def main() -> None:
    print(my_func[i32](2, 2))
```

This is nice, but I don't think it is the proper long term solution. For example, it's bad that `spy parse` gives something quite different from the code.