### PR TITLE
Support multi-arg print()

### DIFF
--- a/spy/libspy/include/spy/__spy__.h
+++ b/spy/libspy/include/spy/__spy__.h
@@ -11,10 +11,9 @@ spy___spy__$is_compiled(void) {
 }
 
 static inline void
-spy___spy__$_stdio_write(spy_Str *s) {
+spy___spy__$_stdout_write(spy_Str *s) {
     for (size_t i = 0; i < s->length; i++)
         putchar(s->utf8[i]);
-    putchar('\n');
 }
 
 #endif /* SPY___SPY___H */

--- a/spy/tests/compiler/test_builtins.py
+++ b/spy/tests/compiler/test_builtins.py
@@ -329,6 +329,32 @@ class TestBuiltins(CompilerTest):
             ]
         )
 
+    def test_print_multi_args(self, capfd):
+        mod = self.compile("""
+        def foo() -> None:
+            print()
+            print("hello", "world")
+            print(1, 2, 3)
+            print("x =", 42)
+            print("a", 1, 2.5, True)
+            print("mix", i32, None)
+        """)
+        mod.foo()
+        if self.backend == "C":
+            mod.ll.call("spy_flush")
+        out, err = capfd.readouterr()
+        assert out == "\n".join(
+            [
+                "",
+                "hello world",
+                "1 2 3",
+                "x = 42",
+                "a 1 2.5 True",
+                "mix <spy type 'i32'> None",
+                "",
+            ]
+        )
+
     def test_print_blue(self, capfd):
         mod = self.compile("""
         def foo() -> None:

--- a/spy/tests/compiler/test_linearize.py
+++ b/spy/tests/compiler/test_linearize.py
@@ -353,7 +353,7 @@ class TestLinearize(CompilerTest):
                     $v0: i32 = `test::tick`()
                     if `operator::bool_not`($v0 < 3):
                         break
-                    `_print::_print_one[i32]::impl`(`test::N`)
+                    `_print::println[i32]::p`(`test::N`)
                 return `test::N`
             """
             self.assert_linearize("foo", expected)

--- a/spy/tests/test_cli.py
+++ b/spy/tests/test_cli.py
@@ -141,7 +141,7 @@ class TestMain:
 
     def test_redshift_full_fqn(self):
         _, stdout = self.run("redshift", "--full-fqn", self.main_spy)
-        assert "_print::_print_one[str]::impl" in stdout
+        assert "_print::println[str]::p" in stdout
 
     def test_redshift_spy_output(self):
         _, stdout = self.run("redshift", self.main_spy)

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -195,8 +195,8 @@ class TestDoppler:
             x: i32 = 0
             `test::foo`(x := 1)
             `test::foo`(2)
-            `_print::_print_one[i32]::impl`(x)
-            `_print::_print_one[str]::impl`('2')
+            `_print::println[i32]::p`(x)
+            `_print::println[str]::p`('2')
         """)
 
     def test_call_blue_closure(self):
@@ -238,7 +238,7 @@ class TestDoppler:
             `test::make_foo::foo`()
 
         def `test::make_foo::fn`() -> None:
-            `_print::_print_one[str]::impl`('fn')
+            `_print::println[str]::p`('fn')
 
         def `test::make_foo::foo`() -> None:
             `test::make_foo::fn`()

--- a/spy/vm/modules/__spy__/misc.py
+++ b/spy/vm/modules/__spy__/misc.py
@@ -1,3 +1,4 @@
+import sys
 from typing import TYPE_CHECKING, Any
 
 from spy.errors import SPyError
@@ -124,5 +125,5 @@ def w_force_inline(vm: "SPyVM", w_func: W_Object) -> W_Object:
 
 
 @SPY.builtin_func
-def w__stdio_write(vm: "SPyVM", w_s: W_Str) -> None:
-    print(vm.unwrap(w_s))
+def w__stdout_write(vm: "SPyVM", w_s: W_Str) -> None:
+    sys.stdout.write(vm.unwrap(w_s))

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -94,7 +94,7 @@ def w_print(vm: "SPyVM", *args_wam: W_MetaArg) -> W_OpSpec:
     #         println[T3](c)
     func_args: list[ast.FuncArg] = []
     params: list[FuncParam] = []
-    body = []
+    body: list[ast.Stmt] = []
     n = len(new_args_wam)
     for i, wam in enumerate(new_args_wam):
         loc = wam.loc

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -6,10 +6,13 @@ The first half is in vm/b.py. See its docstring for more details.
 
 from typing import TYPE_CHECKING
 
+from spy import ast
+from spy.analyze.scope import ScopeAnalyzer
 from spy.errors import SPyError
 from spy.fqn import FQN
+from spy.location import Loc
 from spy.vm.b import BUILTINS, TYPES, B
-from spy.vm.function import W_Func, W_FuncType
+from spy.vm.function import FuncParam, W_ASTFunc, W_Func, W_FuncType
 from spy.vm.modules.__spy__ import SPY
 from spy.vm.modules.__spy__.interp_list import (
     W_StrInterpList,
@@ -54,27 +57,104 @@ def w_min(vm: "SPyVM", w_x: W_I32, w_y: W_I32) -> W_I32:
 
 
 @BUILTINS.builtin_func(color="blue", kind="metafunc")
-def w_print(vm: "SPyVM", wam_obj: W_MetaArg) -> W_OpSpec:
+def w_print(vm: "SPyVM", *args_wam: W_MetaArg) -> W_OpSpec:
     vm.import_("_print")
-    w_print_one = vm.lookup_global(FQN("_print::_print_one"))
+    w_print1 = vm.lookup_global(FQN("_print::print1"))
+    w_println = vm.lookup_global(FQN("_print::println"))
 
-    if wam_obj.color == "blue":
-        # precompute eagerly the str() of blue objects.  This makes it possible to print
-        # e.g. types (like in `print(int)`), even if they are not currently supported by
-        # the C backend.
-        wam_s = vm.str_wam(wam_obj, loc=wam_obj.loc)
-        if wam_s.color != "blue":
-            wam_s = W_MetaArg.from_w_obj(vm, wam_s.w_val)
+    # Blue args are eagerly str()'d so that e.g. `print(int)` works even when
+    # the type isn't supported by the C backend. Non-last args use print1[T];
+    # the last arg uses println[T].
+    new_args_wam: list[W_MetaArg] = []
+    for wam in args_wam:
+        if wam.color == "blue":
+            wam_s = vm.str_wam(wam, loc=wam.loc)
+            if wam_s.color != "blue":
+                wam_s = W_MetaArg.from_w_obj(vm, wam_s.w_val, loc=wam.loc)
+            new_args_wam.append(wam_s)
+        else:
+            new_args_wam.append(wam)
 
-        w_print_one_impl = vm.getitem_w(w_print_one, B.w_str)
-        assert isinstance(w_print_one_impl, W_Func)
-        return W_OpSpec(w_print_one_impl, [wam_s])
+    if len(new_args_wam) == 0:
+        # print() with no args: equivalent to println("")
+        new_args_wam.append(W_MetaArg.from_w_obj(vm, vm.wrap("")))
 
-    else:
-        w_T = wam_obj.w_static_T
-        w_print_one_impl = vm.getitem_w(w_print_one, w_T)
-        assert isinstance(w_print_one_impl, W_Func)
-        return W_OpSpec(w_print_one_impl)
+    if len(new_args_wam) == 1:
+        # single arg: equivalent to println[T](arg)
+        wam = new_args_wam[0]
+        w_impl = vm.getitem_w(w_println, wam.w_static_T)
+        assert isinstance(w_impl, W_Func)
+        return W_OpSpec(w_impl, [wam])
+
+    # generic case: for e.g. print(a, b, c) we synthesise an ASTFunc like this:
+    #     @force_inline
+    #     def impl(a: T1, b: T2, c: T3) -> None:
+    #         print1[T1](a)
+    #         print1[T2](b)
+    #         println[T3](c)
+    func_args: list[ast.FuncArg] = []
+    params: list[FuncParam] = []
+    body = []
+    n = len(new_args_wam)
+    for i, wam in enumerate(new_args_wam):
+        loc = wam.loc
+        w_T = wam.w_static_T
+        arg_name = f"arg{i}"
+        func_args.append(
+            ast.FuncArg(loc, arg_name, ast.FQNConst(loc, w_T.fqn), "simple")
+        )
+        params.append(FuncParam(w_T, "simple"))
+        # print1[T] for non-last args; println[T] for the last one
+        w_print_func = w_println if i == n - 1 else w_print1
+        w_impl = vm.getitem_w(w_print_func, w_T)
+        assert isinstance(w_impl, W_Func)
+        body.append(
+            ast.StmtExpr(
+                loc,
+                ast.Call(
+                    loc,
+                    ast.FQNConst(loc, w_impl.fqn),
+                    [ast.Name(loc, arg_name)],
+                ),
+            )
+        )
+
+    loc = Loc.here()
+    body.append(ast.Return(loc, ast.Constant(loc, None)))
+
+    fqn = FQN("_print::print::impl")
+    fqn = vm.get_unique_FQN(fqn)
+    funcdef = ast.FuncDef(
+        loc=loc,
+        color="red",
+        kind="plain",
+        name="print",
+        args=func_args,
+        return_type=ast.FQNConst(loc, TYPES.w_NoneType.fqn),
+        defaults=[],
+        docstring=None,
+        body=body,
+        decorators=[],
+    )
+    module = ast.Module(
+        loc=loc,
+        filename="<generated>",
+        docstring=None,
+        decls=[ast.GlobalFuncDef(loc, funcdef)],
+    )
+    ScopeAnalyzer("_print", module).analyze()
+    w_functype = W_FuncType.new(params, w_restype=TYPES.w_NoneType)
+    w_func = W_ASTFunc(
+        w_functype,
+        fqn,
+        funcdef,
+        closure=(),
+        defaults_w=[],
+        lowering_stage="source",
+        is_force_inline=True,
+    )
+    vm.add_global(fqn, w_func)
+    return W_OpSpec(w_func, new_args_wam)
 
 
 @BUILTINS.builtin_func(color="blue", kind="metafunc")

--- a/stdlib/_print.spy
+++ b/stdlib/_print.spy
@@ -1,9 +1,27 @@
-from __spy__ import _stdio_write
+from __spy__ import _stdout_write
 
 
 @blue.generic
-def _print_one(T):
-    def impl(x: T) -> None:
-        _stdio_write(str(x))
+def print1(T):
+    """
+    print a single item and a space
+    """
 
-    return impl
+    def p(x: T) -> None:
+        _stdout_write(str(x))
+        _stdout_write(" ")
+
+    return p
+
+
+@blue.generic
+def println(T):
+    """
+    print a single item and a newline
+    """
+
+    def p(x: T) -> None:
+        _stdout_write(str(x))
+        _stdout_write("\n")
+
+    return p


### PR DESCRIPTION
`print(a, b, c)` becomes a call to the following synthetic function:

```python
    @force_inline
    def impl(a: T1, b: T2, c: T3) -> None:
        print1[T1](a)
        print1[T2](b)
        println[T3](c)
```

The func is `@force_inline` so the caller ends up with a sequence of one-argument prints in its body.

E.g.:
```python
def main() -> None:
    print("hello", 42)
```

```
❯ spy rs --linearize /tmp/x.spy 
def main() -> None:
    arg0$0: str = 'hello'
    arg1$0: str = '42'
    `_print::print1[str]::p`(arg0$0)
    `_print::println[str]::p`(arg1$0)
    None
```