### PR TITLE
Add Documentation Previews to PRs

### DIFF
--- a/.github/workflows/docs-preview-build.yml
+++ b/.github/workflows/docs-preview-build.yml
@@ -1,0 +1,53 @@
+name: Build PR Docs Preview
+
+# Splitting the preview docs build into an (untrusted) build step (this one)
+# and a trusted deployment step helps prevent a class of issues that allow 
+# secret exfiltration from a repo.
+# See https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/ 
+permissions:
+  contents: read
+
+# When a new udpate is made to this PR, cancel any still-running builds from previous pushes
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs**'
+    types:
+      - opened
+      - synchronize
+      - reopened
+  workflow_dispatch:
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+           pip install .[docs]
+
+      - name: Build and mkdocs
+        run: |
+          mkdocs build --config-file docs/mkdocs.yml --site-dir ./site -v
+          
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-preview-docs-${{ github.event.number }}
+          path: docs/site
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -1,0 +1,48 @@
+name: Remove PR Preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-cleanup-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create empty deploy folder
+        run: mkdir -p empty
+
+      - name: Remove PR Preview folder using GitHub Pages Deploy Action
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: ./empty
+          target-folder: pr-preview/pr-${{ github.event.pull_request.number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          clean: true
+
+      - name: Get timestamp (UTC)
+        id: ts
+        run: echo "utc=$(date -u '+%Y-%m-%d %H:%M UTC')" >> "$GITHUB_OUTPUT"
+
+      - name: Post removal sticky PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ github.event.pull_request.number }}
+          header: pr-preview
+          message: |
+            Documentation Preview
+            :---:
+            Preview removed because the pull request was closed.
+            Preview removed ${{ steps.ts.outputs.utc }}
+            <!-- Sticky Pull Request Commentpr-preview -->

--- a/.github/workflows/docs-preview-deploy.yml
+++ b/.github/workflows/docs-preview-deploy.yml
@@ -76,7 +76,7 @@ jobs:
           number: ${{ steps.pr.outputs.pr_number }}
           header: pr-preview
           message: |
-            [Documentation Preview](https://jeffersglass.github.io/spy/pr-preview/pr-${{ steps.pr.outputs.pr_number }})
+            [Documentation Preview](https://spylang.github.io/spy/pr-preview/pr-${{ steps.pr.outputs.pr_number }})
             :---:
             Preview documentation for PR #${{ steps.pr.outputs.pr_number }}.
             Last Updated: ${{ steps.ts.outputs.utc }}

--- a/.github/workflows/docs-preview-deploy.yml
+++ b/.github/workflows/docs-preview-deploy.yml
@@ -1,0 +1,83 @@
+name: Deploy PR Docs Preview
+#
+# Triggers after 'Build PR Docs Preview' completes successfully.
+#
+on:
+  workflow_run:
+    workflows: [Build PR Docs Preview]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: write
+  pages: write
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: pr-docs-deploy-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: List artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts
+
+      - name: Get PR number from artifact name
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts \
+            --jq '.artifacts[].name | select(startswith("pr-preview-docs-")) | sub("^pr-preview-docs-"; "")' | head -n1)
+          if [ -z "$PR_NUMBER" ]; then
+            echo "Failed to determine PR number from artifacts" >&2
+            exit 1
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "Deploying preview for PR #$PR_NUMBER"
+
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+          name: pr-preview-docs-${{ steps.pr.outputs.pr_number }}
+          path: ./site
+
+      - name: List downloaded files (debug)
+        run: find ./site -maxdepth 4 -type f | head -100
+
+      - name: Deploy PR Preview
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: ./site
+          target-folder: pr-preview/pr-${{ steps.pr.outputs.pr_number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get timestamp (UTC)
+        id: ts
+        run: echo "utc=$(date -u '+%Y-%m-%d %H:%M UTC')" >> "$GITHUB_OUTPUT"
+
+      - name: Post preview link as sticky PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.pr.outputs.pr_number }}
+          header: pr-preview
+          message: |
+            [Documentation Preview](https://jeffersglass.github.io/spy/pr-preview/pr-${{ steps.pr.outputs.pr_number }})
+            :---:
+            Preview documentation for PR #${{ steps.pr.outputs.pr_number }}.
+            Last Updated: ${{ steps.ts.outputs.utc }}
+            <!-- Sticky Pull Request Commentpr-preview -->

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -71,3 +71,5 @@ Once you're happy with your changes, add them to your git branch and push them t
 ```
 
 Finally, open a Pull Request on the [SPy GitHub page](https://github.com/spylang/spy).
+
+Once the pull request is open, a preview build of the documentation site with your changes will be generated automatically. Click on the generated link that appears in a comment on your PR, and give your documentation one final review to ensure everything still looks correct after it's been built in CI.


### PR DESCRIPTION
Adds 3 workflows to automatically build a preview copy of the documentation whenever the docs are touched in a PR; this should make it more comfortable to review documentation PRs (epecially since it seems like there's excitement around the docs, aka #494). It hopefully will help us catch other docs regressions sooner as well, like what happened with #470.

You can see an example of what this looks like [over on my fork](https://github.com/JeffersGlass/spy/pull/7). The action only ever creates one 'sticky' comment in the PR with a link to the docs preview, which gets edited. That way the PR thread isn't cluttered with bot comments.

When the PR is closed, the cleanup action deletes its files and edits the comment one last time to clear the link. Yes the files live in git history forever, but given how they're going to be 98% identical to other files, the addition to clone size should be negligible. And if it really does get bit in the long term, we could do some [`git-filter-repo` kung-foo](https://stackoverflow.com/questions/10067848/remove-folder-and-its-contents-from-git-githubs-history) to actually remove the old previews.