### PR TITLE
Support tuple targets in for loops

### DIFF
--- a/spy/analyze/scope.py
+++ b/spy/analyze/scope.py
@@ -427,13 +427,18 @@ class ScopeAnalyzer:
         # What is the "type_loc" of i? It's an implicit declaration, and its
         # value depends on the iterator returned by range. So we use
         # "range(10)" as the type_loc.
-        self.define_name(
-            forstmt.target.value,
-            "var",
-            "auto",
-            forstmt.target.loc,
-            forstmt.iter.loc,
-        )
+        if isinstance(forstmt.target, ast.StrConst):
+            targets = [forstmt.target]
+        else:
+            targets = forstmt.target
+        for target in targets:
+            self.define_name(
+                target.value,
+                "var",
+                "auto",
+                target.loc,
+                forstmt.iter.loc,
+            )
 
         # Increment loop depth before processing body
         self.loop_depth += 1
@@ -535,7 +540,12 @@ class ScopeAnalyzer:
 
     def flatten_For(self, forstmt: ast.For) -> None:
         # capture the loop variable and flatten the iterator
-        self.capture_maybe(forstmt.target.value)
+        if isinstance(forstmt.target, ast.StrConst):
+            self.capture_maybe(forstmt.target.value)
+        else:
+            self.mod_scope.implicit_imports.add("_tuple")
+            for target in forstmt.target:
+                self.capture_maybe(target.value)
         self.flatten(forstmt.iter)
         # flatten the body
         for stmt in forstmt.body:

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -675,7 +675,7 @@ class While(Stmt):
 @astnode
 class For(Stmt):
     seq: int  # unique id within a funcdef
-    target: StrConst
+    target: StrConst | list[StrConst]
     iter: Expr
     body: list[Stmt]
 

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -294,7 +294,10 @@ class SPyBackend:
                 self.emit_stmt(stmt)
 
     def emit_stmt_For(self, for_node: ast.For) -> None:
-        target = for_node.target.value
+        if isinstance(for_node.target, ast.StrConst):
+            target = for_node.target.value
+        else:
+            target = ", ".join([t.value for t in for_node.target])
         iter_expr = self.fmt_expr(for_node.iter)
         self.wl(f"for {target} in {iter_expr}:")
         with self.out.indent():

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -591,16 +591,27 @@ class Parser:
             )
             self.error(msg, "this is not supported", forloc)
 
-        # Only support simple names as targets for now
-        if not isinstance(py_node.target, py_ast.Name):
-            self.unsupported(py_node.target, "complex for loop targets")
+        py_target = py_node.target
+        if isinstance(py_target, py_ast.Name):
+            target: spy.ast.StrConst | list[spy.ast.StrConst] = spy.ast.StrConst(
+                py_target.loc, py_target.id
+            )
+        elif isinstance(py_target, py_ast.Tuple):
+            targets = []
+            for item in py_target.elts:
+                if not isinstance(item, py_ast.Name):
+                    self.unsupported(item, "complex for loop targets")
+                targets.append(spy.ast.StrConst(item.loc, item.id))
+            target = targets
+        else:
+            self.unsupported(py_target, "complex for loop targets")
 
         seq = self.for_loop_seq
         self.for_loop_seq += 1
         return spy.ast.For(
             loc=py_node.loc,
             seq=seq,
-            target=spy.ast.StrConst(py_node.target.loc, py_node.target.id),
+            target=target,
             iter=self.from_py_expr(py_node.iter),
             body=self.from_py_body(py_node.body),
         )

--- a/spy/tests/test_backend_spy.py
+++ b/spy/tests/test_backend_spy.py
@@ -418,3 +418,12 @@ class TestSPyBackend(CompilerTest):
         """
         self.compile(src)
         self.assert_dump(src)
+
+    def test_for_tuple_target(self):
+        src = """
+        def foo() -> None:
+            for i, j in pairs:
+                pass
+        """
+        self.compile(src)
+        self.assert_dump(src)

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -1115,16 +1115,38 @@ class TestParser:
             ("this is not supported", "for"),
         )
 
+    def test_for_tuple_target(self):
+        mod = self.parse("""
+        def foo() -> None:
+            for i, j in pairs:
+                pass
+        """)
+        stmt = mod.get_funcdef("foo").body[0]
+        expected = """
+        For(
+            seq=0,
+            target=[
+                StrConst(value='i'),
+                StrConst(value='j'),
+            ],
+            iter=Name(id='pairs'),
+            body=[
+                Pass(),
+            ],
+        )
+        """
+        self.assert_dump(stmt, expected)
+
     def test_For_complex_target_unsupported(self):
         src = """
         def foo() -> None:
-            for i, j in pairs:
+            for (i, (j, k)) in pairs:
                 pass
         """
         self.expect_errors(
             src,
             "not implemented yet: complex for loop targets",
-            ("this is not supported", "i, j"),
+            ("this is not supported", "(j, k)"),
         )
 
     def test_multiple_For(self):

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -753,16 +753,29 @@ class AbstractFrame:
             ),
         )
         # i = it.__item__()
-        assign_item = ast.Assign(
-            loc=for_node.loc,
-            target=for_node.target,
-            value=ast.CallMethod(
+        if isinstance(for_node.target, ast.StrConst):
+            assign_item: ast.Stmt = ast.Assign(
                 loc=for_node.loc,
-                target=ast.NameLocalDirect(for_node.loc, iter_sym),
-                method=ast.StrConst(for_node.loc, "__item__"),
-                args=[],
-            ),
-        )
+                target=for_node.target,
+                value=ast.CallMethod(
+                    loc=for_node.loc,
+                    target=ast.NameLocalDirect(for_node.loc, iter_sym),
+                    method=ast.StrConst(for_node.loc, "__item__"),
+                    args=[],
+                ),
+            )
+        else:
+            assign_item = ast.UnpackAssign(
+                loc=for_node.loc,
+                targets=for_node.target,
+                value=ast.CallMethod(
+                    loc=for_node.loc,
+                    target=ast.NameLocalDirect(for_node.loc, iter_sym),
+                    method=ast.StrConst(for_node.loc, "__item__"),
+                    args=[],
+                ),
+            )
+
         # it = it.__next__()
         advance_iter = ast.Assign(
             loc=for_node.loc,


### PR DESCRIPTION
Closes #455 
## Summary

This PR adds support for tuple targets in `for` loops.

Example:
```python
for a, b in pairs:
    pass
```
Before this change, `for` loops only supported a single name target.

## Changes
- allow `ast.For.target` to be either a single name or a list of names
- parse tuple targets in `for` loops
- declare and flatten all names from tuple targets
- emit `UnpackAssign` in `_desugar_For` for tuple targets
- update backend output to print `for a, b in pairs:`

## Notes
This PR supports simple tuple targets only.
Nested unpacking is still rejected.

## Testing

Added tests for parser and backend output.

While testing, I found a separate doppler issue:
`for t in lst` fails when `lst` is `list[tuple[...]]`, with what seems to be a `gc_ref[tuple]` vs `tuple` mismatch.

Because that looks independent from tuple targets in `for` loops, I did not include that compiler-level test in this PR.

Happy to make any changes if needed.