### PR TITLE
Implement str(dynamic)

### DIFF
--- a/spy/libspy/include/spy/str.h
+++ b/spy/libspy/include/spy/str.h
@@ -44,7 +44,13 @@ int32_t WASM_EXPORT(spy_str_hash)(spy_Str *s);
 #define spy_builtins$str$replace spy_str_replace
 #define spy_builtins$str$__getitem__ spy_str_getitem
 #define spy_builtins$str$__len__ spy_str_len
+#define spy_builtins$str$__str__ spy_str_identity
 #define spy_builtins$str$__repr__ spy_str_repr
+
+static inline spy_Str *
+spy_str_identity(spy_Str *s) {
+    return s;
+}
 #define spy_builtins$hash_str spy_str_hash
 
 // __str__ methods of common builtin types

--- a/spy/tests/compiler/test_str.py
+++ b/spy/tests/compiler/test_str.py
@@ -233,6 +233,30 @@ class TestStr(CompilerTest):
         mod = self.compile(src)
         assert mod.foo("hello") == "hello"
 
+    @skip_backends("C", reason="dynamic not supported")
+    def test_str_of_dynamic(self):
+        src = """
+        def dyn(x: dynamic) -> dynamic:
+            return x
+
+        def foo_str() -> str:
+            return str(dyn("hello"))
+
+        def foo_i32() -> str:
+            return str(dyn(42))
+
+        def foo_f64() -> str:
+            return str(dyn(12.3))
+
+        def foo_bool() -> str:
+            return str(dyn(True))
+        """
+        mod = self.compile(src)
+        assert mod.foo_str() == "hello"
+        assert mod.foo_i32() == "42"
+        assert mod.foo_f64() == "12.3"
+        assert mod.foo_bool() == "True"
+
     def test_str_replace(self):
         mod = self.compile("""
         def foo(s: str, old: str, new: str) -> str:

--- a/spy/tests/compiler/test_str.py
+++ b/spy/tests/compiler/test_str.py
@@ -225,6 +225,14 @@ class TestStr(CompilerTest):
         mod = self.compile(src)
         assert mod.foo() == "\nBall"
 
+    def test_str_of_str(self):
+        src = """
+        def foo(s: str) -> str:
+            return str(s)
+        """
+        mod = self.compile(src)
+        assert mod.foo("hello") == "hello"
+
     def test_str_replace(self):
         mod = self.compile("""
         def foo(s: str, old: str, new: str) -> str:

--- a/spy/vm/modules/operator/opimpl_dynamic.py
+++ b/spy/vm/modules/operator/opimpl_dynamic.py
@@ -135,3 +135,16 @@ def w_dynamic_call(vm: "SPyVM", w_obj: W_Dynamic, *args_w: W_Dynamic) -> W_Dynam
     all_args_wam = [W_MetaArg.from_w_obj(vm, w_x) for i, w_x in enumerate(all_args_w)]
     w_opimpl = vm.call_OP(None, OP.w_CALL, all_args_wam)
     return w_opimpl._execute(vm, all_args_w)  # XXX
+
+
+@OP.builtin_func
+def w_dynamic_str(vm: "SPyVM", w_x: W_Dynamic) -> W_Str:
+    w_T = vm.dynamic_type(w_x)
+    w_fn = w_T.lookup_func("__str__")
+    assert w_fn is not None
+    wam_arg = W_MetaArg.from_w_obj(vm, w_x)
+    w_opspec = vm.fast_metacall(w_fn, [wam_arg])
+    assert w_opspec._w_func is not None
+    w_res = vm.fast_call(w_opspec._w_func, [w_x])
+    assert isinstance(w_res, W_Str)
+    return w_res

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -644,6 +644,14 @@ class W_Type(W_Object):
         """
         Return a list of all the supertypes.
         """
+        if self is B.w_dynamic:
+            msg = (
+                "Cannot call .get_mro(), .lookup() or .lookup_func() on B.w_dynamic. "
+                + "This is likely an internal bug: the caller should detect B.w_dynamic "
+                + "and do the lookup on the real type."
+            )
+            raise AssertionError(msg)
+
         mro = []
         w_T: Union["W_Type", "W_NoneType"] = self
         while w_T is not B.w_None:

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from spy.llwasm import LLWasmInstance
-from spy.vm.b import BUILTINS, B
+from spy.vm.b import BUILTINS, OP, B
 from spy.vm.builtin import builtin_method
 from spy.vm.object import W_Object, W_Type
 from spy.vm.opspec import W_MetaArg, W_OpSpec
@@ -84,6 +84,8 @@ class W_Str(W_Object):
         if len(args_wam) == 1:
             wam_arg = args_wam[0]
             w_T = wam_arg.w_static_T
+            if w_T is B.w_dynamic:
+                return W_OpSpec(OP.w_dynamic_str, [wam_arg])
             if w_fn := w_T.lookup_func("__str__"):
                 w_opspec = vm.fast_metacall(w_fn, [wam_arg])
                 return w_opspec

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -109,6 +109,11 @@ class W_Str(W_Object):
         length = vm.ll.call("spy_str_len", w_s.ptr)
         return vm.wrap(length)
 
+    @builtin_method("__str__")
+    @staticmethod
+    def w_str(vm: "SPyVM", w_s: "W_Str") -> "W_Str":
+        return w_s
+
     @builtin_method("__repr__")
     @staticmethod
     def w_repr(vm: "SPyVM", w_s: "W_Str") -> "W_Str":


### PR DESCRIPTION
- Implement `str.__str__`
- implement `str(dynamic)`
- add a sanity check so we fail early next time we try to `.lookup()` something on `dynamic` (it should never happen)