### PR TITLE
Fix calls to @force_inlined functions inside a loop

### DIFF
--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -418,7 +418,9 @@ class SPyBackend:
 
     def fmt_expr_BlockExpr(self, block: ast.BlockExpr) -> str:
         b = SPyBackend(self.vm, fqn_format=self.fqn_format)
-        b.vars_declared = set()
+        b.w_func = self.w_func
+        b.scope_stack = self.scope_stack
+        b.vars_declared = self.vars_declared
         for stmt in block.body:
             b.emit_stmt(stmt)
         parts = [l for l in b.out.build().splitlines() if l]

--- a/spy/force_inline.py
+++ b/spy/force_inline.py
@@ -201,18 +201,16 @@ def inline_call(
 
     functype = w_callee.w_functype
     funcdef_args = w_callee.funcdef.args
-    param_vardefs: list[ast.Stmt] = []
+    param_assigns: list[ast.Stmt] = []
     for i, (func_param, funcdef_arg) in enumerate(zip(functype.params, funcdef_args)):
         param_name = funcdef_arg.name
         new_name = f"{param_name}{suffix}"
         new_locals_types_w[new_name] = func_param.w_T
 
-        param_vardefs.append(
-            ast.VarDef(
+        param_assigns.append(
+            ast.AssignLocal(
                 loc=op.loc,
-                kind=None,
-                name=ast.StrConst(op.loc, new_name).as_typed_node(),
-                type=make_const(vm, op.loc, func_param.w_T),
+                target=ast.StrConst(op.loc, new_name).as_typed_node(),
                 value=real_args[i],
             )
         )
@@ -235,7 +233,7 @@ def inline_call(
         stmts_before_return = renamed_body
         result_value = ast.Constant(op.loc, None, w_T=TYPES.w_NoneType)
 
-    body = [*param_vardefs, *stmts_before_return]
+    body = [*param_assigns, *stmts_before_return]
     block = ast.BlockExpr(
         loc=op.loc,
         body=body,

--- a/spy/tests/compiler/test_force_inline.py
+++ b/spy/tests/compiler/test_force_inline.py
@@ -403,3 +403,21 @@ class TestForceInline(CompilerTest):
             return double(21)
         """)
         assert mod.foo() == 42
+
+    def test_force_inline_in_loop(self):
+        mod = self.compile("""
+        from __spy__ import force_inline
+
+        @force_inline
+        def inc(x: i32) -> i32:
+            return x + 1
+
+        def foo() -> i32:
+            var result = 0
+            var i = 0
+            while i < 3:
+                result = result + inc(i)
+                i = i + 1
+            return result
+        """)
+        assert mod.foo() == 6


### PR DESCRIPTION
Use AssignLocal instead of VarDef for inlined parameters, so that
re-execution in a loop assigns rather than re-declares. Also fix the
SPy backend's fmt_expr_BlockExpr to share the parent's scope state.

