### PR TITLE
Implement hasattr (blue arg)

### DIFF
--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -580,7 +580,7 @@ class DopplerFrame(ASTFrame):
         newfunc = self.shifted_expr[call.func]
         newargs = [self.shifted_expr[arg] for arg in call.args]
 
-        if self.special_calls.get(call) in ("getattr", "setattr"):
+        if self.special_calls.get(call) in ("getattr", "hasattr", "setattr"):
             # see also the corresponding code in ASTFrame.eval_expr_Call.
             return self.shift_opimpl(call, w_opimpl, newargs, w_T=wam.w_static_T)
         else:

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -652,7 +652,7 @@ class DopplerFrame(ASTFrame):
         newfunc = self.shifted_expr[call.func]
         newargs = [self.shifted_expr[arg] for arg in call.args]
 
-        if self.special_calls.get(call) in ("getattr", "setattr"):
+        if self.special_calls.get(call) in ("getattr", "hasattr", "setattr"):
             # see also the corresponding code in ASTFrame.eval_expr_Call.
             return self.shift_opimpl(call, w_opimpl, newargs)
         else:

--- a/spy/tests/compiler/test_builtins.py
+++ b/spy/tests/compiler/test_builtins.py
@@ -262,6 +262,52 @@ class TestBuiltins(CompilerTest):
         )
         self.compile_raises(src, "foo", errors)
 
+    def test_hasattr(self):
+        src = """
+        @struct
+        class Point:
+            x: i32
+            y: i32
+
+        def foo() -> bool:
+            p = Point(1, 2)
+            return hasattr(p, 'x')
+        """
+        mod = self.compile(src)
+        assert mod.foo() == True
+
+    def test_hasattr_false(self):
+        src = """
+        @struct
+        class Point:
+            x: i32
+            y: i32
+
+        def foo() -> bool:
+            p = Point(1, 2)
+            return hasattr(p, 'z')
+        """
+        mod = self.compile(src)
+        assert mod.foo() == False
+
+    def test_hasattr_red(self):
+        src = """
+        @struct
+        class Point:
+            x: i32
+            y: i32
+
+        def foo() -> bool:
+            var attr = "x"  # this is red
+            p = Point(1, 2)
+            return hasattr(p, attr)
+        """
+        errors = expect_errors(
+            "expected blue argument",
+            ("this is red", "attr"),
+        )
+        self.compile_raises(src, "foo", errors)
+
     @only_interp
     def test_dir(self):
         src = """

--- a/spy/tests/compiler/test_builtins.py
+++ b/spy/tests/compiler/test_builtins.py
@@ -1,6 +1,12 @@
 import pytest
 
-from spy.tests.support import CompilerTest, expect_errors, no_C, only_interp
+from spy.tests.support import (
+    CompilerTest,
+    expect_errors,
+    no_C,
+    only_interp,
+    skip_backends,
+)
 from spy.vm.builtin import builtin_method
 from spy.vm.opspec import W_MetaArg, W_OpSpec
 from spy.vm.primitive import W_I32, W_Dynamic
@@ -307,6 +313,62 @@ class TestBuiltins(CompilerTest):
             ("this is red", "attr"),
         )
         self.compile_raises(src, "foo", errors)
+
+    @skip_backends("C", reason="dynamic not supported in C backend")
+    def test_hasattr_dynamic_true(self):
+        src = """
+        @struct
+        class Point:
+            x: i32
+            y: i32
+
+        def foo() -> bool:
+            p: dynamic = Point(1, 2)
+            return hasattr(p, 'x')
+        """
+        mod = self.compile(src)
+        assert mod.foo() == True
+
+    @skip_backends("C", reason="dynamic not supported in C backend")
+    def test_hasattr_dynamic_false(self):
+        src = """
+        @struct
+        class Point:
+            x: i32
+            y: i32
+
+        def foo() -> bool:
+            p: dynamic = Point(1, 2)
+            return hasattr(p, 'z')
+        """
+        mod = self.compile(src)
+        assert mod.foo() == False
+
+    def test_hasattr_custom_getattribute(self):
+        mod = self.compile("""
+        from operator import OpSpec
+
+        @struct
+        class MyClass:
+
+            @blue.metafunc
+            def __getattribute__(m_self, m_name):
+                if m_name.blueval == 'x':
+                    def impl(obj: MyClass, name: str) -> i32:
+                        return 42
+                    return OpSpec(impl)
+                return OpSpec.NULL
+
+        def foo() -> bool:
+            obj = MyClass()
+            return hasattr(obj, 'x')
+
+        def bar() -> bool:
+            obj = MyClass()
+            return hasattr(obj, 'z')
+        """)
+        assert mod.foo() == True
+        assert mod.bar() == False
 
     @only_interp
     def test_dir(self):

--- a/spy/tests/compiler/test_builtins.py
+++ b/spy/tests/compiler/test_builtins.py
@@ -278,23 +278,14 @@ class TestBuiltins(CompilerTest):
         def foo() -> bool:
             p = Point(1, 2)
             return hasattr(p, 'x')
-        """
-        mod = self.compile(src)
-        assert mod.foo() == True
 
-    def test_hasattr_false(self):
-        src = """
-        @struct
-        class Point:
-            x: i32
-            y: i32
-
-        def foo() -> bool:
+        def bar() -> bool:
             p = Point(1, 2)
             return hasattr(p, 'z')
         """
         mod = self.compile(src)
-        assert mod.foo() == False
+        assert mod.foo() == True
+        assert mod.bar() == False
 
     def test_hasattr_red(self):
         src = """
@@ -315,7 +306,7 @@ class TestBuiltins(CompilerTest):
         self.compile_raises(src, "foo", errors)
 
     @skip_backends("C", reason="dynamic not supported in C backend")
-    def test_hasattr_dynamic_true(self):
+    def test_hasattr_dynamic(self):
         src = """
         @struct
         class Point:
@@ -325,24 +316,14 @@ class TestBuiltins(CompilerTest):
         def foo() -> bool:
             p: dynamic = Point(1, 2)
             return hasattr(p, 'x')
-        """
-        mod = self.compile(src)
-        assert mod.foo() == True
 
-    @skip_backends("C", reason="dynamic not supported in C backend")
-    def test_hasattr_dynamic_false(self):
-        src = """
-        @struct
-        class Point:
-            x: i32
-            y: i32
-
-        def foo() -> bool:
+        def bar() -> bool:
             p: dynamic = Point(1, 2)
             return hasattr(p, 'z')
         """
         mod = self.compile(src)
-        assert mod.foo() == False
+        assert mod.foo() == True
+        assert mod.bar() == False
 
     def test_hasattr_custom_getattribute(self):
         mod = self.compile("""

--- a/spy/tests/compiler/test_builtins.py
+++ b/spy/tests/compiler/test_builtins.py
@@ -296,23 +296,14 @@ class TestBuiltins(CompilerTest):
         def foo() -> bool:
             p = Point(1, 2)
             return hasattr(p, 'x')
-        """
-        mod = self.compile(src)
-        assert mod.foo() == True
 
-    def test_hasattr_false(self):
-        src = """
-        @struct
-        class Point:
-            x: i32
-            y: i32
-
-        def foo() -> bool:
+        def bar() -> bool:
             p = Point(1, 2)
             return hasattr(p, 'z')
         """
         mod = self.compile(src)
-        assert mod.foo() == False
+        assert mod.foo() == True
+        assert mod.bar() == False
 
     def test_hasattr_red(self):
         src = """
@@ -333,7 +324,7 @@ class TestBuiltins(CompilerTest):
         self.compile_raises(src, "foo", errors)
 
     @skip_backends("C", reason="dynamic not supported in C backend")
-    def test_hasattr_dynamic_true(self):
+    def test_hasattr_dynamic(self):
         src = """
         @struct
         class Point:
@@ -343,24 +334,14 @@ class TestBuiltins(CompilerTest):
         def foo() -> bool:
             p: dynamic = Point(1, 2)
             return hasattr(p, 'x')
-        """
-        mod = self.compile(src)
-        assert mod.foo() == True
 
-    @skip_backends("C", reason="dynamic not supported in C backend")
-    def test_hasattr_dynamic_false(self):
-        src = """
-        @struct
-        class Point:
-            x: i32
-            y: i32
-
-        def foo() -> bool:
+        def bar() -> bool:
             p: dynamic = Point(1, 2)
             return hasattr(p, 'z')
         """
         mod = self.compile(src)
-        assert mod.foo() == False
+        assert mod.foo() == True
+        assert mod.bar() == False
 
     def test_hasattr_custom_getattribute(self):
         mod = self.compile("""

--- a/spy/tests/compiler/test_builtins.py
+++ b/spy/tests/compiler/test_builtins.py
@@ -1,6 +1,12 @@
 import pytest
 
-from spy.tests.support import CompilerTest, expect_errors, no_C, only_interp
+from spy.tests.support import (
+    CompilerTest,
+    expect_errors,
+    no_C,
+    only_interp,
+    skip_backends,
+)
 from spy.vm.builtin import builtin_method
 from spy.vm.opspec import W_MetaArg, W_OpSpec
 from spy.vm.primitive import W_I32, W_Dynamic
@@ -325,6 +331,62 @@ class TestBuiltins(CompilerTest):
             ("this is red", "attr"),
         )
         self.compile_raises(src, "foo", errors)
+
+    @skip_backends("C", reason="dynamic not supported in C backend")
+    def test_hasattr_dynamic_true(self):
+        src = """
+        @struct
+        class Point:
+            x: i32
+            y: i32
+
+        def foo() -> bool:
+            p: dynamic = Point(1, 2)
+            return hasattr(p, 'x')
+        """
+        mod = self.compile(src)
+        assert mod.foo() == True
+
+    @skip_backends("C", reason="dynamic not supported in C backend")
+    def test_hasattr_dynamic_false(self):
+        src = """
+        @struct
+        class Point:
+            x: i32
+            y: i32
+
+        def foo() -> bool:
+            p: dynamic = Point(1, 2)
+            return hasattr(p, 'z')
+        """
+        mod = self.compile(src)
+        assert mod.foo() == False
+
+    def test_hasattr_custom_getattribute(self):
+        mod = self.compile("""
+        from operator import OpSpec
+
+        @struct
+        class MyClass:
+
+            @blue.metafunc
+            def __getattribute__(m_self, m_name):
+                if m_name.blueval == 'x':
+                    def impl(obj: MyClass, name: str) -> i32:
+                        return 42
+                    return OpSpec(impl)
+                return OpSpec.NULL
+
+        def foo() -> bool:
+            obj = MyClass()
+            return hasattr(obj, 'x')
+
+        def bar() -> bool:
+            obj = MyClass()
+            return hasattr(obj, 'z')
+        """)
+        assert mod.foo() == True
+        assert mod.bar() == False
 
     @only_interp
     def test_dir(self):

--- a/spy/tests/compiler/test_builtins.py
+++ b/spy/tests/compiler/test_builtins.py
@@ -280,6 +280,52 @@ class TestBuiltins(CompilerTest):
         mod = self.compile(src)
         assert mod.foo() == 42
 
+    def test_hasattr(self):
+        src = """
+        @struct
+        class Point:
+            x: i32
+            y: i32
+
+        def foo() -> bool:
+            p = Point(1, 2)
+            return hasattr(p, 'x')
+        """
+        mod = self.compile(src)
+        assert mod.foo() == True
+
+    def test_hasattr_false(self):
+        src = """
+        @struct
+        class Point:
+            x: i32
+            y: i32
+
+        def foo() -> bool:
+            p = Point(1, 2)
+            return hasattr(p, 'z')
+        """
+        mod = self.compile(src)
+        assert mod.foo() == False
+
+    def test_hasattr_red(self):
+        src = """
+        @struct
+        class Point:
+            x: i32
+            y: i32
+
+        def foo() -> bool:
+            var attr = "x"  # this is red
+            p = Point(1, 2)
+            return hasattr(p, attr)
+        """
+        errors = expect_errors(
+            "expected blue argument",
+            ("this is red", "attr"),
+        )
+        self.compile_raises(src, "foo", errors)
+
     @only_interp
     def test_dir(self):
         src = """

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -1102,7 +1102,7 @@ class AbstractFrame:
         args_wam = [self.eval_expr(arg) for arg in call.args]
         w_opimpl = self.vm.call_OP(call.loc, OP.w_CALL, [wam_func] + args_wam)
 
-        # special case getattr and setattr: if we arrive at this point it means that the
+        # special case getattr, hasattr and setattr: if we arrive at this point it means that the
         # call typed correctly (right number, type and color of arguments). The returned
         # opimpl is not supposed to be executed, see builtins.w_getattr.
         #
@@ -1112,6 +1112,11 @@ class AbstractFrame:
         if wam_func.color == "blue" and wam_func.w_blueval is B.w_getattr:
             self.special_calls[call] = "getattr"
             w_opimpl = self.vm.call_OP(call.loc, OP.w_GETATTR, args_wam)
+            return self.eval_opimpl(call, w_opimpl, args_wam)
+
+        elif wam_func.color == "blue" and wam_func.w_blueval is B.w_hasattr:
+            self.special_calls[call] = "hasattr"
+            w_opimpl = self.vm.call_OP(call.loc, OP.w_HASATTR, args_wam)
             return self.eval_opimpl(call, w_opimpl, args_wam)
 
         elif wam_func.color == "blue" and wam_func.w_blueval is B.w_setattr:

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -1112,7 +1112,7 @@ class AbstractFrame:
         args_wam = [self.eval_expr(arg) for arg in call.args]
         w_opimpl = self.vm.call_OP(call.loc, OP.w_CALL, [wam_func] + args_wam)
 
-        # special case getattr and setattr: if we arrive at this point it means that the
+        # special case getattr, hasattr and setattr: if we arrive at this point it means that the
         # call typed correctly (right number, type and color of arguments). The returned
         # opimpl is not supposed to be executed, see builtins.w_getattr.
         #
@@ -1122,6 +1122,11 @@ class AbstractFrame:
         if wam_func.color == "blue" and wam_func.w_blueval is B.w_getattr:
             self.special_calls[call] = "getattr"
             w_opimpl = self.vm.call_OP(call.loc, OP.w_GETATTR, args_wam)
+            return self.eval_opimpl(call, w_opimpl, args_wam)
+
+        elif wam_func.color == "blue" and wam_func.w_blueval is B.w_hasattr:
+            self.special_calls[call] = "hasattr"
+            w_opimpl = self.vm.call_OP(call.loc, OP.w_HASATTR, args_wam)
             return self.eval_opimpl(call, w_opimpl, args_wam)
 
         elif wam_func.color == "blue" and wam_func.w_blueval is B.w_setattr:

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -243,13 +243,27 @@ def w_getattr(vm: "SPyVM", wam_obj: W_MetaArg, wam_name: W_MetaArg) -> W_OpSpec:
 
 
 @BUILTINS.builtin_func(color="blue", kind="metafunc")
+def w_hasattr(vm: "SPyVM", wam_obj: W_MetaArg, wam_name: W_MetaArg) -> W_OpSpec:
+    # ensure that wam_name is blue; raise TypeError if not
+    name = wam_name.blue_unwrap_str(vm)
+
+    @vm.register_builtin_func("builtins", "hasattr", [name])
+    def w_fn(vm: "SPyVM", w_obj: W_Object, w_name: W_Str) -> W_Object:
+        assert False, (
+            "this function shouldn't be called, it's special cased by astframe"
+        )
+
+    return W_OpSpec(w_fn)
+
+
+@BUILTINS.builtin_func(color="blue", kind="metafunc")
 def w_setattr(
     vm: "SPyVM", wam_obj: W_MetaArg, wam_name: W_MetaArg, wam_value: W_MetaArg
 ) -> W_OpSpec:
     # ensure that wam_name is blue; raise TypeError if not
     name = wam_name.blue_unwrap_str(vm)
 
-    @vm.register_builtin_func("builtins", "getattr", [name])
+    @vm.register_builtin_func("builtins", "setattr", [name])
     def w_fn(vm: "SPyVM", w_obj: W_Object, w_name: W_Str, w_val: W_Object) -> W_Object:
         assert False, (
             "this function shouldn't be called, it's special cased by astframe"

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -278,6 +278,20 @@ def w_getattr(vm: "SPyVM", wam_obj: W_MetaArg, wam_name: W_MetaArg) -> W_OpSpec:
 
 
 @BUILTINS.builtin_func(color="blue", kind="metafunc")
+def w_hasattr(vm: "SPyVM", wam_obj: W_MetaArg, wam_name: W_MetaArg) -> W_OpSpec:
+    # ensure that wam_name is blue; raise TypeError if not
+    name = wam_name.blue_unwrap_str(vm)
+
+    @vm.register_builtin_func("builtins", "hasattr", [name])
+    def w_fn(vm: "SPyVM", w_obj: W_Object, w_name: W_Str) -> W_Object:
+        assert False, (
+            "this function shouldn't be called, it's special cased by astframe"
+        )
+
+    return W_OpSpec(w_fn)
+
+
+@BUILTINS.builtin_func(color="blue", kind="metafunc")
 def w_setattr(
     vm: "SPyVM", wam_obj: W_MetaArg, wam_name: W_MetaArg, wam_value: W_MetaArg
 ) -> W_OpSpec:

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -45,6 +45,37 @@ def w_GETATTR(vm: "SPyVM", wam_obj: W_MetaArg, wam_name: W_MetaArg) -> W_OpImpl:
     )
 
 
+@OP.builtin_func(color="blue")
+def w_HASATTR(vm: "SPyVM", wam_obj: W_MetaArg, wam_name: W_MetaArg) -> W_OpImpl:
+    from spy.vm.typechecker import typecheck_opspec
+
+    name = unwrap_name_maybe(vm, wam_name)
+
+    w_T = wam_obj.w_static_T
+    if w_T is B.w_dynamic:
+        w_opspec = W_OpSpec(OP.w_dynamic_hasattr)
+    elif w_getattribute := w_T.lookup_func("__getattribute__"):
+        w_opspec_inner = vm.fast_metacall(w_getattribute, [wam_obj, wam_name])
+        if w_opspec_inner.is_null():
+            w_opspec = W_OpSpec.const(B.w_False)
+        else:
+            w_opspec = W_OpSpec.const(B.w_True)
+    else:
+        w_opspec_inner = default_getattribute(vm, wam_obj, wam_name, name)
+        if w_opspec_inner.is_null():
+            w_opspec = W_OpSpec.const(B.w_False)
+        else:
+            w_opspec = W_OpSpec.const(B.w_True)
+
+    return typecheck_opspec(
+        vm,
+        w_opspec,
+        [wam_obj, wam_name],
+        dispatch="single",
+        errmsg="type `{0}` has no attribute '%s'" % name,
+    )
+
+
 def default_getattribute(
     vm: "SPyVM", wam_obj: W_MetaArg, wam_name: W_MetaArg, name: str
 ) -> W_OpSpec:

--- a/spy/vm/modules/operator/opimpl_dynamic.py
+++ b/spy/vm/modules/operator/opimpl_dynamic.py
@@ -130,6 +130,14 @@ def w_dynamic_getattr(vm: "SPyVM", w_obj: W_Dynamic, w_name: W_Str) -> W_Dynamic
 
 
 @OP.builtin_func
+def w_dynamic_hasattr(vm: "SPyVM", w_obj: W_Dynamic, w_name: W_Str) -> W_Dynamic:
+    wam_obj = W_MetaArg.from_w_obj(vm, w_obj)
+    wam_name = W_MetaArg.from_w_obj(vm, w_name)
+    w_opimpl = vm.call_OP(None, OP.w_HASATTR, [wam_obj, wam_name])
+    return w_opimpl._execute(vm, [w_obj, w_name])  # XXX
+
+
+@OP.builtin_func
 def w_dynamic_call(vm: "SPyVM", w_obj: W_Dynamic, *args_w: W_Dynamic) -> W_Dynamic:
     all_args_w = [w_obj] + list(args_w)
     all_args_wam = [W_MetaArg.from_w_obj(vm, w_x) for i, w_x in enumerate(all_args_w)]


### PR DESCRIPTION
Fixes #247

I needed hasattr, and I saw #247 and https://github.com/spylang/spy/pull/399.

I did the simple part with a LLM.

The code in spy/vm/modules/operator/attrop.py has to be improved. I'm going to think about it.