### PR TITLE
353: Add support `argv` parameter of SPy main function

### DIFF
--- a/spy/backend/c/cmodwriter.py
+++ b/spy/backend/c/cmodwriter.py
@@ -157,17 +157,18 @@ class CModuleWriter:
             w_main = self.ctx.vm.globals_w[fqn_main]
             assert isinstance(w_main, W_ASTFunc)
 
-            w_restype, needs_argv = self.ctx.vm.typecheck_main(w_main)
+            w_restype, has_argv = self.ctx.vm.typecheck_main(w_main)
             returns_i32 = w_restype == B.w_i32
 
-            if needs_argv:
+            if has_argv:
                 self.tbc.wb("""
+                    /* helper code for C->SPy argv wrapping */
+
                     #define spy_list_str spy__list$list__builtins$str$_ListImpl
                     #define spy_list_str_new spy__list$list__builtins$str$_ListImpl$__new__
                     #define spy_list_str_push spy__list$list__builtins$str$_ListImpl$_push
 
-                    spy_list_str
-                    spy_wrap_argv(int argc, const char *argv[]) {
+                    spy_list_str spy_wrap_argv(int argc, const char *argv[]) {
                         spy_list_str lst = spy_list_str_new();
                         for (int i = 0; i < argc; i++) {
                             size_t length = strlen(argv[i]);
@@ -178,22 +179,28 @@ class CModuleWriter:
                         }
                         return lst;
                     }
+
+                    #undef spy_list_str
+                    #undef spy_list_str_new
+                    #undef spy_list_str_push
+
+                    /* end of helper code */
                 """)
 
-            if needs_argv and returns_i32:
+            if has_argv and returns_i32:
                 main_src = f"""
                     int main(int argc, const char *argv[]) {{
                         return {fqn_main.c_name}(spy_wrap_argv(argc, argv));
                     }}
                     """
-            elif needs_argv and not returns_i32:
+            elif has_argv and not returns_i32:
                 main_src = f"""
                     int main(int argc, const char *argv[]) {{
                         {fqn_main.c_name}(spy_wrap_argv(argc, argv));
                         return 0;
                     }}
                     """
-            elif not needs_argv and returns_i32:
+            elif not has_argv and returns_i32:
                 main_src = f"""
                     int main(void) {{
                         return {fqn_main.c_name}();

--- a/spy/tests/test_cli.py
+++ b/spy/tests/test_cli.py
@@ -127,27 +127,6 @@ class TestMain:
             _, stdout = self.run(*argset, self.main_spy)
             assert stdout == "hello world\n"
 
-    def test_exit_code(self):
-        src = """
-        def main() -> i32:
-            print("This main return 99 as exit code")
-            return 99
-        """
-        f = self.write("test.spy", src)
-        res = self.runner.invoke(app, [str(f)])
-        assert res.exit_code == 99
-
-    def test_main_wrong_return_type(self):
-        src = """
-        def main() -> str:
-            return "oops"
-        """
-        f = self.write("test.spy", src)
-        res = self.runner.invoke(app, [str(f)])
-        assert res.exit_code == 1
-        output = decolorize(res.output)
-        assert "`main` has the wrong signature" in output
-
     def test_timeit(self):
         _, stdout = self.run("--timeit", self.main_spy)
         assert "main()" in stdout
@@ -235,75 +214,6 @@ class TestMain:
         csrc = main_c.read()
         assert csrc.startswith('#include "main.h"')
 
-    def test_return_exit_code_cwrite(self):
-        src = """
-        def main() -> i32:
-            print("This main return 99 as exit code")
-            return 99
-        """
-        f = self.write("test.spy", src)
-        self.run("build", "--no-compile", "--build-dir", self.tmpdir, f)
-        test_c = self.tmpdir.join("src", "test.c")
-        assert test_c.exists()
-        csrc = test_c.read()
-        assert "return 99;" in csrc
-
-    def test_nested_functions_exit_code_cwrite(self):
-        src = """
-        def actual_exit_code_return() -> i32:
-            return 88
-
-        def main() -> i32:
-            print("This main return 88 as exit code")
-            result = actual_exit_code_return()
-            return result
-        """
-        f = self.write("test.spy", src)
-        self.run("build", "--no-compile", "--build-dir", self.tmpdir, f)
-        test_c = self.tmpdir.join("src", "test.c")
-        assert test_c.exists()
-        csrc = test_c.read()
-        assert "return 88;" in csrc
-
-    def test_argv_no_exit_code_cwrite(self):
-        src = """
-        def main(argv: list[str]) -> None:
-            print(len(argv))
-        """
-        f = self.write("test.spy", src)
-        self.run("build", "--no-compile", "--build-dir", self.tmpdir, f)
-        test_c = self.tmpdir.join("src", "test.c")
-        assert test_c.exists()
-        csrc = test_c.read()
-        assert "spy_wrap_argv" in csrc
-        assert "int main(int argc" in csrc
-
-    def test_argv_with_exit_code_cwrite(self):
-        src = """
-        def main(argv: list[str]) -> i32:
-            return len(argv)
-        """
-        f = self.write("test.spy", src)
-        self.run("build", "--no-compile", "--build-dir", self.tmpdir, f)
-        test_c = self.tmpdir.join("src", "test.c")
-        assert test_c.exists()
-        csrc = test_c.read()
-        assert "spy_wrap_argv" in csrc
-        assert "int main(int argc" in csrc
-
-    def test_no_argv_no_wrap_cwrite(self):
-        src = """
-        def main() -> None:
-            print("hello")
-        """
-        f = self.write("test.spy", src)
-        self.run("build", "--no-compile", "--build-dir", self.tmpdir, f)
-        test_c = self.tmpdir.join("src", "test.c")
-        assert test_c.exists()
-        csrc = test_c.read()
-        assert "spy_wrap_argv" not in csrc
-        assert "int main(void)" in csrc
-
     @pytest.mark.parametrize(
         "target",
         [
@@ -362,19 +272,6 @@ class TestMain:
         out, err = capfd.readouterr()
         assert "hello world" in out
 
-    def test_exit_code_C_backend(self):
-        src = """
-        def main() -> i32:
-            print("hello")
-            return 99
-        """
-        f = self.write("test.spy", src)
-        self.run("build", f)
-        test_exe = self.tmpdir.join("build", "test")
-        status, out = getstatusoutput([str(test_exe)])
-        assert status == 99
-        assert out == "hello"
-
     @pytest.mark.skipif(PYODIDE_EXE is None, reason="./pyodide/venv not found")
     @pytest.mark.pyodide
     def test_execute_pyodide(self):
@@ -431,28 +328,27 @@ class TestMain:
         _, stdout = self.run("imports", self.main_spy)
         assert stdout.startswith("Import tree:")
 
-    def test_compile_execute_argv(self):
+    def test_interp_exit_code(self):
         src = """
-        def main(argv: list[str]) -> i32:
-            for a in argv:
-                print(a)
+        def main() -> i32:
+            return 99
+        """
+        f = self.write("test.spy", src)
+        res = self.runner.invoke(app, [str(f)])
+        assert res.exit_code == 99
 
+    def test_compile_exit_code(self):
+        src = """
+        def main() -> i32:
             return 99
         """
         f = self.write("test.spy", src)
         self.run("build", f)
         test_exe = self.tmpdir.join("build", "test")
-        cmd = f"{str(test_exe)} arg1=value1 arg2=value2 arg3=value3"
-        status, out = getstatusoutput(cmd)
+        status, out = getstatusoutput([str(test_exe)])
         assert status == 99
-        assert out.split() == [
-            str(test_exe),
-            "arg1=value1",
-            "arg2=value2",
-            "arg3=value3",
-        ]
 
-    def test_execute_argv(self):
+    def test_interp_argv(self):
         src = """
         def main(argv: list[str]) -> None:
             for a in argv:
@@ -463,6 +359,18 @@ class TestMain:
         assert res.exit_code == 0
         output = decolorize(res.output)
         assert output.split() == [str(f), "aaa", "bbb", "ccc"]
+
+    def test_compile_argv(self):
+        src = """
+        def main(argv: list[str]) -> None:
+            for a in argv:
+                print(a)
+        """
+        f = self.write("test.spy", src)
+        self.run("build", f)
+        test_exe = self.tmpdir.join("build", "test")
+        status, out = getstatusoutput(f"{test_exe} aaa bbb ccc")
+        assert out.split() == [str(test_exe), "aaa", "bbb", "ccc"]
 
     def test_redshift_argv(self):
         src = """
@@ -475,25 +383,3 @@ class TestMain:
         assert res.exit_code == 0
         output = decolorize(res.output)
         assert output.split() == [str(f), "aaa", "bbb", "ccc"]
-
-    def test_main_wrong_param_type(self):
-        src = """
-        def main(x: i32) -> None:
-            pass
-        """
-        f = self.write("test.spy", src)
-        res = self.runner.invoke(app, [str(f)])
-        assert res.exit_code == 1
-        output = decolorize(res.output)
-        assert "`main` has the wrong signature" in output
-
-    def test_main_too_many_params(self):
-        src = """
-        def main(a: list[str], b: list[str]) -> None:
-            pass
-        """
-        f = self.write("test.spy", src)
-        res = self.runner.invoke(app, [str(f)])
-        assert res.exit_code == 1
-        output = decolorize(res.output)
-        assert "`main` has the wrong signature" in output


### PR DESCRIPTION
Issue: https://github.com/spylang/spy/issues/353

Hi everyone,

this is implementation of **backend** SPy argv parameter for main function.

I separated argument wrapper to `list.c` and `list.h` then calling it in `cmodwriter`.

### However, there is a tricky part happening

<img width="2400" height="1056" alt="image" src="https://github.com/user-attachments/assets/4dbf82f3-8c67-4348-b3b6-3c0f61bec7fb" />

if any spy files need argument in main like below
```
def main(argv: list[str]) ...
```

It will include `list.h` to such compiled C file to use `spy_wrap_argv`. However, such implementation is in `list.c` which requires to compile before such current working file got compile.

Rough correct pipeline.
```
1) **pre-compile stage**
_list.c (and other built-in standard lib)

2) **current working files**
-> list.c -> [any current working file with `main(argv: list[str])`]
```

Our current pipeline does compile all standard libraries (e.g. _list.spy) at once. It's challenging to modify current pipeline to receive **customized on-the-fly `.c`** to compile as above pipeline. Also, to compile `list.c` with all `libspy` is challenging because `list.c` need `_list.c` to compiled first.

So, now I juggled by copy content of `list.c` and compile it with [any current working file with `main(argv: list[str])`] instead.

Well, I'm not sure I explained it clearly. Please let me know if you need elaboration.