### PR TITLE
fix bug setattr register

### DIFF
--- a/spy/tests/compiler/test_builtins.py
+++ b/spy/tests/compiler/test_builtins.py
@@ -262,6 +262,24 @@ class TestBuiltins(CompilerTest):
         )
         self.compile_raises(src, "foo", errors)
 
+    def test_setattr_getattr(self):
+        src = """
+        from unsafe import gc_alloc
+
+        @struct
+        class Point:
+            x: i32
+
+        def foo() -> i32:
+            ptr = gc_alloc[Point](1)
+            setattr(ptr[0], "x", 2)
+
+            p = Point(42)
+            return getattr(p, "x")
+        """
+        mod = self.compile(src)
+        assert mod.foo() == 42
+
     @only_interp
     def test_dir(self):
         src = """

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -249,7 +249,7 @@ def w_setattr(
     # ensure that wam_name is blue; raise TypeError if not
     name = wam_name.blue_unwrap_str(vm)
 
-    @vm.register_builtin_func("builtins", "getattr", [name])
+    @vm.register_builtin_func("builtins", "setattr", [name])
     def w_fn(vm: "SPyVM", w_obj: W_Object, w_name: W_Str, w_val: W_Object) -> W_Object:
         assert False, (
             "this function shouldn't be called, it's special cased by astframe"


### PR DESCRIPTION
This is a 1-character-long fix with fixes a typo leading to a strange bug for this code:

```python
from unsafe import gc_alloc

@struct
class Point:
    x: i32
    y: i32

def main() -> None:
    ptr_point = gc_alloc[Point](1)
    setattr(ptr_point[0], "x", 1)

    point = Point(1, 2)
    print(getattr(point, "x"))
```

