### PR TITLE
Add docs on the main function, argv and return codes (again)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ docs = [
     "mkdocs-material==9.7.0",
     "mkdocs-material-extensions==1.3.1",
     "pymdown-extensions==10.20",
-    "mike==2.1.3"
+    "mike==2.1.3",
+    "pygments==2.19.1"
 ]
 
 [project.urls]


### PR DESCRIPTION
Retrying to add the docs update originally in #470, but with `pygments` pinned to `2.19.1` to avoid a regression that breaks superfences.

> Adds a documentation page for current info on the main function, and optionally providing command line arguments and return codes. Based on the work in https://github.com/spylang/spy/issues/353 and elsewhere.