### PR TITLE
Fix file descriptor leak during tests

### DIFF
--- a/spy/llwasm/base.py
+++ b/spy/llwasm/base.py
@@ -1,4 +1,5 @@
 import struct
+import weakref
 from typing import Any, Literal, Self
 
 import py.path
@@ -13,7 +14,22 @@ class HostModule:
     Each host module can provide one or more WASM import, used by link().
     """
 
-    ll: "LLWasmInstanceBase"  # this attribute is set by LLWasmInstance.__init__
+    # Use a weakref to avoid a reference cycle: LLWasmInstance sets
+    # hostmod.ll = self (see wasmtime.py), creating a cycle
+    # LLWasmInstance.libspy -> HostModule.ll -> LLWasmInstance.  Because
+    # wasmtime.Store is a C extension with __del__, the cyclic GC cannot
+    # break the cycle, so the Store (and its preopen_dir fd) would leak.
+    _ll_ref: "weakref.ref[LLWasmInstanceBase]"
+
+    @property
+    def ll(self) -> "LLWasmInstanceBase":
+        ll = self._ll_ref()
+        assert ll is not None
+        return ll
+
+    @ll.setter
+    def ll(self, value: "LLWasmInstanceBase") -> None:
+        self._ll_ref = weakref.ref(value)
 
 
 class LLWasmModuleBase:

--- a/spy/tests/support.py
+++ b/spy/tests/support.py
@@ -124,6 +124,14 @@ class CompilerTest:
         self.vm = SPyVM()
         self.vm.path.append(str(self.tmpdir))
 
+        # pytest keeps CompilerTest instances alive for the whole session, meaning that
+        # tmpdir and vm are collected only at the end of the process. This causes many
+        # problems, including a fd leak because each SPyVM opens a fd (to map '/' to '/'
+        # in wasmtime).  The following make sure to release them early.
+        yield
+        self.tmpdir = None
+        self.vm = None  # type: ignore
+
     def write_file(self, filename: str, src: str) -> Any:
         """
         Write the give source code to the specified filename, in the tmpdir.


### PR DESCRIPTION
This was introduced by PR 438.

There were two problems:

  1. CompilerTest.vm was never freed because pytest keeps the instances alive. Set it to None explicitly to collect it.

  2. even if SPyVM is collected, wt.Store is never closed. The problem
     is that HostModule.ll created a reference cycle (LLWasmInstance ->
     LibSPyHost -> LLWasmInstance) that prevented cyclic GC from collecting
     wt.Store (C extension with __del__), leaking one "/" FD per
     SPyVM instance. Fix by making HostModule.ll a weakref property.
