### PR TITLE
Support isolated module-level str

### DIFF
--- a/spy/parser.py
+++ b/spy/parser.py
@@ -159,6 +159,13 @@ class Parser:
             elif isinstance(py_stmt, py_ast.Import):
                 importdecls = self.from_py_Import(py_stmt)
                 mod.decls += importdecls
+            elif (
+                isinstance(py_stmt, py_ast.Expr)
+                and isinstance(py_stmt.value, py_ast.Constant)
+                and isinstance(py_stmt.value.value, str)
+            ):
+                # this is an isolated module-level str
+                pass
             else:
                 msg = (
                     "only function and variable definitions are allowed at global scope"

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -1703,3 +1703,11 @@ class TestParser:
             )
             """,
         )
+
+    def test_module_level_str(self):
+        mod = self.parse("""
+        "The docstring"
+        a = 1
+        "A module-level string"
+        """)
+        assert mod.docstring == "The docstring"

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -1708,6 +1708,6 @@ class TestParser:
         mod = self.parse("""
         "The docstring"
         a = 1
-        "A module-level string"
+        "This string will be ignored"
         """)
         assert mod.docstring == "The docstring"


### PR DESCRIPTION
This is a very simple and small PR to support isolated strings at the module level. A commit comes from #448 and I added a simple test.

Isolated strings at the module level are useful for examples and I would need this for my work on examples and playground (related to #416).

Since this corresponds to a very small change, I guess it should be easier/faster to review (and merge when ready).