### PR TITLE
list.pop(index) and list[:slice:] = ...

### DIFF
--- a/spy/tests/stdlib/test__list.py
+++ b/spy/tests/stdlib/test__list.py
@@ -196,6 +196,15 @@ class TestList(CompilerTest):
         with SPyError.raises("W_IndexError"):
             mod.test_error()
 
+    def test_setitem_slice_same_size(self):
+        mod = self.compile("""
+            def fn() -> list[i32]:
+                lst = [1, 2, 3, 4, 5]
+                lst[1:3] = [10, 20]
+                return lst
+            """)
+        assert mod.fn() == [1, 10, 20, 4, 5]
+
     def test_pop(self):
         src = """
         from _list import list

--- a/spy/tests/stdlib/test__list.py
+++ b/spy/tests/stdlib/test__list.py
@@ -212,10 +212,16 @@ class TestList(CompilerTest):
                 lst = [1, 2, 3, 4, 5]
                 lst[1:4] = [10]
                 return lst
+
+            def test_delete() -> list[i32]:
+                lst = [1, 2, 3, 4, 5]
+                lst[1:3] = []
+                return lst
             """)
         assert mod.test_same_size() == [1, 10, 20, 4, 5]
         assert mod.test_grow() == [1, 10, 20, 30, 3, 4, 5]
         assert mod.test_shrink() == [1, 10, 5]
+        assert mod.test_delete() == [1, 4, 5]
 
     def test_pop(self):
         src = """

--- a/spy/tests/stdlib/test__list.py
+++ b/spy/tests/stdlib/test__list.py
@@ -217,11 +217,17 @@ class TestList(CompilerTest):
                 lst = [1, 2, 3, 4, 5]
                 lst[1:3] = []
                 return lst
+
+            def test_insert() -> list[i32]:
+                lst = [1, 2, 3]
+                lst[1:1] = [10, 20]
+                return lst
             """)
         assert mod.test_same_size() == [1, 10, 20, 4, 5]
         assert mod.test_grow() == [1, 10, 20, 30, 3, 4, 5]
         assert mod.test_shrink() == [1, 10, 5]
         assert mod.test_delete() == [1, 4, 5]
+        assert mod.test_insert() == [1, 10, 20, 2, 3]
 
     def test_pop(self):
         src = """

--- a/spy/tests/stdlib/test__list.py
+++ b/spy/tests/stdlib/test__list.py
@@ -218,6 +218,52 @@ class TestList(CompilerTest):
         with SPyError.raises("W_IndexError"):
             mod.test_empty()
 
+    def test_pop_index(self):
+        src = """
+        from _list import list
+
+        def test_pop_first() -> tuple[i32, i32]:
+            lst = list[int]()
+            lst.append(10)
+            lst.append(20)
+            lst.append(30)
+            x = lst.pop(0)
+            return x, len(lst)
+
+        def test_pop_middle() -> tuple[i32, i32, i32]:
+            lst = list[int]()
+            lst.append(10)
+            lst.append(20)
+            lst.append(30)
+            x = lst.pop(1)
+            return x, lst[0], lst[1]
+
+        def test_pop_negative() -> int:
+            lst = list[int]()
+            lst.append(10)
+            lst.append(20)
+            lst.append(30)
+            return lst.pop(-2)
+
+        def test_pop_out_of_bounds() -> int:
+            lst = list[int]()
+            lst.append(10)
+            return lst.pop(5)
+
+        def test_pop_negative_out_of_bounds() -> int:
+            lst = list[int]()
+            lst.append(10)
+            return lst.pop(-5)
+        """
+        mod = self.compile(src)
+        assert mod.test_pop_first() == (10, 2)
+        assert mod.test_pop_middle() == (20, 10, 30)
+        assert mod.test_pop_negative() == 20
+        with SPyError.raises("W_IndexError"):
+            mod.test_pop_out_of_bounds()
+        with SPyError.raises("W_IndexError"):
+            mod.test_pop_negative_out_of_bounds()
+
     def test_insert(self):
         src = """
         from _list import list

--- a/spy/tests/stdlib/test__list.py
+++ b/spy/tests/stdlib/test__list.py
@@ -202,8 +202,14 @@ class TestList(CompilerTest):
                 lst = [1, 2, 3, 4, 5]
                 lst[1:3] = [10, 20]
                 return lst
+
+            def test_grow() -> list[i32]:
+                lst = [1, 2, 3, 4, 5]
+                lst[1:2] = [10, 20, 30]
+                return lst
             """)
         assert mod.test_same_size() == [1, 10, 20, 4, 5]
+        assert mod.test_grow() == [1, 10, 20, 30, 3, 4, 5]
 
     def test_pop(self):
         src = """

--- a/spy/tests/stdlib/test__list.py
+++ b/spy/tests/stdlib/test__list.py
@@ -174,7 +174,7 @@ class TestList(CompilerTest):
         mod = self.compile(src)
         assert mod.test() == 10
 
-    def test_setitem(self):
+    def test_setitem_int(self):
         src = """
         from _list import list
 

--- a/spy/tests/stdlib/test__list.py
+++ b/spy/tests/stdlib/test__list.py
@@ -207,9 +207,15 @@ class TestList(CompilerTest):
                 lst = [1, 2, 3, 4, 5]
                 lst[1:2] = [10, 20, 30]
                 return lst
+
+            def test_shrink() -> list[i32]:
+                lst = [1, 2, 3, 4, 5]
+                lst[1:4] = [10]
+                return lst
             """)
         assert mod.test_same_size() == [1, 10, 20, 4, 5]
         assert mod.test_grow() == [1, 10, 20, 30, 3, 4, 5]
+        assert mod.test_shrink() == [1, 10, 5]
 
     def test_pop(self):
         src = """

--- a/spy/tests/stdlib/test__list.py
+++ b/spy/tests/stdlib/test__list.py
@@ -222,12 +222,24 @@ class TestList(CompilerTest):
                 lst = [1, 2, 3]
                 lst[1:1] = [10, 20]
                 return lst
+
+            def test_extended() -> list[i32]:
+                lst = [1, 2, 3, 4, 5]
+                lst[::2] = [10, 20, 30]
+                return lst
+
+            def test_extended_wrong_size() -> None:
+                lst = [1, 2, 3, 4, 5]
+                lst[::2] = [10, 20]
             """)
         assert mod.test_same_size() == [1, 10, 20, 4, 5]
         assert mod.test_grow() == [1, 10, 20, 30, 3, 4, 5]
         assert mod.test_shrink() == [1, 10, 5]
         assert mod.test_delete() == [1, 4, 5]
         assert mod.test_insert() == [1, 10, 20, 2, 3]
+        assert mod.test_extended() == [10, 2, 20, 4, 30]
+        with SPyError.raises("W_ValueError"):
+            mod.test_extended_wrong_size()
 
     def test_pop(self):
         src = """

--- a/spy/tests/stdlib/test__list.py
+++ b/spy/tests/stdlib/test__list.py
@@ -196,14 +196,14 @@ class TestList(CompilerTest):
         with SPyError.raises("W_IndexError"):
             mod.test_error()
 
-    def test_setitem_slice_same_size(self):
+    def test_setitem_slice(self):
         mod = self.compile("""
-            def fn() -> list[i32]:
+            def test_same_size() -> list[i32]:
                 lst = [1, 2, 3, 4, 5]
                 lst[1:3] = [10, 20]
                 return lst
             """)
-        assert mod.fn() == [1, 10, 20, 4, 5]
+        assert mod.test_same_size() == [1, 10, 20, 4, 5]
 
     def test_pop(self):
         src = """

--- a/stdlib/_list.spy
+++ b/stdlib/_list.spy
@@ -155,78 +155,76 @@ def list(T):
                 )
 
         @blue.metafunc
-        def __setitem__(self, m_x: MetaArg, value: MetaArg):
+        def __setitem__(m_self, m_x: MetaArg, value: MetaArg):
             if m_x.static_type == i32:
-
-                def setitem_int(_self: _ListImpl, i: int, _value: T) -> None:
-                    ll = _self.__ll__
-                    if i < 0:
-                        i = i + ll.length
-                    if i < 0:
-                        raise IndexError
-                    if i >= ll.length:
-                        raise IndexError
-                    ll.items[i] = _value
-
-                return OpSpec(setitem_int)
+                return OpSpec(_ListImpl._setitem_int)
             elif m_x.static_type == Slice:
-
-                def setitem_slice(_self: _ListImpl, s: Slice, _value: _ListImpl) -> None:
-                    ll = _self.__ll__
-                    vll = _value.__ll__
-                    unpacked = _py_slice_unpack(ll.length, s)
-                    slice_len = _py_adjust_indexes(
-                        ll.length, unpacked.start, unpacked.stop, unpacked.step
-                    )
-                    indices = s.indices(ll.length)
-                    new_len = vll.length
-
-                    if indices.step != 1:
-                        if new_len != slice_len:
-                            raise ValueError
-                        cur: i32 = indices.start
-                        k = 0
-                        while k < new_len:
-                            ll.items[cur] = vll.items[k]
-                            cur = cur + indices.step
-                            k = k + 1
-                    else:
-                        start = indices.start
-                        diff = new_len - slice_len
-                        new_total = ll.length + diff
-
-                        if new_total > ll.capacity:
-                            new_cap = new_total * 2
-                            new_items = gc_alloc[T](new_cap)
-                            j = 0
-                            while j < ll.length:
-                                new_items[j] = ll.items[j]
-                                j = j + 1
-                            ll.items = new_items
-                            ll.capacity = new_cap
-
-                        if diff > 0:
-                            # shift right to make room
-                            j = ll.length - 1
-                            while j >= start + slice_len:
-                                ll.items[j + diff] = ll.items[j]
-                                j = j - 1
-                        elif diff < 0:
-                            # shift left to close gap
-                            j = start + slice_len
-                            while j < ll.length:
-                                ll.items[j + diff] = ll.items[j]
-                                j = j + 1
-
-                        k = 0
-                        while k < new_len:
-                            ll.items[start + k] = vll.items[k]
-                            k = k + 1
-                        ll.length = new_total
-
-                return OpSpec(setitem_slice)
+                return OpSpec(_ListImpl._setitem_slice)
             else:
                 return OpSpec.NULL
+
+        def _setitem_int(self, i: int, _value: T) -> None:
+            ll = self.__ll__
+            if i < 0:
+                i = i + ll.length
+            if i < 0:
+                raise IndexError
+            if i >= ll.length:
+                raise IndexError
+            ll.items[i] = _value
+
+        def _setitem_slice(self, s: Slice, _value: _ListImpl) -> None:
+            ll = self.__ll__
+            vll = _value.__ll__
+            unpacked = _py_slice_unpack(ll.length, s)
+            slice_len = _py_adjust_indexes(
+                ll.length, unpacked.start, unpacked.stop, unpacked.step
+            )
+            indices = s.indices(ll.length)
+            new_len = vll.length
+
+            if indices.step != 1:
+                if new_len != slice_len:
+                    raise ValueError
+                cur: i32 = indices.start
+                k = 0
+                while k < new_len:
+                    ll.items[cur] = vll.items[k]
+                    cur = cur + indices.step
+                    k = k + 1
+            else:
+                start = indices.start
+                diff = new_len - slice_len
+                new_total = ll.length + diff
+
+                if new_total > ll.capacity:
+                    new_cap = new_total * 2
+                    new_items = gc_alloc[T](new_cap)
+                    j = 0
+                    while j < ll.length:
+                        new_items[j] = ll.items[j]
+                        j = j + 1
+                    ll.items = new_items
+                    ll.capacity = new_cap
+
+                if diff > 0:
+                    # shift right to make room
+                    j = ll.length - 1
+                    while j >= start + slice_len:
+                        ll.items[j + diff] = ll.items[j]
+                        j = j - 1
+                elif diff < 0:
+                    # shift left to close gap
+                    j = start + slice_len
+                    while j < ll.length:
+                        ll.items[j + diff] = ll.items[j]
+                        j = j + 1
+
+                k = 0
+                while k < new_len:
+                    ll.items[start + k] = vll.items[k]
+                    k = k + 1
+                ll.length = new_total
 
         def pop(self, i: i32 = -1) -> T:
             ll = self.__ll__

--- a/stdlib/_list.spy
+++ b/stdlib/_list.spy
@@ -169,8 +169,67 @@ def list(T):
                     ll.items[i] = _value
 
                 return OpSpec(setitem_int)
-            elif m_x.static_type == slice:
-                raise StaticError("WIP: list.__setitem__(slice) is not implemented yet")
+            elif m_x.static_type == Slice:
+
+                def setitem_slice(_self: _ListImpl, s: Slice, _value: _ListImpl) -> None:
+                    ll = _self.__ll__
+                    vll = _value.__ll__
+                    unpacked = _py_slice_unpack(ll.length, s)
+                    slice_len = _py_adjust_indexes(
+                        ll.length, unpacked.start, unpacked.stop, unpacked.step
+                    )
+                    indices = s.indices(slice_len)
+                    new_len = vll.length
+
+                    if indices.step != 1:
+                        if new_len != slice_len:
+                            raise ValueError(
+                                "attempt to assign sequence of size "
+                                + str(new_len)
+                                + " to extended slice of size "
+                                + str(slice_len)
+                            )
+                        cur: i32 = indices.start
+                        k = 0
+                        while k < new_len:
+                            ll.items[cur] = vll.items[k]
+                            cur = cur + indices.step
+                            k = k + 1
+                    else:
+                        start = indices.start
+                        diff = new_len - slice_len
+                        new_total = ll.length + diff
+
+                        if new_total > ll.capacity:
+                            new_cap = new_total * 2
+                            new_items = gc_alloc[T](new_cap)
+                            j = 0
+                            while j < ll.length:
+                                new_items[j] = ll.items[j]
+                                j = j + 1
+                            ll.items = new_items
+                            ll.capacity = new_cap
+
+                        if diff > 0:
+                            # shift right to make room
+                            j = ll.length - 1
+                            while j >= start + slice_len:
+                                ll.items[j + diff] = ll.items[j]
+                                j = j - 1
+                        elif diff < 0:
+                            # shift left to close gap
+                            j = start + slice_len
+                            while j < ll.length:
+                                ll.items[j + diff] = ll.items[j]
+                                j = j + 1
+
+                        k = 0
+                        while k < new_len:
+                            ll.items[start + k] = vll.items[k]
+                            k = k + 1
+                        ll.length = new_total
+
+                return OpSpec(setitem_slice)
             else:
                 return OpSpec.NULL
 

--- a/stdlib/_list.spy
+++ b/stdlib/_list.spy
@@ -97,62 +97,58 @@ def list(T):
             return self.__ll__.length
 
         @blue.metafunc
-        def __getitem__(self, m_x: MetaArg):
+        def __getitem__(m_self, m_x: MetaArg):
             if m_x.static_type == i32:
-
-                def getitem_int(_self: _ListImpl, i: int) -> T:
-                    ll = _self.__ll__
-                    if i < 0:
-                        i = i + ll.length
-                    if i < 0:
-                        raise IndexError
-                    if i >= ll.length:
-                        raise IndexError
-                    return ll.items[i]
-
-                return OpSpec(getitem_int)
-
+                return OpSpec(_ListImpl._getitem_int)
             elif m_x.static_type == Slice:
-
-                def getitem_slice(_self: _ListImpl, s: Slice) -> _ListImpl:
-                    ll = _self.__ll__
-                    unpacked = _py_slice_unpack(ll.length, s)
-                    new_length = _py_adjust_indexes(
-                        ll.length, unpacked.start, unpacked.stop, unpacked.step
-                    )
-                    indices = s.indices(new_length)
-
-                    if new_length <= 0:
-                        return []
-                    elif indices.step == 1:
-                        new_data = gc_alloc[ListData](1)
-                        new_data.length = new_length
-                        new_data.capacity = new_length + 1
-                        new_data.items = gc_alloc[T](ll.capacity)
-
-                        for i in range(new_length):
-                            new_data.items[i] = ll.items[indices.start + i]
-
-                        return _ListImpl.__make__(new_data)
-                    else:
-                        new_data = gc_alloc[ListData](1)
-                        new_data.length = new_length
-                        new_data.capacity = new_length + 1
-                        new_data.items = gc_alloc[T](ll.capacity)
-
-                        cur: int = indices.start
-                        for _i in range(new_length):
-                            new_data.items[_i] = ll.items[cur]
-                            cur += indices.step
-
-                        return _ListImpl.__make__(new_data)
-
-                return OpSpec(getitem_slice)
-
+                return OpSpec(_ListImpl._getitem_slice)
             else:
                 raise TypeError(
                     "Subscript to list must be i32 or Slice, got " + str(m_x)
                 )
+
+        def _getitem_int(self, i: int) -> T:
+            ll = self.__ll__
+            if i < 0:
+                i = i + ll.length
+            if i < 0:
+                raise IndexError
+            if i >= ll.length:
+                raise IndexError
+            return ll.items[i]
+
+        def _getitem_slice(self, s: Slice) -> _ListImpl:
+            ll = self.__ll__
+            unpacked = _py_slice_unpack(ll.length, s)
+            new_length = _py_adjust_indexes(
+                ll.length, unpacked.start, unpacked.stop, unpacked.step
+            )
+            indices = s.indices(new_length)
+
+            if new_length <= 0:
+                return []
+            elif indices.step == 1:
+                new_data = gc_alloc[ListData](1)
+                new_data.length = new_length
+                new_data.capacity = new_length + 1
+                new_data.items = gc_alloc[T](ll.capacity)
+
+                for i in range(new_length):
+                    new_data.items[i] = ll.items[indices.start + i]
+
+                return _ListImpl.__make__(new_data)
+            else:
+                new_data = gc_alloc[ListData](1)
+                new_data.length = new_length
+                new_data.capacity = new_length + 1
+                new_data.items = gc_alloc[T](ll.capacity)
+
+                cur: int = indices.start
+                for _i in range(new_length):
+                    new_data.items[_i] = ll.items[cur]
+                    cur += indices.step
+
+                return _ListImpl.__make__(new_data)
 
         @blue.metafunc
         def __setitem__(m_self, m_x: MetaArg, value: MetaArg):

--- a/stdlib/_list.spy
+++ b/stdlib/_list.spy
@@ -178,7 +178,7 @@ def list(T):
                     slice_len = _py_adjust_indexes(
                         ll.length, unpacked.start, unpacked.stop, unpacked.step
                     )
-                    indices = s.indices(slice_len)
+                    indices = s.indices(ll.length)
                     new_len = vll.length
 
                     if indices.step != 1:

--- a/stdlib/_list.spy
+++ b/stdlib/_list.spy
@@ -183,12 +183,7 @@ def list(T):
 
                     if indices.step != 1:
                         if new_len != slice_len:
-                            raise ValueError(
-                                "attempt to assign sequence of size "
-                                + str(new_len)
-                                + " to extended slice of size "
-                                + str(slice_len)
-                            )
+                            raise ValueError
                         cur: i32 = indices.start
                         k = 0
                         while k < new_len:

--- a/stdlib/_list.spy
+++ b/stdlib/_list.spy
@@ -174,12 +174,23 @@ def list(T):
             else:
                 return OpSpec.NULL
 
-        def pop(self) -> T:
+        def pop(self, i: i32 = -1) -> T:
             ll = self.__ll__
             if ll.length == 0:
                 raise IndexError
+            if i < 0:
+                i = i + ll.length
+            if i < 0:
+                raise IndexError
+            if i >= ll.length:
+                raise IndexError
+            value = ll.items[i]
+            j = i
+            while j < ll.length - 1:
+                ll.items[j] = ll.items[j + 1]
+                j = j + 1
             ll.length = ll.length - 1
-            return ll.items[ll.length]
+            return value
 
         def insert(self, i: i32, item: T) -> None:
             ll = self.__ll__


### PR DESCRIPTION
- Add support for `list.pop(i)`
- Add support for `list[x] = y` where x is a slice
