### PR TITLE
Support for blue if

### DIFF
--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -290,7 +290,13 @@ class DopplerFrame(ASTFrame):
         return newbody
 
     def shift_stmt_If(self, if_node: ast.If) -> list[ast.Stmt]:
-        newtest = self.eval_and_shift(if_node.test, varname="@if")
+        wam_test = self.eval_expr(if_node.test, varname="@if")
+        newtest = self.shifted_expr[if_node.test]
+        if wam_test.is_blue():
+            if self.vm.is_True(wam_test.w_val):
+                return self.shift_body(if_node.then_body)
+            else:
+                return self.shift_body(if_node.else_body)
         newthen = self.shift_body(if_node.then_body)
         newelse = self.shift_body(if_node.else_body)
         return [if_node.replace(test=newtest, then_body=newthen, else_body=newelse)]

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -354,6 +354,19 @@ class TestDoppler:
             `test::x` = 1
         """)
 
+    def test_blue_if(self):
+        self.redshift("""
+        def foo() -> i32:
+            if True:
+                return 1
+            else:
+                return 0
+        """)
+        self.assert_dump("""
+        def foo() -> i32:
+            return 1
+        """)
+
     def test_format_prebuilt_exception(self):
         fname = str(self.tmpdir.join("test.spy"))
         self.redshift("""


### PR DESCRIPTION
When the `if` condition is blue, doppler now evaluates it and emits
only the body of the taken branch, dropping the `if` node.

This was just an experiment to see how far I could go, but it require some thinking.