### PR TITLE
@force_inline to force inlining of red functions

### DIFF
--- a/examples/force_inline.spy
+++ b/examples/force_inline.spy
@@ -1,0 +1,41 @@
+"""
+@force_inline is a special decorator (like the @blue family) that forces
+inlining of a red function at the end of redshift.
+
+The main use cases are:
+
+1. Readability: write small helper functions without polluting the
+   redshifted output with extra call sites.
+
+2. Predictable inlining: guarantee that the SPy compiler inlines a
+   function regardless of C compiler heuristics.
+
+Currently @force_inline only supports functions with a single `return`
+statement (no intermediate assignments).
+
+To inspect what inlining does, compare:
+
+  $ spy redshift force_inline.spy
+  $ spy redshift force_inline.spy --no-inline
+
+With inlining, the body of `polynomial` becomes a single expression:
+
+  def polynomial(a: i32) -> i32:
+      return a * a + (a + 1) * (a + 1) + 2 * (a + 2)
+"""
+
+
+@force_inline
+def square(x: i32) -> i32:
+    return x * x
+
+
+def polynomial(a: i32) -> i32:
+    return square(a) + square(a + 1)
+
+
+def main() -> None:
+    x = 2
+    assert polynomial(x) == x * x + (x + 1) * (x + 1)
+    # 4 + 9 -> 13
+    print(polynomial(x))

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -544,6 +544,7 @@ class FuncDef(Stmt):
     docstring: Optional[str]
     body: list["Stmt"]
     decorators: list["Expr"]
+    is_force_inline: bool = False
     symtable: Any = field(repr=False, default=None)
 
     def shortrepr(self) -> Optional[str]:

--- a/spy/backend/interp.py
+++ b/spy/backend/interp.py
@@ -47,13 +47,12 @@ class InterpModuleWrapper:
 
         if isinstance(w_obj, W_ASTFunc):
             w_func = w_obj
-            if not w_func.is_valid:
-                # let's find the redshifted version
+            while not w_func.is_valid:
+                # follow the chain: orig -> redshifted -> inlined (if applicable)
                 assert w_func.w_redshifted_into is not None
                 w_func = w_func.w_redshifted_into
-                assert w_func.redshifted
-                # tmp change so that force_inline tests pass
-                # assert self.vm.lookup_global(w_func.fqn) is w_func
+            if w_func.redshifted:
+                assert self.vm.lookup_global(w_func.fqn) is w_func
             return InterpFuncWrapper(self.vm, w_func)
         elif isinstance(w_obj, W_Func):
             assert False, "WHAT?"

--- a/spy/backend/interp.py
+++ b/spy/backend/interp.py
@@ -52,7 +52,8 @@ class InterpModuleWrapper:
                 assert w_func.w_redshifted_into is not None
                 w_func = w_func.w_redshifted_into
                 assert w_func.redshifted
-                assert self.vm.lookup_global(w_func.fqn) is w_func
+                # tmp change so that force_inline tests pass
+                # assert self.vm.lookup_global(w_func.fqn) is w_func
             return InterpFuncWrapper(self.vm, w_func)
         elif isinstance(w_obj, W_Func):
             assert False, "WHAT?"

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -108,6 +108,8 @@ class SPyBackend:
         else:
             ret = self.fmt_w_obj(w_functype.w_restype)
         self.scope_stack.append(w_func.funcdef.symtable)
+        if w_func.funcdef.is_force_inline:
+            self.wl("@force_inline")
         self.wl(f"def {name}({params}) -> {ret}:")
         with self.out.indent():
             for stmt in w_func.funcdef.body:
@@ -195,6 +197,8 @@ class SPyBackend:
         params = ", ".join(paramlist)
         ret = self.fmt_expr(funcdef.return_type)
         self.scope_stack.append(funcdef.symtable)
+        if funcdef.is_force_inline:
+            self.wl("@force_inline")
         self.wl(f"def {name}({params}) -> {ret}:")
         with self.out.indent():
             for stmt in funcdef.body:

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -372,42 +372,42 @@ class SPyBackend:
     def fmt_expr_BinOp(self, binop: ast.BinOp) -> str:
         l = self.fmt_expr(binop.left)
         r = self.fmt_expr(binop.right)
-        if binop.left.precedence < binop.precedence:
+        if self._effective_precedence(binop.left) < binop.precedence:
             l = f"({l})"
-        if binop.right.precedence < binop.precedence:
+        if self._effective_precedence(binop.right) < binop.precedence:
             r = f"({r})"
         return f"{l} {binop.op} {r}"
 
     def fmt_expr_CmpOp(self, op: ast.CmpOp) -> str:
         l = self.fmt_expr(op.left)
         r = self.fmt_expr(op.right)
-        if op.left.precedence < op.precedence:
+        if self._effective_precedence(op.left) < op.precedence:
             l = f"({l})"
-        if op.right.precedence < op.precedence:
+        if self._effective_precedence(op.right) < op.precedence:
             r = f"({r})"
         return f"{l} {op.op} {r}"
 
     def fmt_expr_And(self, op: ast.And) -> str:
         l = self.fmt_expr(op.left)
         r = self.fmt_expr(op.right)
-        if op.left.precedence < op.precedence:
+        if self._effective_precedence(op.left) < op.precedence:
             l = f"({l})"
-        if op.right.precedence < op.precedence:
+        if self._effective_precedence(op.right) < op.precedence:
             r = f"({r})"
         return f"{l} and {r}"
 
     def fmt_expr_Or(self, op: ast.Or) -> str:
         l = self.fmt_expr(op.left)
         r = self.fmt_expr(op.right)
-        if op.left.precedence < op.precedence:
+        if self._effective_precedence(op.left) < op.precedence:
             l = f"({l})"
-        if op.right.precedence < op.precedence:
+        if self._effective_precedence(op.right) < op.precedence:
             r = f"({r})"
         return f"{l} or {r}"
 
     def fmt_expr_UnaryOp(self, unary: ast.UnaryOp) -> str:
         v = self.fmt_expr(unary.value)
-        if unary.value.precedence < unary.precedence:
+        if self._effective_precedence(unary.value) < unary.precedence:
             v = f"({v})"
         return f"{unary.op}{v}"
 
@@ -461,6 +461,31 @@ class SPyBackend:
         FQN("operator::f64_gt"): ">",
         FQN("operator::f64_ge"): ">=",
     }
+
+    def _effective_precedence(self, expr: ast.Expr) -> int:
+        """
+        Return the effective precedence of an expression for parenthesisation.
+
+        For most nodes this is just expr.precedence, but ast.Call nodes that
+        pretty-print as binary operators (via pprint_call_maybe) must report
+        the precedence of that operator rather than the Call precedence (16),
+        so that their callers can correctly decide whether to wrap them in
+        parentheses.
+        """
+        if (
+            isinstance(expr, ast.Call)
+            and isinstance(expr.func, ast.FQNConst)
+            and expr.func.fqn in self.FQN2BinOp
+        ):
+            op = self.FQN2BinOp[expr.func.fqn]
+            return ast.BinOp._precedence[op]
+        if (
+            isinstance(expr, ast.Call)
+            and isinstance(expr.func, ast.FQNConst)
+            and expr.func.fqn in self.FQN2CmpOp
+        ):
+            return 6  # all cmp ops have precedence 6
+        return expr.precedence
 
     def pprint_call_maybe(self, call: ast.Call) -> Optional[str]:
         if not isinstance(call.func, ast.FQNConst):

--- a/spy/cli/commands/build.py
+++ b/spy/cli/commands/build.py
@@ -20,6 +20,7 @@ from spy.cli.commands.shared_args import (
     Filename_Required_Args,
     _execute_flag,
     _execute_options,
+    _no_inline_mixin,
 )
 
 
@@ -111,7 +112,12 @@ class _build_mixin:
 
 @dataclass
 class Build_Args(
-    Base_Args, _build_mixin, _execute_flag, _execute_options, Filename_Required_Args
+    Base_Args,
+    _build_mixin,
+    _no_inline_mixin,
+    _execute_flag,
+    _execute_options,
+    Filename_Required_Args,
 ): ...
 
 
@@ -125,7 +131,7 @@ async def build(args: Build_Args) -> None:
     importer.import_all()
 
     vm.ast_color_map = {}
-    vm.redshift(error_mode=args.error_mode)
+    vm.redshift(error_mode=args.error_mode, no_inline=args.no_inline)
 
     gc: GCOption
     if args.gc == "auto":

--- a/spy/cli/commands/redshift.py
+++ b/spy/cli/commands/redshift.py
@@ -14,6 +14,7 @@ from spy.cli.commands.shared_args import (
     Filename_Required_Args,
     _execute_flag,
     _execute_options,
+    _no_inline_mixin,
 )
 
 
@@ -46,7 +47,12 @@ class _redshift_mixin:
 
 @dataclass
 class Redshift_Args(
-    Base_Args, _redshift_mixin, _execute_flag, _execute_options, Filename_Required_Args
+    Base_Args,
+    _redshift_mixin,
+    _no_inline_mixin,
+    _execute_flag,
+    _execute_options,
+    Filename_Required_Args,
 ):
     extra_dump: Annotated[
         Optional[list[Path]],
@@ -77,7 +83,7 @@ async def redshift(args: Redshift_Args) -> None:
     importer.import_all()
 
     vm.ast_color_map = {}
-    vm.redshift(error_mode=args.error_mode)
+    vm.redshift(error_mode=args.error_mode, no_inline=args.no_inline)
 
     if args.execute:
         w_mod = vm.modules_w[modname]

--- a/spy/cli/commands/shared_args.py
+++ b/spy/cli/commands/shared_args.py
@@ -80,6 +80,14 @@ class _execute_options(_timeit_mixin):
 
 
 @dataclass
+class _no_inline_mixin:
+    no_inline: Annotated[
+        bool,
+        Option("--no-inline", help="Skip @force_inline inlining pass (for inspection)"),
+    ] = False
+
+
+@dataclass
 class _execute_flag:
     execute: Annotated[
         bool, Option("-x", "--execute", help="Execute the given module")

--- a/spy/inliner.py
+++ b/spy/inliner.py
@@ -160,7 +160,8 @@ def inline_expr(vm: "SPyVM", expr: ast.Expr) -> ast.Expr:
                 and w_callee.is_force_inline
                 and w_callee.redshifted
             ):
-                return _substitute(vm, w_callee, new_args, expr)
+                substituted = _substitute(vm, w_callee, new_args, expr)
+                return inline_expr(vm, substituted)
 
         # Not a force_inline call: rebuild if anything changed.
         if new_func is expr.func and all(n is o for n, o in zip(new_args, expr.args)):

--- a/spy/inliner.py
+++ b/spy/inliner.py
@@ -1,0 +1,294 @@
+"""
+Inlining pass for @force_inline functions.
+
+This pass runs AFTER redshift. It walks the body of every red W_ASTFunc and
+replaces each ast.Call to a @force_inline callee with the callee's return
+expression, substituting parameters with the call-site arguments.
+
+For now @force_inline functions must consist of a single `return <expr>`
+statement (validated by W_ASTFunc.check_force_inline_valid).
+"""
+
+from typing import TYPE_CHECKING
+
+from spy import ast
+from spy.vm.function import W_ASTFunc
+
+if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
+
+
+def inline_all(vm: "SPyVM") -> None:
+    """
+    Apply inlining to every redshifted W_ASTFunc in the VM.
+
+    First validate all @force_inline functions, then rewrite callers.
+    """
+    for fqn, w_func in list(vm.globals_w.items()):
+        if isinstance(w_func, W_ASTFunc) and w_func.is_force_inline:
+            w_func.check_force_inline_valid()
+
+    # Rewrite all redshifted functions (including @force_inline ones
+    # themselves, in case they call other @force_inline functions).
+    for fqn, w_func in list(vm.globals_w.items()):
+        if isinstance(w_func, W_ASTFunc) and w_func.redshifted:
+            new_func = inline_func(vm, w_func)
+            if new_func is not w_func:
+                vm.globals_w[fqn] = new_func
+
+
+def inline_func(vm: "SPyVM", w_func: W_ASTFunc) -> W_ASTFunc:
+    """
+    Return a new W_ASTFunc with all calls to @force_inline functions inlined.
+    If nothing changed, return the same object.
+    """
+    new_body = inline_body(vm, w_func.funcdef.body)
+    if new_body is w_func.funcdef.body:
+        return w_func
+
+    new_funcdef = w_func.funcdef.replace(body=new_body)
+    new_w_func = W_ASTFunc(
+        w_functype=w_func.w_functype,
+        fqn=w_func.fqn,
+        funcdef=new_funcdef,
+        closure=w_func.closure,
+        defaults_w=w_func.defaults_w,
+        locals_types_w=w_func.locals_types_w,
+    )
+    return new_w_func
+
+
+def inline_body(vm: "SPyVM", body: list[ast.Stmt]) -> list[ast.Stmt]:
+    """Inline calls inside a list of statements. Returns the same list if unchanged."""
+    new_body = [inline_stmt(vm, stmt) for stmt in body]
+    if all(new is old for new, old in zip(new_body, body)):
+        return body
+    return new_body
+
+
+def inline_stmt(vm: "SPyVM", stmt: ast.Stmt) -> ast.Stmt:
+    """Inline calls inside a single statement."""
+    if isinstance(stmt, ast.Return):
+        new_value = inline_expr(vm, stmt.value)
+        return stmt if new_value is stmt.value else stmt.replace(value=new_value)
+
+    if isinstance(stmt, ast.AssignLocal):
+        new_value = inline_expr(vm, stmt.value)
+        return stmt if new_value is stmt.value else stmt.replace(value=new_value)
+
+    if isinstance(stmt, ast.Assign):
+        new_value = inline_expr(vm, stmt.value)
+        return stmt if new_value is stmt.value else stmt.replace(value=new_value)
+
+    if isinstance(stmt, ast.StmtExpr):
+        new_value = inline_expr(vm, stmt.value)
+        return stmt if new_value is stmt.value else stmt.replace(value=new_value)
+
+    if isinstance(stmt, ast.If):
+        new_test = inline_expr(vm, stmt.test)
+        new_then = inline_body(vm, stmt.then_body)
+        new_else = inline_body(vm, stmt.else_body)
+        if (
+            new_test is stmt.test
+            and new_then is stmt.then_body
+            and new_else is stmt.else_body
+        ):
+            return stmt
+        return stmt.replace(test=new_test, then_body=new_then, else_body=new_else)
+
+    if isinstance(stmt, ast.While):
+        new_test = inline_expr(vm, stmt.test)
+        new_body = inline_body(vm, stmt.body)
+        if new_test is stmt.test and new_body is stmt.body:
+            return stmt
+        return stmt.replace(test=new_test, body=new_body)
+
+    if isinstance(stmt, ast.VarDef):
+        if stmt.value is None:
+            return stmt
+        new_value = inline_expr(vm, stmt.value)
+        return stmt if new_value is stmt.value else stmt.replace(value=new_value)
+
+    if isinstance(stmt, ast.UnpackAssign):
+        new_value = inline_expr(vm, stmt.value)
+        return stmt if new_value is stmt.value else stmt.replace(value=new_value)
+
+    if isinstance(stmt, ast.SetAttr):
+        new_target = inline_expr(vm, stmt.target)
+        new_value = inline_expr(vm, stmt.value)
+        if new_target is stmt.target and new_value is stmt.value:
+            return stmt
+        return stmt.replace(target=new_target, value=new_value)
+
+    if isinstance(stmt, ast.SetItem):
+        new_target = inline_expr(vm, stmt.target)
+        new_args = [inline_expr(vm, a) for a in stmt.args]
+        new_value = inline_expr(vm, stmt.value)
+        if (
+            new_target is stmt.target
+            and all(n is o for n, o in zip(new_args, stmt.args))
+            and new_value is stmt.value
+        ):
+            return stmt
+        return stmt.replace(target=new_target, args=new_args, value=new_value)
+
+    # Raise, Pass, Break, Continue, AssignCell, Assert, AugAssign — recurse into
+    # any Expr children via the generic path below.
+    # For now, anything we don't specifically handle is returned unchanged
+    # (conservative: we may miss inlining inside e.g. Assert, but that's fine).
+    return stmt
+
+
+def inline_expr(vm: "SPyVM", expr: ast.Expr) -> ast.Expr:
+    """
+    Recursively inline @force_inline calls inside an expression.
+
+    The key case: if `expr` is an `ast.Call` whose callee is an
+    `ast.FQNConst` pointing to a @force_inline W_ASTFunc, substitute the
+    callee's return expression with the call-site args.
+    """
+    if isinstance(expr, ast.Call):
+        # First recursively inline the arguments.
+        new_args = [inline_expr(vm, a) for a in expr.args]
+        new_func = inline_expr(vm, expr.func)
+
+        # Check if the callee is a @force_inline function.
+        if isinstance(new_func, ast.FQNConst):
+            w_callee = vm.globals_w.get(new_func.fqn)
+            if (
+                isinstance(w_callee, W_ASTFunc)
+                and w_callee.is_force_inline
+                and w_callee.redshifted
+            ):
+                return _substitute(vm, w_callee, new_args, expr)
+
+        # Not a force_inline call: rebuild if anything changed.
+        if new_func is expr.func and all(n is o for n, o in zip(new_args, expr.args)):
+            return expr
+        return expr.replace(func=new_func, args=new_args)
+
+    # For all other expression types recurse into children.
+    return _recurse_expr(vm, expr)
+
+
+def _substitute(
+    vm: "SPyVM",
+    w_callee: W_ASTFunc,
+    call_args: list[ast.Expr],
+    call_node: ast.Call,
+) -> ast.Expr:
+    """
+    Replace a call to a @force_inline function with its return expression,
+    substituting each parameter name with the corresponding call-site argument.
+
+    The callee body is exactly [Return(value=<expr>)].
+    """
+    assert isinstance(w_callee.funcdef.body[0], ast.Return)
+    return_expr: ast.Expr = w_callee.funcdef.body[0].value
+
+    param_names = [arg.name for arg in w_callee.funcdef.args]
+    assert len(param_names) == len(call_args), (
+        f"@force_inline arity mismatch for {w_callee.fqn}: "
+        f"expected {len(param_names)} args, got {len(call_args)}"
+    )
+
+    # Map the symbol objects from the callee's symtable to the call-site exprs.
+    symtable = w_callee.funcdef.symtable
+    sym_to_expr: dict[int, ast.Expr] = {}  # id(sym) -> replacement
+    for name, arg_expr in zip(param_names, call_args):
+        sym = symtable.lookup(name)
+        sym_to_expr[id(sym)] = arg_expr
+
+    # Substitute and preserve the w_T of the original call node.
+    result = _subst_expr(return_expr, sym_to_expr)
+    # Propagate the call's result type onto the top-level node if it isn't set.
+    if call_node.w_T is not None and result.w_T is None:
+        result = result.replace(w_T=call_node.w_T)
+    return result
+
+
+def _subst_expr(expr: ast.Expr, sym_to_expr: dict[int, ast.Expr]) -> ast.Expr:
+    """Recursively substitute NameLocalDirect nodes that match our param syms."""
+
+    if isinstance(expr, ast.NameLocalDirect):
+        replacement = sym_to_expr.get(id(expr.sym))
+        if replacement is not None:
+            # Keep the w_T from the original parameter reference so the tree
+            # stays consistently typed.
+            if expr.w_T is not None and replacement.w_T is None:
+                return replacement.replace(w_T=expr.w_T)
+            return replacement
+
+    # Leaf nodes (Constant, FQNConst, StrConst, LocConst, etc.)
+    if not expr.get_children():
+        return expr
+
+    # Recurse: rebuild only if something changed.
+    return _rebuild_expr(expr, sym_to_expr)
+
+
+def _rebuild_expr(expr: ast.Expr, sym_to_expr: dict[int, ast.Expr]) -> ast.Expr:
+    """
+    Rebuild an expression node, substituting inside all Expr children.
+    Returns the same object if nothing changed.
+    """
+    changes: dict[str, object] = {}
+    for f in expr.__dataclass_fields__.values():
+        val = getattr(expr, f.name)
+        if isinstance(val, ast.Expr):
+            new_val = _subst_expr(val, sym_to_expr)
+            if new_val is not val:
+                changes[f.name] = new_val
+        elif isinstance(val, list):
+            new_list = _subst_list(val, sym_to_expr)
+            if new_list is not val:
+                changes[f.name] = new_list
+
+    if not changes:
+        return expr
+    return expr.replace(**changes)
+
+
+def _subst_list(items: list, sym_to_expr: dict[int, ast.Expr]) -> list:
+    """Substitute inside a list of AST nodes. Returns same list if unchanged."""
+    new_items = []
+    changed = False
+    for item in items:
+        if isinstance(item, ast.Expr):
+            new_item = _subst_expr(item, sym_to_expr)
+            new_items.append(new_item)
+            if new_item is not item:
+                changed = True
+        else:
+            new_items.append(item)
+    return new_items if changed else items
+
+
+def _recurse_expr(vm: "SPyVM", expr: ast.Expr) -> ast.Expr:
+    """
+    Recurse into an arbitrary expression to find and inline any nested calls.
+    """
+    changes: dict[str, object] = {}
+    for f in expr.__dataclass_fields__.values():
+        val = getattr(expr, f.name)
+        if isinstance(val, ast.Expr):
+            new_val = inline_expr(vm, val)
+            if new_val is not val:
+                changes[f.name] = new_val
+        elif isinstance(val, list):
+            new_list = []
+            list_changed = False
+            for item in val:
+                if isinstance(item, ast.Expr):
+                    new_item = inline_expr(vm, item)
+                    new_list.append(new_item)
+                    if new_item is not item:
+                        list_changed = True
+                else:
+                    new_list.append(item)
+            if list_changed:
+                changes[f.name] = new_list
+
+    if not changes:
+        return expr
+    return expr.replace(**changes)

--- a/spy/inliner.py
+++ b/spy/inliner.py
@@ -34,6 +34,7 @@ def inline_all(vm: "SPyVM") -> None:
         if isinstance(w_func, W_ASTFunc) and w_func.redshifted:
             new_func = inline_func(vm, w_func)
             if new_func is not w_func:
+                w_func.invalidate(new_func)
                 vm.globals_w[fqn] = new_func
 
 

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -173,9 +173,10 @@ class Parser:
         func_kind: spy.ast.FuncKind = "plain"
         decorators: list[spy.ast.Expr] = []
 
+        is_force_inline = False
         for deco in py_funcdef.decorator_list:
             d = parse_special_decorator(deco)
-            # @blue.* are special cased
+            # @blue.* and @force_inline are special cased
             if d == "blue":
                 color = "blue"
             elif d == "blue.generic":
@@ -184,6 +185,8 @@ class Parser:
             elif d == "blue.metafunc":
                 color = "blue"
                 func_kind = "metafunc"
+            elif d == "force_inline":
+                is_force_inline = True
             else:
                 # other decorators are stored as general decorators
                 decorators.append(self.from_py_expr(deco))
@@ -208,7 +211,9 @@ class Parser:
                 inner=inner_funcdef,
             )
 
-        return self._parse_py_funcdef(py_funcdef, color, func_kind, decorators)
+        return self._parse_py_funcdef(
+            py_funcdef, color, func_kind, decorators, is_force_inline
+        )
 
     def _parse_type_params(
         self, py_funcdef: py_ast.FunctionDef
@@ -243,6 +248,7 @@ class Parser:
         color: spy.ast.Color,
         func_kind: spy.ast.FuncKind,
         decorators: list[spy.ast.Expr],
+        is_force_inline: bool = False,
     ) -> spy.ast.FuncDef:
         args, defaults = self.from_py_arguments(color, py_funcdef.args)
         #
@@ -286,6 +292,7 @@ class Parser:
             body=body,
             docstring=docstring,
             decorators=decorators,
+            is_force_inline=is_force_inline,
         )
 
     def from_py_arguments(

--- a/spy/tests/support.py
+++ b/spy/tests/support.py
@@ -86,6 +86,10 @@ def only_interp(func):
     return parametrize_compiler_backend(["interp"], func)
 
 
+def only_doppler(func):
+    return parametrize_compiler_backend(["doppler"], func)
+
+
 def only_C(func):
     return parametrize_compiler_backend(["C"], func)
 
@@ -162,6 +166,7 @@ class CompilerTest:
         modname: str = "test",
         *,
         error_mode: ErrorMode = "eager",
+        no_inline: bool = False,
     ) -> Any:
         """
         Compile the W_Module into something which can be accessed and called by
@@ -194,7 +199,7 @@ class CompilerTest:
             return interp_mod
 
         # all backends apart 'interp' require redshifting
-        self.vm.redshift(error_mode=error_mode)
+        self.vm.redshift(error_mode=error_mode, no_inline=no_inline)
         if self.dump_redshift:
             self.dump_module(modname)
 

--- a/spy/tests/test_backend_html.py
+++ b/spy/tests/test_backend_html.py
@@ -141,6 +141,7 @@ class TestHTMLBackend:
                     return_type: <Name: void> (expr, amber)
                         id: <'void'> (leaf, emerald)
                     body[0]: <Pass> (stmt, default)
+                    is_force_inline: <False> (leaf, emerald)
         """
         self.assert_dump(d, expected)
 
@@ -169,6 +170,7 @@ class TestHTMLBackend:
                         id: <'x'> (leaf, emerald)
                     right: <Constant: 1> (expr, amber)
                         value: <1> (leaf, emerald)
+            is_force_inline: <False> (leaf, emerald)
         """
         self.assert_dump(funcdef, expected)
 
@@ -206,6 +208,7 @@ class TestHTMLBackend:
                     right: <Constant: 1> (expr, amber)
                         | 1
                         value: <1> (leaf, emerald)
+            is_force_inline: <False> (leaf, emerald)
         """
         self.assert_dump(funcdef, expected, show_src=True)
 

--- a/spy/tests/test_force_inline.py
+++ b/spy/tests/test_force_inline.py
@@ -42,13 +42,14 @@ class TestForceInline(CompilerTest):
     def test_inline_two_args(self):
         mod = self.compile("""
         @force_inline
-        def add(x: i32, y: i32) -> i32:
-            return x + y
+        def is_lower(x: i32, y: i32) -> bool:
+            return x < y
 
-        def foo(a: i32, b: i32) -> i32:
-            return add(a, b)
+        def is_larger(y: i32, x: i32) -> bool:
+            return not is_lower(y, x)
         """)
-        assert mod.foo(3, 4) == 7
+        assert not mod.is_larger(3, 4)
+        assert mod.is_larger(4, 3)
 
     def test_inline_called_multiple_times(self):
         mod = self.compile("""
@@ -101,19 +102,19 @@ class TestForceInline(CompilerTest):
     def test_dump_inline_two_args(self):
         self.compile("""
         @force_inline
-        def add(x: i32, y: i32) -> i32:
-            return x + y
+        def is_lower(x: i32, y: i32) -> bool:
+            return y > x
 
-        def foo(a: i32, b: i32) -> i32:
-            return add(a, b)
+        def is_larger(y: i32, x: i32) -> bool:
+            return not is_lower(y, x)
         """)
         self.assert_dump("""
         @force_inline
-        def add(x: i32, y: i32) -> i32:
-            return x + y
+        def is_lower(x: i32, y: i32) -> bool:
+            return y > x
 
-        def foo(a: i32, b: i32) -> i32:
-            return a + b
+        def is_larger(y: i32, x: i32) -> bool:
+            return `operator::bool_not`(x > y)
         """)
 
     def test_dump_inline_multiple_callsites(self):

--- a/spy/tests/test_force_inline.py
+++ b/spy/tests/test_force_inline.py
@@ -12,20 +12,7 @@ from spy.tests.support import CompilerTest, only_doppler
 from spy.util import print_diff
 
 
-@only_doppler
 class TestForceInline(CompilerTest):
-    def assert_dump(self, expected: str, *, modname: str = "test") -> None:
-        b = SPyBackend(self.vm)
-        got = b.dump_mod(modname).strip()
-        expected = textwrap.dedent(expected).strip()
-        if got != expected:
-            print_diff(expected, got, "expected", "got")
-            pytest.fail("assert_dump failed")
-
-    # ------------------------------------------------------------------ #
-    # Basic correctness: inlined functions still produce the right value #
-    # ------------------------------------------------------------------ #
-
     def test_basic_inline_correctness(self):
         mod = self.compile("""
         @force_inline
@@ -74,9 +61,67 @@ class TestForceInline(CompilerTest):
         """)
         assert mod.foo(2, 3) == 10
 
-    # ------------------------------------------------------------------ #
-    # Dump tests: verify the redshifted source looks correctly inlined   #
-    # ------------------------------------------------------------------ #
+    def test_no_inline_still_executes_correctly(self):
+        mod = self.compile(
+            """
+        @force_inline
+        def double(x: i32) -> i32:
+            return x * 2
+
+        def foo(a: i32) -> i32:
+            return double(a)
+        """,
+            no_inline=True,
+        )
+        assert mod.foo(5) == 10
+
+    def test_inline_constant_body(self):
+        mod = self.compile("""
+        @force_inline
+        def forty_two() -> i32:
+            return 42
+
+        def foo() -> i32:
+            return forty_two()
+        """)
+        assert mod.foo() == 42
+
+    def test_inline_inside_nested_expr(self):
+        mod = self.compile("""
+        @force_inline
+        def inc(x: i32) -> i32:
+            return x + 1
+
+        def foo(a: i32) -> i32:
+            return inc(inc(a))
+        """)
+        assert mod.foo(3) == 5
+
+    def test_force_inline_does_not_affect_blue(self):
+        mod = self.compile("""
+        @blue
+        def SCALE():
+            return 3
+
+        @force_inline
+        def triple(x: i32) -> i32:
+            return x * SCALE()
+
+        def foo(a: i32) -> i32:
+            return triple(a)
+        """)
+        assert mod.foo(4) == 12
+
+
+@only_doppler
+class TestForceInlineDump(CompilerTest):
+    def assert_dump(self, expected: str, *, modname: str = "test") -> None:
+        b = SPyBackend(self.vm)
+        got = b.dump_mod(modname).strip()
+        expected = textwrap.dedent(expected).strip()
+        if got != expected:
+            print_diff(expected, got, "expected", "got")
+            pytest.fail("assert_dump failed")
 
     def test_dump_simple_inline(self):
         self.compile("""
@@ -89,7 +134,7 @@ class TestForceInline(CompilerTest):
         """)
         # The inlined call `double(a)` becomes `a * 2`.
         # @force_inline functions themselves are still present in the dump
-        # (they remain valid W_ASTFuncs), but callers no longer call them.
+        # (they remain valid W_ASTFuncs).
         self.assert_dump("""
         @force_inline
         def double(x: i32) -> i32:
@@ -168,10 +213,6 @@ class TestForceInline(CompilerTest):
             return 4 + 2 * arg
         """)
 
-    # ------------------------------------------------------------------ #
-    # --no-inline: the flag must suppress inlining                       #
-    # ------------------------------------------------------------------ #
-
     def test_no_inline_flag_suppresses_inlining(self):
         self.compile(
             """
@@ -194,24 +235,9 @@ class TestForceInline(CompilerTest):
             return `test::double`(a)
         """)
 
-    def test_no_inline_still_executes_correctly(self):
-        mod = self.compile(
-            """
-        @force_inline
-        def double(x: i32) -> i32:
-            return x * 2
 
-        def foo(a: i32) -> i32:
-            return double(a)
-        """,
-            no_inline=True,
-        )
-        assert mod.foo(5) == 10
-
-    # ------------------------------------------------------------------ #
-    # Error cases                                                          #
-    # ------------------------------------------------------------------ #
-
+@only_doppler
+class TestForceInlineError(CompilerTest):
     def test_error_multi_statement_body(self):
         src = """
         @force_inline
@@ -237,44 +263,3 @@ class TestForceInline(CompilerTest):
         """
         with pytest.raises(SPyError, match="@force_inline"):
             self.compile(src)
-
-    # ------------------------------------------------------------------ #
-    # Edge cases                                                         #
-    # ------------------------------------------------------------------ #
-
-    def test_inline_constant_body(self):
-        mod = self.compile("""
-        @force_inline
-        def forty_two() -> i32:
-            return 42
-
-        def foo() -> i32:
-            return forty_two()
-        """)
-        assert mod.foo() == 42
-
-    def test_inline_inside_nested_expr(self):
-        mod = self.compile("""
-        @force_inline
-        def inc(x: i32) -> i32:
-            return x + 1
-
-        def foo(a: i32) -> i32:
-            return inc(inc(a))
-        """)
-        assert mod.foo(3) == 5
-
-    def test_force_inline_does_not_affect_blue(self):
-        mod = self.compile("""
-        @blue
-        def SCALE():
-            return 3
-
-        @force_inline
-        def triple(x: i32) -> i32:
-            return x * SCALE()
-
-        def foo(a: i32) -> i32:
-            return triple(a)
-        """)
-        assert mod.foo(4) == 12

--- a/spy/tests/test_force_inline.py
+++ b/spy/tests/test_force_inline.py
@@ -134,6 +134,39 @@ class TestForceInline(CompilerTest):
             return a * a + (a + 1) * (a + 1)
         """)
 
+    def test_dump_inline_blue_with_inlined(self):
+        self.compile("""
+        @force_inline
+        def func_a(arg: i32) -> i32:
+            return 2 * arg
+
+        @blue
+        def blue_b():
+
+            @force_inline
+            def func_b(arg: i32) -> i32:
+                return 4 + func_a(arg)
+
+            return func_b
+
+        def main() -> None:
+            var x = 2
+            print(blue_b()(x))
+        """)
+        self.assert_dump("""
+        @force_inline
+        def func_a(arg: i32) -> i32:
+            return 2 * arg
+
+        def main() -> None:
+            x: i32 = 2
+            print_i32(4 + 2 * x)
+
+        @force_inline
+        def `test::blue_b::func_b`(arg: i32) -> i32:
+            return 4 + 2 * arg
+        """)
+
     # ------------------------------------------------------------------ #
     # --no-inline: the flag must suppress inlining                       #
     # ------------------------------------------------------------------ #

--- a/spy/tests/test_force_inline.py
+++ b/spy/tests/test_force_inline.py
@@ -1,0 +1,246 @@
+"""
+Tests for the @force_inline decorator.
+"""
+
+import textwrap
+
+import pytest
+
+from spy.backend.spy import SPyBackend
+from spy.errors import SPyError
+from spy.tests.support import CompilerTest, only_doppler
+from spy.util import print_diff
+
+
+@only_doppler
+class TestForceInline(CompilerTest):
+    def assert_dump(self, expected: str, *, modname: str = "test") -> None:
+        b = SPyBackend(self.vm)
+        got = b.dump_mod(modname).strip()
+        expected = textwrap.dedent(expected).strip()
+        if got != expected:
+            print_diff(expected, got, "expected", "got")
+            pytest.fail("assert_dump failed")
+
+    # ------------------------------------------------------------------ #
+    # Basic correctness: inlined functions still produce the right value #
+    # ------------------------------------------------------------------ #
+
+    def test_basic_inline_correctness(self):
+        mod = self.compile("""
+        @force_inline
+        def double(x: i32) -> i32:
+            return x * 2
+
+        def foo(a: i32) -> i32:
+            return double(a)
+        """)
+        assert mod.foo(3) == 6
+        assert mod.foo(0) == 0
+        assert mod.foo(-5) == -10
+
+    def test_inline_two_args(self):
+        mod = self.compile("""
+        @force_inline
+        def add(x: i32, y: i32) -> i32:
+            return x + y
+
+        def foo(a: i32, b: i32) -> i32:
+            return add(a, b)
+        """)
+        assert mod.foo(3, 4) == 7
+
+    def test_inline_called_multiple_times(self):
+        mod = self.compile("""
+        @force_inline
+        def square(x: i32) -> i32:
+            return x * x
+
+        def foo(a: i32) -> i32:
+            return square(a) + square(a + 1)
+        """)
+        assert mod.foo(3) == 9 + 16
+        assert mod.foo(0) == 0 + 1
+
+    def test_inline_with_expr_arg(self):
+        mod = self.compile("""
+        @force_inline
+        def double(x: i32) -> i32:
+            return x * 2
+
+        def foo(a: i32, b: i32) -> i32:
+            return double(a + b)
+        """)
+        assert mod.foo(2, 3) == 10
+
+    # ------------------------------------------------------------------ #
+    # Dump tests: verify the redshifted source looks correctly inlined   #
+    # ------------------------------------------------------------------ #
+
+    def test_dump_simple_inline(self):
+        self.compile("""
+        @force_inline
+        def double(x: i32) -> i32:
+            return x * 2
+
+        def foo(a: i32) -> i32:
+            return double(a)
+        """)
+        # The inlined call `double(a)` becomes `a * 2`.
+        # @force_inline functions themselves are still present in the dump
+        # (they remain valid W_ASTFuncs), but callers no longer call them.
+        self.assert_dump("""
+        @force_inline
+        def double(x: i32) -> i32:
+            return x * 2
+
+        def foo(a: i32) -> i32:
+            return a * 2
+        """)
+
+    def test_dump_inline_two_args(self):
+        self.compile("""
+        @force_inline
+        def add(x: i32, y: i32) -> i32:
+            return x + y
+
+        def foo(a: i32, b: i32) -> i32:
+            return add(a, b)
+        """)
+        self.assert_dump("""
+        @force_inline
+        def add(x: i32, y: i32) -> i32:
+            return x + y
+
+        def foo(a: i32, b: i32) -> i32:
+            return a + b
+        """)
+
+    def test_dump_inline_multiple_callsites(self):
+        self.compile("""
+        @force_inline
+        def square(x: i32) -> i32:
+            return x * x
+
+        def foo(a: i32) -> i32:
+            return square(a) + square(a + 1)
+        """)
+        self.assert_dump("""
+        @force_inline
+        def square(x: i32) -> i32:
+            return x * x
+
+        def foo(a: i32) -> i32:
+            return a * a + (a + 1) * (a + 1)
+        """)
+
+    # ------------------------------------------------------------------ #
+    # --no-inline: the flag must suppress inlining                       #
+    # ------------------------------------------------------------------ #
+
+    def test_no_inline_flag_suppresses_inlining(self):
+        self.compile(
+            """
+        @force_inline
+        def double(x: i32) -> i32:
+            return x * 2
+
+        def foo(a: i32) -> i32:
+            return double(a)
+        """,
+            no_inline=True,
+        )
+        # With no_inline, the call is NOT replaced
+        self.assert_dump("""
+        @force_inline
+        def double(x: i32) -> i32:
+            return x * 2
+
+        def foo(a: i32) -> i32:
+            return `test::double`(a)
+        """)
+
+    def test_no_inline_still_executes_correctly(self):
+        mod = self.compile(
+            """
+        @force_inline
+        def double(x: i32) -> i32:
+            return x * 2
+
+        def foo(a: i32) -> i32:
+            return double(a)
+        """,
+            no_inline=True,
+        )
+        assert mod.foo(5) == 10
+
+    # ------------------------------------------------------------------ #
+    # Error cases                                                          #
+    # ------------------------------------------------------------------ #
+
+    def test_error_multi_statement_body(self):
+        src = """
+        @force_inline
+        def bad(x: i32) -> i32:
+            y: i32 = x + 1
+            return y
+
+        def foo(a: i32) -> i32:
+            return bad(a)
+        """
+        with pytest.raises(SPyError, match="@force_inline"):
+            self.compile(src)
+
+    def test_error_multiple_returns(self):
+        src = """
+        @force_inline
+        def bad(x: i32) -> i32:
+            return x
+            return x + 1
+
+        def foo(a: i32) -> i32:
+            return bad(a)
+        """
+        with pytest.raises(SPyError, match="@force_inline"):
+            self.compile(src)
+
+    # ------------------------------------------------------------------ #
+    # Edge cases                                                         #
+    # ------------------------------------------------------------------ #
+
+    def test_inline_constant_body(self):
+        mod = self.compile("""
+        @force_inline
+        def forty_two() -> i32:
+            return 42
+
+        def foo() -> i32:
+            return forty_two()
+        """)
+        assert mod.foo() == 42
+
+    def test_inline_inside_nested_expr(self):
+        mod = self.compile("""
+        @force_inline
+        def inc(x: i32) -> i32:
+            return x + 1
+
+        def foo(a: i32) -> i32:
+            return inc(inc(a))
+        """)
+        assert mod.foo(3) == 5
+
+    def test_force_inline_does_not_affect_blue(self):
+        mod = self.compile("""
+        @blue
+        def SCALE():
+            return 3
+
+        @force_inline
+        def triple(x: i32) -> i32:
+            return x * SCALE()
+
+        def foo(a: i32) -> i32:
+            return triple(a)
+        """)
+        assert mod.foo(4) == 12

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -62,6 +62,7 @@ class TestParser:
                             Pass(),
                         ],
                         decorators=[],
+                        is_force_inline=False,
                     ),
                 ),
             ],
@@ -104,6 +105,7 @@ class TestParser:
                             Pass(),
                         ],
                         decorators=[],
+                        is_force_inline=False,
                     ),
                 ),
             ],
@@ -143,6 +145,7 @@ class TestParser:
                 Pass(),
             ],
             decorators=[],
+            is_force_inline=False,
         )
         """
         self.assert_dump(funcdef, expected)
@@ -202,6 +205,7 @@ class TestParser:
             decorators=[
                 Name(id='mydecorator'),
             ],
+            is_force_inline=False,
         )
         """
         self.assert_dump(funcdef, expected)
@@ -240,6 +244,7 @@ class TestParser:
                     ],
                 ),
             ],
+            is_force_inline=False,
         )
         """
         self.assert_dump(funcdef, expected)
@@ -271,6 +276,7 @@ class TestParser:
                 Name(id='mydecorator'),
                 Name(id='another_deco'),
             ],
+            is_force_inline=False,
         )
         """
         self.assert_dump(funcdef, expected)
@@ -296,6 +302,7 @@ class TestParser:
                 ),
             ],
             decorators=[],
+            is_force_inline=False,
         )
         """
         self.assert_dump(funcdef, expected)
@@ -322,6 +329,7 @@ class TestParser:
                 ),
             ],
             decorators=[],
+            is_force_inline=False,
         )
         """
         self.assert_dump(funcdef, expected)
@@ -348,6 +356,7 @@ class TestParser:
                 ),
             ],
             decorators=[],
+            is_force_inline=False,
         )
         """
         self.assert_dump(funcdef, expected)
@@ -374,6 +383,7 @@ class TestParser:
                 ),
             ],
             decorators=[],
+            is_force_inline=False,
         )
         """
         self.assert_dump(funcdef, expected)
@@ -419,6 +429,7 @@ class TestParser:
                     ),
                 ],
                 decorators=[],
+                is_force_inline=False,
             ),
         )
         """
@@ -446,6 +457,7 @@ class TestParser:
                 ),
             ],
             decorators=[],
+            is_force_inline=False,
         )
         """
         self.assert_dump(funcdef, expected)
@@ -834,6 +846,7 @@ class TestParser:
                 ),
             ],
             decorators=[],
+            is_force_inline=False,
         )
         """
         self.assert_dump(funcdef, expected)
@@ -1343,9 +1356,11 @@ class TestParser:
                                     Pass(),
                                 ],
                                 decorators=[],
+                                is_force_inline=False,
                             ),
                         ],
                         decorators=[],
+                        is_force_inline=False,
                     ),
                 ),
             ],
@@ -1539,6 +1554,7 @@ class TestParser:
                         Pass(),
                     ],
                     decorators=[],
+                    is_force_inline=False,
                 ),
             ],
         )
@@ -1576,6 +1592,7 @@ class TestParser:
                 Pass(),
             ],
             decorators=[],
+            is_force_inline=False,
         )
         """
         self.assert_dump(funcdef, expected)

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -367,8 +367,29 @@ class W_ASTFunc(W_Func):
         self.w_redshifted_into = None
 
     @property
+    def is_force_inline(self) -> bool:
+        return self.funcdef.is_force_inline
+
+    @property
     def redshifted(self) -> bool:
         return self.locals_types_w is not None
+
+    def check_force_inline_valid(self) -> None:
+        """
+        Validate that a @force_inline function is suitable for
+        inlining: exactly one statement which must be a Return.
+        Called after redshifting.
+        """
+        assert self.redshifted, "check_force_inline_valid requires a redshifted func"
+        body = self.funcdef.body
+        if len(body) != 1 or not isinstance(body[0], ast.Return):
+            raise SPyError.simple(
+                "W_TypeError",
+                "@force_inline requires a single-return body",
+                "this function cannot be inlined: "
+                "body must be a single `return <expr>` statement",
+                self.def_loc,
+            )
 
     @property
     def is_valid(self) -> bool:

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -12,6 +12,7 @@ from spy.ast import Color, FuncKind
 from spy.doppler import ErrorMode, redshift
 from spy.errors import WIP, SPyError
 from spy.fqn import FQN, QUALIFIERS
+from spy.inliner import inline_all
 from spy.libspy import LLSPyInstance
 from spy.location import Loc
 from spy.util import func_equals
@@ -183,9 +184,11 @@ class SPyVM:
 
         return None
 
-    def redshift(self, error_mode: ErrorMode) -> None:
+    def redshift(self, error_mode: ErrorMode, *, no_inline: bool = False) -> None:
         """
         Perform a redshift on all W_ASTFunc.
+
+        If no_inline is True, skip the @force_inline inlining pass.
         """
 
         def should_redshift(w_func: W_ASTFunc) -> bool:
@@ -202,6 +205,9 @@ class SPyVM:
             if not funcs:
                 break
             self._redshift_some(funcs, error_mode)
+
+        if not no_inline:
+            inline_all(self)
 
     def _redshift_some(
         self,


### PR DESCRIPTION
Fixes #464 

I didn't want to touch too much doppler so here is an implementation with a new file spy/inliner.py.

For now `@force-inline` functions must consist only in one return statement.

It was a bit too difficult alone so it is mostly AI generated.

In particular, Claude told me that it found a bug about precedence in backend/spy.py (one of the test didn't pass).