### PR TITLE
Enable ruff formatting for .spy files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Format check
         run: |
-          ruff format --check .
+          ruff format --check --extension spy:python .
 
       - name: Build libspy
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,9 @@ repos:
         args:
           - --fix
       - id: ruff-format
+        args:
+          - --extension
+          - spy:python
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v21.1.5
     hooks:


### PR DESCRIPTION
Adds `--extension spy:python` to both the pre-commit `ruff-format` hook and the CI format check in `tests.yml`. This tells ruff to treat `.spy` files as Python so they're included in formatting enforcement.

Verified that all 41 existing `.spy` files already pass the formatter with no changes needed. The `--extension` flag was added in ruff 0.4.8.

Closes #387

**This PR was authored by a human with AI coding assistance.**