### PR TITLE
Handle LocConst in AlphaRenamer for @force_inline

### DIFF
--- a/spy/force_inline.py
+++ b/spy/force_inline.py
@@ -137,6 +137,9 @@ class AlphaRenamer:
     def rename_expr_StrConst(self, expr: ast.StrConst) -> ast.Expr:
         return expr
 
+    def rename_expr_LocConst(self, expr: ast.LocConst) -> ast.Expr:
+        return expr
+
     def rename_expr_And(self, expr: ast.And) -> ast.Expr:
         return expr.replace(
             left=self.rename_expr(expr.left),

--- a/spy/tests/compiler/test_force_inline.py
+++ b/spy/tests/compiler/test_force_inline.py
@@ -404,6 +404,22 @@ class TestForceInline(CompilerTest):
         """)
         assert mod.foo() == 42
 
+    def test_LocConst(self):
+        mod = self.compile("""
+        from unsafe import gc_alloc, gc_ptr
+        from __spy__ import force_inline
+
+        @force_inline
+        def kernel(p: gc_ptr[i32], i: i32) -> i32:
+            return p[i]
+
+        def foo() -> i32:
+            p = gc_alloc[i32](1)
+            p[0] = 42
+            return kernel(p, 0)
+        """)
+        assert mod.foo() == 42
+
     def test_force_inline_in_loop(self):
         mod = self.compile("""
         from __spy__ import force_inline


### PR DESCRIPTION
When a @force_inline function body contains an operation that injects
an ast.LocConst (e.g. `gc_ptr[T].__getitem__`) passing a W_Loc for panic
reporting), AlphaRenamer raised NotImplementedError. LocConst is
immutable, so just return it unchanged.

Fixes #508.
