### PR TITLE
Add type.__origin__ and function.__origin__

### DIFF
--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -58,7 +58,7 @@ def make_const(vm: "SPyVM", loc: Loc, w_val: W_Object) -> ast.Expr:
         items = [make_const(vm, loc, w_item) for w_item in w_val.items_w]
         res = ast.Tuple(loc, items, w_T=w_T)
 
-    elif w_T.fqn.match("_tuple::tuple[*]::_tup"):
+    elif vm.is_tuple_type(w_T):
         # transform the struct into a syntactical ast.Tuple node, so that we can put it
         # in the AST without necessarily create a FQN
         assert isinstance(w_val, W_Struct)

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -956,6 +956,75 @@ class TestBasic(CompilerTest):
         assert mod.foo() == 3
         assert mod.bar() == "hello world"
 
+    @only_interp
+    def test_generic_type_origin(self):
+        mod = self.compile("""
+        @blue.generic
+        def MyType(T):
+            @struct
+            class _impl:
+                data: T
+            return _impl
+
+        def get_origin() -> dynamic:
+            Concrete = MyType[i32]
+            return Concrete.__origin__
+        """)
+        w_origin = mod.get_origin(unwrap=False)
+        w_mod = self.vm.modules_w["test"]
+        w_MyType = w_mod.getattr("MyType")
+        assert w_origin is w_MyType
+
+    @only_interp
+    def test_non_generic_type_origin_is_none(self):
+        mod = self.compile("""
+        @struct
+        class Foo:
+            data: i32
+
+        def get_origin() -> dynamic:
+            return Foo.__origin__
+        """)
+        assert mod.get_origin() is None
+
+    @only_interp
+    def test_generic_origin_not_overwritten(self):
+        mod = self.compile("""
+        @blue.generic
+        def Type(T):
+            @struct
+            class _impl:
+                data: T
+            return _impl
+
+        @blue.generic
+        def Bar(T):
+            return Type[T]
+
+        def get_origin() -> dynamic:
+            return Bar[i32].__origin__
+        """)
+        w_origin = mod.get_origin(unwrap=False)
+        w_mod = self.vm.modules_w["test"]
+        w_Type = w_mod.getattr("Type")
+        assert w_origin is w_Type
+
+    @only_interp
+    def test_generic_origin_not_set_for_external_type(self):
+        mod = self.compile("""
+        @struct
+        class Outer:
+            data: i32
+
+        @blue.generic
+        def passthrough(T):
+            return Outer
+
+        def get_origin() -> dynamic:
+            return passthrough[i32].__origin__
+        """)
+        assert mod.get_origin() is None
+
     def test_cannot_call_blue_generic(self):
         src = """
         @blue.generic

--- a/spy/tests/vm/test_function.py
+++ b/spy/tests/vm/test_function.py
@@ -6,7 +6,14 @@ from spy import ast
 from spy.fqn import FQN
 from spy.location import Loc
 from spy.vm.b import B
-from spy.vm.function import Color, FuncKind, FuncParam, LoweringStage, W_ASTFunc
+from spy.vm.function import (
+    Color,
+    FuncKind,
+    FuncParam,
+    LoweringStage,
+    W_ASTFunc,
+    W_BuiltinFunc,
+)
 from spy.vm.object import W_Type
 from spy.vm.vm import SPyVM
 from spy.vm.w import W_FuncType
@@ -131,6 +138,24 @@ class TestFunction:
         w_f2 = make_w_func("test::bar")
         with pytest.raises(AssertionError):
             w_f1.replace_with(w_f2)
+
+    def test_compute_inner_ns_no_type_args(self):
+        vm = SPyVM()
+        w_f = make_w_func("test::foo")
+        ns = w_f.compute_inner_ns([vm.wrap(42)])
+        # non-type arg is ignored: no qualifiers
+        assert ns == FQN("test::foo")
+
+    def test_compute_inner_ns_with_type_args(self):
+        w_f = make_w_func("test::add")
+        ns = w_f.compute_inner_ns([B.w_i32])
+        assert ns == FQN("test::add[i32]")
+
+    def test_compute_inner_ns_builtin(self):
+        w_functype = make_FuncType(B.w_i32, w_restype=B.w_i32, color="blue")
+        w_f = W_BuiltinFunc(w_functype, FQN("test::myfunc"), lambda vm, x: x)
+        ns = w_f.compute_inner_ns([B.w_i32])
+        assert ns == FQN("test::myfunc[i32]")
 
     def test_W_ASTFunc_repr(self):
         w_f1 = make_w_func("test::foo")

--- a/spy/tests/wasm_wrapper.py
+++ b/spy/tests/wasm_wrapper.py
@@ -170,7 +170,7 @@ class WasmFuncWrapper:
             if w_T.fqn == FQN("_list::list[i32]::_ListImpl"):
                 # we support only reading list[i32] for tests
                 return self._to_pylist_i32(pyres)
-            elif str(w_T.fqn).startswith("_list::list["):
+            elif self.vm.is_list_type(w_T):
                 raise NotImplementedError(f"Reading {w_T.fqn} out of WASM memory")
             elif w_T.fqn == FQN("_dict::dict[i32, i32]::_dict"):
                 # we support only reading dict[i32, i32] for test

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -601,7 +601,7 @@ class AbstractFrame:
         w_T = wam_tup.w_static_T
 
         is_interp_tuple = w_T is SPY.w_interp_tuple
-        is_stdlib_tuple = w_T.fqn.match("_tuple::tuple[*]::_tup")
+        is_stdlib_tuple = self.vm.is_tuple_type(w_T)
         if not (is_interp_tuple or is_stdlib_tuple):
             t = wam_tup.w_static_T.fqn.human_name
             err = SPyError(

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -1334,7 +1334,7 @@ class ASTFrame(AbstractFrame):
         # if w_func was lowered, automatically use the most lowered version
         w_func = w_func.get_most_lowered_version()
         assert isinstance(w_func, W_ASTFunc)
-        ns = self.compute_ns(w_func, args_w)
+        ns = w_func.compute_inner_ns(args_w or [])
         super().__init__(
             vm, ns, w_func.funcdef.loc, w_func.funcdef.symtable, w_func.closure
         )
@@ -1350,45 +1350,6 @@ class ASTFrame(AbstractFrame):
         else:
             extra = ""
         return f"<{cls} for `{self.w_func.fqn}`{extra}>"
-
-    def compute_ns(
-        self, w_func: W_ASTFunc, args_w: Optional[Sequence[W_Object]]
-    ) -> FQN:
-        """
-        Try to generate a meaningful namespace for blue functions. The
-        idea is that if we blue func takes type parameters, we want to include
-        them in the qualifiers. E.g.:
-
-            @blue
-            def add(T):
-                def impl(x: T, y: T) -> T:
-                    return x + y
-                return impl
-
-            add(i32) # ==> add[i32]::impl
-            add(str) # ==> add[str]::impl
-
-        At the moment, the implementation is a bit ad-hoc and hackish, as it
-        considers ONLY type params as qualifiers, and ignores everything else.
-
-        Note that this is more about readability than correctness: in case of
-        blue params which are ignored, we might get clashing namespaces, but
-        this is still ok, because uniqueness of FQNs is guaranteed by
-        vm.get_unique_FQN().
-
-        This is fine as long as we don't support separate compilation. For sep
-        comp, we will probably need a deterministic and reproducible way to
-        compute unique FQNs out of a blue call.
-        """
-        if w_func.color == "red":
-            return w_func.fqn
-        assert args_w is not None
-        ns = w_func.fqn
-        quals = []
-        for w_arg in args_w:
-            if isinstance(w_arg, W_Type):
-                quals.append(w_arg.fqn)
-        return ns.with_qualifiers(quals)
 
     def run(self, args_w: Sequence[W_Object]) -> W_Object:
         assert self.w_func.is_valid, "w_func has been redshifted"

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -242,6 +242,36 @@ class W_Func(W_Object):
         FQN("builtins::type::__new__"),
     }
 
+    def compute_inner_ns(self, args_w: Sequence[W_Object]) -> FQN:
+        """
+        Try to generate a meaningful namespace for blue functions. The
+        idea is that if a blue func takes type parameters, we want to include
+        them in the qualifiers. E.g.:
+
+            @blue
+            def add(T):
+                def impl(x: T, y: T) -> T:
+                    return x + y
+                return impl
+
+            add(i32) # ==> add[i32]::impl
+            add(str) # ==> add[str]::impl
+
+        At the moment, the implementation is a bit ad-hoc and hackish, as it
+        considers ONLY type params as qualifiers, and ignores everything else.
+
+        Note that this is more about readability than correctness: in case of
+        blue params which are ignored, we might get clashing namespaces, but
+        this is still ok, because uniqueness of FQNs is guaranteed by
+        vm.get_unique_FQN().
+
+        This is fine as long as we don't support separate compilation. For sep
+        comp, we will probably need a deterministic and reproducible way to
+        compute unique FQNs out of a blue call.
+        """
+        quals = [w_arg.fqn for w_arg in args_w if isinstance(w_arg, W_Type)]
+        return self.fqn.with_qualifiers(quals)
+
     def spy_get_w_type(self, vm: "SPyVM") -> W_Type:
         return self.w_functype
 

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -212,6 +212,7 @@ class W_Func(W_Object):
     w_functype: W_FuncType
     fqn: FQN
     def_loc: Loc
+    w_origin: Optional["W_Object"]
 
     @property
     def color(self) -> Color:
@@ -412,6 +413,7 @@ class W_ASTFunc(W_Func):
         self.lowering_stage = lowering_stage
         self.w_replaced_by = None
         self.is_force_inline = is_force_inline
+        self.w_origin = None
 
         # sanity check
         if lowering_stage in ("source", "redshift_in_progress"):
@@ -512,6 +514,7 @@ class W_BuiltinFunc(W_Func):
         # bluecache
         self._pyfunc = pyfunc
         self._is_pure = is_pure
+        self.w_origin = None
 
     def __repr__(self) -> str:
         return f"<spy function '{self.fqn}' (builtin)>"

--- a/spy/vm/modules/operator/convop.py
+++ b/spy/vm/modules/operator/convop.py
@@ -247,9 +247,10 @@ def w_from_dynamic(vm: "SPyVM", w_T: W_Type) -> W_Dynamic:
         b: i32 = from_dynamic[i32](a)
     """
     T = Annotated[W_Object, w_T]
+    ns = OP.w_from_dynamic.compute_inner_ns([w_T])
 
-    # operator::from_dynamic[i32]
-    @vm.register_builtin_func("operator", "from_dynamic", [w_T.fqn])
+    # operator::from_dynamic[i32]::impl
+    @vm.register_builtin_func(ns, "impl")
     def w_from_dynamic_T(vm: "SPyVM", w_obj: W_Dynamic) -> T:
         # XXX, we can probably generate better errors
         #

--- a/spy/vm/modules/unsafe/mem.py
+++ b/spy/vm/modules/unsafe/mem.py
@@ -58,9 +58,9 @@ def w_gc_alloc(vm: "SPyVM", w_T: W_Type) -> W_Dynamic:
 @UNSAFE.builtin_func(color="blue")
 def w_mem_read(vm: "SPyVM", w_T: W_Type) -> W_Dynamic:
     T = Annotated[W_Object, w_T]
+    ns = UNSAFE.w_mem_read.compute_inner_ns([w_T])
 
-    # unsafe::mem_read[T]
-    @vm.register_builtin_func("unsafe", "mem_read", [w_T.fqn])
+    @vm.register_builtin_func(ns, "impl")
     def w_mem_read_T(vm: "SPyVM", w_addr: W_I32) -> T:
         addr = vm.unwrap_i32(w_addr)
         return generic_mem_read(vm, addr, w_T)
@@ -71,9 +71,9 @@ def w_mem_read(vm: "SPyVM", w_T: W_Type) -> W_Dynamic:
 @UNSAFE.builtin_func(color="blue")
 def w_mem_write(vm: "SPyVM", w_T: W_Type) -> W_Dynamic:
     T = Annotated[W_Object, w_T]
+    ns = UNSAFE.w_mem_write.compute_inner_ns([w_T])
 
-    # unsafe::mem_write[T]
-    @vm.register_builtin_func("unsafe", "mem_write", [w_T.fqn])
+    @vm.register_builtin_func(ns, "impl")
     def w_mem_write_T(vm: "SPyVM", w_addr: W_I32, w_val: T) -> None:
         addr = vm.unwrap_i32(w_addr)
         generic_mem_write(vm, addr, w_T, w_val)

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -481,14 +481,14 @@ def w_ptr_getfield(vm: "SPyVM", w_T: W_Type, w_memkind: W_Str) -> W_Dynamic:
         by = "byval"
 
     T = Annotated[W_Object, w_T]
-
+    ns = UNSAFE.w_ptr_getfield.compute_inner_ns([w_T])
     # example FQNs:
-    #     unsafe::ptr_getfield_byval[i32]
-    #     unsafe::ptr_getfield_byref[raw_ref[Point]]
-    #     unsafe::ptr_getfield_byref[gc_ref[Point]]
+    #     unsafe::ptr_getfield[i32]::byval
+    #     unsafe::ptr_getfield[raw_ref[Point]]::byref
+    #     unsafe::ptr_getfield[gc_ref[Point]]::byref
     tag = IRTag("ptr.getfield", by=by)
 
-    @vm.register_builtin_func("unsafe", f"ptr_getfield_{by}", [w_T.fqn], irtag=tag)
+    @vm.register_builtin_func(ns, by, irtag=tag)
     def w_ptr_getfield_T(
         vm: "SPyVM", w_ptr: W_Ptr, w_name: W_Str, w_offset: W_I32
     ) -> T:
@@ -508,11 +508,11 @@ def w_ptr_getfield(vm: "SPyVM", w_T: W_Type, w_memkind: W_Str) -> W_Dynamic:
 @UNSAFE.builtin_func(color="blue")
 def w_ptr_setfield(vm: "SPyVM", w_T: W_Type) -> W_Dynamic:
     T = Annotated[W_Object, w_T]
-
-    # example FQN: unsafe::ptr_setfield[i32]
+    ns = UNSAFE.w_ptr_setfield.compute_inner_ns([w_T])
+    # example FQN: unsafe::ptr_setfield[i32]::impl
     irtag = IRTag("ptr.setfield")
 
-    @vm.register_builtin_func("unsafe", "ptr_setfield", [w_T.fqn], irtag=irtag)
+    @vm.register_builtin_func(ns, "impl", irtag=irtag)
     def w_ptr_setfield_T(
         vm: "SPyVM", w_ptr: W_Ptr, w_name: W_Str, w_offset: W_I32, w_val: T
     ) -> None:

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -430,6 +430,7 @@ class W_Type(W_Object):
     fqn: FQN
     _pyclass: Optional[Type[W_Object]]
     _dict_w: Optional[dict[str, W_Object]]
+    w_origin: Optional["W_Object"]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         cls = self.__class__.__name__
@@ -465,6 +466,7 @@ class W_Type(W_Object):
         w_T.fqn = fqn
         w_T._pyclass = None
         w_T._dict_w = None
+        w_T.w_origin = None
         return w_T
 
     @classmethod
@@ -712,6 +714,15 @@ class W_Type(W_Object):
         return None
 
     # ======== app-level interface ========
+
+    @builtin_property("__origin__")
+    @staticmethod
+    def w_get_origin(vm: "SPyVM", w_self: "W_Type") -> "W_Dynamic":
+        from spy.vm.b import B
+
+        if w_self.w_origin is None:
+            return B.w_None
+        return w_self.w_origin
 
     @builtin_method("__new__")
     @staticmethod

--- a/spy/vm/struct.py
+++ b/spy/vm/struct.py
@@ -307,16 +307,13 @@ class W_Struct(W_Object):
         return ("struct", self.w_structtype.spy_key(vm)) + tuple(values_key)
 
     def spy_unwrap(self, vm: "SPyVM") -> Any:
-        fqn = self.w_structtype.fqn
-
-        # hack hack hack, as we don't have a better way to check whether w_T is a 'list'
-        is_list = str(fqn).startswith("_list::list[")
-        if is_list:
+        if vm.is_list_type(self.w_structtype):
             return unwrap_list(vm, self)
 
-        is_dict = str(fqn).startswith("_dict::dict[")
-        if is_dict:
+        if vm.is_dict_type(self.w_structtype):
             return unwrap_dict(vm, self)
+
+        fqn = self.w_structtype.fqn
 
         fields = {key: w_obj.spy_unwrap(vm) for key, w_obj in self.values_w.items()}
         return UnwrappedStruct(fqn, fields)

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -765,6 +765,14 @@ class SPyVM:
                 return w_result
             w_result = self._raw_call(w_func, args_w)
             self.bluecache.record(w_func, args_w, w_result)
+            if (
+                w_func.w_functype.kind == "generic"
+                and isinstance(w_result, (W_Type, W_Func))
+                and w_result.w_origin is None
+            ):
+                expected_ns = w_func.compute_inner_ns(args_w)
+                if w_result.fqn.namespace == expected_ns:
+                    w_result.w_origin = w_func
             return w_result
         else:
             # for red functions, we just call them

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -549,9 +549,7 @@ class SPyVM:
         # check parameters
         has_argv = False
         if len(params) == 1:
-            fqn_str = str(params[0].w_T.fqn)
-            if fqn_str.startswith("_list::list[str]"):
-                has_argv = True
+            has_argv = self.is_list_of_str_type(params[0].w_T)
 
         if len(params) > 1 or (len(params) == 1 and not has_argv):
             msg = "parameters must be `main(argv: list[str])`"
@@ -747,6 +745,25 @@ class SPyVM:
         if not isinstance(w_value, W_Bool):
             raise Exception("Type mismatch")
         return w_value.value
+
+    @staticmethod
+    def is_list_type(w_T: W_Type) -> bool:
+        w_origin = w_T.w_origin
+        return isinstance(w_origin, W_Func) and w_origin.fqn == FQN("_list::list")
+
+    @staticmethod
+    def is_dict_type(w_T: W_Type) -> bool:
+        w_origin = w_T.w_origin
+        return isinstance(w_origin, W_Func) and w_origin.fqn == FQN("_dict::dict")
+
+    @staticmethod
+    def is_tuple_type(w_T: W_Type) -> bool:
+        w_origin = w_T.w_origin
+        return isinstance(w_origin, W_Func) and w_origin.fqn == FQN("_tuple::tuple")
+
+    @staticmethod
+    def is_list_of_str_type(w_T: W_Type) -> bool:
+        return w_T.fqn == FQN("_list::list[str]::_ListImpl")
 
     def fast_call(self, w_func: W_Func, args_w: Sequence[W_Object]) -> W_Object:
         """


### PR DESCRIPTION
Add `__origin__` to types and functions. This is used to keep track of which `@blue.generic` function a concrete object come from.

For example:

```python
@blue.generic
class MyList(T):
    @struct
    class impl:
         ...

    return impl


assert MyList[T].__origin__ is MyList
```

This becomes even more useful as soon as we merge #448 because then we can write `class list[T]: ...` but we still have the notion of "this type is a list".

The `__origin__` is set ONLY:
1. upon returning something from a `@blue.generic` function
2. if the returned value was defined INSIDE the function
3. if the `__origin__` has not been set already

This means that e.g.:
```python
@blue.generic
def foo(T):
    return list[T]

# origin was already set, don't overwrite it
assert foo[T].__origin__ is list 
```

And:
```python
@struct
class Point:
    ...

@blue.generic
def bar(T):
    return Point

# don't set the origin because Point was not defined inside bar
assert Point.__origin__ is None
```

This is also the groundwork for a subsequent PR to display "better" FQNs: e.g. we will declare that `_list::list[i32]::_ListImpl` can be shown as `list[i32]`.