### PR TITLE
Fix and improve the slice object

### DIFF
--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -423,6 +423,9 @@ class DopplerFrame(ASTFrame):
     def _shift_opimpl_args(
         self, w_opimpl: W_OpImpl, orig_args: list[ast.Expr]
     ) -> list[ast.Expr]:
+        # sanity check
+        assert w_opimpl.w_functype.arity == len(orig_args)
+
         def getarg(spec: ArgSpec) -> ast.Expr:
             if isinstance(spec, ArgSpec.Arg):
                 return orig_args[spec.i]
@@ -526,11 +529,12 @@ class DopplerFrame(ASTFrame):
 
     def shift_expr_Slice(self, op: ast.Slice, wam: W_MetaArg) -> ast.Expr:
         w_opimpl = self.opimpl[op]
+        v_T = make_const(self.vm, op.loc, wam.w_static_T)
         v_start = self.shifted_expr[op.start]
         v_stop = self.shifted_expr[op.stop]
         v_step = self.shifted_expr[op.step]
         return self.shift_opimpl(
-            op, w_opimpl, [v_start, v_stop, v_step], w_T=wam.w_static_T
+            op, w_opimpl, [v_T, v_start, v_stop, v_step], w_T=wam.w_static_T
         )
 
     def shift_expr_Dict(self, dict: ast.Dict, wam: W_MetaArg) -> ast.Expr:

--- a/spy/tests/stdlib/test__list.py
+++ b/spy/tests/stdlib/test__list.py
@@ -131,9 +131,13 @@ class TestList(CompilerTest):
             def reverse_slice() -> list[i32]:
                 m = [1,2,3]
                 return m[::-1]
-            """)
 
+            def reverse_from(a: i32) -> list[i32]:
+                m = [1, 2, 3, 4, 5]
+                return m[a::-1]
+            """)
         assert mod.reverse_slice() == [3, 2, 1]
+        assert mod.reverse_from(3) == [4, 3, 2, 1]
 
     def test_fastiter(self):
         src = """

--- a/stdlib/_slice.spy
+++ b/stdlib/_slice.spy
@@ -52,12 +52,6 @@ class Slice:
         TYPES = interp_tuple(
             m_start.static_type, m_stop.static_type, m_step.static_type
         )
-
-        # We can't use a normal list to hold the MetaArgs, since the _list module
-        # imports the _slice module (to use in list.__getitem__ and __setitem__)
-        # TO avoid a circular import, we use an interp_list
-        args_m = interp_list[MetaArg](m_start, m_stop, m_step)
-
         # For each of the 8 possible combinations of three variables which
         # can be either None and i32, create an mplementation with the
         # correct parameter types. Each implementation calls Slice.__make__
@@ -72,52 +66,52 @@ class Slice:
 
         elif TYPES == interp_tuple(NoneType, i32, i32):
 
-            def impl2(_start: NoneType, _stop: i32, _step: i32) -> Slice:
+            def impl2(_stop: i32, _step: i32) -> Slice:
                 return Slice.__make__(0, 1, _stop, 0, _step, 0)
 
-            return OpSpec(impl2, interp_list[MetaArg](m_start, m_stop, m_step))
+            return OpSpec(impl2, interp_list[MetaArg](m_stop, m_step))
 
         elif TYPES == interp_tuple(i32, NoneType, i32):
 
-            def impl3(_start: i32, _stop: NoneType, _step: i32) -> Slice:
+            def impl3(_start: i32, _step: i32) -> Slice:
                 return Slice.__make__(_start, 0, 0, 1, _step, 0)
 
-            return OpSpec(impl3, interp_list[MetaArg](m_start, m_stop, m_step))
+            return OpSpec(impl3, interp_list[MetaArg](m_start, m_step))
 
         elif TYPES == interp_tuple(i32, i32, NoneType):
 
-            def impl4(_start: i32, _stop: i32, _step: NoneType) -> Slice:
+            def impl4(_start: i32, _stop: i32) -> Slice:
                 return Slice.__make__(_start, 0, _stop, 0, 1, 1)
 
-            return OpSpec(impl4, interp_list[MetaArg](m_start, m_stop, m_step))
+            return OpSpec(impl4, interp_list[MetaArg](m_start, m_stop))
 
         elif TYPES == interp_tuple(NoneType, NoneType, i32):
 
-            def impl5(_start: NoneType, _stop: NoneType, _step: i32) -> Slice:
+            def impl5(_step: i32) -> Slice:
                 return Slice.__make__(0, 1, 0, 1, _step, 0)
 
-            return OpSpec(impl5, interp_list[MetaArg](m_start, m_stop, m_step))
+            return OpSpec(impl5, interp_list[MetaArg](m_step))
 
         elif TYPES == interp_tuple(NoneType, i32, NoneType):
 
-            def impl6(_start: None, _stop: i32, _step: None) -> Slice:
+            def impl6(_stop: i32) -> Slice:
                 return Slice.__make__(0, 1, _stop, 0, 1, 1)
 
-            return OpSpec(impl6, interp_list[MetaArg](m_start, m_stop, m_step))
+            return OpSpec(impl6, interp_list[MetaArg](m_stop))
 
         elif TYPES == interp_tuple(i32, NoneType, NoneType):
 
-            def impl7(_start: i32, _stop: None, _step: None) -> Slice:
+            def impl7(_start: i32) -> Slice:
                 return Slice.__make__(_start, 0, 0, 1, 1, 1)
 
-            return OpSpec(impl7, interp_list[MetaArg](m_start, m_stop, m_step))
+            return OpSpec(impl7, interp_list[MetaArg](m_start))
 
         elif TYPES == interp_tuple(NoneType, NoneType, NoneType):
 
-            def impl8(_start: NoneType, _stop: NoneType, _step: NoneType) -> Slice:
+            def impl8() -> Slice:
                 return Slice.__make__(0, 1, 0, 1, 1, 1)
 
-            return OpSpec(impl8, interp_list[MetaArg](m_start, m_stop, m_step))
+            return OpSpec(impl8, interp_list[MetaArg]())
 
         return OpSpec.NULL
 


### PR DESCRIPTION
This solves a very nasty bug in when redshifting slice literals.

The bug was that shift_expr_Slice did NOT pass v_T, so the opimpl got the wrong number of arguments, resulting in a messed-up call.

While we are at it, simplify a bit `slice.__new__`