### PR TITLE
Fix var NULL ptr global and the tests

### DIFF
--- a/spy/backend/c/cmodwriter.py
+++ b/spy/backend/c/cmodwriter.py
@@ -251,23 +251,23 @@ class CModuleWriter:
         elif isinstance(w_obj, W_Cell):
             w_content = w_obj.get()
             w_T = self.ctx.vm.dynamic_type(w_content)
-            # we support only int global variables for now
-            assert isinstance(w_content, W_I32), "WIP: var type not supported"
-            intval = self.ctx.vm.unwrap(w_content)
-            c_type = self.ctx.w2c(w_T)
-            self.tbh_globals.wl(f"extern {c_type} {fqn.c_name};")
-            self.tbc_globals.wl(f"{c_type} {fqn.c_name} = {intval};")
-
-        # ==== misc consts ====
-        elif isinstance(w_T, W_PtrType):
-            # for now, we only support NULL constnts
-            assert isinstance(w_obj, W_Ptr)
-            assert w_obj.addr == 0, (
-                "only NULL pointers can be stored in constants for now"
-            )
-            c_type = self.ctx.w2c(w_T)
-            self.tbh_globals.wl(f"extern {c_type} {fqn.c_name};")
-            self.tbc_globals.wl(f"{c_type} {fqn.c_name} = {{0}};")
+            # we support only int and pointer global variables for now
+            if isinstance(w_content, W_I32):
+                intval = self.ctx.vm.unwrap(w_content)
+                c_type = self.ctx.w2c(w_T)
+                self.tbh_globals.wl(f"extern {c_type} {fqn.c_name};")
+                self.tbc_globals.wl(f"{c_type} {fqn.c_name} = {intval};")
+            elif isinstance(w_T, W_PtrType):
+                # for now, we only support NULL constnts
+                assert isinstance(w_content, W_Ptr)
+                assert w_content.addr == 0, (
+                    "only NULL pointers can be stored in constants for now"
+                )
+                c_type = self.ctx.w2c(w_T)
+                self.tbh_globals.wl(f"extern {c_type} {fqn.c_name};")
+                self.tbc_globals.wl(f"{c_type} {fqn.c_name} = {{0}};")
+            else:
+                raise WIP("var type `{w_T}` not supported")
 
         else:
             raise NotImplementedError("WIP")

--- a/spy/tests/compiler/unsafe/test_ptr.py
+++ b/spy/tests/compiler/unsafe/test_ptr.py
@@ -415,7 +415,7 @@ class TestUnsafePtr(CompilerTest):
         mod = self.compile(f"""
         from unsafe import {k}_ptr as k_ptr
 
-        null_ptr: k_ptr[i32] = k_ptr[i32].NULL
+        var null_ptr: k_ptr[i32] = k_ptr[i32].NULL
 
         def foo(i: i32) -> i32:
             return null_ptr[i]
@@ -431,14 +431,19 @@ class TestUnsafePtr(CompilerTest):
     def test_NULL_in_global(self, memkind):
         k = memkind
         mod = self.compile(f"""
-        from unsafe import {k}_ptr as k_ptr
+        from unsafe import {k}_ptr as k_ptr, {k}_alloc as k_alloc
 
-        global_ptr: k_ptr[i32] = k_ptr[i32].NULL
+        var global_ptr: k_ptr[i32] = k_ptr[i32].NULL
 
         def is_null() -> bool:
             return global_ptr == k_ptr[i32].NULL
+
+        def alloc_global_ptr() -> None:
+            global_ptr = k_alloc[i32](1)
         """)
         assert mod.is_null() is True
+        mod.alloc_global_ptr()
+        assert mod.is_null() is False
 
     def test_ptr_truth(self, memkind):
         k = memkind


### PR DESCRIPTION
@antocuni, this is a very simple PR just to fix `var BUF: gc_ptr[u8] = gc_ptr[u8].NULL` at the global level.

The diff was given by @antocuni in https://github.com/spylang/spy/pull/484#issuecomment-4317123524 and I just modified two existing tests.

It seems to me that it is not very useful to have a constant null global pointer so I added `var` to the related tests, so that they fail.

Is it correct?