### PR TITLE
Add the @force_inline decorator

### DIFF
--- a/spy/analyze/symtable.py
+++ b/spy/analyze/symtable.py
@@ -241,6 +241,12 @@ class SymTable:
                 f"{indent}    [{sym.level}] {sym.varkind:5s} {sym_name} {storage} {impref}"
             )
 
+    def copy(self) -> "SymTable":
+        new_st = SymTable(self.name, self.color, self.kind)
+        new_st._symbols = dict(self._symbols)
+        new_st.implicit_imports = set(self.implicit_imports)
+        return new_st
+
     def add(self, sym: Symbol) -> None:
         assert sym.name not in self._symbols
         self._symbols[sym.name] = sym

--- a/spy/analyze/symtable.py
+++ b/spy/analyze/symtable.py
@@ -92,7 +92,7 @@ class ImportRef:
         return f"<ImportRef {n}>"
 
 
-@dataclass
+@dataclass(frozen=True)
 class Symbol:
     name: str
     varkind: VarKind

--- a/spy/backend/c/cbackend.py
+++ b/spy/backend/c/cbackend.py
@@ -225,6 +225,7 @@ class CBackend:
                 if (
                     isinstance(w_obj, W_ASTFunc)
                     and w_obj.color == "red"
+                    and not w_obj.is_force_inline
                     or isinstance(w_obj, W_Cell)
                 )
             ]

--- a/spy/backend/c/cmodwriter.py
+++ b/spy/backend/c/cmodwriter.py
@@ -239,8 +239,8 @@ class CModuleWriter:
 
         # ==== functions ====
         if isinstance(w_obj, W_ASTFunc):
-            # emit red functions, ignore blue ones
-            if w_obj.color == "red":
+            # emit red functions, ignore blue ones and @force_inline (no call sites)
+            if w_obj.color == "red" and not w_obj.is_force_inline:
                 self.emit_func(fqn, w_obj)
 
         elif isinstance(w_obj, W_BuiltinFunc):

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Literal, Optional
 from fixedint import FixedInt
 
 from spy import ast
-from spy.analyze.symtable import Color
+from spy.analyze.symtable import Color, Symbol
 from spy.errors import SPyError
 from spy.fqn import FQN
 from spy.location import Loc
@@ -103,6 +103,9 @@ class DopplerFrame(ASTFrame):
         self.opimpl = {}
         assert error_mode != "warn"
         self.error_mode = error_mode
+        self._inline_counter = 0
+        self._new_symbols: list["Symbol"] = []
+        self._new_locals_types_w: dict[str, "W_Type"] = {}
 
     # overridden
     @property
@@ -114,7 +117,6 @@ class DopplerFrame(ASTFrame):
         self.w_func.lowering_stage = "redshift_in_progress"
         self.declare_arguments()
         funcdef = self.w_func.funcdef
-        new_symtable = funcdef.symtable.copy()
         new_body = []
         # fwdecl of types
         for stmt in funcdef.body:
@@ -124,6 +126,9 @@ class DopplerFrame(ASTFrame):
         for stmt in funcdef.body:
             new_body += self.shift_stmt(stmt)
 
+        new_symtable = funcdef.symtable.copy()
+        for sym in self._new_symbols:
+            new_symtable.add(sym)
         new_funcdef = funcdef.replace(body=new_body, symtable=new_symtable)
         #
         new_fqn = self.w_func.fqn
@@ -131,7 +136,7 @@ class DopplerFrame(ASTFrame):
         # closure will be empty
         new_closure = ()
         w_newfunctype = self.w_func.w_functype
-        locals_types_w = self.get_locals_types_w()
+        locals_types_w = {**self.get_locals_types_w(), **self._new_locals_types_w}
         w_newfunc = W_ASTFunc(
             fqn=new_fqn,
             closure=new_closure,
@@ -435,10 +440,45 @@ class DopplerFrame(ASTFrame):
             return make_const(self.vm, op.loc, w_opimpl.w_const)
 
         assert w_opimpl.is_func_call()
-        func = make_const(self.vm, op.loc, w_opimpl.w_func)
         real_args = self._shift_opimpl_args(w_opimpl, orig_args)
         w_T = w_opimpl.w_functype.w_restype
+
+        w_func = w_opimpl.w_func
+        if isinstance(w_func, W_ASTFunc) and w_func.is_force_inline:
+            return self._inline_call(op, w_func, real_args)
+
+        func = make_const(self.vm, op.loc, w_func)
         return ast.Call(op.loc, func, real_args, w_T=w_T)
+
+    def _inline_call(
+        self,
+        op: ast.Node,
+        w_func: W_ASTFunc,
+        real_args: list[ast.Expr],
+    ) -> ast.Expr:
+        from spy.force_inline import inline_call
+
+        w_callee = w_func.get_most_lowered_version()
+        stage = w_callee.lowering_stage
+        if stage == "redshift_in_progress":
+            err = SPyError(
+                "W_TypeError",
+                f"cannot inline a recursive call to @force_inline function"
+                f" `{w_callee.fqn.human_name}`",
+            )
+            err.add("error", "recursive inline call", op.loc)
+            raise err
+        if stage == "source":
+            self.vm._redshift_some([(w_callee.fqn, w_callee)], self.error_mode)
+            w_callee = w_callee.get_most_lowered_version()
+        assert w_callee.lowering_stage == "redshift"
+
+        n = self._inline_counter
+        self._inline_counter += 1
+        result = inline_call(self.vm, op, w_callee, real_args, n)
+        self._new_symbols.extend(result.new_symbols)
+        self._new_locals_types_w.update(result.new_locals_types_w)
+        return result.block
 
     def _shift_opimpl_args(
         self, w_opimpl: W_OpImpl, orig_args: list[ast.Expr]

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -111,8 +111,10 @@ class DopplerFrame(ASTFrame):
 
     def redshift(self) -> W_ASTFunc:
         assert self.w_func.lowering_stage == "source", "cannot redshift twice"
+        self.w_func.lowering_stage = "redshift_in_progress"
         self.declare_arguments()
         funcdef = self.w_func.funcdef
+        new_symtable = funcdef.symtable.copy()
         new_body = []
         # fwdecl of types
         for stmt in funcdef.body:
@@ -122,13 +124,14 @@ class DopplerFrame(ASTFrame):
         for stmt in funcdef.body:
             new_body += self.shift_stmt(stmt)
 
-        new_funcdef = funcdef.replace(body=new_body)
+        new_funcdef = funcdef.replace(body=new_body, symtable=new_symtable)
         #
         new_fqn = self.w_func.fqn
         # all the non-local lookups are redshifted into constants, so the
         # closure will be empty
         new_closure = ()
         w_newfunctype = self.w_func.w_functype
+        locals_types_w = self.get_locals_types_w()
         w_newfunc = W_ASTFunc(
             fqn=new_fqn,
             closure=new_closure,
@@ -136,7 +139,8 @@ class DopplerFrame(ASTFrame):
             funcdef=new_funcdef,
             defaults_w=self.w_func.defaults_w,
             lowering_stage="redshift",
-            locals_types_w=self.get_locals_types_w(),
+            locals_types_w=locals_types_w,
+            is_force_inline=self.w_func.is_force_inline,
         )
         # mark the original function as invalid
         self.w_func.replace_with(w_newfunc)

--- a/spy/force_inline.py
+++ b/spy/force_inline.py
@@ -1,0 +1,35 @@
+"""
+Helpers for @force_inline.
+"""
+
+from spy import ast
+from spy.errors import SPyError
+from spy.vm.function import W_ASTFunc
+from spy.vm.primitive import TYPES
+
+
+def validate_force_inline(w_func: W_ASTFunc) -> None:
+    body = w_func.funcdef.body
+    last_stmt = body[-1] if body else None
+    returns_none = w_func.w_functype.w_restype is TYPES.w_NoneType
+    if not returns_none and not isinstance(last_stmt, ast.Return):
+        err = SPyError(
+            "W_TypeError",
+            "@force_inline requires a single tail return",
+        )
+        err.add("error", "missing `return` at the end of the body", w_func.def_loc)
+        raise err
+
+    for ret in w_func.funcdef.walk(ast.Return):
+        if ret is not last_stmt:
+            # found a 'return' in the wrong place
+            err = SPyError(
+                "W_TypeError",
+                "@force_inline requires a single tail return",
+            )
+            err.add(
+                "error",
+                "`return` must be the last statement of the body",
+                ret.loc,
+            )
+            raise err

--- a/spy/force_inline.py
+++ b/spy/force_inline.py
@@ -1,11 +1,20 @@
 """
-Helpers for @force_inline.
+Helpers for @force_inline: validation and inlining mechanics.
 """
 
+from typing import TYPE_CHECKING
+
 from spy import ast
+from spy.analyze.symtable import Symbol
+from spy.doppler import make_const
 from spy.errors import SPyError
+from spy.util import magic_dispatch
 from spy.vm.function import W_ASTFunc
 from spy.vm.primitive import TYPES
+
+if TYPE_CHECKING:
+    from spy.vm.object import W_Type
+    from spy.vm.vm import SPyVM
 
 
 def validate_force_inline(w_func: W_ASTFunc) -> None:
@@ -22,7 +31,6 @@ def validate_force_inline(w_func: W_ASTFunc) -> None:
 
     for ret in w_func.funcdef.walk(ast.Return):
         if ret is not last_stmt:
-            # found a 'return' in the wrong place
             err = SPyError(
                 "W_TypeError",
                 "@force_inline requires a single tail return",
@@ -33,3 +41,233 @@ def validate_force_inline(w_func: W_ASTFunc) -> None:
                 ret.loc,
             )
             raise err
+
+
+class AlphaRenamer:
+    """
+    Deep-copy a redshifted function body, renaming every callee-local Symbol
+    by appending suffix (e.g. "$0") to its name.
+    """
+
+    def __init__(self, suffix: str) -> None:
+        self.suffix = suffix
+        self.sym_map: dict[Symbol, Symbol] = {}
+        self.new_symbols: list[Symbol] = []
+
+    def newsym(self, old_sym: Symbol) -> Symbol:
+        if old_sym not in self.sym_map:
+            new_name = f"{old_sym.name}{self.suffix}"
+            new_sym = old_sym.replace(name=new_name)
+            self.sym_map[old_sym] = new_sym
+            self.new_symbols.append(new_sym)
+        return self.sym_map[old_sym]
+
+    def rename_stmts(self, stmts: list[ast.Stmt]) -> list[ast.Stmt]:
+        return [self.rename_stmt(s) for s in stmts]
+
+    def rename_stmt(self, stmt: ast.Stmt) -> ast.Stmt:
+        return magic_dispatch(self, "rename_stmt", stmt)
+
+    def rename_expr(self, expr: ast.Expr) -> ast.Expr:
+        return magic_dispatch(self, "rename_expr", expr)
+
+    # ---- statements ----
+
+    def rename_stmt_Return(self, stmt: ast.Return) -> ast.Stmt:
+        return stmt.replace(value=self.rename_expr(stmt.value))
+
+    def rename_stmt_VarDef(self, stmt: ast.VarDef) -> ast.Stmt:
+        old_name = stmt.name.value
+        new_name_node = stmt.name.replace(value=f"{old_name}{self.suffix}")
+        new_value = self.rename_expr(stmt.value) if stmt.value is not None else None
+        return stmt.replace(name=new_name_node, value=new_value)
+
+    def rename_stmt_AssignLocal(self, stmt: ast.AssignLocal) -> ast.Stmt:
+        new_target = stmt.target.replace(value=f"{stmt.target.value}{self.suffix}")
+        return stmt.replace(target=new_target, value=self.rename_expr(stmt.value))
+
+    def rename_stmt_AssignCell(self, stmt: ast.AssignCell) -> ast.Stmt:
+        new_target = stmt.target.replace(value=f"{stmt.target.value}{self.suffix}")
+        return stmt.replace(target=new_target, value=self.rename_expr(stmt.value))
+
+    def rename_stmt_If(self, stmt: ast.If) -> ast.Stmt:
+        return stmt.replace(
+            test=self.rename_expr(stmt.test),
+            then_body=self.rename_stmts(stmt.then_body),
+            else_body=self.rename_stmts(stmt.else_body),
+        )
+
+    def rename_stmt_While(self, stmt: ast.While) -> ast.Stmt:
+        return stmt.replace(
+            test=self.rename_expr(stmt.test),
+            body=self.rename_stmts(stmt.body),
+        )
+
+    def rename_stmt_Pass(self, stmt: ast.Pass) -> ast.Stmt:
+        return stmt
+
+    def rename_stmt_Break(self, stmt: ast.Break) -> ast.Stmt:
+        return stmt
+
+    def rename_stmt_Continue(self, stmt: ast.Continue) -> ast.Stmt:
+        return stmt
+
+    def rename_stmt_Raise(self, stmt: ast.Raise) -> ast.Stmt:
+        return stmt
+
+    def rename_stmt_StmtExpr(self, stmt: ast.StmtExpr) -> ast.Stmt:
+        return stmt.replace(value=self.rename_expr(stmt.value))
+
+    # ---- expressions ----
+
+    def rename_expr_NameLocalDirect(self, expr: ast.NameLocalDirect) -> ast.Expr:
+        return expr.replace(sym=self.newsym(expr.sym))
+
+    def rename_expr_NameOuterDirect(self, expr: ast.NameOuterDirect) -> ast.Expr:
+        return expr
+
+    def rename_expr_NameOuterCell(self, expr: ast.NameOuterCell) -> ast.Expr:
+        return expr
+
+    def rename_expr_FQNConst(self, expr: ast.FQNConst) -> ast.Expr:
+        return expr
+
+    def rename_expr_Constant(self, expr: ast.Constant) -> ast.Expr:
+        return expr
+
+    def rename_expr_StrConst(self, expr: ast.StrConst) -> ast.Expr:
+        return expr
+
+    def rename_expr_BinOp(self, expr: ast.BinOp) -> ast.Expr:
+        return expr.replace(
+            left=self.rename_expr(expr.left),
+            right=self.rename_expr(expr.right),
+        )
+
+    def rename_expr_CmpOp(self, expr: ast.CmpOp) -> ast.Expr:
+        return expr.replace(
+            left=self.rename_expr(expr.left),
+            right=self.rename_expr(expr.right),
+        )
+
+    def rename_expr_UnaryOp(self, expr: ast.UnaryOp) -> ast.Expr:
+        return expr.replace(value=self.rename_expr(expr.value))
+
+    def rename_expr_GetItem(self, expr: ast.GetItem) -> ast.Expr:
+        return expr.replace(
+            value=self.rename_expr(expr.value),
+            args=[self.rename_expr(a) for a in expr.args],
+        )
+
+    def rename_expr_And(self, expr: ast.And) -> ast.Expr:
+        return expr.replace(
+            left=self.rename_expr(expr.left),
+            right=self.rename_expr(expr.right),
+        )
+
+    def rename_expr_Or(self, expr: ast.Or) -> ast.Expr:
+        return expr.replace(
+            left=self.rename_expr(expr.left),
+            right=self.rename_expr(expr.right),
+        )
+
+    def rename_expr_Call(self, expr: ast.Call) -> ast.Expr:
+        return expr.replace(
+            func=self.rename_expr(expr.func),
+            args=[self.rename_expr(a) for a in expr.args],
+        )
+
+    def rename_expr_AssignExprLocal(self, expr: ast.AssignExprLocal) -> ast.Expr:
+        new_target = expr.target.replace(value=f"{expr.target.value}{self.suffix}")
+        return expr.replace(target=new_target, value=self.rename_expr(expr.value))
+
+    def rename_expr_BlockExpr(self, expr: ast.BlockExpr) -> ast.Expr:
+        return expr.replace(
+            body=self.rename_stmts(expr.body),
+            value=self.rename_expr(expr.value),
+        )
+
+    def rename_expr_CallMethod(self, expr: ast.CallMethod) -> ast.Expr:
+        return expr.replace(
+            target=self.rename_expr(expr.target),
+            args=[self.rename_expr(a) for a in expr.args],
+        )
+
+
+class InlineResult:
+    block: ast.BlockExpr
+    new_symbols: list[Symbol]
+    new_locals_types_w: "dict[str, W_Type]"
+
+    def __init__(
+        self,
+        block: ast.BlockExpr,
+        new_symbols: list[Symbol],
+        new_locals_types_w: "dict[str, W_Type]",
+    ) -> None:
+        self.block = block
+        self.new_symbols = new_symbols
+        self.new_locals_types_w = new_locals_types_w
+
+
+def inline_call(
+    vm: "SPyVM",
+    op: ast.Node,
+    w_callee: W_ASTFunc,
+    real_args: list[ast.Expr],
+    inline_counter: int,
+) -> InlineResult:
+    """
+    Build a BlockExpr that inlines the callee at the call site.
+    w_callee must already be at lowering_stage == "redshift".
+    """
+    assert w_callee.lowering_stage == "redshift"
+    suffix = f"${inline_counter}"
+
+    assert w_callee.locals_types_w is not None
+    new_locals_types_w: dict[str, "W_Type"] = {}
+
+    functype = w_callee.w_functype
+    funcdef_args = w_callee.funcdef.args
+    param_vardefs: list[ast.Stmt] = []
+    for i, (func_param, funcdef_arg) in enumerate(zip(functype.params, funcdef_args)):
+        param_name = funcdef_arg.name
+        new_name = f"{param_name}{suffix}"
+        new_locals_types_w[new_name] = func_param.w_T
+
+        param_vardefs.append(
+            ast.VarDef(
+                loc=op.loc,
+                kind=None,
+                name=ast.StrConst(op.loc, new_name).as_typed_node(),
+                type=make_const(vm, op.loc, func_param.w_T),
+                value=real_args[i],
+            )
+        )
+
+    for old_name, w_T in w_callee.locals_types_w.items():
+        if old_name.startswith("@"):
+            continue  # skip @return and other internal names
+        new_name = f"{old_name}{suffix}"
+        if new_name not in new_locals_types_w:
+            new_locals_types_w[new_name] = w_T
+
+    renamer = AlphaRenamer(suffix)
+    renamed_body = renamer.rename_stmts(w_callee.funcdef.body)
+
+    last_stmt = renamed_body[-1] if renamed_body else None
+    if isinstance(last_stmt, ast.Return):
+        stmts_before_return = renamed_body[:-1]
+        result_value = last_stmt.value
+    else:
+        stmts_before_return = renamed_body
+        result_value = ast.Constant(op.loc, None, w_T=TYPES.w_NoneType)
+
+    body = [*param_vardefs, *stmts_before_return]
+    block = ast.BlockExpr(
+        loc=op.loc,
+        body=body,
+        value=result_value,
+        w_T=w_callee.w_functype.w_restype,
+    )
+    return InlineResult(block, renamer.new_symbols, new_locals_types_w)

--- a/spy/force_inline.py
+++ b/spy/force_inline.py
@@ -112,9 +112,6 @@ class AlphaRenamer:
     def rename_stmt_Continue(self, stmt: ast.Continue) -> ast.Stmt:
         return stmt
 
-    def rename_stmt_Raise(self, stmt: ast.Raise) -> ast.Stmt:
-        return stmt
-
     def rename_stmt_StmtExpr(self, stmt: ast.StmtExpr) -> ast.Stmt:
         return stmt.replace(value=self.rename_expr(stmt.value))
 
@@ -122,9 +119,6 @@ class AlphaRenamer:
 
     def rename_expr_NameLocalDirect(self, expr: ast.NameLocalDirect) -> ast.Expr:
         return expr.replace(sym=self.newsym(expr.sym))
-
-    def rename_expr_NameOuterDirect(self, expr: ast.NameOuterDirect) -> ast.Expr:
-        return expr
 
     def rename_expr_NameOuterCell(self, expr: ast.NameOuterCell) -> ast.Expr:
         return expr
@@ -137,27 +131,6 @@ class AlphaRenamer:
 
     def rename_expr_StrConst(self, expr: ast.StrConst) -> ast.Expr:
         return expr
-
-    def rename_expr_BinOp(self, expr: ast.BinOp) -> ast.Expr:
-        return expr.replace(
-            left=self.rename_expr(expr.left),
-            right=self.rename_expr(expr.right),
-        )
-
-    def rename_expr_CmpOp(self, expr: ast.CmpOp) -> ast.Expr:
-        return expr.replace(
-            left=self.rename_expr(expr.left),
-            right=self.rename_expr(expr.right),
-        )
-
-    def rename_expr_UnaryOp(self, expr: ast.UnaryOp) -> ast.Expr:
-        return expr.replace(value=self.rename_expr(expr.value))
-
-    def rename_expr_GetItem(self, expr: ast.GetItem) -> ast.Expr:
-        return expr.replace(
-            value=self.rename_expr(expr.value),
-            args=[self.rename_expr(a) for a in expr.args],
-        )
 
     def rename_expr_And(self, expr: ast.And) -> ast.Expr:
         return expr.replace(
@@ -185,12 +158,6 @@ class AlphaRenamer:
         return expr.replace(
             body=self.rename_stmts(expr.body),
             value=self.rename_expr(expr.value),
-        )
-
-    def rename_expr_CallMethod(self, expr: ast.CallMethod) -> ast.Expr:
-        return expr.replace(
-            target=self.rename_expr(expr.target),
-            args=[self.rename_expr(a) for a in expr.args],
         )
 
 

--- a/spy/linearize.py
+++ b/spy/linearize.py
@@ -124,6 +124,7 @@ class Linearizer:
             defaults_w=self.w_func.defaults_w,
             lowering_stage="linearize",
             locals_types_w=new_locals_types_w,
+            is_force_inline=self.w_func.is_force_inline,
         )
         # mark the original function as invalid
         self.w_func.replace_with(w_newfunc)

--- a/spy/linearize.py
+++ b/spy/linearize.py
@@ -132,9 +132,7 @@ class Linearizer:
     # ==== helpers ====
 
     def _copy_symtable(self, symtable: SymTable) -> SymTable:
-        new_st = SymTable(symtable.name, symtable.color, symtable.kind)
-        new_st._symbols = dict(symtable._symbols)
-        new_st.implicit_imports = set(symtable.implicit_imports)
+        new_st = symtable.copy()
         for sym in self.new_symbols:
             new_st.add(sym)
         return new_st

--- a/spy/tests/compiler/test_force_inline.py
+++ b/spy/tests/compiler/test_force_inline.py
@@ -367,7 +367,7 @@ class TestForceInline(CompilerTest):
         """)
         assert mod.foo() == 12
 
-    def test_assignexpr_walrus_in_body(self):
+    def test_assignexpr(self):
         mod = self.compile("""
         from __spy__ import force_inline
 
@@ -385,6 +385,7 @@ class TestForceInline(CompilerTest):
         """)
         assert mod.foo() == 14
 
+    # XXX what is that?
     def test_assignexpr_in_body(self):
         mod = self.compile("""
         from __spy__ import force_inline

--- a/spy/tests/compiler/test_force_inline.py
+++ b/spy/tests/compiler/test_force_inline.py
@@ -265,26 +265,6 @@ class TestForceInline(CompilerTest):
         """)
         assert mod.foo() == 10
 
-    def test_loop_with_break(self):
-        mod = self.compile("""
-        from __spy__ import force_inline
-
-        @force_inline
-        def find_first(n: i32) -> i32:
-            var i = 0
-            var result = -1
-            while i < n:
-                if i > 1:
-                    result = i
-                    break
-                i = i + 1
-            return result
-
-        def foo() -> i32:
-            return find_first(5)
-        """)
-        assert mod.foo() == 2
-
     def test_outer_var(self):
         mod = self.compile("""
         from __spy__ import force_inline
@@ -319,20 +299,22 @@ class TestForceInline(CompilerTest):
         from __spy__ import force_inline
 
         @force_inline
-        def count_odd(n: i32) -> i32:
+        def sum_odd_up_to(n: i32) -> i32:
             var result = 0
             var i = 0
             while i < n:
                 i = i + 1
                 if i % 2 == 0:
                     continue
-                result = result + 1
+                if i > 4:
+                    break
+                result = result + i
             return result
 
         def foo() -> i32:
-            return count_odd(6)
+            return sum_odd_up_to(10)
         """)
-        assert mod.foo() == 3
+        assert mod.foo() == 4  # 1 + 3
 
     def test_raise(self):
         src = """

--- a/spy/tests/compiler/test_force_inline.py
+++ b/spy/tests/compiler/test_force_inline.py
@@ -76,14 +76,17 @@ class TestForceInline(CompilerTest):
         mod = self.compile("""
         from __spy__ import force_inline
 
-        @force_inline
-        def greet(x: i32) -> None:
-            print(x)
+        var calls: i32 = 0
 
-        def foo() -> None:
-            greet(42)
+        @force_inline
+        def inc(x: i32) -> None:
+            calls = calls + x
+
+        def foo() -> i32:
+            inc(42)
+            return calls
         """)
-        mod.foo()
+        assert mod.foo() == 42
 
     def test_error_missing_return(self):
         src = """

--- a/spy/tests/compiler/test_force_inline.py
+++ b/spy/tests/compiler/test_force_inline.py
@@ -9,6 +9,19 @@ from spy.tests.support import (
 
 
 class TestForceInline(CompilerTest):
+    def test_simple_tail_return(self):
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        @force_inline
+        def add1(x: i32) -> i32:
+            return x + 1
+
+        def foo(x: i32) -> i32:
+            return add1(x) + add1(x)
+        """)
+        assert mod.foo(10) == 22
+
     @only_interp
     def test_decorator(self):
         mod = self.compile("""
@@ -20,6 +33,27 @@ class TestForceInline(CompilerTest):
 
         """)
         assert mod.inc.w_func.is_force_inline
+
+    def test_arg_evaluated_once(self):
+        # arg expressions are bound via VarDef so they run exactly once
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        var calls: i32 = 0
+
+        def bump() -> i32:
+            calls = calls + 1
+            return calls
+
+        @force_inline
+        def double(x: i32) -> i32:
+            return x + x
+
+        def foo() -> i32:
+            return double(bump())
+        """)
+        assert mod.foo() == 2
+        assert mod.calls == 1
 
     def test_error_applied_to_blue_function(self):
         src = """
@@ -85,3 +119,283 @@ class TestForceInline(CompilerTest):
             ("`return` must be the last statement of the body", "return lo"),
         )
         self.compile_raises(src, "foo", errors, error_reporting="eager")
+
+    def test_binop_cmpop_unaryop(self):
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        @force_inline
+        def compute(x: i32) -> bool:
+            var y = x + 1
+            y = y * 2
+            return not (y == x - 1)
+
+        def foo() -> bool:
+            return compute(3)
+        """)
+        assert mod.foo() is True
+
+    def test_if_stmt(self):
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        @force_inline
+        def abs_val(x: i32) -> i32:
+            var y = x
+            if x < 0:
+                y = -x
+            return y
+
+        def foo() -> i32:
+            return abs_val(-5)
+        """)
+        assert mod.foo() == 5
+
+    def test_while_stmt(self):
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        @force_inline
+        def sum_to(n: i32) -> i32:
+            var result = 0
+            var i = 0
+            while i < n:
+                result = result + i
+                i = i + 1
+            return result
+
+        def foo() -> i32:
+            return sum_to(4)
+        """)
+        assert mod.foo() == 6
+
+    def test_getitem(self):
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        @force_inline
+        def first(xs: list[i32]) -> i32:
+            return xs[0]
+
+        def foo() -> i32:
+            var xs: list[i32] = [10, 20, 30]
+            return first(xs)
+        """)
+        assert mod.foo() == 10
+
+    def test_logical_and_or(self):
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        @force_inline
+        def both(a: bool, b: bool) -> bool:
+            return a and b
+
+        @force_inline
+        def either(a: bool, b: bool) -> bool:
+            return a or b
+
+        def foo() -> bool:
+            return both(True, False) or either(False, True)
+        """)
+        assert mod.foo() is True
+
+    def test_str_const(self):
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        @force_inline
+        def greet() -> str:
+            return 'hello'
+
+        def foo() -> str:
+            return greet()
+        """)
+        assert mod.foo() == "hello"
+
+    def test_tuple(self):
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        @force_inline
+        def pair(x: i32, y: i32) -> tuple[i32, i32]:
+            return (x, y)
+
+        def foo() -> i32:
+            var t = pair(3, 4)
+            return t[0] + t[1]
+        """)
+        assert mod.foo() == 7
+
+    def test_getattr(self):
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        @struct
+        class Point:
+            x: i32
+            y: i32
+
+        @force_inline
+        def get_x(p: Point) -> i32:
+            return p.x
+
+        def foo() -> i32:
+            var p = Point(10, 20)
+            return get_x(p)
+        """)
+        assert mod.foo() == 10
+
+    def test_loop_with_break(self):
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        @force_inline
+        def find_first(n: i32) -> i32:
+            var i = 0
+            var result = -1
+            while i < n:
+                if i > 1:
+                    result = i
+                    i = n
+                i = i + 1
+            return result
+
+        def foo() -> i32:
+            return find_first(5)
+        """)
+        assert mod.foo() == 2
+
+    def test_assignexpr(self):
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        @force_inline
+        def inc_and_get(x: i32) -> i32:
+            return x + 1
+
+        def foo() -> i32:
+            var y: i32 = 0
+            var z = inc_and_get(y := 5)
+            return y + z
+        """)
+        assert mod.foo() == 11
+
+    def test_outer_var(self):
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        var counter: i32 = 0
+
+        @force_inline
+        def bump_and_get() -> i32:
+            counter = counter + 1
+            return counter
+
+        def foo() -> i32:
+            return bump_and_get() + bump_and_get()
+        """)
+        assert mod.foo() == 3
+
+    def test_pass(self):
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        @force_inline
+        def noop() -> None:
+            pass
+
+        def foo() -> None:
+            noop()
+        """)
+        mod.foo()
+
+    def test_break_continue(self):
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        @force_inline
+        def count_odd(n: i32) -> i32:
+            var result = 0
+            var i = 0
+            while i < n:
+                i = i + 1
+                if i % 2 == 0:
+                    continue
+                result = result + 1
+            return result
+
+        def foo() -> i32:
+            return count_odd(6)
+        """)
+        assert mod.foo() == 3
+
+    def test_raise(self):
+        src = """
+        from __spy__ import force_inline
+
+        @force_inline
+        def check(x: i32) -> i32:
+            if x < 0:
+                raise ValueError('negative')
+            return x
+
+        def foo() -> i32:
+            return check(5)
+        """
+        mod = self.compile(src)
+        assert mod.foo() == 5
+
+    def test_nested_force_inline(self):
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        @force_inline
+        def add1(x: i32) -> i32:
+            return x + 1
+
+        @force_inline
+        def add2(x: i32) -> i32:
+            return add1(add1(x))
+
+        def foo() -> i32:
+            return add2(10)
+        """)
+        assert mod.foo() == 12
+
+    def test_assignexpr_walrus_in_body(self):
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        def get_val() -> i32:
+            return 7
+
+        @force_inline
+        def use_walrus() -> i32:
+            var x: i32 = 0
+            var y = (x := get_val()) + x
+            return y
+
+        def foo() -> i32:
+            return use_walrus()
+        """)
+        assert mod.foo() == 14
+
+    def test_assignexpr_in_body(self):
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        @force_inline
+        def compute(x: i32) -> i32:
+            var items: list[i32] = [x, x + 1, x + 2]
+            var result: i32 = 0
+            var i = 0
+            while i < 3:
+                result = result + items[i]
+                i = i + 1
+            return result
+
+        def foo() -> i32:
+            return compute(10)
+        """)
+        assert mod.foo() == 33

--- a/spy/tests/compiler/test_force_inline.py
+++ b/spy/tests/compiler/test_force_inline.py
@@ -9,6 +9,18 @@ from spy.tests.support import (
 
 
 class TestForceInline(CompilerTest):
+    @only_interp
+    def test_decorator(self):
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        @force_inline
+        def inc(x: i32) -> i32:
+            return x + 1
+
+        """)
+        assert mod.inc.w_func.is_force_inline
+
     def test_simple_tail_return(self):
         mod = self.compile("""
         from __spy__ import force_inline
@@ -21,18 +33,6 @@ class TestForceInline(CompilerTest):
             return inc(x) + inc(x)
         """)
         assert mod.foo(10) == 22
-
-    @only_interp
-    def test_decorator(self):
-        mod = self.compile("""
-        from __spy__ import force_inline
-
-        @force_inline
-        def inc(x: i32) -> i32:
-            return x + 1
-
-        """)
-        assert mod.inc.w_func.is_force_inline
 
     def test_arg_evaluated_once(self):
         # arg expressions are bound via VarDef so they run exactly once

--- a/spy/tests/compiler/test_force_inline.py
+++ b/spy/tests/compiler/test_force_inline.py
@@ -416,3 +416,21 @@ class TestForceInline(CompilerTest):
             return compute(10)
         """)
         assert mod.foo() == 33
+
+    def test_metafunc(self):
+        # see also test_doppler.py:test_force_inline_in_metafunc
+        mod = self.compile("""
+        from __spy__ import force_inline
+        from operator import OpSpec
+
+        @blue.metafunc
+        def double(m_x):
+            @force_inline
+            def impl(x: i32) -> i32:
+                return x + x
+            return OpSpec(impl)
+
+        def foo() -> i32:
+            return double(21)
+        """)
+        assert mod.foo() == 42

--- a/spy/tests/compiler/test_force_inline.py
+++ b/spy/tests/compiler/test_force_inline.py
@@ -146,7 +146,7 @@ class TestForceInline(CompilerTest):
 
         @force_inline
         def compute(x: i32) -> bool:
-            var y = x + 1
+            y: i32 = x + 1
             y = y * 2
             return not (y == x - 1)
 
@@ -277,7 +277,7 @@ class TestForceInline(CompilerTest):
             while i < n:
                 if i > 1:
                     result = i
-                    i = n
+                    break
                 i = i + 1
             return result
 

--- a/spy/tests/compiler/test_force_inline.py
+++ b/spy/tests/compiler/test_force_inline.py
@@ -14,11 +14,11 @@ class TestForceInline(CompilerTest):
         from __spy__ import force_inline
 
         @force_inline
-        def add1(x: i32) -> i32:
+        def inc(x: i32) -> i32:
             return x + 1
 
         def foo(x: i32) -> i32:
-            return add1(x) + add1(x)
+            return inc(x) + inc(x)
         """)
         assert mod.foo(10) == 22
 
@@ -368,12 +368,12 @@ class TestForceInline(CompilerTest):
         from __spy__ import force_inline
 
         @force_inline
-        def add1(x: i32) -> i32:
+        def inc(x: i32) -> i32:
             return x + 1
 
         @force_inline
         def add2(x: i32) -> i32:
-            return add1(add1(x))
+            return inc(inc(x))
 
         def foo() -> i32:
             return add2(10)

--- a/spy/tests/compiler/test_force_inline.py
+++ b/spy/tests/compiler/test_force_inline.py
@@ -120,6 +120,23 @@ class TestForceInline(CompilerTest):
         )
         self.compile_raises(src, "foo", errors, error_reporting="eager")
 
+    @skip_backends("interp", reason="recursion detected at redshift time, not interp")
+    def test_error_recursive_inline(self):
+        src = """
+        from __spy__ import force_inline
+
+        @force_inline
+        def fact(n: i32) -> i32:
+            return fact(n - 1)
+
+        def foo() -> i32:
+            return fact(5)
+        """
+        errors = expect_errors(
+            "cannot inline a recursive call to @force_inline function `test::fact#__bare__`",
+        )
+        self.compile_raises(src, "foo", errors, error_reporting="eager")
+
     def test_binop_cmpop_unaryop(self):
         mod = self.compile("""
         from __spy__ import force_inline

--- a/spy/tests/compiler/test_force_inline.py
+++ b/spy/tests/compiler/test_force_inline.py
@@ -367,26 +367,6 @@ class TestForceInline(CompilerTest):
         """)
         assert mod.foo() == 14
 
-    # XXX what is that?
-    def test_assignexpr_in_body(self):
-        mod = self.compile("""
-        from __spy__ import force_inline
-
-        @force_inline
-        def compute(x: i32) -> i32:
-            var items: list[i32] = [x, x + 1, x + 2]
-            var result: i32 = 0
-            var i = 0
-            while i < 3:
-                result = result + items[i]
-                i = i + 1
-            return result
-
-        def foo() -> i32:
-            return compute(10)
-        """)
-        assert mod.foo() == 33
-
     def test_metafunc(self):
         # see also test_doppler.py:test_force_inline_in_metafunc
         mod = self.compile("""

--- a/spy/tests/compiler/test_force_inline.py
+++ b/spy/tests/compiler/test_force_inline.py
@@ -17,7 +17,6 @@ class TestForceInline(CompilerTest):
         @force_inline
         def inc(x: i32) -> i32:
             return x + 1
-
         """)
         assert mod.inc.w_func.is_force_inline
 
@@ -285,21 +284,6 @@ class TestForceInline(CompilerTest):
             return find_first(5)
         """)
         assert mod.foo() == 2
-
-    def test_assignexpr(self):
-        mod = self.compile("""
-        from __spy__ import force_inline
-
-        @force_inline
-        def inc_and_get(x: i32) -> i32:
-            return x + 1
-
-        def foo() -> i32:
-            var y: i32 = 0
-            var z = inc_and_get(y := 5)
-            return y + z
-        """)
-        assert mod.foo() == 11
 
     def test_outer_var(self):
         mod = self.compile("""

--- a/spy/tests/compiler/test_force_inline.py
+++ b/spy/tests/compiler/test_force_inline.py
@@ -1,0 +1,87 @@
+import pytest
+
+from spy.tests.support import (
+    CompilerTest,
+    expect_errors,
+    only_interp,
+    skip_backends,
+)
+
+
+class TestForceInline(CompilerTest):
+    @only_interp
+    def test_decorator(self):
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        @force_inline
+        def inc(x: i32) -> i32:
+            return x + 1
+
+        """)
+        assert mod.inc.w_func.is_force_inline
+
+    def test_error_applied_to_blue_function(self):
+        src = """
+        from __spy__ import force_inline
+
+        @force_inline
+        @blue
+        def inc(x: i32) -> i32:
+            return x + 1
+
+        def foo(x: i32) -> i32:
+            return inc(x)
+        """
+        errors = expect_errors(
+            "@force_inline cannot be applied to @blue functions",
+        )
+        self.compile_raises(src, "foo", errors, error_reporting="eager")
+
+    def test_none_return_type(self):
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        @force_inline
+        def greet(x: i32) -> None:
+            print(x)
+
+        def foo() -> None:
+            greet(42)
+        """)
+        mod.foo()
+
+    def test_error_missing_return(self):
+        src = """
+        from __spy__ import force_inline
+
+        @force_inline
+        def inc(x: i32) -> i32:
+            var y = x + 1
+
+        def foo() -> i32:
+            return inc(3)
+        """
+        errors = expect_errors(
+            "@force_inline requires a single tail return",
+        )
+        self.compile_raises(src, "foo", errors, error_reporting="eager")
+
+    def test_error_multiple_returns(self):
+        src = """
+        from __spy__ import force_inline
+
+        @force_inline
+        def clamp(x: i32, lo: i32) -> i32:
+            if x < lo:
+                return lo
+            return x
+
+        def foo() -> i32:
+            return clamp(3, 0)
+        """
+        errors = expect_errors(
+            "@force_inline requires a single tail return",
+            ("`return` must be the last statement of the body", "return lo"),
+        )
+        self.compile_raises(src, "foo", errors, error_reporting="eager")

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -467,3 +467,25 @@ class TestDoppler:
             return __block__(x$0: i32 = a; x$0 + 1) + __block__(x$1: i32 = b; x$1 + 1)
         """
         self.assert_dump(expected, funcname="foo")
+
+    def test_force_inline_in_metafunc(self):
+        # see also test_force_inline.py:test_metafunc
+        self.redshift("""
+        from __spy__ import force_inline
+        from operator import OpSpec
+
+        @blue.metafunc
+        def double(m_x):
+            @force_inline
+            def impl(x: i32) -> i32:
+                return x + x
+            return OpSpec(impl)
+
+        def foo() -> i32:
+            return double(21)
+        """)
+        expected = """
+        def foo() -> i32:
+            return __block__(x$0: i32 = 21; x$0 + x$0)
+        """
+        self.assert_dump(expected, funcname="foo")

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -8,6 +8,7 @@ from spy.analyze.symtable import Color
 from spy.backend.spy import FQN_FORMAT, SPyBackend
 from spy.fqn import FQN
 from spy.util import print_diff
+from spy.vm.function import W_ASTFunc
 from spy.vm.vm import SPyVM
 
 
@@ -30,9 +31,23 @@ class TestDoppler:
         self.import_src(src)
         self.vm.redshift(error_mode="eager")
 
-    def assert_dump(self, expected: str, *, fqn_format: FQN_FORMAT = "short") -> None:
+    def assert_dump(
+        self,
+        expected: str,
+        *,
+        fqn_format: FQN_FORMAT = "short",
+        funcname: Optional[str] = None,
+    ) -> None:
         b = SPyBackend(self.vm, fqn_format=fqn_format)
-        got = b.dump_mod("test").strip()
+        if funcname is not None:
+            fqn = FQN(f"test::{funcname}")
+            w_func = self.vm.globals_w[fqn]
+            assert isinstance(w_func, W_ASTFunc)
+            b.modname = "test"
+            b.dump_w_func(fqn, w_func)
+            got = b.out.build().strip()
+        else:
+            got = b.dump_mod("test").strip()
         expected = textwrap.dedent(expected).strip()
         if got != expected:
             print_diff(expected, got, "expected", "got")
@@ -418,3 +433,37 @@ class TestDoppler:
 
         dumper._dump_node(blue_node, "test", [], text_color="turquoise")
         mock_write.assert_any_call("test", color=None, bg="blue")
+
+    def test_force_inline_replaces_call(self):
+        self.redshift("""
+        from __spy__ import force_inline
+
+        @force_inline
+        def add1(x: i32) -> i32:
+            return x + 1
+
+        def foo() -> i32:
+            return add1(10)
+        """)
+        expected = """
+        def foo() -> i32:
+            return __block__(x$0: i32 = 10; x$0 + 1)
+        """
+        self.assert_dump(expected, funcname="foo")
+
+    def test_force_inline_multiple_sites_unique_names(self):
+        self.redshift("""
+        from __spy__ import force_inline
+
+        @force_inline
+        def add1(x: i32) -> i32:
+            return x + 1
+
+        def foo(a: i32, b: i32) -> i32:
+            return add1(a) + add1(b)
+        """)
+        expected = """
+        def foo(a: i32, b: i32) -> i32:
+            return __block__(x$0: i32 = a; x$0 + 1) + __block__(x$1: i32 = b; x$1 + 1)
+        """
+        self.assert_dump(expected, funcname="foo")

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -439,11 +439,11 @@ class TestDoppler:
         from __spy__ import force_inline
 
         @force_inline
-        def add1(x: i32) -> i32:
+        def inc(x: i32) -> i32:
             return x + 1
 
         def foo() -> i32:
-            return add1(10)
+            return inc(10)
         """)
         expected = """
         def foo() -> i32:
@@ -456,11 +456,11 @@ class TestDoppler:
         from __spy__ import force_inline
 
         @force_inline
-        def add1(x: i32) -> i32:
+        def inc(x: i32) -> i32:
             return x + 1
 
         def foo(a: i32, b: i32) -> i32:
-            return add1(a) + add1(b)
+            return inc(a) + inc(b)
         """)
         expected = """
         def foo(a: i32, b: i32) -> i32:

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -489,3 +489,24 @@ class TestDoppler:
             return __block__(x$0: i32 = 21; x$0 + x$0)
         """
         self.assert_dump(expected, funcname="foo")
+
+    def test_nested_force_inline(self):
+        self.redshift("""
+        from __spy__ import force_inline
+
+        @force_inline
+        def inc(x: i32) -> i32:
+            return x + 1
+
+        @force_inline
+        def add2(x: i32) -> i32:
+            return inc(inc(x))
+
+        def foo() -> i32:
+            return add2(10)
+        """)
+        expected = """
+        def foo() -> i32:
+            return __block__(x$0: i32 = 10; __block__(x$1$0: i32 = __block__(x$0$0: i32 = x$0; x$0$0 + 1); x$1$0 + 1))
+        """
+        self.assert_dump(expected, funcname="foo")

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -339,7 +339,7 @@ class W_Func(W_Object):
 # versions of the function. Once a function has been lowered it becomes "invalid", and
 # we set the `w_replaced_by` field.
 
-LoweringStage = Literal["source", "redshift", "linearize"]
+LoweringStage = Literal["source", "redshift_in_progress", "redshift", "linearize"]
 
 
 class W_ASTFunc(W_Func):
@@ -355,6 +355,9 @@ class W_ASTFunc(W_Func):
     lowering_stage: LoweringStage
     w_replaced_by: Optional["W_ASTFunc"]
 
+    # set by the @force_inline decorator
+    is_force_inline: bool
+
     def __init__(
         self,
         w_functype: W_FuncType,
@@ -365,6 +368,7 @@ class W_ASTFunc(W_Func):
         *,
         lowering_stage: LoweringStage,
         locals_types_w: Optional[dict[str, W_Type]] = None,
+        is_force_inline: bool = False,
     ) -> None:
         self.w_functype = w_functype
         self.fqn = fqn
@@ -375,9 +379,10 @@ class W_ASTFunc(W_Func):
         self.locals_types_w = locals_types_w
         self.lowering_stage = lowering_stage
         self.w_replaced_by = None
+        self.is_force_inline = is_force_inline
 
         # sanity check
-        if lowering_stage == "source":
+        if lowering_stage in ("source", "redshift_in_progress"):
             assert self.locals_types_w is None
         else:
             assert self.locals_types_w is not None

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -409,8 +409,9 @@ class W_ASTFunc(W_Func):
         extras = []
         if self.color == "blue":
             extras.append("blue")
-        if self.lowering_stage != "source":
-            extras.append(self.lowering_stage)
+        stage = self.lowering_stage
+        if stage not in ("source", "redshift_in_progress"):
+            extras.append(stage)
         if not self.is_valid:
             extras.append("invalid")
 

--- a/spy/vm/modules/__spy__/__init__.py
+++ b/spy/vm/modules/__spy__/__init__.py
@@ -5,7 +5,6 @@ SPy `__spy__` module.
 from typing import TYPE_CHECKING, Annotated, Any
 
 from spy.errors import SPyError
-from spy.force_inline import validate_force_inline
 from spy.vm.b import B
 from spy.vm.builtin import builtin_method
 from spy.vm.function import W_ASTFunc
@@ -106,6 +105,8 @@ SPY.add("empty_dict", W_EmptyDictType.__new__(W_EmptyDictType))
 
 @SPY.builtin_func(color="blue")
 def w_force_inline(vm: "SPyVM", w_func: W_Object) -> W_Object:
+    from spy.force_inline import validate_force_inline
+
     if not isinstance(w_func, W_ASTFunc):
         err = SPyError(
             "W_TypeError",

--- a/spy/vm/modules/__spy__/__init__.py
+++ b/spy/vm/modules/__spy__/__init__.py
@@ -5,8 +5,10 @@ SPy `__spy__` module.
 from typing import TYPE_CHECKING, Annotated, Any
 
 from spy.errors import SPyError
+from spy.force_inline import validate_force_inline
 from spy.vm.b import B
 from spy.vm.builtin import builtin_method
+from spy.vm.function import W_ASTFunc
 from spy.vm.object import W_Object
 from spy.vm.opspec import W_MetaArg, W_OpSpec
 from spy.vm.primitive import W_Bool
@@ -100,3 +102,23 @@ class W_EmptyDictType(W_Object):
 
 SPY.add("empty_list", W_EmptyListType.__new__(W_EmptyListType))
 SPY.add("empty_dict", W_EmptyDictType.__new__(W_EmptyDictType))
+
+
+@SPY.builtin_func(color="blue")
+def w_force_inline(vm: "SPyVM", w_func: W_Object) -> W_Object:
+    if not isinstance(w_func, W_ASTFunc):
+        err = SPyError(
+            "W_TypeError",
+            "@force_inline can only be applied to def'd functions",
+        )
+        raise err
+    if w_func.color != "red":
+        err = SPyError(
+            "W_TypeError",
+            "@force_inline cannot be applied to @blue functions",
+        )
+        err.add("error", "this is not a red function", w_func.def_loc)
+        raise err
+    validate_force_inline(w_func)
+    w_func.is_force_inline = True
+    return w_func


### PR DESCRIPTION
Add a `@force_inline` decorator.

Inlining happens during redshift. At the current moment it is possible to apply the decoator only to functions which are "simple enough": in particular, they must a `return` as the last statement of the body, and cannot have other `return`s anywhere.

Code written by claude with *heavy* supervision and editing by me.
