### PR TITLE
Kill @typedef in assertion

### DIFF
--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -411,7 +411,7 @@ class AbstractFrame:
         if classdef.kind == "struct":
             return W_StructType
         else:
-            assert False, "only @struct and @typedef are supported for now"
+            assert False, "only @struct classes are supported for now"
 
     def fwdecl_ClassDef(self, classdef: ast.ClassDef) -> None:
         """


### PR DESCRIPTION
The warning about classdef kinds still references the now-dead `@typedef`. This is a tiny PR to remove that.