### PR TITLE
add the script name to the argv list to match Python behavior

### DIFF
--- a/spy/cli/commands/execute.py
+++ b/spy/cli/commands/execute.py
@@ -23,5 +23,5 @@ async def execute(args: Execute_Args) -> None:
     importer.import_all()
     w_mod = vm.modules_w[modname]
 
-    argv: list[str] = args.argv or []
+    argv: list[str] = [str(args.filename)] + (args.argv or [])
     execute_spy_main(vm, w_mod, argv, redshift=False, _timeit=args.timeit)

--- a/spy/cli/commands/redshift.py
+++ b/spy/cli/commands/redshift.py
@@ -81,7 +81,7 @@ async def redshift(args: Redshift_Args) -> None:
 
     if args.execute:
         w_mod = vm.modules_w[modname]
-        argv = args.argv or []
+        argv = [str(args.filename)] + (args.argv or [])
         execute_spy_main(vm, w_mod, argv, redshift=True, _timeit=args.timeit)
     else:
         all_files = [args.filename] + extra_files

--- a/spy/tests/test_cli.py
+++ b/spy/tests/test_cli.py
@@ -372,7 +372,7 @@ class TestMain:
         res = self.runner.invoke(app, [str(f), "aaa", "bbb", "ccc"])
         assert res.exit_code == 0
         output = decolorize(res.output)
-        assert output.split() == ["aaa", "bbb", "ccc"]
+        assert output.split() == [str(f), "aaa", "bbb", "ccc"]
 
     def test_redshift_argv(self):
         src = """
@@ -384,7 +384,7 @@ class TestMain:
         res = self.runner.invoke(app, ["redshift", "-x", str(f), "aaa", "bbb", "ccc"])
         assert res.exit_code == 0
         output = decolorize(res.output)
-        assert output.split() == ["aaa", "bbb", "ccc"]
+        assert output.split() == [str(f), "aaa", "bbb", "ccc"]
 
     def test_main_wrong_param_type(self):
         src = """


### PR DESCRIPTION
Fixes issue #443 so that the argv list matches the same convention used by Python.