### PR TITLE
Generic types (syntactic sugar for blue.generic)

### DIFF
--- a/examples/myarray.spy
+++ b/examples/myarray.spy
@@ -2,83 +2,91 @@
 This is one of the most advanced examples of SPy so far.
 
 It implements the basics of a generic array type
+
+Note that struct are passed by values (i.e. copied).
 """
 
-from operator import OpSpec, MetaArg
 from unsafe import gc_alloc, gc_ptr
 
+
+@struct
+class ArrayData[DTYPE]:
+    length: i32
+    capacity: i32
+    items: gc_ptr[DTYPE]
+
+
+"""
+This generic class is just syntactic sugar for
 
 @blue.generic
 def ArrayData(DTYPE):
     @struct
-    class _ArrayData:
+    class Self:
         length: i32
         capacity: i32
         items: gc_ptr[DTYPE]
 
-    return _ArrayData
+    return Self
+
+Note that the name of the concrete type is always "Self".
+"""
 
 
-@blue
-def ndarray1(DTYPE):
-    """
-    Currently generics are implemented using blue functions taking a
-    type. Eventually we will support a syntax like `ndarray[i32]`, which will
-    be equivalent to this.
-    """
+@struct
+class Array1d[DTYPE]:
+    # This struct only contains a low level ("__ll__") pointer towards the data leaving on the heap (allocated)
+    __ll__: gc_ptr[ArrayData[DTYPE]]
 
-    @struct
-    class ndarray:
-        __ll__: gc_ptr[ArrayData[DTYPE]]
+    # note: here, Self corresponds to the concrete type Array1d[DTYPE].
 
-        def __new__(length: i32) -> ndarray:
-            data = gc_alloc[ArrayData[DTYPE]](1)
-            data.length = length
-            data.capacity = length
-            data.items = gc_alloc[DTYPE](length)
+    def __new__(length: i32) -> Self:
+        # a pointer towards the array data
+        ll = gc_alloc[ArrayData[DTYPE]](1)
+        ll.length = length
+        ll.capacity = length
+        ll.items = gc_alloc[DTYPE](length)
+        i = 0
+        while i < length:
+            ll.items[i] = 0
+            i = i + 1
+        return Self.__make__(ll)
+
+    def append(self, value: DTYPE) -> None:
+        ll = self.__ll__
+        if ll.length >= ll.capacity:
+            # resize needed - double the capacity
+            new_capacity = ll.capacity * 2
+            if new_capacity == 0:
+                new_capacity = 1
+            new_items = gc_alloc[DTYPE](new_capacity)
+            # copy existing items
             i = 0
-            while i < length:
-                data.items[i] = 0
+            while i < ll.length:
+                new_items[i] = ll.items[i]
                 i = i + 1
-            return ndarray.__make__(data)
+            ll.items = new_items
+            ll.capacity = new_capacity
 
-        def append(self, value: DTYPE) -> None:
-            ll = self.__ll__
-            if ll.length >= ll.capacity:
-                # resize needed - double the capacity
-                new_capacity = ll.capacity * 2
-                if new_capacity == 0:
-                    new_capacity = 1
-                new_items = gc_alloc[DTYPE](new_capacity)
-                # copy existing items
-                i = 0
-                while i < ll.length:
-                    new_items[i] = ll.items[i]
-                    i = i + 1
-                ll.items = new_items
-                ll.capacity = new_capacity
+        ll.items[ll.length] = value
+        ll.length = ll.length + 1
 
-            ll.items[ll.length] = value
-            ll.length = ll.length + 1
+    def __getitem__(self, i: i32) -> DTYPE:
+        ll = self.__ll__
+        if i >= ll.length:
+            raise IndexError
+        return ll.items[i]
 
-        def __getitem__(self, i: i32) -> DTYPE:
-            ll = self.__ll__
-            if i >= ll.length:
-                raise IndexError
-            return ll.items[i]
-
-        def __setitem__(self, i: i32, v: DTYPE) -> None:
-            ll = self.__ll__
-            if i >= ll.length:
-                raise IndexError
-            ll.items[i] = v
-
-    return ndarray
+    def __setitem__(self, i: i32, v: DTYPE) -> None:
+        ll = self.__ll__
+        if i >= ll.length:
+            raise IndexError
+        ll.items[i] = v
 
 
 def main() -> None:
-    a_floats = ndarray1(f64)(10)
-    a_ints = ndarray1(i32)(4)
+    a_floats = Array1d[f64](10)
+    a_ints = Array1d[i32](4)
     a_ints[0] = 1
     a_ints[1] = 2
     a_ints[2] = 3

--- a/examples/myarray.spy
+++ b/examples/myarray.spy
@@ -35,7 +35,7 @@ Note that the name of the concrete type is always "Self".
 
 @struct
 class Array1d[DTYPE]:
-    # This struct only contains a low level ("__ll__") pointer towards the data leaving on the heap (allocated)
+    # this struct is a thin zero-cost wrapper around the "__ll__" pointer. The actual data is heap-allocated.
     __ll__: gc_ptr[ArrayData[DTYPE]]
 
     # note: here, Self corresponds to the concrete type Array1d[DTYPE].

--- a/spy/analyze/importing.py
+++ b/spy/analyze/importing.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 MODULE = Union[ast.Module, "W_Module", None]
 
 # Cache version: increment this when ast.Module or SymTable structure changes
-SPYC_VERSION = 3
+SPYC_VERSION = 4
 
 
 @dataclass

--- a/spy/analyze/scope.py
+++ b/spy/analyze/scope.py
@@ -366,13 +366,13 @@ class ScopeAnalyzer:
         loc = gclassdef.inner.loc
         self.define_name(gclassdef.name, "const", "funcdef", loc, loc)
 
-        # outer scope: blue, contains only the generic args (T, ...) and __Impl
+        # outer scope: blue, contains only the generic args (T, ...) and Self
         inner_scope = self.new_SymTable(gclassdef.name, "blue", "function")
         self.push_scope(inner_scope)
         self.inner_scopes[gclassdef] = inner_scope
         for arg in gclassdef.args:
             self.define_name(arg.name, "const", "blue-param", arg.loc, arg.type.loc)
-        self.define_name("__Impl", "const", "classdef", loc, loc)
+        self.define_name("Self", "const", "classdef", loc, loc)
         self.define_name("@return", "var", "auto", loc, loc)
         self.declare(gclassdef.inner)
         self.pop_scope()

--- a/spy/analyze/scope.py
+++ b/spy/analyze/scope.py
@@ -53,7 +53,9 @@ class ScopeAnalyzer:
 
     mod: ast.Module
     stack: list[SymTable]
-    inner_scopes: dict[ast.FuncDef | ast.GenericFuncDef | ast.ClassDef, SymTable]
+    inner_scopes: dict[
+        ast.FuncDef | ast.GenericFuncDef | ast.ClassDef | ast.GenericClassDef, SymTable
+    ]
     loop_depth: int
 
     def __init__(self, modname: str, mod: ast.Module) -> None:
@@ -91,6 +93,9 @@ class ScopeAnalyzer:
 
     def by_classdef(self, classdef: ast.ClassDef) -> SymTable:
         return self.inner_scopes[classdef]
+
+    def by_generic_classdef(self, gclassdef: ast.GenericClassDef) -> SymTable:
+        return self.inner_scopes[gclassdef]
 
     def pp(self) -> None:
         print("Implicit imports:")
@@ -356,6 +361,22 @@ class ScopeAnalyzer:
             self.declare(stmt)
         self.pop_scope()
 
+    def declare_GenericClassDef(self, gclassdef: ast.GenericClassDef) -> None:
+        # declare the name in the outer scope, just like declare_FuncDef does
+        loc = gclassdef.inner.loc
+        self.define_name(gclassdef.name, "const", "funcdef", loc, loc)
+
+        # outer scope: blue, contains only the generic args (T, ...) and __Impl
+        inner_scope = self.new_SymTable(gclassdef.name, "blue", "function")
+        self.push_scope(inner_scope)
+        self.inner_scopes[gclassdef] = inner_scope
+        for arg in gclassdef.args:
+            self.define_name(arg.name, "const", "blue-param", arg.loc, arg.type.loc)
+        self.define_name("__Impl", "const", "classdef", loc, loc)
+        self.define_name("@return", "var", "auto", loc, loc)
+        self.declare(gclassdef.inner)
+        self.pop_scope()
+
     def declare_Assign(self, assign: ast.Assign) -> None:
         self._declare_target_maybe(assign.target, assign.value)
         self.declare(assign.value)
@@ -521,6 +542,15 @@ class ScopeAnalyzer:
         self.pop_scope()
         #
         classdef.symtable = inner_scope
+
+    def flatten_GenericClassDef(self, gclassdef: ast.GenericClassDef) -> None:
+        for arg in gclassdef.args:
+            self.flatten(arg)
+        inner_scope = self.by_generic_classdef(gclassdef)
+        self.push_scope(inner_scope)
+        self.flatten_ClassDef(gclassdef.inner)
+        self.pop_scope()
+        gclassdef.symtable = inner_scope
 
     def flatten_Name(self, name: ast.Name) -> None:
         self.capture_maybe(name.id)

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -227,6 +227,15 @@ class Module(Node):
                 return decl.classdef
         raise KeyError(name)
 
+    def get_generic_classdef(self, name: str) -> "GenericClassDef":
+        """
+        Search for the GenericClassDef with the given name.
+        """
+        for decl in self.decls:
+            if isinstance(decl, GlobalGenericClassDef) and decl.classdef.name == name:
+                return decl.classdef
+        raise KeyError(name)
+
 
 class Decl(Node):
     pass
@@ -250,6 +259,11 @@ class GlobalVarDef(Decl):
 @astnode
 class GlobalClassDef(Decl):
     classdef: "ClassDef"
+
+
+@astnode
+class GlobalGenericClassDef(Decl):
+    classdef: "GenericClassDef"
 
 
 @astnode
@@ -615,6 +629,28 @@ class ClassDef(Stmt):
 
     def shortrepr(self) -> Optional[str]:
         return f"{self.kind} {self.name}"
+
+
+@astnode
+class GenericClassDef(Stmt):
+    """
+    If you have this:
+
+        @struct
+        class Point[T]:
+            x: T
+            y: T
+
+    Then GenericClassDef represents the "outer" function. Its argument list contains "T".
+    """
+
+    name: str
+    args: list[FuncArg]
+    inner: ClassDef
+    symtable: Any = field(repr=False, default=None)
+
+    def shortrepr(self) -> Optional[str]:
+        return self.name
 
 
 @astnode

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -365,7 +365,7 @@ class Parser:
         if py_classdef.type_params:
             generic_args = self._parse_type_params(py_classdef)
             inner_classdef = self._parse_py_classdef(py_classdef)
-            inner_classdef.name = "__Impl"
+            inner_classdef.name = "Self"
             return spy.ast.GenericClassDef(
                 loc=py_classdef.loc,
                 name=py_classdef.name,

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -143,7 +143,11 @@ class Parser:
                 mod.decls.append(globfunc)
             elif isinstance(py_stmt, py_ast.ClassDef):
                 classdef = self.from_py_stmt_ClassDef(py_stmt)
-                globclass = spy.ast.GlobalClassDef(classdef.loc, classdef)
+                globclass: spy.ast.GlobalGenericClassDef | spy.ast.GlobalClassDef
+                if isinstance(classdef, spy.ast.GenericClassDef):
+                    globclass = spy.ast.GlobalGenericClassDef(classdef.loc, classdef)
+                else:
+                    globclass = spy.ast.GlobalClassDef(classdef.loc, classdef)
                 mod.decls.append(globclass)
             elif isinstance(py_stmt, py_ast.AnnAssign):
                 vardef = self.from_py_AnnAssign(py_stmt)
@@ -219,10 +223,10 @@ class Parser:
         return self._parse_py_funcdef(py_funcdef, color, func_kind, decorators)
 
     def _parse_type_params(
-        self, py_funcdef: py_ast.FunctionDef
+        self, py_def: py_ast.FunctionDef | py_ast.ClassDef
     ) -> list[spy.ast.FuncArg]:
         generic_args = []
-        for tp in py_funcdef.type_params:
+        for tp in py_def.type_params:
             if not isinstance(tp, py_ast.TypeVar):
                 self.error(
                     "only plain TypeVar type parameters are supported",
@@ -340,7 +344,9 @@ class Parser:
             kind=kind,
         )
 
-    def from_py_stmt_ClassDef(self, py_classdef: py_ast.ClassDef) -> spy.ast.ClassDef:
+    def from_py_stmt_ClassDef(
+        self, py_classdef: py_ast.ClassDef
+    ) -> spy.ast.ClassDef | spy.ast.GenericClassDef:
         if py_classdef.bases:
             self.error(
                 "base classes not supported yet",
@@ -355,6 +361,21 @@ class Parser:
                 py_classdef.keywords[0].loc,
             )
 
+        # generic arguments: class Cls[T]()
+        if py_classdef.type_params:
+            generic_args = self._parse_type_params(py_classdef)
+            inner_classdef = self._parse_py_classdef(py_classdef)
+            inner_classdef.name = "__Impl"
+            return spy.ast.GenericClassDef(
+                loc=py_classdef.loc,
+                name=py_classdef.name,
+                args=generic_args,
+                inner=inner_classdef,
+            )
+
+        return self._parse_py_classdef(py_classdef)
+
+    def _parse_py_classdef(self, py_classdef: py_ast.ClassDef) -> spy.ast.ClassDef:
         # decorators are not supported yet, but @struct and @typelif are
         # special-cased
         struct_loc: Optional[Loc] = None

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -925,21 +925,6 @@ class TestBasic(CompilerTest):
         """)
         assert mod.foo() == 9
 
-    def test_generic_class(self):
-        mod = self.compile("""
-        @struct
-        class Point[T]:
-            x: T
-            y: T
-
-            def compute(self) -> T:
-                return self.x*self.x + self.y*self.y
-
-        def foo() -> i32:
-            return Point[i32](2, 4).compute()
-        """)
-        assert mod.foo() == 20
-
     def test_call_func_already_redshifted(self):
         mod = self.compile("""
         @blue

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -925,6 +925,21 @@ class TestBasic(CompilerTest):
         """)
         assert mod.foo() == 9
 
+    def test_generic_class(self):
+        mod = self.compile("""
+        @struct
+        class Point[T]:
+            x: T
+            y: T
+
+            def compute(self) -> T:
+                return self.x*self.x + self.y*self.y
+
+        def foo() -> i32:
+            return Point[i32](2, 4).compute()
+        """)
+        assert mod.foo() == 20
+
     def test_call_func_already_redshifted(self):
         mod = self.compile("""
         @blue

--- a/spy/tests/compiler/test_blue_generic.py
+++ b/spy/tests/compiler/test_blue_generic.py
@@ -34,6 +34,21 @@ class TestBlueGeneric(CompilerTest):
         assert mod.foo() == 3
         assert mod.bar() == "hello world"
 
+    def test_generic_class(self):
+        mod = self.compile("""
+        @struct
+        class Point[T]:
+            x: T
+            y: T
+
+            def compute(self) -> T:
+                return self.x*self.x + self.y*self.y
+
+        def foo() -> i32:
+            return Point[i32](2, 4).compute()
+        """)
+        assert mod.foo() == 20
+
     @only_interp
     def test_generic_type_origin(self):
         mod = self.compile("""

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -425,6 +425,40 @@ class TestParser:
         """
         self.assert_dump(funcdef, expected)
 
+    def test_GenericClassDef(self):
+        mod = self.parse("""
+        @struct
+        class Point[T]:
+            x: T
+        """)
+        classdef = mod.get_generic_classdef("Point")
+        expected = """
+        GenericClassDef(
+            name='Point',
+            args=[
+                FuncArg(
+                    name='T',
+                    type=Auto(),
+                    kind='simple',
+                ),
+            ],
+            inner=ClassDef(
+                name='__Impl',
+                kind='struct',
+                docstring=None,
+                body=[
+                    VarDef(
+                        kind=None,
+                        name=StrConst(value='x'),
+                        type=Name(id='T'),
+                        value=None,
+                    ),
+                ],
+            ),
+        )
+        """
+        self.assert_dump(classdef, expected)
+
     def test_blue_metafunc_FuncDef(self):
         mod = self.parse("""
         @blue.metafunc

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -443,7 +443,7 @@ class TestParser:
                 ),
             ],
             inner=ClassDef(
-                name='__Impl',
+                name='Self',
                 kind='struct',
                 docstring=None,
                 body=[

--- a/spy/tests/test_scope.py
+++ b/spy/tests/test_scope.py
@@ -479,12 +479,12 @@ class TestScopeAnalyzer:
         assert scope.color == "blue"
         assert scope._symbols == {
             "T": MatchSymbol("T", "const", "blue-param"),
-            "__Impl": MatchSymbol("__Impl", "const", "classdef"),
+            "Self": MatchSymbol("Self", "const", "classdef"),
             "@return": MatchSymbol("@return", "var", "auto"),
         }
 
         inner_scope = scopes.by_classdef(gclassdef.inner)
-        assert inner_scope.name == "test::Foo::__Impl"
+        assert inner_scope.name == "test::Foo::Self"
         assert inner_scope._symbols == {
             "x": MatchSymbol("x", "var", "class-field"),
             "foo": MatchSymbol("foo", "const", "funcdef"),

--- a/spy/tests/test_scope.py
+++ b/spy/tests/test_scope.py
@@ -464,6 +464,33 @@ class TestScopeAnalyzer:
             "i32": MatchSymbol("i32", "const", "explicit", level=2),
         }
 
+    def test_generic_class(self):
+        scopes = self.analyze("""
+        @struct
+        class Foo[T]:
+            x: T
+
+            def foo(self) -> T:
+                return self.x
+        """)
+        gclassdef = self.mod.get_generic_classdef("Foo")
+        scope = scopes.by_generic_classdef(gclassdef)
+        assert scope.name == "test::Foo"
+        assert scope.color == "blue"
+        assert scope._symbols == {
+            "T": MatchSymbol("T", "const", "blue-param"),
+            "__Impl": MatchSymbol("__Impl", "const", "classdef"),
+            "@return": MatchSymbol("@return", "var", "auto"),
+        }
+
+        inner_scope = scopes.by_classdef(gclassdef.inner)
+        assert inner_scope.name == "test::Foo::__Impl"
+        assert inner_scope._symbols == {
+            "x": MatchSymbol("x", "var", "class-field"),
+            "foo": MatchSymbol("foo", "const", "funcdef"),
+            "T": MatchSymbol("T", "const", "blue-param", level=1),
+        }
+
     def test_vararg(self):
         scopes = self.analyze("""
         def foo(a: i32, *args: str) -> None:
@@ -547,7 +574,7 @@ class TestScopeAnalyzer:
         }
 
         inner_scope = scopes.by_funcdef(gfuncdef.inner)
-        assert inner_scope.name == f"test::foo::__impl"
+        assert inner_scope.name == "test::foo::__impl"
         assert inner_scope.color == "red"
         assert inner_scope._symbols == {
             "x": MatchSymbol("x", "var", "red-param"),

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -447,6 +447,49 @@ class AbstractFrame:
         w_T.define_from_classbody(self.vm, body)
         assert w_T.is_defined()
 
+    def exec_stmt_GenericClassDef(self, gclassdef: ast.GenericClassDef) -> None:
+        """
+        Desugar generic argument syntax sugar:
+
+            @struct
+            class Point[T]:
+                x: T
+
+        into the equivalent of:
+
+            @blue.generic
+            def Point(T):
+                @struct
+                class __Impl:
+                    x: T
+                return __Impl
+        """
+        loc = gclassdef.loc
+        assert gclassdef.symtable is not None
+
+        # build synthetic return: return __Impl
+        impl_symbol = gclassdef.symtable.lookup("__Impl")
+        return_stmt = ast.Return(
+            loc=loc,
+            value=ast.NameLocalDirect(loc=loc, sym=impl_symbol),
+        )
+
+        outer_funcdef = ast.FuncDef(
+            loc=loc,
+            color="blue",
+            kind="generic",
+            name=gclassdef.name,
+            args=gclassdef.args,
+            return_type=ast.Auto(loc),
+            defaults=[],
+            docstring=None,
+            body=[gclassdef.inner, return_stmt],
+            decorators=[],
+            symtable=gclassdef.symtable,
+        )
+
+        self.exec_stmt_FuncDef(outer_funcdef)
+
     def exec_stmt_VarDef(self, vardef: ast.VarDef) -> None:
         # Possible cases:
         #   declaration    (not is_auto and not value):  [var] x: i32

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -460,15 +460,15 @@ class AbstractFrame:
             @blue.generic
             def Point(T):
                 @struct
-                class __Impl:
+                class Self:
                     x: T
-                return __Impl
+                return Self
         """
         loc = gclassdef.loc
         assert gclassdef.symtable is not None
 
-        # build synthetic return: return __Impl
-        impl_symbol = gclassdef.symtable.lookup("__Impl")
+        # build synthetic return: return Self
+        impl_symbol = gclassdef.symtable.lookup("Self")
         return_stmt = ast.Return(
             loc=loc,
             value=ast.NameLocalDirect(loc=loc, sym=impl_symbol),

--- a/spy/vm/modframe.py
+++ b/spy/vm/modframe.py
@@ -59,7 +59,7 @@ class ModFrame(AbstractFrame):
                 self.exec_Import(decl)
             elif isinstance(decl, (ast.GlobalFuncDef, ast.GlobalGenericFuncDef)):
                 self.exec_stmt(decl.funcdef)
-            elif isinstance(decl, ast.GlobalClassDef):
+            elif isinstance(decl, (ast.GlobalClassDef, ast.GlobalGenericClassDef)):
                 self.exec_stmt(decl.classdef)
             elif isinstance(decl, ast.GlobalVarDef):
                 self.exec_GlobalVarDef(decl)


### PR DESCRIPTION
Related to #417 and direct continuation of #437.

At this point, this PR is mostly to show that it's possible and to be able to discuss about Generic types.

Now that we have `def func[T](x: T) -> T`, it really makes sense to have something equivalent for classes.

```python
@struct
class ArrayData[DTYPE]:
    length: i32
    capacity: i32
    items: gc_ptr[DTYPE]
```

would just be syntactic sugar for

```python
@blue.generic
def ArrayData(DTYPE):
    @struct
    class Self:
        length: i32
        capacity: i32
        items: gc_ptr[DTYPE]

    return Self
```

The current method to write generic types is by using a blue.generic function (it is widely used in the standard lib).

I understand (as discussed in #417) that there are unresolved issues with this with respect to wanted behavior of generic types, in particular regarding `isinstance` and `issubclass`. However,

- these issues are only weakly related to this syntactic sugar
- SPy has currently no `isinstance` and `issubclass`

Therefore, it seems to me that these issues will be treated later and that we can introduce the generic type syntactic sugar before.

We see the potential of this syntactic sugar with the simplification of playground/myarray.spy, which becomes much more readable and understandable for Python developers.

Remark: I had to use `Self` for the name of the concrete type since this concrete type has to be used to be able to implement `__new__` (currently we cannot write `ndarray[DTYPE]` in the definition of `ndarray[DTYPE]` so we need `Self`)

Remark 2 (detail): it could help to also support `type ArrayData_c = ArrayData[DTYPE]` at the class level (as in Python).

Remark 3: I had to allow isolated module level strings for the example, but this has nothing to do with the subject of this PR and it should be done correctly in another PR.