### PR TITLE
Docs: Add Pages For SPy Builtins and `__spy__` module

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -53,6 +53,8 @@ nav:
     - howto/main_function.md
   - API Reference:
     - api_reference/python_builtins.md
+    - api_reference/spy_builtins.md
+    - api_reference/spy_module.md
   - Unsorted notes:
       - Low-level memory model: llmem.md
 

--- a/docs/src/api_reference/python_builtins.md
+++ b/docs/src/api_reference/python_builtins.md
@@ -73,9 +73,9 @@ The following built-in functions work similarly to their equivalents in CPython;
 
 :   `object` is implemented as a type, and can be used as a parameter or return type. "Plain" objects (i.e. `x = object()`) are not supported.
 
-### __print__(obj) { data-toc-label='print()' }
+### __print__(*objects) { data-toc-label='print()' }
 
-:   The print function is currently not variadic, in the sense that it only accepts a single argument. The built-in types are special-cased, and SPy can always print blue objects by pre-computing their string representation
+:   Prints objects to standard out, utilizing the objects `__str__` method if necessary. Extra keyworld arguments a la [CPythons' print()](https://docs.python.org/3/library/functions.html#print) are not currently supported.
 
 ### __range__(stop) { data-toc-label='range()' }
 <h3> <b>range</b>(start, stop, step)</h3> <!-- An HTML label to hide this in the TOC -->

--- a/docs/src/api_reference/spy_builtins.md
+++ b/docs/src/api_reference/spy_builtins.md
@@ -1,0 +1,91 @@
+title: SPy Builtins
+
+<style> {
+  font-family: "Lucida Console", "Courier New", monospace;
+}
+</style>
+
+
+
+/// warning
+XXXXXXXXXXXXx
+///
+
+
+## Class and Callable Decorators
+
+### __@struct__
+
+:   Used to create a struct from a class definition. See the [low level memory section on structs](/llmem/#stack-allocated-structs) for more details.
+
+### __@blue__
+:   Declares that a function should be executed at [redshift time](https://antocuni.eu/2025/10/29/inside-spy-part-1-motivations-and-goals/#redshifting); that is, at the point when method and function lookups are resolved, and prior to compilation to C or WASM, if any.
+
+:   `@blue` decorated functions are not required to specify types for their parameters, nor are they required to specify return types.
+
+### __@blue.generic__
+:   Denotes that the decorated function accepts a type as its first argument. Generic functions should return a function object.
+
+:   Generic functions are called using the spy-specific syntax `func[Type](args)`.
+
+```python
+  @blue.generic
+  def add(T):
+      def impl(x:T, y: T) -> T:
+          return x + y
+      return impl
+
+  def main() -> None:
+      print(add[i32](1, 2))
+      print(add[str]('hello ', 'world'))
+```
+
+### __@blue.metafunc__
+:   Unlike `blue.generic` functions, `metafunc`s accept one or more arguments, and return an [OpSpec]() appropriate to those arguments based on their static type.
+
+```python
+  from operator import OpSpec
+
+  @blue.metafunc
+  def myprint(m_x):
+      if m_x.static_type == int:
+          def myprint_int(x: int) -> None:
+              print(x)
+          return OpSpec(myprint_int)
+
+      if m_x.static_type == str:
+          def myprint_str(x: str) -> None:
+              print(x)
+          return OpSpec(myprint_str)
+
+      raise TypeError("don't know how to print this")
+
+  def main() -> None:
+      print(42)
+      myprint("hello")
+      myprint(5.2)  # raises TypeError
+```
+
+### @force_inline
+
+:   Causes the decorated functino to be inlined **during redshifting**. 
+
+Only functions with a single return statement at the end of the funciton can be forced inline. Blue functions cannot be forced inline, nor can forced-inline statements be used recursively.
+
+```py
+#inline_demo.spy
+from __spy__ import force_inline
+
+@force_inline
+def inc(x: i32) -> i32:
+    return x + 1
+
+def main() -> None:
+    print(inc(1))
+```
+```sh
+# spy rs inline_demo.spy
+def main() -> None:
+    `_print::_print_one[i32]::impl`(__block__(x$0: i32 = 1; x$0 + 1))
+```
+

--- a/docs/src/api_reference/spy_builtins.md
+++ b/docs/src/api_reference/spy_builtins.md
@@ -25,7 +25,7 @@ For a deeper explanation of the current state of SPy's coloring nomenclature, se
 ### __@blue__
 :   Declares that a function should be executed at [redshift time](https://antocuni.eu/2025/10/29/inside-spy-part-1-motivations-and-goals/#redshifting); that is, at the point when method and function lookups are resolved, and prior to compilation to C or WASM, if any.
 
-:   `@blue` decorated functions are not required to specify types for their parameters, nor are they required to specify return types.
+:   type annotations for `@blue` functions are optional. If omitted, the arguments and return types default to `dynamic`.
 
 : In this example, the two blue functions are evaluated during redshift time, and the emitted C code is just a print statement of a constant number.
 
@@ -48,9 +48,7 @@ def main() -> None:
 ```
 
 ### __@blue.generic__
-:   Denotes that the decorated function accepts a type as its first argument. Generic functions should return a function object.
-
-:   Generic functions are called using the spy-specific syntax `func[type](args)`.
+:   Functions decorated with `@blue.generic` are called using square brackets `[]` instead of parentheses `()`. Other than that, they are identical to other blue functions. While they may be used anywhere, the primary purposes is to allow the creation of functions that look like [PEP 695](https://peps.python.org/pep-0695/) functions with type parameters:
 
 ```python
   @blue.generic

--- a/docs/src/api_reference/spy_builtins.md
+++ b/docs/src/api_reference/spy_builtins.md
@@ -5,10 +5,14 @@ title: SPy Builtins
 }
 </style>
 
-
+SPy adds several new builtins to the global namespace. Currently, all of them happen to be decorators for classes or callables.
 
 /// warning
-XXXXXXXXXXXXx
+The contents of the `__spy__` module and SPy's builtins form the API surface of a language that's rapidly evolving. All of the constructs, names, functions, or decorators here are likely to change!
+///
+
+/// important
+For a deeper explanation of the current state of SPy's coloring nomenclature, see [this post by Antonio Cuni](https://antocuni.eu/2026/03/25/inside-spy-part-2-language-semantics/#blue-functions).
 ///
 
 
@@ -16,17 +20,37 @@ XXXXXXXXXXXXx
 
 ### __@struct__
 
-:   Used to create a struct from a class definition. See the [low level memory section on structs](/llmem/#stack-allocated-structs) for more details.
+:   Used to create a struct from a class definition. See the [low level memory section on structs](../llmem.md#stack-allocated-structs) for more details.
 
 ### __@blue__
 :   Declares that a function should be executed at [redshift time](https://antocuni.eu/2025/10/29/inside-spy-part-1-motivations-and-goals/#redshifting); that is, at the point when method and function lookups are resolved, and prior to compilation to C or WASM, if any.
 
 :   `@blue` decorated functions are not required to specify types for their parameters, nor are they required to specify return types.
 
+: In this example, the two blue functions are evaluated during redshift time, and the emitted C code is just a print statement of a constant number.
+
+```py
+@blue
+def factorial(x)
+    if x == 0: return 1
+    if x == 1: return 1
+    return x * factorial(x-1)
+
+@blue
+def calc_e(terms):
+    sum: float = 0
+    for i in range(terms):
+        sum += 1/factorial(i)
+    return sum
+
+def main() -> None:
+    print(calc_e(10))
+```
+
 ### __@blue.generic__
 :   Denotes that the decorated function accepts a type as its first argument. Generic functions should return a function object.
 
-:   Generic functions are called using the spy-specific syntax `func[Type](args)`.
+:   Generic functions are called using the spy-specific syntax `func[type](args)`.
 
 ```python
   @blue.generic
@@ -66,11 +90,11 @@ XXXXXXXXXXXXx
       myprint(5.2)  # raises TypeError
 ```
 
-### @force_inline
+### __@force_inline__
 
-:   Causes the decorated functino to be inlined **during redshifting**. 
+:   Causes the decorated function to be inlined **during redshifting**. 
 
-Only functions with a single return statement at the end of the funciton can be forced inline. Blue functions cannot be forced inline, nor can forced-inline statements be used recursively.
+:   Only functions with a single return statement at the end of the function can be forced inline. Blue functions cannot be forced inline, nor can forced-inline statements be used recursively.
 
 ```py
 #inline_demo.spy

--- a/docs/src/api_reference/spy_module.md
+++ b/docs/src/api_reference/spy_module.md
@@ -11,14 +11,16 @@ The `__spy__` module provides functions for introspecting and manipulating SPy o
 The contents of the `__spy__` module and SPy's builtins form the API surface of a language that's rapidly evolving. All of the constructs, names, functions, or decorators here are likely to change!
 ///
 
-### __COLOR__(object) -> Literal["red", "blue"] { #markdown data-toc-label='Color()' }
-:   Returns the current color of the passed object. Mainly useful in tests, but may be useful to give users a view into the color of objects during development.
+### __COLOR__(expr) -> Literal["red", "blue"] { #markdown data-toc-label='Color()' }
+:   Returns the current color of the passed expression. Mainly useful in tests, but may be useful to give users a view into the color of expressions during development.
 
 ### __as_red__(object) -> Literal["red", "blue"] { #markdown data-toc-label='as_red()' }
-:   Returns a copy of the object as a red object. May be useful during metaprograming ensure that blue objects which are equal do not get optimized into the same object at redshift time. See, for example, the [implementation of `exal_expr_List`](https://github.com/spylang/spy/blob/main/spy/vm/astframe.py#L1161).
+:   If `object` is a reference type (e.g. strings, int, etc.), `as_red` simply changes the passed object's color to red. If `object` is a value type, returns a copy of the object as a red object. 
+
+: May be useful during metaprograming ensure that blue objects which are equal do not get optimized into the same object at redshift time. See, for example, the [implementation of `exal_expr_List`](https://github.com/spylang/spy/blob/main/spy/vm/astframe.py#L1161).
 
 ### __STATIC_TYPE__(object) { #markdown data-toc-label='\_\_STATIC_TYPE\_\_()' }
-:   Returns the type of the object determined in a static context. Useful in tests, and is used in some of SPy's internal machinery.
+:   Returns the type of the expression determined in a static context. Useful in tests, and is used in some of SPy's internal machinery.
 
 ### __interp_list__(object) { #markdown data-toc-label='interp_list' }
 :   A `list` object that functions only within the interpreter, and is not supported by the C backend. Highly likely to be removed in the future, but currently useful for prototyping internal to SPy for object types that cannot currently be held in 'real' lists, like types, `object()`s, and dynamic objects.

--- a/docs/src/api_reference/spy_module.md
+++ b/docs/src/api_reference/spy_module.md
@@ -19,8 +19,12 @@ The contents of the `__spy__` module and SPy's builtins form the API surface of 
 
 : May be useful during metaprograming ensure that blue objects which are equal do not get optimized into the same object at redshift time. See, for example, the [implementation of `exal_expr_List`](https://github.com/spylang/spy/blob/main/spy/vm/astframe.py#L1161).
 
-### __STATIC_TYPE__(object) { #markdown data-toc-label='\_\_STATIC_TYPE\_\_()' }
+### __STATIC_TYPE__(object) { #markdown data-toc-label='STATIC_TYPE()' }
 :   Returns the type of the expression determined in a static context. Useful in tests, and is used in some of SPy's internal machinery.
+
+### __is_compiled__() { #markdown data-toc-label='is_compiled()' }
+:   Returns `False` when run in the interpreter, with or without redshifting. Returns `True` in compiled C code. Useful for testing and benchmarks, where it may be useful to adjust parameters depending on whether the code is compiled or not.
+
 
 ### __interp_list__(object) { #markdown data-toc-label='interp_list' }
 :   A `list` object that functions only within the interpreter, and is not supported by the C backend. Highly likely to be removed in the future, but currently useful for prototyping internal to SPy for object types that cannot currently be held in 'real' lists, like types, `object()`s, and dynamic objects.

--- a/docs/src/api_reference/spy_module.md
+++ b/docs/src/api_reference/spy_module.md
@@ -1,4 +1,4 @@
-title: The __spy__ module
+title: The __spy__ Module
 ---
 <style> {
   font-family: "Lucida Console", "Courier New", monospace;

--- a/docs/src/api_reference/spy_module.md
+++ b/docs/src/api_reference/spy_module.md
@@ -1,32 +1,30 @@
-title: The `__spy__` module
+title: The __spy__ module
 ---
 <style> {
   font-family: "Lucida Console", "Courier New", monospace;
 }
 </style>
 
-Another class of useful functions is found in the `__spy__` module, available in the SPy standard library.
+The `__spy__` module provides functions for introspecting and manipulating SPy objects' at colors and types at runtime. It also contains some objects - `interp_list`, `interp_dict`, and `interp_tuple` -  that act as fallback implementations for those data structures that only function within the interpreter.
 
 /// warning
-XXXXXXXXXXXXx
+The contents of the `__spy__` module and SPy's builtins form the API surface of a language that's rapidly evolving. All of the constructs, names, functions, or decorators here are likely to change!
 ///
 
-### __interp_list__(object) { #markdown data-toc-label='interp_list' }
-:   xxxx
-
-### __interp_dict__(object) { #markdown data-toc-label='interp_list' }
-:   xxxx
-
-### __interp_tuple__(object) { #markdown data-toc-label='interp_list' }
-:   xxxx
-
 ### __COLOR__(object) -> Literal["red", "blue"] { #markdown data-toc-label='Color()' }
-:   Returns the current color of the passed object. Mainly useful in tests, but may be useful to give users a view into the color of their objets during development.
+:   Returns the current color of the passed object. Mainly useful in tests, but may be useful to give users a view into the color of objects during development.
 
 ### __as_red__(object) -> Literal["red", "blue"] { #markdown data-toc-label='as_red()' }
 :   Returns a copy of the object as a red object. May be useful during metaprograming ensure that blue objects which are equal do not get optimized into the same object at redshift time. See, for example, the [implementation of `exal_expr_List`](https://github.com/spylang/spy/blob/main/spy/vm/astframe.py#L1161).
 
 ### __STATIC_TYPE__(object) { #markdown data-toc-label='\_\_STATIC_TYPE\_\_()' }
-:   Returns the type of the object determined in a static context. Useful in tests, and used in some of SPy's internal machinery.
+:   Returns the type of the object determined in a static context. Useful in tests, and is used in some of SPy's internal machinery.
 
+### __interp_list__(object) { #markdown data-toc-label='interp_list' }
+:   A `list` object that functions only within the interpreter, and is not supported by the C backend. Highly likely to be removed in the future, but currently useful for prototyping internal to SPy for object types that cannot currently be held in 'real' lists, like types, `object()`s, and dynamic objects.
 
+### __interp_dict__(object) { #markdown data-toc-label='interp_dict' }
+:   A `dict` object that functions only within the interpreter, and is not supported by the C backend. Highly likely to be removed in the future, but currently useful for prototyping internal to SPy to support key types that cannot currently be keys of 'real' dicts, like union types.
+
+### __interp_tuple__(object) { #markdown data-toc-label='interp_tuple' }
+:   A `tuple` object that functions only within the interpreter, and is not supported by the C backend. Highly likely to be removed in the future, but solves some bootstrapping issues related to other types and operations implemented in SPy.

--- a/docs/src/api_reference/spy_module.md
+++ b/docs/src/api_reference/spy_module.md
@@ -1,0 +1,32 @@
+title: The `__spy__` module
+---
+<style> {
+  font-family: "Lucida Console", "Courier New", monospace;
+}
+</style>
+
+Another class of useful functions is found in the `__spy__` module, available in the SPy standard library.
+
+/// warning
+XXXXXXXXXXXXx
+///
+
+### __interp_list__(object) { #markdown data-toc-label='interp_list' }
+:   xxxx
+
+### __interp_dict__(object) { #markdown data-toc-label='interp_list' }
+:   xxxx
+
+### __interp_tuple__(object) { #markdown data-toc-label='interp_list' }
+:   xxxx
+
+### __COLOR__(object) -> Literal["red", "blue"] { #markdown data-toc-label='Color()' }
+:   Returns the current color of the passed object. Mainly useful in tests, but may be useful to give users a view into the color of their objets during development.
+
+### __as_red__(object) -> Literal["red", "blue"] { #markdown data-toc-label='as_red()' }
+:   Returns a copy of the object as a red object. May be useful during metaprograming ensure that blue objects which are equal do not get optimized into the same object at redshift time. See, for example, the [implementation of `exal_expr_List`](https://github.com/spylang/spy/blob/main/spy/vm/astframe.py#L1161).
+
+### __STATIC_TYPE__(object) { #markdown data-toc-label='\_\_STATIC_TYPE\_\_()' }
+:   Returns the type of the object determined in a static context. Useful in tests, and used in some of SPy's internal machinery.
+
+


### PR DESCRIPTION
Adds two new pages - `SPy Builtins` and `The __spy__ Module`.

Not every last thing is detailed here - I omitted things that feel 'temporary enough' to be not worth mentioning for now.

- Module `__INIT__()` feels like an implementation detail for builtin types... but may be worth documentating?
- `_stdio_write()` seems transient enough to not be worth documenting yet.
- `is_compiled()` feels like it's just for SPy's tests

Of course, happy to add these if wanted!