### PR TITLE
Add an applevel "dual" of str

### DIFF
--- a/spy/backend/c/cmodwriter.py
+++ b/spy/backend/c/cmodwriter.py
@@ -172,7 +172,7 @@ class CModuleWriter:
                         spy_list_str lst = spy_list_str_new();
                         for (int i = 0; i < argc; i++) {
                             size_t length = strlen(argv[i]);
-                            spy_Str *s = spy_str_alloc(length);
+                            spy_StrObject *s = spy_str_alloc(length);
                             char *buf = (char *)s->utf8;
                             memcpy(buf, argv[i], length);
                             lst = spy_list_str_push(lst, s);

--- a/spy/backend/c/cmodwriter.py
+++ b/spy/backend/c/cmodwriter.py
@@ -173,7 +173,7 @@ class CModuleWriter:
                         for (int i = 0; i < argc; i++) {
                             size_t length = strlen(argv[i]);
                             spy_StrObject *s = spy_str_alloc(length);
-                            char *buf = (char *)s->utf8;
+                            char *buf = (char *)spy_StrObject_UTF8(s);
                             memcpy(buf, argv[i], length);
                             lst = spy_list_str_push(lst, s);
                         }

--- a/spy/backend/c/context.py
+++ b/spy/backend/c/context.py
@@ -136,7 +136,7 @@ class Context:
         self._d[B.w_f32] = C_Type("float")
         self._d[B.w_complex128] = C_Type("spy_Complex128")
         self._d[B.w_bool] = C_Type("bool")
-        self._d[B.w_str] = C_Type("spy_Str *")
+        self._d[B.w_str] = C_Type("spy_StrObject *")
         self._d[RB.w_RawBuffer] = C_Type("spy_RawBuffer *")
         self._d[JSFFI.w_JsRef] = C_Type("JsRef")
         self._d[POSIX.w__FILE] = C_Type("FILE *")

--- a/spy/backend/c/cstructwriter.py
+++ b/spy/backend/c/cstructwriter.py
@@ -124,6 +124,16 @@ class CStructWriter:
             )
             return
 
+        # _str::StrObject MUST stay layout-compatible with the C-level
+        # spy_StrObject (see stdlib/_str.spy and libspy/include/spy/str.h).
+        # Emit it as a typedef alias of spy_StrObject so they really are
+        # the same type, not just bitwise-compatible.
+        if str(w_st.fqn) == "_str::StrObject":
+            self.tbh_fwdecl.wl(
+                f"typedef spy_StrObject {c_st}; /* alias of spy_StrObject */"
+            )
+            return
+
         human_fqn = w_st.fqn.human_name(self.ctx.vm)
         self.tbh_fwdecl.wl(f"typedef struct {c_st} {c_st}; /* {human_fqn} */")
 
@@ -165,6 +175,16 @@ class CStructWriter:
         #define {c_ptrtype}$NULL (({c_ptrtype}){{0}})
         """)
         self.tbh_ptrs_def.wl()
+
+        # detect gc_ptr[_str::StrObject] and emit the implementetion for as_StrObject.
+        if str(w_ptrtype.fqn) == "unsafe::gc_ptr[_str::StrObject]":
+            self.tbh_ptrs_def.wb(f"""
+            static inline {c_ptrtype}
+            spy_unsafe$as_StrObject$impl(spy_StrObject *s) {{
+                return {c_ptrtype}_from_addr(({c_itemT} *)s);
+            }}
+            """)
+            self.tbh_ptrs_def.wl()
 
     def emit_RefType(self, fqn: FQN, w_reftype: W_RefType) -> None:
         w_ptrtype = w_reftype.as_ptrtype(self.ctx.vm)

--- a/spy/backend/c/cstructwriter.py
+++ b/spy/backend/c/cstructwriter.py
@@ -152,11 +152,18 @@ class CStructWriter:
         c_ptrtype = C_Type(w_ptrtype.fqn.c_name)
         w_itemT = w_ptrtype.w_itemT
         c_itemT = self.ctx.w2c(w_itemT)
-        # gc_ptr[u8] is predeclared manually by unsafe.h. Make sure to keep the code
+
+        # some ptr types are predeclared manually in libspy. Make sure to keep the code
         # generated here and the code manually written there always in sync.
-        if str(w_ptrtype.fqn) == "unsafe::gc_ptr[u8]":
-            self.tbh_fwdecl.wl(f"// {c_ptrtype}: already pre-declared by unsafe.h")
+        if str(w_ptrtype.fqn) in (
+            "unsafe::gc_ptr[u8]",
+            "unsafe::gc_ptr[_str::StrObject]",
+        ):
+            self.tbh_fwdecl.wl(
+                f"// {c_ptrtype}: skip as it's already pre-declared by libspy"
+            )
             return
+
         self.tbh_fwdecl.wb(f"""
         typedef struct {c_ptrtype} {{
             {c_itemT} *p;
@@ -173,16 +180,6 @@ class CStructWriter:
         #define {c_ptrtype}$NULL (({c_ptrtype}){{0}})
         """)
         self.tbh_ptrs_def.wl()
-
-        # detect gc_ptr[_str::StrObject] and emit the implementetion for as_StrObject.
-        if str(w_ptrtype.fqn) == "unsafe::gc_ptr[_str::StrObject]":
-            self.tbh_ptrs_def.wb(f"""
-            static inline {c_ptrtype}
-            spy_unsafe$as_StrObject$impl(spy_StrObject *s) {{
-                return {c_ptrtype}_from_addr(({c_itemT} *)s);
-            }}
-            """)
-            self.tbh_ptrs_def.wl()
 
     def emit_RefType(self, fqn: FQN, w_reftype: W_RefType) -> None:
         w_ptrtype = w_reftype.as_ptrtype(self.ctx.vm)

--- a/spy/backend/c/cstructwriter.py
+++ b/spy/backend/c/cstructwriter.py
@@ -124,10 +124,8 @@ class CStructWriter:
             )
             return
 
-        # _str::StrObject MUST stay layout-compatible with the C-level
-        # spy_StrObject (see stdlib/_str.spy and libspy/include/spy/str.h).
-        # Emit it as a typedef alias of spy_StrObject so they really are
-        # the same type, not just bitwise-compatible.
+        # _str::StrObject is already declared in str.h as spy_StrObject. Just emit a
+        # typedef.
         if str(w_st.fqn) == "_str::StrObject":
             self.tbh_fwdecl.wl(
                 f"typedef spy_StrObject {c_st}; /* alias of spy_StrObject */"

--- a/spy/backend/c/cstructwriter.py
+++ b/spy/backend/c/cstructwriter.py
@@ -144,6 +144,11 @@ class CStructWriter:
         c_ptrtype = C_Type(w_ptrtype.fqn.c_name)
         w_itemT = w_ptrtype.w_itemT
         c_itemT = self.ctx.w2c(w_itemT)
+        # gc_ptr[u8] is predeclared manually by unsafe.h. Make sure to keep the code
+        # generated here and the code manually written there always in sync.
+        if str(w_ptrtype.fqn) == "unsafe::gc_ptr[u8]":
+            self.tbh_fwdecl.wl(f"// {c_ptrtype}: already pre-declared by unsafe.h")
+            return
         self.tbh_fwdecl.wb(f"""
         typedef struct {c_ptrtype} {{
             {c_itemT} *p;

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -258,7 +258,7 @@ class CFuncWriter:
                 # TODO: assuming msg is always a string. extend the logic to work with other types
                 msg = self.fmt_expr(assert_node.msg)
                 self.tbc.wl(
-                    f'spy_panic("AssertionError", spy_Str_CHARS({msg}), '
+                    f'spy_panic("AssertionError", spy_StrObject_CHARS({msg}), '
                     f'"{assert_node.loc.filename}", {assert_node.loc.line_start});'
                 )
             else:
@@ -295,7 +295,7 @@ class CFuncWriter:
         # generate the following:
         #
         #     // global declarations
-        #     static spy_Str SPY_g_str0 = {5, 0, (const uint8_t *)"hello"};
+        #     static spy_StrObject SPY_g_str0 = {5, 0, (const uint8_t *)"hello"};
         #     ...
         #     // literal expr
         #     &SPY_g_str0 /* "hello" */
@@ -311,7 +311,7 @@ class CFuncWriter:
         n = len(utf8)
         lit = C.Literal.from_bytes(utf8)
         init = "{%d, 0, (const uint8_t *)%s}" % (n, lit)
-        self.cmodw.tbc_globals.wl(f"static spy_Str {v} = {init};")
+        self.cmodw.tbc_globals.wl(f"static spy_StrObject {v} = {init};")
         #
         # shortstr is what we show in the comment, with a length limit
         comment = shortrepr(utf8.decode("utf-8"), 15)

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -295,10 +295,13 @@ class CFuncWriter:
         # generate the following:
         #
         #     // global declarations
-        #     static spy_StrObject SPY_g_str0 = {5, 0, (const uint8_t *)"hello"};
+        #     static spy_StrObject SPY_g_str0 = SPY_STR_LITERAL(5, "hello");
         #     ...
         #     // literal expr
         #     &SPY_g_str0 /* "hello" */
+        #
+        # SPY_STR_LITERAL hides the difference between debug and release
+        # layouts of spy_gc_ptr_u8 (see str.h).
         #
         # Note that in the literal expr we also put a comment showing what is
         # the content of the literal: hopefully this will make the code more
@@ -310,7 +313,7 @@ class CFuncWriter:
         v = self.cmodw.new_global_var("str")  # SPY_g_str0
         n = len(utf8)
         lit = C.Literal.from_bytes(utf8)
-        init = "{%d, 0, (const uint8_t *)%s}" % (n, lit)
+        init = f"SPY_STR_LITERAL({n}, {lit})"
         self.cmodw.tbc_globals.wl(f"static spy_StrObject {v} = {init};")
         #
         # shortstr is what we show in the comment, with a length limit

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -258,7 +258,7 @@ class CFuncWriter:
                 # TODO: assuming msg is always a string. extend the logic to work with other types
                 msg = self.fmt_expr(assert_node.msg)
                 self.tbc.wl(
-                    f'spy_panic("AssertionError", ({msg})->utf8, '
+                    f'spy_panic("AssertionError", spy_Str_CHARS({msg}), '
                     f'"{assert_node.loc.filename}", {assert_node.loc.line_start});'
                 )
             else:
@@ -295,7 +295,7 @@ class CFuncWriter:
         # generate the following:
         #
         #     // global declarations
-        #     static spy_Str SPY_g_str0 = {5, 0, "hello"};
+        #     static spy_Str SPY_g_str0 = {5, 0, (const uint8_t *)"hello"};
         #     ...
         #     // literal expr
         #     &SPY_g_str0 /* "hello" */
@@ -310,7 +310,7 @@ class CFuncWriter:
         v = self.cmodw.new_global_var("str")  # SPY_g_str0
         n = len(utf8)
         lit = C.Literal.from_bytes(utf8)
-        init = "{%d, 0, %s}" % (n, lit)
+        init = "{%d, 0, (const uint8_t *)%s}" % (n, lit)
         self.cmodw.tbc_globals.wl(f"static spy_Str {v} = {init};")
         #
         # shortstr is what we show in the comment, with a length limit

--- a/spy/libspy/__init__.py
+++ b/spy/libspy/__init__.py
@@ -83,7 +83,7 @@ class LibSPyHost(HostModule):
 
 @dataclass
 class StrLayout:
-    # See also the struct _spy_Str_layout in str.h
+    # See also the struct _spy_StrObject_layout in str.h
     size: int
     length_offset: int
     hash_offset: int
@@ -106,12 +106,12 @@ class LLSPyInstance(LLWasmInstance):
         self.libspy = LibSPyHost()
         hostmods = [self.libspy] + hostmods
         super().__init__(llmod, hostmods, instance=instance)
-        layout = self.call("_spy_Str_layout")
+        layout = self.call("_spy_StrObject_layout")
         self.str_layout = StrLayout(*layout)
 
     def read_str(self, ptr: int) -> tuple[int, int, bytes]:
         """
-        Read a spy_Str at ptr from linear memory.
+        Read a spy_StrObject at ptr from linear memory.
         Returns (length, hash, utf8_bytes).
         """
         layout = self.str_layout

--- a/spy/libspy/__init__.py
+++ b/spy/libspy/__init__.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Any, Optional
 
 import spy
@@ -49,7 +50,7 @@ class LibSPyHost(HostModule):
         self.panic_filename = None
         self.panic_lineno = 0
 
-    def _read_str(self, ptr: int) -> str:
+    def _read_cstr(self, ptr: int) -> str:
         # ptr is const char*
         ba = self.ll.mem.read_cstr(ptr)
         return ba.decode("utf-8")
@@ -57,12 +58,12 @@ class LibSPyHost(HostModule):
     # ========== WASM imports ==========
 
     def env_spy_debug_log(self, ptr: int) -> None:
-        s = self._read_str(ptr)
+        s = self._read_cstr(ptr)
         self.log.append(s)
         print("[log]", s)
 
     def env_spy_debug_log_i32(self, ptr: int, n: int) -> None:
-        s = self._read_str(ptr)
+        s = self._read_cstr(ptr)
         msg = f"{s} {n}"
         self.log.append(msg)
         print("[log]", msg)
@@ -74,10 +75,19 @@ class LibSPyHost(HostModule):
         assert ptr_etype != 0
         assert ptr_msg != 0
         assert ptr_fname != 0
-        self.panic_etype = self._read_str(ptr_etype)
-        self.panic_message = self._read_str(ptr_msg)
-        self.panic_filename = self._read_str(ptr_fname)
+        self.panic_etype = self._read_cstr(ptr_etype)
+        self.panic_message = self._read_cstr(ptr_msg)
+        self.panic_filename = self._read_cstr(ptr_fname)
         self.panic_lineno = lineno
+
+
+@dataclass
+class StrLayout:
+    # See also the struct _spy_Str_layout in str.h
+    size: int
+    length_offset: int
+    hash_offset: int
+    utf8_offset: int
 
 
 class LLSPyInstance(LLWasmInstance):
@@ -96,6 +106,20 @@ class LLSPyInstance(LLWasmInstance):
         self.libspy = LibSPyHost()
         hostmods = [self.libspy] + hostmods
         super().__init__(llmod, hostmods, instance=instance)
+        layout = self.call("_spy_Str_layout")
+        self.str_layout = StrLayout(*layout)
+
+    def read_str(self, ptr: int) -> tuple[int, int, bytes]:
+        """
+        Read a spy_Str at ptr from linear memory.
+        Returns (length, hash, utf8_bytes).
+        """
+        layout = self.str_layout
+        length = self.mem.read_i32(ptr + layout.length_offset)
+        hash_ = self.mem.read_i32(ptr + layout.hash_offset)
+        utf8_ptr = self.mem.read_i32(ptr + layout.utf8_offset)
+        utf8 = bytes(self.mem.read(utf8_ptr, length))
+        return length, hash_, utf8
 
     def call(self, name: str, *args: Any) -> Any:
         try:

--- a/spy/libspy/include/spy/__spy__.h
+++ b/spy/libspy/include/spy/__spy__.h
@@ -11,7 +11,7 @@ spy___spy__$is_compiled(void) {
 }
 
 static inline void
-spy___spy__$_stdout_write(spy_Str *s) {
+spy___spy__$_stdout_write(spy_StrObject *s) {
     for (size_t i = 0; i < s->length; i++)
         putchar(s->utf8[i]);
 }

--- a/spy/libspy/include/spy/__spy__.h
+++ b/spy/libspy/include/spy/__spy__.h
@@ -13,7 +13,7 @@ spy___spy__$is_compiled(void) {
 static inline void
 spy___spy__$_stdout_write(spy_StrObject *s) {
     for (size_t i = 0; i < s->length; i++)
-        putchar(s->utf8[i]);
+        putchar(spy_StrObject_UTF8(s)[i]);
 }
 
 #endif /* SPY___SPY___H */

--- a/spy/libspy/include/spy/jsffi.h
+++ b/spy/libspy/include/spy/jsffi.h
@@ -26,7 +26,7 @@ void WASM_EXPORT(jsffi_setattr)(JsRef c_target, const char *c_name, JsRef c_val)
 // SPy JSFFI module
 static inline void
 spy_jsffi$debug(spy_Str *s) {
-    jsffi_debug(s->utf8);
+    jsffi_debug(spy_Str_CHARS(s));
 }
 
 static inline void
@@ -46,7 +46,7 @@ spy_jsffi$get_Console(void) {
 
 static inline JsRef
 spy_jsffi$js_string(spy_Str *s) {
-    return jsffi_string(s->utf8);
+    return jsffi_string(spy_Str_CHARS(s));
 }
 
 static inline JsRef
@@ -61,17 +61,17 @@ spy_jsffi$js_wrap_func(em_callback_func fn) {
 
 static inline JsRef
 spy_jsffi$js_call_method_1(JsRef target, spy_Str *name, JsRef arg0) {
-    return jsffi_call_method_1(target, name->utf8, arg0);
+    return jsffi_call_method_1(target, spy_Str_CHARS(name), arg0);
 }
 
 static inline JsRef
 spy_jsffi$JsRef$__getattribute__(JsRef target, spy_Str *name) {
-    return jsffi_getattr(target, name->utf8);
+    return jsffi_getattr(target, spy_Str_CHARS(name));
 }
 
 static inline void
 spy_jsffi$JsRef$__setattr__(JsRef target, spy_Str *name, JsRef val) {
-    jsffi_setattr(target, name->utf8, val);
+    jsffi_setattr(target, spy_Str_CHARS(name), val);
 }
 
 /* This is a workaround for an emscripten bug/limitation which triggers in the

--- a/spy/libspy/include/spy/jsffi.h
+++ b/spy/libspy/include/spy/jsffi.h
@@ -25,8 +25,8 @@ void WASM_EXPORT(jsffi_setattr)(JsRef c_target, const char *c_name, JsRef c_val)
 
 // SPy JSFFI module
 static inline void
-spy_jsffi$debug(spy_Str *s) {
-    jsffi_debug(spy_Str_CHARS(s));
+spy_jsffi$debug(spy_StrObject *s) {
+    jsffi_debug(spy_StrObject_CHARS(s));
 }
 
 static inline void
@@ -45,8 +45,8 @@ spy_jsffi$get_Console(void) {
 }
 
 static inline JsRef
-spy_jsffi$js_string(spy_Str *s) {
-    return jsffi_string(spy_Str_CHARS(s));
+spy_jsffi$js_string(spy_StrObject *s) {
+    return jsffi_string(spy_StrObject_CHARS(s));
 }
 
 static inline JsRef
@@ -60,18 +60,18 @@ spy_jsffi$js_wrap_func(em_callback_func fn) {
 }
 
 static inline JsRef
-spy_jsffi$js_call_method_1(JsRef target, spy_Str *name, JsRef arg0) {
-    return jsffi_call_method_1(target, spy_Str_CHARS(name), arg0);
+spy_jsffi$js_call_method_1(JsRef target, spy_StrObject *name, JsRef arg0) {
+    return jsffi_call_method_1(target, spy_StrObject_CHARS(name), arg0);
 }
 
 static inline JsRef
-spy_jsffi$JsRef$__getattribute__(JsRef target, spy_Str *name) {
-    return jsffi_getattr(target, spy_Str_CHARS(name));
+spy_jsffi$JsRef$__getattribute__(JsRef target, spy_StrObject *name) {
+    return jsffi_getattr(target, spy_StrObject_CHARS(name));
 }
 
 static inline void
-spy_jsffi$JsRef$__setattr__(JsRef target, spy_Str *name, JsRef val) {
-    jsffi_setattr(target, spy_Str_CHARS(name), val);
+spy_jsffi$JsRef$__setattr__(JsRef target, spy_StrObject *name, JsRef val) {
+    jsffi_setattr(target, spy_StrObject_CHARS(name), val);
 }
 
 /* This is a workaround for an emscripten bug/limitation which triggers in the

--- a/spy/libspy/include/spy/operator.h
+++ b/spy/libspy/include/spy/operator.h
@@ -75,9 +75,15 @@ spy_operator$f32_to_i32(float x) {
 }
 
 static inline void
-spy_operator$raise(spy_Str *etype, spy_Str *message, spy_Str *fname, int32_t lineno) {
+spy_operator$raise(
+    spy_StrObject *etype,
+    spy_StrObject *message,
+    spy_StrObject *fname,
+    int32_t lineno
+) {
     spy_panic(
-        spy_Str_CHARS(etype), spy_Str_CHARS(message), spy_Str_CHARS(fname), lineno
+        spy_StrObject_CHARS(etype), spy_StrObject_CHARS(message),
+        spy_StrObject_CHARS(fname), lineno
     );
 }
 

--- a/spy/libspy/include/spy/operator.h
+++ b/spy/libspy/include/spy/operator.h
@@ -76,7 +76,9 @@ spy_operator$f32_to_i32(float x) {
 
 static inline void
 spy_operator$raise(spy_Str *etype, spy_Str *message, spy_Str *fname, int32_t lineno) {
-    spy_panic(etype->utf8, message->utf8, fname->utf8, lineno);
+    spy_panic(
+        spy_Str_CHARS(etype), spy_Str_CHARS(message), spy_Str_CHARS(fname), lineno
+    );
 }
 
 static inline double

--- a/spy/libspy/include/spy/posix.h
+++ b/spy/libspy/include/spy/posix.h
@@ -8,14 +8,14 @@
 #endif
 #include <unistd.h>
 
-FILE *WASM_EXPORT(spy_posix$_fopen)(spy_Str *filename, spy_Str *mode);
-spy_Str *WASM_EXPORT(spy_posix$_fread)(FILE *f, int32_t size);
-spy_Str *WASM_EXPORT(spy_posix$__freadall_chunked)(FILE *f);
-spy_Str *WASM_EXPORT(spy_posix$_freadall)(FILE *f);
-spy_Str *WASM_EXPORT(spy_posix$_freadline)(FILE *f);
+FILE *WASM_EXPORT(spy_posix$_fopen)(spy_StrObject *filename, spy_StrObject *mode);
+spy_StrObject *WASM_EXPORT(spy_posix$_fread)(FILE *f, int32_t size);
+spy_StrObject *WASM_EXPORT(spy_posix$__freadall_chunked)(FILE *f);
+spy_StrObject *WASM_EXPORT(spy_posix$_freadall)(FILE *f);
+spy_StrObject *WASM_EXPORT(spy_posix$_freadline)(FILE *f);
 int32_t WASM_EXPORT(spy_posix$_ftell)(FILE *f);
 void WASM_EXPORT(spy_posix$_fseek)(FILE *f, int32_t offset, int32_t whence);
-void WASM_EXPORT(spy_posix$_fwrite)(FILE *f, spy_Str *data);
+void WASM_EXPORT(spy_posix$_fwrite)(FILE *f, spy_StrObject *data);
 void WASM_EXPORT(spy_posix$_fflush)(FILE *f);
 int32_t WASM_EXPORT(spy_posix$_fileno)(FILE *f);
 bool WASM_EXPORT(spy_posix$_isatty)(int32_t fd);

--- a/spy/libspy/include/spy/str.h
+++ b/spy/libspy/include/spy/str.h
@@ -7,10 +7,11 @@
 
 /* === String layout ===
 
-   spy_Str contains length, hash and a ptr to utf8 data.
+   spy_StrObject contains length, hash and a ptr to utf8 data.
 
-   spy_Str_alloc allocates spy_Str AND the data buffer in a single allocation. So the
-   memory layout for "foo" is more or less this (assuming 32 bit WASM):
+   spy_str_alloc allocates spy_StrObject AND the data buffer in a single
+   allocation. So the memory layout for "foo" is more or less this (assuming 32 bit
+   WASM):
 
    ADDR     3          length
    ADDR+4   ...        hash
@@ -26,10 +27,10 @@ typedef struct {
     size_t length;
     int32_t hash;
     const uint8_t *utf8;
-} spy_Str;
+} spy_StrObject;
 
 // Convenience macro to get (const char*)utf8
-#define spy_Str_CHARS(s) ((const char *)(s)->utf8)
+#define spy_StrObject_CHARS(s) ((const char *)(s)->utf8)
 
 // Layout info exported for str.py.
 typedef struct {
@@ -37,34 +38,37 @@ typedef struct {
     size_t length_offset;
     size_t hash_offset;
     size_t utf8_offset;
-} _spy_Str_Layout;
+} _spy_StrObject_Layout;
 
-_spy_Str_Layout WASM_EXPORT(_spy_Str_layout)(void);
+_spy_StrObject_Layout WASM_EXPORT(_spy_StrObject_layout)(void);
 
-spy_Str *WASM_EXPORT(spy_str_alloc)(size_t length);
+spy_StrObject *WASM_EXPORT(spy_str_alloc)(size_t length);
 
-spy_Str *WASM_EXPORT(spy_str_add)(spy_Str *a, spy_Str *b);
+spy_StrObject *WASM_EXPORT(spy_str_add)(spy_StrObject *a, spy_StrObject *b);
 
-spy_Str
-    *WASM_EXPORT(spy_str_replace)(spy_Str *original, spy_Str *old, spy_Str *new_str);
+spy_StrObject *WASM_EXPORT(spy_str_replace)(
+    spy_StrObject *original,
+    spy_StrObject *old,
+    spy_StrObject *new_str
+);
 
-spy_Str *WASM_EXPORT(spy_str_mul)(spy_Str *a, int32_t b);
+spy_StrObject *WASM_EXPORT(spy_str_mul)(spy_StrObject *a, int32_t b);
 
-bool WASM_EXPORT(spy_str_eq)(spy_Str *a, spy_Str *b);
+bool WASM_EXPORT(spy_str_eq)(spy_StrObject *a, spy_StrObject *b);
 
 static inline bool
-spy_str_ne(spy_Str *a, spy_Str *b) {
+spy_str_ne(spy_StrObject *a, spy_StrObject *b) {
     return !spy_str_eq(a, b);
 }
 
 // XXX: should we introduce a separate type Char?
-spy_Str *WASM_EXPORT(spy_str_getitem)(spy_Str *s, int32_t i);
+spy_StrObject *WASM_EXPORT(spy_str_getitem)(spy_StrObject *s, int32_t i);
 
-int32_t WASM_EXPORT(spy_str_len)(spy_Str *s);
+int32_t WASM_EXPORT(spy_str_len)(spy_StrObject *s);
 
-spy_Str *WASM_EXPORT(spy_str_repr)(spy_Str *s);
+spy_StrObject *WASM_EXPORT(spy_str_repr)(spy_StrObject *s);
 
-int32_t WASM_EXPORT(spy_str_hash)(spy_Str *s);
+int32_t WASM_EXPORT(spy_str_hash)(spy_StrObject *s);
 
 #define spy_operator$str_add spy_str_add
 #define spy_operator$str_mul spy_str_mul
@@ -77,32 +81,32 @@ int32_t WASM_EXPORT(spy_str_hash)(spy_Str *s);
 #define spy_builtins$str$__str__ spy_str_identity
 #define spy_builtins$str$__repr__ spy_str_repr
 
-static inline spy_Str *
-spy_str_identity(spy_Str *s) {
+static inline spy_StrObject *
+spy_str_identity(spy_StrObject *s) {
     return s;
 }
 #define spy_builtins$hash_str spy_str_hash
 
 // __str__ methods of common builtin types
-spy_Str *spy_builtins$i32$__str__(int32_t x);
+spy_StrObject *spy_builtins$i32$__str__(int32_t x);
 
-spy_Str *spy_builtins$i8$__str__(int8_t x);
+spy_StrObject *spy_builtins$i8$__str__(int8_t x);
 
-spy_Str *spy_builtins$u8$__str__(uint8_t x);
+spy_StrObject *spy_builtins$u8$__str__(uint8_t x);
 
-spy_Str *spy_builtins$f64$__str__(double x);
+spy_StrObject *spy_builtins$f64$__str__(double x);
 
-spy_Str *spy_builtins$bool$__str__(bool x);
+spy_StrObject *spy_builtins$bool$__str__(bool x);
 
 // str -> numeric conversion operators
-int32_t spy_operator$str_to_i32(spy_Str *s);
+int32_t spy_operator$str_to_i32(spy_StrObject *s);
 
-uint32_t spy_operator$str_to_u32(spy_Str *s);
+uint32_t spy_operator$str_to_u32(spy_StrObject *s);
 
-int8_t spy_operator$str_to_i8(spy_Str *s);
+int8_t spy_operator$str_to_i8(spy_StrObject *s);
 
-uint8_t spy_operator$str_to_u8(spy_Str *s);
+uint8_t spy_operator$str_to_u8(spy_StrObject *s);
 
-spy_Complex128 WASM_EXPORT(spy_str_to_complex128)(spy_Str *s);
+spy_Complex128 WASM_EXPORT(spy_str_to_complex128)(spy_StrObject *s);
 
 #endif /* SPY_STR_H */

--- a/spy/libspy/include/spy/str.h
+++ b/spy/libspy/include/spy/str.h
@@ -5,11 +5,41 @@
 #include "spy/complex.h"
 #include <stddef.h>
 
+/* === String layout ===
+
+   spy_Str contains length, hash and a ptr to utf8 data.
+
+   spy_Str_alloc allocates spy_Str AND the data buffer in a single allocation. So the
+   memory layout for "foo" is more or less this (assuming 32 bit WASM):
+
+   ADDR     3          length
+   ADDR+4   ...        hash
+   ADDR+8   ADDR+12    utf8
+   ADDR+12  'f'
+   ADDR+13  'o'
+   ADDR+14  'o'
+
+   Note that "co-allocation" is just an optimization, not a requirement.
+*/
+
 typedef struct {
     size_t length;
     int32_t hash;
-    const char utf8[];
+    const uint8_t *utf8;
 } spy_Str;
+
+// Convenience macro to get (const char*)utf8
+#define spy_Str_CHARS(s) ((const char *)(s)->utf8)
+
+// Layout info exported for str.py.
+typedef struct {
+    size_t size;
+    size_t length_offset;
+    size_t hash_offset;
+    size_t utf8_offset;
+} _spy_Str_Layout;
+
+_spy_Str_Layout WASM_EXPORT(_spy_Str_layout)(void);
 
 spy_Str *WASM_EXPORT(spy_str_alloc)(size_t length);
 

--- a/spy/libspy/include/spy/str.h
+++ b/spy/libspy/include/spy/str.h
@@ -3,6 +3,7 @@
 
 #include "spy.h"
 #include "spy/complex.h"
+#include "spy/unsafe.h"
 #include <stddef.h>
 
 /* === String layout ===
@@ -26,11 +27,31 @@
 typedef struct {
     size_t length;
     int32_t hash;
-    const uint8_t *utf8;
+    spy_gc_ptr_u8 utf8;
 } spy_StrObject;
 
-// Convenience macro to get (const char*)utf8
-#define spy_StrObject_CHARS(s) ((const char *)(s)->utf8)
+// Convenience macros for accessing the utf8 buffer.
+#define spy_StrObject_UTF8(s) ((s)->utf8.p)
+#define spy_StrObject_CHARS(s) ((const char *)spy_StrObject_UTF8(s))
+
+/* SPY_STR_LITERAL(N, "content") is a struct initializer for spy_StrObject,
+   useful for static globals and for-test literals. There are two versions
+   depending on whether spy_gc_ptr_u8 carries a length (SPY_DEBUG). */
+#ifdef SPY_DEBUG
+#  define SPY_STR_LITERAL(N, S)                                                        \
+      {                                                                                \
+          (N), 0, {                                                                    \
+              (uint8_t *)(S), (ptrdiff_t)(N)                                           \
+          }                                                                            \
+      }
+#else
+#  define SPY_STR_LITERAL(N, S)                                                        \
+      {                                                                                \
+          (N), 0, {                                                                    \
+              (uint8_t *)(S)                                                           \
+          }                                                                            \
+      }
+#endif
 
 // Layout info exported for str.py.
 typedef struct {

--- a/spy/libspy/include/spy/str.h
+++ b/spy/libspy/include/spy/str.h
@@ -34,6 +34,26 @@ typedef struct {
 #define spy_StrObject_UTF8(s) ((s)->utf8.p)
 #define spy_StrObject_CHARS(s) ((const char *)spy_StrObject_UTF8(s))
 
+/* gc_ptr[_str::StrObject] is predeclared here, see also
+   cstructwriter.py:emit_PtrType. Make sure that they stay in sync. */
+typedef struct spy_unsafe$gc_ptr___str$StrObject {
+    spy_StrObject *p;
+#ifdef SPY_DEBUG
+    ptrdiff_t length;
+#endif
+} spy_unsafe$gc_ptr___str$StrObject;
+
+SPY_PTR_FUNCTIONS(gc, spy_unsafe$gc_ptr___str$StrObject, spy_StrObject)
+#define spy_unsafe$gc_ptr___str$StrObject$NULL ((spy_unsafe$gc_ptr___str$StrObject){0})
+
+// short alias for manual use
+typedef spy_unsafe$gc_ptr___str$StrObject spy_gc_ptr_StrObject;
+
+static inline spy_gc_ptr_StrObject
+spy_unsafe$as_StrObject$impl(spy_StrObject *s) {
+    return spy_unsafe$gc_ptr___str$StrObject_from_addr(s);
+}
+
 /* SPY_STR_LITERAL(N, "content") is a struct initializer for spy_StrObject,
    useful for static globals and for-test literals. There are two versions
    depending on whether spy_gc_ptr_u8 carries a length (SPY_DEBUG). */

--- a/spy/libspy/include/spy/unsafe.h
+++ b/spy/libspy/include/spy/unsafe.h
@@ -9,9 +9,12 @@ void *WASM_EXPORT(spy_raw_alloc)(size_t size);
 // When compiling with bdwgc, override spy_gc_alloc with an inline that calls
 // GC_MALLOC. This takes precedence over the function in libspy.a.
 #ifdef SPY_GC_BDWGC
-#include <gc.h>
-static inline void *spy_gc_alloc_bdwgc(size_t size) { return GC_MALLOC(size); }
-#define spy_gc_alloc(size) spy_gc_alloc_bdwgc(size)
+#  include <gc.h>
+static inline void *
+spy_gc_alloc_bdwgc(size_t size) {
+    return GC_MALLOC(size);
+}
+#  define spy_gc_alloc(size) spy_gc_alloc_bdwgc(size)
 #endif
 
 /* Define the struct and accessor functions to represent a managed pointer to
@@ -114,5 +117,20 @@ static inline void *spy_gc_alloc_bdwgc(size_t size) { return GC_MALLOC(size); }
     static inline bool PTR##$to_bool(PTR p) {                                          \
         return p.p;                                                                    \
     }
+
+/* gc_ptr[u8] is predeclared here, see also cstructwriter.py:emit_PtrType.
+   Make sure that they stay in sync. */
+typedef struct spy_unsafe$gc_ptr__builtins$u8 {
+    uint8_t *p;
+#ifdef SPY_DEBUG
+    ptrdiff_t length;
+#endif
+} spy_unsafe$gc_ptr__builtins$u8;
+
+SPY_PTR_FUNCTIONS(gc, spy_unsafe$gc_ptr__builtins$u8, uint8_t)
+#define spy_unsafe$gc_ptr__builtins$u8$NULL ((spy_unsafe$gc_ptr__builtins$u8){0})
+
+// short alias for manual use
+typedef spy_unsafe$gc_ptr__builtins$u8 spy_gc_ptr_u8;
 
 #endif /* SPY_UNSAFE_H */

--- a/spy/libspy/include/spy/unsafe.h
+++ b/spy/libspy/include/spy/unsafe.h
@@ -2,6 +2,7 @@
 #define SPY_UNSAFE_H
 
 #include "spy.h"
+#include <stddef.h>
 
 void *WASM_EXPORT(spy_gc_alloc)(size_t size);
 void *WASM_EXPORT(spy_raw_alloc)(size_t size);

--- a/spy/libspy/src/posix.c
+++ b/spy/libspy/src/posix.c
@@ -1,12 +1,12 @@
 #include "spy.h"
 #include <stdio.h>
 
-// Parse a spy_Str mode into a C fopen mode string.
+// Parse a spy_StrObject mode into a C fopen mode string.
 // Valid modes contain exactly one of 'r', 'w', 'a', and optionally '+'.
 // Returns false if the mode is invalid; otherwise writes the normalized
 // mode into `out` (which must have room for at least 3 bytes).
 static bool
-spy_posix$_parse_mode(spy_Str *mode, char *out) {
+spy_posix$_parse_mode(spy_StrObject *mode, char *out) {
     char base = 0;
     bool plus = false;
     for (int32_t i = 0; i < mode->length; i++) {
@@ -36,14 +36,14 @@ spy_posix$_parse_mode(spy_Str *mode, char *out) {
 }
 
 FILE *
-spy_posix$_fopen(spy_Str *filename, spy_Str *mode) {
+spy_posix$_fopen(spy_StrObject *filename, spy_StrObject *mode) {
     char cmode[3];
     if (!spy_posix$_parse_mode(mode, cmode)) {
         spy_panic("PanicError", "invalid mode for _fopen", __FILE__, __LINE__);
         return NULL;
     }
 
-    // spy_Str is not null-terminated, make a temporary copy for fopen
+    // spy_StrObject is not null-terminated, make a temporary copy for fopen
     char *fname = (char *)malloc(filename->length + 1);
     memcpy(fname, filename->utf8, filename->length);
     fname[filename->length] = '\0';
@@ -57,20 +57,20 @@ spy_posix$_fopen(spy_Str *filename, spy_Str *mode) {
     return f;
 }
 
-spy_Str *
+spy_StrObject *
 spy_posix$_fread(FILE *f, int32_t size) {
-    spy_Str *res = spy_str_alloc(size);
+    spy_StrObject *res = spy_str_alloc(size);
     size_t n = fread((char *)res->utf8, 1, size, f);
     if (n < (size_t)size) {
         // short read: reallocate to actual size
-        spy_Str *trimmed = spy_str_alloc(n);
+        spy_StrObject *trimmed = spy_str_alloc(n);
         memcpy((char *)trimmed->utf8, res->utf8, n);
         res = trimmed;
     }
     return res;
 }
 
-spy_Str *
+spy_StrObject *
 spy_posix$__freadall_chunked(FILE *f) {
     size_t capacity = 4096;
     size_t total = 0;
@@ -90,7 +90,7 @@ spy_posix$__freadall_chunked(FILE *f) {
         spy_panic("OSError", "freadall: read error", __FILE__, __LINE__);
         return NULL;
     }
-    spy_Str *res = spy_str_alloc(total);
+    spy_StrObject *res = spy_str_alloc(total);
     memcpy((char *)res->utf8, buf, total);
     free(buf);
     return res;
@@ -105,7 +105,7 @@ spy_posix$_is_seekable(FILE *f) {
     return true;
 }
 
-spy_Str *
+spy_StrObject *
 spy_posix$_freadall(FILE *f) {
     if (!spy_posix$_is_seekable(f))
         return spy_posix$__freadall_chunked(f);
@@ -115,7 +115,7 @@ spy_posix$_freadall(FILE *f) {
     long end = ftell(f);
     fseek(f, cur, SEEK_SET);
     size_t size = end - cur;
-    spy_Str *res = spy_str_alloc(size);
+    spy_StrObject *res = spy_str_alloc(size);
     size_t n = fread((char *)res->utf8, 1, size, f);
     if (n < size) {
         if (ferror(f)) {
@@ -123,14 +123,14 @@ spy_posix$_freadall(FILE *f) {
             return NULL;
         }
         // EOF before expected: e.g. file was truncated concurrently
-        spy_Str *trimmed = spy_str_alloc(n);
+        spy_StrObject *trimmed = spy_str_alloc(n);
         memcpy((char *)trimmed->utf8, res->utf8, n);
         res = trimmed;
     }
     return res;
 }
 
-spy_Str *
+spy_StrObject *
 spy_posix$_freadline(FILE *f) {
     char *line = NULL;
     size_t bufsize = 0;
@@ -144,7 +144,7 @@ spy_posix$_freadline(FILE *f) {
         // EOF: return empty string
         return spy_str_alloc(0);
     }
-    spy_Str *res = spy_str_alloc(n);
+    spy_StrObject *res = spy_str_alloc(n);
     memcpy((char *)res->utf8, line, n);
     free(line);
     return res;
@@ -168,7 +168,7 @@ spy_posix$_fseek(FILE *f, int32_t offset, int32_t whence) {
 }
 
 void
-spy_posix$_fwrite(FILE *f, spy_Str *data) {
+spy_posix$_fwrite(FILE *f, spy_StrObject *data) {
     size_t n = fwrite(data->utf8, 1, data->length, f);
     if (n < data->length) {
         spy_panic("OSError", "fwrite: write error", __FILE__, __LINE__);

--- a/spy/libspy/src/posix.c
+++ b/spy/libspy/src/posix.c
@@ -10,7 +10,7 @@ spy_posix$_parse_mode(spy_StrObject *mode, char *out) {
     char base = 0;
     bool plus = false;
     for (int32_t i = 0; i < mode->length; i++) {
-        char c = mode->utf8[i];
+        char c = spy_StrObject_UTF8(mode)[i];
         if (c == 'r' || c == 'w' || c == 'a') {
             if (base != 0)
                 return false;
@@ -45,7 +45,7 @@ spy_posix$_fopen(spy_StrObject *filename, spy_StrObject *mode) {
 
     // spy_StrObject is not null-terminated, make a temporary copy for fopen
     char *fname = (char *)malloc(filename->length + 1);
-    memcpy(fname, filename->utf8, filename->length);
+    memcpy(fname, spy_StrObject_UTF8(filename), filename->length);
     fname[filename->length] = '\0';
 
     FILE *f = fopen(fname, cmode);
@@ -60,11 +60,11 @@ spy_posix$_fopen(spy_StrObject *filename, spy_StrObject *mode) {
 spy_StrObject *
 spy_posix$_fread(FILE *f, int32_t size) {
     spy_StrObject *res = spy_str_alloc(size);
-    size_t n = fread((char *)res->utf8, 1, size, f);
+    size_t n = fread((char *)spy_StrObject_UTF8(res), 1, size, f);
     if (n < (size_t)size) {
         // short read: reallocate to actual size
         spy_StrObject *trimmed = spy_str_alloc(n);
-        memcpy((char *)trimmed->utf8, res->utf8, n);
+        memcpy((char *)spy_StrObject_UTF8(trimmed), spy_StrObject_UTF8(res), n);
         res = trimmed;
     }
     return res;
@@ -91,7 +91,7 @@ spy_posix$__freadall_chunked(FILE *f) {
         return NULL;
     }
     spy_StrObject *res = spy_str_alloc(total);
-    memcpy((char *)res->utf8, buf, total);
+    memcpy((char *)spy_StrObject_UTF8(res), buf, total);
     free(buf);
     return res;
 }
@@ -116,7 +116,7 @@ spy_posix$_freadall(FILE *f) {
     fseek(f, cur, SEEK_SET);
     size_t size = end - cur;
     spy_StrObject *res = spy_str_alloc(size);
-    size_t n = fread((char *)res->utf8, 1, size, f);
+    size_t n = fread((char *)spy_StrObject_UTF8(res), 1, size, f);
     if (n < size) {
         if (ferror(f)) {
             spy_panic("OSError", "freadall: read error", __FILE__, __LINE__);
@@ -124,7 +124,7 @@ spy_posix$_freadall(FILE *f) {
         }
         // EOF before expected: e.g. file was truncated concurrently
         spy_StrObject *trimmed = spy_str_alloc(n);
-        memcpy((char *)trimmed->utf8, res->utf8, n);
+        memcpy((char *)spy_StrObject_UTF8(trimmed), spy_StrObject_UTF8(res), n);
         res = trimmed;
     }
     return res;
@@ -145,7 +145,7 @@ spy_posix$_freadline(FILE *f) {
         return spy_str_alloc(0);
     }
     spy_StrObject *res = spy_str_alloc(n);
-    memcpy((char *)res->utf8, line, n);
+    memcpy((char *)spy_StrObject_UTF8(res), line, n);
     free(line);
     return res;
 }
@@ -169,7 +169,7 @@ spy_posix$_fseek(FILE *f, int32_t offset, int32_t whence) {
 
 void
 spy_posix$_fwrite(FILE *f, spy_StrObject *data) {
-    size_t n = fwrite(data->utf8, 1, data->length, f);
+    size_t n = fwrite(spy_StrObject_UTF8(data), 1, data->length, f);
     if (n < data->length) {
         spy_panic("OSError", "fwrite: write error", __FILE__, __LINE__);
     }

--- a/spy/libspy/src/str.c
+++ b/spy/libspy/src/str.c
@@ -1,15 +1,28 @@
 #include "spy.h"
 #include <errno.h>
 #include <stdarg.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 
+_spy_Str_Layout
+_spy_Str_layout(void) {
+    return (_spy_Str_Layout){
+        .size = sizeof(spy_Str),
+        .length_offset = offsetof(spy_Str, length),
+        .hash_offset = offsetof(spy_Str, hash),
+        .utf8_offset = offsetof(spy_Str, utf8),
+    };
+}
+
 spy_Str *
 spy_str_alloc(size_t length) {
+    // allocate a spy_Str AND the utf8 buffer as a single allocation
     size_t size = sizeof(spy_Str) + length;
     spy_Str *res = (spy_Str *)spy_GcAlloc(size).p;
     res->length = length;
     res->hash = 0;
+    res->utf8 = (const uint8_t *)(res + 1);
     return res;
 }
 
@@ -130,8 +143,13 @@ spy_str_repr(spy_Str *s) {
     // Choose quote character: use double quotes if string contains ' but not "
     char quote = '\'';
     for (size_t i = 0; i < s->length; i++) {
-        if (s->utf8[i] == '\'') { quote = '"'; }
-        if (s->utf8[i] == '"')  { quote = '\''; break; }
+        if (s->utf8[i] == '\'') {
+            quote = '"';
+        }
+        if (s->utf8[i] == '"') {
+            quote = '\'';
+            break;
+        }
     }
 
     // First pass: calculate the output length
@@ -156,15 +174,20 @@ spy_str_repr(spy_Str *s) {
     for (size_t i = 0; i < s->length; i++) {
         unsigned char c = (unsigned char)s->utf8[i];
         if (c == '\\') {
-            *buf++ = '\\'; *buf++ = '\\';
+            *buf++ = '\\';
+            *buf++ = '\\';
         } else if (c == quote) {
-            *buf++ = '\\'; *buf++ = quote;
+            *buf++ = '\\';
+            *buf++ = quote;
         } else if (c == '\n') {
-            *buf++ = '\\'; *buf++ = 'n';
+            *buf++ = '\\';
+            *buf++ = 'n';
         } else if (c == '\r') {
-            *buf++ = '\\'; *buf++ = 'r';
+            *buf++ = '\\';
+            *buf++ = 'r';
         } else if (c == '\t') {
-            *buf++ = '\\'; *buf++ = 't';
+            *buf++ = '\\';
+            *buf++ = 't';
         } else if (c < 0x20) {
             buf += sprintf(buf, "\\x%02x", c);
         } else {

--- a/spy/libspy/src/str.c
+++ b/spy/libspy/src/str.c
@@ -22,7 +22,11 @@ spy_str_alloc(size_t length) {
     spy_StrObject *res = (spy_StrObject *)spy_GcAlloc(size).p;
     res->length = length;
     res->hash = 0;
-    res->utf8 = (const uint8_t *)(res + 1);
+#ifdef SPY_DEBUG
+    res->utf8 = (spy_gc_ptr_u8){(uint8_t *)(res + 1), (ptrdiff_t)length};
+#else
+    res->utf8 = (spy_gc_ptr_u8){(uint8_t *)(res + 1)};
+#endif
     return res;
 }
 
@@ -30,9 +34,9 @@ spy_StrObject *
 spy_str_add(spy_StrObject *a, spy_StrObject *b) {
     size_t l = a->length + b->length;
     spy_StrObject *res = spy_str_alloc(l);
-    char *buf = (char *)res->utf8;
-    memcpy(buf, a->utf8, a->length);
-    memcpy(buf + a->length, b->utf8, b->length);
+    char *buf = (char *)spy_StrObject_UTF8(res);
+    memcpy(buf, spy_StrObject_UTF8(a), a->length);
+    memcpy(buf + a->length, spy_StrObject_UTF8(b), b->length);
     return res;
 }
 
@@ -46,23 +50,23 @@ spy_str_replace(spy_StrObject *original, spy_StrObject *old, spy_StrObject *new_
         // when old_len is empty insert new_str before each byte and after the last
         size_t result_len = orig_len + (orig_len + 1) * new_len;
         spy_StrObject *res = spy_str_alloc(result_len);
-        char *buf = (char *)res->utf8;
+        char *buf = (char *)spy_StrObject_UTF8(res);
         for (size_t i = 0; i < orig_len; i++) {
-            memcpy(buf, new_str->utf8, new_len);
+            memcpy(buf, spy_StrObject_UTF8(new_str), new_len);
             buf += new_len;
-            buf[0] = original->utf8[i];
+            buf[0] = spy_StrObject_UTF8(original)[i];
             buf++;
         }
-        memcpy(buf, new_str->utf8, new_len);
+        memcpy(buf, spy_StrObject_UTF8(new_str), new_len);
         return res;
     }
 
     // First pass -> count occurrences
     size_t count = 0;
-    const char *p = (const char *)original->utf8;
+    const char *p = (const char *)spy_StrObject_UTF8(original);
     const char *end = p + orig_len;
     while (p <= end - old_len) {
-        if (memcmp(p, old->utf8, old_len) == 0) {
+        if (memcmp(p, spy_StrObject_UTF8(old), old_len) == 0) {
             count++;
             p += old_len;
         } else {
@@ -73,18 +77,18 @@ spy_str_replace(spy_StrObject *original, spy_StrObject *old, spy_StrObject *new_
     if (count == 0) {
         // Return the original string when no occurrences are found
         spy_StrObject *res = spy_str_alloc(orig_len);
-        memcpy((char *)res->utf8, original->utf8, orig_len);
+        memcpy((char *)spy_StrObject_UTF8(res), spy_StrObject_UTF8(original), orig_len);
         return res;
     }
 
     // Second pass -> build the result
     size_t result_len = orig_len + count * (new_len - old_len);
     spy_StrObject *res = spy_str_alloc(result_len);
-    char *buf = (char *)res->utf8;
-    p = (const char *)original->utf8;
+    char *buf = (char *)spy_StrObject_UTF8(res);
+    p = (const char *)spy_StrObject_UTF8(original);
     while (p <= end - old_len) {
-        if (memcmp(p, old->utf8, old_len) == 0) {
-            memcpy(buf, new_str->utf8, new_len);
+        if (memcmp(p, spy_StrObject_UTF8(old), old_len) == 0) {
+            memcpy(buf, spy_StrObject_UTF8(new_str), new_len);
             buf += new_len;
             p += old_len;
         } else {
@@ -101,9 +105,9 @@ spy_StrObject *
 spy_str_mul(spy_StrObject *a, int32_t b) {
     size_t l = a->length * b;
     spy_StrObject *res = spy_str_alloc(l);
-    char *buf = (char *)res->utf8;
+    char *buf = (char *)spy_StrObject_UTF8(res);
     for (int i = 0; i < b; i++) {
-        memcpy(buf, a->utf8, a->length);
+        memcpy(buf, spy_StrObject_UTF8(a), a->length);
         buf += a->length;
     }
     return res;
@@ -113,7 +117,7 @@ bool
 spy_str_eq(spy_StrObject *a, spy_StrObject *b) {
     if (a->length != b->length)
         return false;
-    return memcmp(a->utf8, b->utf8, a->length) == 0;
+    return memcmp(spy_StrObject_UTF8(a), spy_StrObject_UTF8(b), a->length) == 0;
 }
 
 spy_StrObject *
@@ -128,8 +132,8 @@ spy_str_getitem(spy_StrObject *s, int32_t i) {
         return NULL;
     }
     spy_StrObject *res = spy_str_alloc(1);
-    char *buf = (char *)res->utf8;
-    buf[0] = s->utf8[i];
+    char *buf = (char *)spy_StrObject_UTF8(res);
+    buf[0] = spy_StrObject_UTF8(s)[i];
     return res;
 }
 
@@ -143,10 +147,10 @@ spy_str_repr(spy_StrObject *s) {
     // Choose quote character: use double quotes if string contains ' but not "
     char quote = '\'';
     for (size_t i = 0; i < s->length; i++) {
-        if (s->utf8[i] == '\'') {
+        if (spy_StrObject_UTF8(s)[i] == '\'') {
             quote = '"';
         }
-        if (s->utf8[i] == '"') {
+        if (spy_StrObject_UTF8(s)[i] == '"') {
             quote = '\'';
             break;
         }
@@ -155,7 +159,7 @@ spy_str_repr(spy_StrObject *s) {
     // First pass: calculate the output length
     size_t out_len = 2; // for the surrounding quotes
     for (size_t i = 0; i < s->length; i++) {
-        unsigned char c = (unsigned char)s->utf8[i];
+        unsigned char c = (unsigned char)spy_StrObject_UTF8(s)[i];
         if (c == '\\' || c == quote) {
             out_len += 2;
         } else if (c == '\n' || c == '\r' || c == '\t') {
@@ -169,10 +173,10 @@ spy_str_repr(spy_StrObject *s) {
 
     // Second pass: fill the buffer
     spy_StrObject *res = spy_str_alloc(out_len);
-    char *buf = (char *)res->utf8;
+    char *buf = (char *)spy_StrObject_UTF8(res);
     *buf++ = quote;
     for (size_t i = 0; i < s->length; i++) {
-        unsigned char c = (unsigned char)s->utf8[i];
+        unsigned char c = (unsigned char)spy_StrObject_UTF8(s)[i];
         if (c == '\\') {
             *buf++ = '\\';
             *buf++ = '\\';
@@ -205,7 +209,7 @@ spy_str_hash(spy_StrObject *s) {
     // FNV-1a hash
     uint32_t h = 2166136261u;
     for (size_t i = 0; i < s->length; i++) {
-        h ^= (uint8_t)s->utf8[i];
+        h ^= (uint8_t)spy_StrObject_UTF8(s)[i];
         h *= 16777619u;
     }
     int32_t result = (int32_t)h;
@@ -229,7 +233,7 @@ spy_str_from_format(const char *fmt, ...) {
     va_end(args);
 
     spy_StrObject *res = spy_str_alloc(length);
-    char *outbuf = (char *)res->utf8;
+    char *outbuf = (char *)spy_StrObject_UTF8(res);
     memcpy(outbuf, buf, length);
     return res;
 }
@@ -271,7 +275,7 @@ spy_str_parse_i64(spy_StrObject *s) {
             "ValueError", "invalid literal for int() with base 10", __FILE__, __LINE__
         );
     }
-    memcpy(buf, s->utf8, len);
+    memcpy(buf, spy_StrObject_UTF8(s), len);
     buf[len] = '\0';
 
     char *end;
@@ -335,7 +339,7 @@ spy_str_to_complex128(spy_StrObject *s) {
         );
     }
 
-    memcpy(buf, s->utf8, len);
+    memcpy(buf, spy_StrObject_UTF8(s), len);
     buf[len] = '\0';
     char *start = buf;
     char *end = start + len - 1;

--- a/spy/libspy/src/str.c
+++ b/spy/libspy/src/str.c
@@ -5,39 +5,39 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-_spy_Str_Layout
-_spy_Str_layout(void) {
-    return (_spy_Str_Layout){
-        .size = sizeof(spy_Str),
-        .length_offset = offsetof(spy_Str, length),
-        .hash_offset = offsetof(spy_Str, hash),
-        .utf8_offset = offsetof(spy_Str, utf8),
+_spy_StrObject_Layout
+_spy_StrObject_layout(void) {
+    return (_spy_StrObject_Layout){
+        .size = sizeof(spy_StrObject),
+        .length_offset = offsetof(spy_StrObject, length),
+        .hash_offset = offsetof(spy_StrObject, hash),
+        .utf8_offset = offsetof(spy_StrObject, utf8),
     };
 }
 
-spy_Str *
+spy_StrObject *
 spy_str_alloc(size_t length) {
-    // allocate a spy_Str AND the utf8 buffer as a single allocation
-    size_t size = sizeof(spy_Str) + length;
-    spy_Str *res = (spy_Str *)spy_GcAlloc(size).p;
+    // allocate a spy_StrObject AND the utf8 buffer as a single allocation
+    size_t size = sizeof(spy_StrObject) + length;
+    spy_StrObject *res = (spy_StrObject *)spy_GcAlloc(size).p;
     res->length = length;
     res->hash = 0;
     res->utf8 = (const uint8_t *)(res + 1);
     return res;
 }
 
-spy_Str *
-spy_str_add(spy_Str *a, spy_Str *b) {
+spy_StrObject *
+spy_str_add(spy_StrObject *a, spy_StrObject *b) {
     size_t l = a->length + b->length;
-    spy_Str *res = spy_str_alloc(l);
+    spy_StrObject *res = spy_str_alloc(l);
     char *buf = (char *)res->utf8;
     memcpy(buf, a->utf8, a->length);
     memcpy(buf + a->length, b->utf8, b->length);
     return res;
 }
 
-spy_Str *
-spy_str_replace(spy_Str *original, spy_Str *old, spy_Str *new_str) {
+spy_StrObject *
+spy_str_replace(spy_StrObject *original, spy_StrObject *old, spy_StrObject *new_str) {
     size_t orig_len = original->length;
     size_t old_len = old->length;
     size_t new_len = new_str->length;
@@ -45,7 +45,7 @@ spy_str_replace(spy_Str *original, spy_Str *old, spy_Str *new_str) {
     if (old_len == 0) {
         // when old_len is empty insert new_str before each byte and after the last
         size_t result_len = orig_len + (orig_len + 1) * new_len;
-        spy_Str *res = spy_str_alloc(result_len);
+        spy_StrObject *res = spy_str_alloc(result_len);
         char *buf = (char *)res->utf8;
         for (size_t i = 0; i < orig_len; i++) {
             memcpy(buf, new_str->utf8, new_len);
@@ -72,14 +72,14 @@ spy_str_replace(spy_Str *original, spy_Str *old, spy_Str *new_str) {
 
     if (count == 0) {
         // Return the original string when no occurrences are found
-        spy_Str *res = spy_str_alloc(orig_len);
+        spy_StrObject *res = spy_str_alloc(orig_len);
         memcpy((char *)res->utf8, original->utf8, orig_len);
         return res;
     }
 
     // Second pass -> build the result
     size_t result_len = orig_len + count * (new_len - old_len);
-    spy_Str *res = spy_str_alloc(result_len);
+    spy_StrObject *res = spy_str_alloc(result_len);
     char *buf = (char *)res->utf8;
     p = (const char *)original->utf8;
     while (p <= end - old_len) {
@@ -97,10 +97,10 @@ spy_str_replace(spy_Str *original, spy_Str *old, spy_Str *new_str) {
     return res;
 }
 
-spy_Str *
-spy_str_mul(spy_Str *a, int32_t b) {
+spy_StrObject *
+spy_str_mul(spy_StrObject *a, int32_t b) {
     size_t l = a->length * b;
-    spy_Str *res = spy_str_alloc(l);
+    spy_StrObject *res = spy_str_alloc(l);
     char *buf = (char *)res->utf8;
     for (int i = 0; i < b; i++) {
         memcpy(buf, a->utf8, a->length);
@@ -110,14 +110,14 @@ spy_str_mul(spy_Str *a, int32_t b) {
 }
 
 bool
-spy_str_eq(spy_Str *a, spy_Str *b) {
+spy_str_eq(spy_StrObject *a, spy_StrObject *b) {
     if (a->length != b->length)
         return false;
     return memcmp(a->utf8, b->utf8, a->length) == 0;
 }
 
-spy_Str *
-spy_str_getitem(spy_Str *s, int32_t i) {
+spy_StrObject *
+spy_str_getitem(spy_StrObject *s, int32_t i) {
     // XXX this is wrong: it should return a code point
     size_t l = s->length;
     if (i < 0) {
@@ -127,19 +127,19 @@ spy_str_getitem(spy_Str *s, int32_t i) {
         spy_panic("IndexError", "string index out of bound", __FILE__, __LINE__);
         return NULL;
     }
-    spy_Str *res = spy_str_alloc(1);
+    spy_StrObject *res = spy_str_alloc(1);
     char *buf = (char *)res->utf8;
     buf[0] = s->utf8[i];
     return res;
 }
 
 int32_t
-spy_str_len(spy_Str *s) {
+spy_str_len(spy_StrObject *s) {
     return (int32_t)s->length;
 }
 
-spy_Str *
-spy_str_repr(spy_Str *s) {
+spy_StrObject *
+spy_str_repr(spy_StrObject *s) {
     // Choose quote character: use double quotes if string contains ' but not "
     char quote = '\'';
     for (size_t i = 0; i < s->length; i++) {
@@ -168,7 +168,7 @@ spy_str_repr(spy_Str *s) {
     }
 
     // Second pass: fill the buffer
-    spy_Str *res = spy_str_alloc(out_len);
+    spy_StrObject *res = spy_str_alloc(out_len);
     char *buf = (char *)res->utf8;
     *buf++ = quote;
     for (size_t i = 0; i < s->length; i++) {
@@ -199,7 +199,7 @@ spy_str_repr(spy_Str *s) {
 }
 
 int32_t
-spy_str_hash(spy_Str *s) {
+spy_str_hash(spy_StrObject *s) {
     if (s->hash != 0)
         return s->hash;
     // FNV-1a hash
@@ -217,10 +217,10 @@ spy_str_hash(spy_Str *s) {
     return result;
 }
 
-// Helper function to format and convert to spy_Str
+// Helper function to format and convert to spy_StrObject
 // XXX probably it would be better to implement it directly, instead of
 // bringing in all the code needed to support sprintf()
-static spy_Str *
+static spy_StrObject *
 spy_str_from_format(const char *fmt, ...) {
     char buf[1024];
     va_list args;
@@ -228,42 +228,42 @@ spy_str_from_format(const char *fmt, ...) {
     int length = vsnprintf(buf, 1024, fmt, args);
     va_end(args);
 
-    spy_Str *res = spy_str_alloc(length);
+    spy_StrObject *res = spy_str_alloc(length);
     char *outbuf = (char *)res->utf8;
     memcpy(outbuf, buf, length);
     return res;
 }
 
-spy_Str *
+spy_StrObject *
 spy_builtins$i32$__str__(int32_t x) {
     return spy_str_from_format("%d", x);
 }
 
-spy_Str *
+spy_StrObject *
 spy_builtins$i8$__str__(int8_t x) {
     return spy_str_from_format("%d", (int)x);
 }
 
-spy_Str *
+spy_StrObject *
 spy_builtins$u8$__str__(uint8_t x) {
     return spy_str_from_format("%u", (unsigned int)x);
 }
 
-spy_Str *
+spy_StrObject *
 spy_builtins$f64$__str__(double x) {
     return spy_str_from_format("%g", x);
 }
 
-spy_Str *
+spy_StrObject *
 spy_builtins$bool$__str__(bool x) {
     return spy_str_from_format("%s", x ? "True" : "False");
 }
 
-// Helper: parse a null-terminated copy of spy_Str as an int64_t, raising
+// Helper: parse a null-terminated copy of spy_StrObject as an int64_t, raising
 // ValueError if the string is not a valid integer.
 static int64_t
-spy_str_parse_i64(spy_Str *s) {
-    // spy_Str is not null-terminated, so we copy it
+spy_str_parse_i64(spy_StrObject *s) {
+    // spy_StrObject is not null-terminated, so we copy it
     char buf[64];
     size_t len = s->length;
     if (len >= sizeof(buf)) {
@@ -298,35 +298,35 @@ spy_check_range(int64_t val, int64_t lo, int64_t hi, const char *tname) {
 }
 
 int32_t
-spy_operator$str_to_i32(spy_Str *s) {
+spy_operator$str_to_i32(spy_StrObject *s) {
     int64_t val = spy_str_parse_i64(s);
     spy_check_range(val, -2147483648LL, 2147483647LL, "i32");
     return (int32_t)val;
 }
 
 uint32_t
-spy_operator$str_to_u32(spy_Str *s) {
+spy_operator$str_to_u32(spy_StrObject *s) {
     int64_t val = spy_str_parse_i64(s);
     spy_check_range(val, 0LL, 4294967295LL, "u32");
     return (uint32_t)val;
 }
 
 int8_t
-spy_operator$str_to_i8(spy_Str *s) {
+spy_operator$str_to_i8(spy_StrObject *s) {
     int64_t val = spy_str_parse_i64(s);
     spy_check_range(val, -128LL, 127LL, "i8");
     return (int8_t)val;
 }
 
 uint8_t
-spy_operator$str_to_u8(spy_Str *s) {
+spy_operator$str_to_u8(spy_StrObject *s) {
     int64_t val = spy_str_parse_i64(s);
     spy_check_range(val, 0LL, 255LL, "u8");
     return (uint8_t)val;
 }
 
 spy_Complex128
-spy_str_to_complex128(spy_Str *s) {
+spy_str_to_complex128(spy_StrObject *s) {
     char buf[128];
     size_t len = s->length;
     if (len == 0 || len >= sizeof(buf)) {

--- a/spy/llwasm/base.py
+++ b/spy/llwasm/base.py
@@ -123,6 +123,10 @@ class LLWasmMemoryBase:
 
     def read_i8(self, addr: int) -> int:
         rawbytes = self.read(addr, 1)
+        return struct.unpack("b", rawbytes)[0]
+
+    def read_u8(self, addr: int) -> int:
+        rawbytes = self.read(addr, 1)
         return rawbytes[0]
 
     def read_f64(self, addr: int) -> int:
@@ -158,6 +162,9 @@ class LLWasmMemoryBase:
 
     def write_i8(self, addr: int, v: int) -> None:
         self.write(addr, struct.pack("b", v))
+
+    def write_u8(self, addr: int, v: int) -> None:
+        self.write(addr, struct.pack("B", v))
 
     def write_f64(self, addr: int, v: float) -> None:
         self.write(addr, struct.pack("d", v))

--- a/spy/tests/compiler/test_str.py
+++ b/spy/tests/compiler/test_str.py
@@ -252,6 +252,17 @@ class TestStr(CompilerTest):
         assert mod.foo_f64() == "12.3"
         assert mod.foo_bool() == "True"
 
+    def test_isascii(self):
+        # isascii is defined in stdlib/_str.spy, so this also tests that "lazy
+        # attributes" work.
+        src = """
+        def isascii(s: str) -> bool:
+            return s.isascii()
+        """
+        mod = self.compile(src)
+        assert mod.isascii("hello")
+        assert not mod.isascii("àèìòù")
+
     def test_str_replace(self):
         mod = self.compile("""
         def foo(s: str, old: str, new: str) -> str:

--- a/spy/tests/compiler/unsafe/test_ptr.py
+++ b/spy/tests/compiler/unsafe/test_ptr.py
@@ -640,3 +640,21 @@ class TestUnsafePtr(CompilerTest):
         addr = w.p.addr
         self.vm.ll.mem.read_i32(addr) == 1
         self.vm.ll.mem.read_i32(addr + 4) == 2
+
+    @only_interp
+    def test_as_StrObject(self):
+        mod = self.compile("""
+        from unsafe import as_StrObject
+        from _str import StrObject
+
+        def get_length(s: str) -> i32:
+            data = as_StrObject(s)
+            return data.length
+
+        def get_byte(s: str, i: i32) -> u8:
+            data = as_StrObject(s)
+            return data.utf8[i]
+        """)
+        assert mod.get_length("hello") == 5
+        assert mod.get_byte("hello", 0) == ord("h")
+        assert mod.get_byte("hello", 4) == ord("o")

--- a/spy/tests/compiler/unsafe/test_ptr.py
+++ b/spy/tests/compiler/unsafe/test_ptr.py
@@ -641,7 +641,6 @@ class TestUnsafePtr(CompilerTest):
         self.vm.ll.mem.read_i32(addr) == 1
         self.vm.ll.mem.read_i32(addr + 4) == 2
 
-    @only_interp
     def test_as_StrObject(self):
         mod = self.compile("""
         from unsafe import as_StrObject

--- a/spy/tests/compiler/unsafe/test_ptr.py
+++ b/spy/tests/compiler/unsafe/test_ptr.py
@@ -64,6 +64,27 @@ class TestUnsafePtr(CompilerTest):
         assert mod.bar(1) == 3.4
         assert mod.bar(2) == 5.6
 
+    def test_gc_ptr_u8(self):
+        # gc_ptr[u8] is special-cased and predeclared manually in unsafe.h. Exercise
+        # alloc/store/load and bounds-checking to make sure that everything works.
+        mod = self.compile("""
+        from unsafe import gc_alloc, gc_ptr
+
+        def foo() -> i32:
+            buf: gc_ptr[u8] = gc_alloc[u8](3)
+            buf[0] = 1
+            buf[1] = 2
+            buf[2] = 3
+            return buf[0] + buf[1] + buf[2]
+
+        def out_of_bound() -> u8:
+            buf = gc_alloc[u8](3)
+            return buf[3]
+        """)
+        assert mod.foo() == 6
+        with SPyError.raises("W_PanicError", match="ptr_getitem out of bounds"):
+            mod.out_of_bound()
+
     def test_out_of_bound(self, memkind):
         k = memkind
         mod = self.compile(f"""

--- a/spy/tests/test_libspy.py
+++ b/spy/tests/test_libspy.py
@@ -32,11 +32,11 @@ class TestLibSPy(CTest):
         src = r"""
         #include <spy.h>
 
-        spy_StrObject H = {6, 0, (const uint8_t *)"hello "};
+        spy_StrObject H = SPY_STR_LITERAL(6, "hello ");
 
         spy_StrObject *mk_W(void) {
             spy_StrObject *s = spy_str_alloc(5);
-            memcpy((void*)s->utf8, "world", 5);
+            memcpy((void*)spy_StrObject_UTF8(s), "world", 5);
             return s;
         }
         """

--- a/spy/tests/test_libspy.py
+++ b/spy/tests/test_libspy.py
@@ -32,10 +32,10 @@ class TestLibSPy(CTest):
         src = r"""
         #include <spy.h>
 
-        spy_Str H = {6, 0, (const uint8_t *)"hello "};
+        spy_StrObject H = {6, 0, (const uint8_t *)"hello "};
 
-        spy_Str *mk_W(void) {
-            spy_Str *s = spy_str_alloc(5);
+        spy_StrObject *mk_W(void) {
+            spy_StrObject *s = spy_str_alloc(5);
             memcpy((void*)s->utf8, "world", 5);
             return s;
         }

--- a/spy/tests/test_libspy.py
+++ b/spy/tests/test_libspy.py
@@ -1,22 +1,6 @@
-import struct
-
 from spy.libspy import LLSPyInstance, SPyError
 from spy.llwasm import LLWasmModule
 from spy.tests.support import CTest
-
-
-def mk_spy_Str(utf8: bytes) -> bytes:
-    """
-    Return the spy_Str representation of the given utf8 bytes.
-
-    For example, for b'hello' we have the following in-memory repr:
-         <i   4 bytes of length, little endian
-         i    4 bytes of hash (0 for uncached)
-         5s   5 bytes of data (b'hello')
-    """
-    n = len(utf8)
-    fmt = f"<ii{n}s"
-    return struct.pack(fmt, n, 0, utf8)
 
 
 class TestLibSPy(CTest):
@@ -48,7 +32,7 @@ class TestLibSPy(CTest):
         src = r"""
         #include <spy.h>
 
-        spy_Str H = {6, 0, "hello "};
+        spy_Str H = {6, 0, (const uint8_t *)"hello "};
 
         spy_Str *mk_W(void) {
             spy_Str *s = spy_str_alloc(5);
@@ -59,13 +43,13 @@ class TestLibSPy(CTest):
         test_wasm = self.c_compile(src, exports=["H", "mk_W"])
         ll = LLSPyInstance.from_file(test_wasm)
         ptr_H = ll.read_global("H")
-        assert ll.mem.read(ptr_H, 14) == mk_spy_Str(b"hello ")
+        assert ll.read_str(ptr_H) == (6, 0, b"hello ")
         #
         ptr_W = ll.call("mk_W")
-        assert ll.mem.read(ptr_W, 13) == mk_spy_Str(b"world")
+        assert ll.read_str(ptr_W) == (5, 0, b"world")
         #
         ptr_HW = ll.call("spy_str_add", ptr_H, ptr_W)
-        assert ll.mem.read(ptr_HW, 19) == mk_spy_Str(b"hello world")
+        assert ll.read_str(ptr_HW) == (11, 0, b"hello world")
 
     def test_debug_log(self):
         src = r"""

--- a/spy/tests/vm/test_builtin.py
+++ b/spy/tests/vm/test_builtin.py
@@ -120,6 +120,8 @@ class TestBuiltin:
         assert w_x is w_y
 
     def test_builtin_method(self):
+        vm = SPyVM()
+
         @builtin_type("test", "Foo")
         class W_Foo(W_Object):
             @builtin_method("make")
@@ -129,7 +131,7 @@ class TestBuiltin:
 
         w_foo = W_Foo._w
         w_make = w_foo.dict_w["make"]
-        assert w_foo.lookup_func("make") is w_make
+        assert w_foo.lookup_func(vm, "make") is w_make
         assert isinstance(w_make, W_BuiltinFunc)
         assert w_make.w_functype.fqn.debug_human_name == "def() -> test::Foo"
         assert w_make.w_functype.w_restype is W_Foo._w
@@ -160,9 +162,10 @@ class TestBuiltin:
         w_super = W_Super._w
         w_sub = W_Sub._w
 
+        vm = SPyVM()
         w_foo = w_super.dict_w["foo"]
-        assert w_super.lookup_func("foo") is w_foo
-        assert w_sub.lookup_func("foo") is w_foo
+        assert w_super.lookup_func(vm, "foo") is w_foo
+        assert w_sub.lookup_func(vm, "foo") is w_foo
 
     def test_metafunc_wrong_color(self):
         class W_Foo(W_Object):

--- a/spy/tests/wasm_wrapper.py
+++ b/spy/tests/wasm_wrapper.py
@@ -13,7 +13,7 @@ from spy.vm.function import W_ASTFunc, W_Func, W_FuncType
 from spy.vm.modules.rawbuffer import RB
 from spy.vm.modules.unsafe.ptr import W_PtrType
 from spy.vm.object import W_Type
-from spy.vm.str import ll_spy_Str_new
+from spy.vm.str import ll_str_new
 from spy.vm.struct import UnwrappedStruct, W_StructType
 from spy.vm.vm import SPyVM
 
@@ -95,7 +95,7 @@ class WasmFuncWrapper:
             return float(pyval)
         elif w_T is B.w_str:
             # XXX: with the GC, we need to think how to keep this alive
-            return ll_spy_Str_new(self.ll, pyval)
+            return ll_str_new(self.ll, pyval)
         elif isinstance(w_T, W_PtrType):
             assert isinstance(pyval, WasmPtr)
             return (pyval.addr, pyval.length)
@@ -279,7 +279,7 @@ def unflatten_struct(
                 content[w_field.name] = WasmPtr(addr, length)
                 idx += 2
             elif w_field.w_T is B.w_str:
-                # str fields are spy_Str* pointers; read from WASM memory
+                # str fields are spy_StrObject* pointers; read from WASM memory
                 addr = flat_values[idx]
                 if ll is not None:
                     _, _, utf8 = ll.read_str(addr)

--- a/spy/tests/wasm_wrapper.py
+++ b/spy/tests/wasm_wrapper.py
@@ -138,10 +138,7 @@ class WasmFuncWrapper:
         elif w_T is B.w_bool:
             return bool(res)
         elif w_T is B.w_str:
-            # res is a  spy_Str*
-            addr = res
-            length = self.ll.mem.read_i32(addr)
-            utf8 = self.ll.mem.read(addr + 8, length)
+            _, _, utf8 = self.ll.read_str(res)
             return utf8.decode("utf-8")
         elif w_T is RB.w_RawBuffer:
             # res is a  spy_RawBuffer*
@@ -285,8 +282,7 @@ def unflatten_struct(
                 # str fields are spy_Str* pointers; read from WASM memory
                 addr = flat_values[idx]
                 if ll is not None:
-                    length = ll.mem.read_i32(addr)
-                    utf8 = ll.mem.read(addr + 8, length)
+                    _, _, utf8 = ll.read_str(addr)
                     content[w_field.name] = utf8.decode("utf-8")
                 else:
                     content[w_field.name] = addr

--- a/spy/vm/modules/builtins.py
+++ b/spy/vm/modules/builtins.py
@@ -160,7 +160,7 @@ def w_print(vm: "SPyVM", *args_wam: W_MetaArg) -> W_OpSpec:
 @BUILTINS.builtin_func(color="blue", kind="metafunc")
 def w_len(vm: "SPyVM", wam_obj: W_MetaArg) -> W_OpSpec:
     w_T = wam_obj.w_static_T
-    if w_fn := w_T.lookup_func("__len__"):
+    if w_fn := w_T.lookup_func(vm, "__len__"):
         w_opspec = vm.fast_metacall(w_fn, [wam_obj])
         return w_opspec
 
@@ -173,7 +173,7 @@ def w_len(vm: "SPyVM", wam_obj: W_MetaArg) -> W_OpSpec:
 @BUILTINS.builtin_func(color="blue", kind="metafunc")
 def w_repr(vm: "SPyVM", wam_obj: W_MetaArg) -> W_OpSpec:
     w_T = wam_obj.w_static_T
-    if w_fn := w_T.lookup_func("__repr__"):
+    if w_fn := w_T.lookup_func(vm, "__repr__"):
         w_opspec = vm.fast_metacall(w_fn, [wam_obj])
         return w_opspec
 
@@ -236,7 +236,7 @@ def w_hash(vm: "SPyVM", wam_obj: W_MetaArg) -> W_OpSpec:
     elif w_T is B.w_str:
         return W_OpSpec(B.w_hash_str)
 
-    if w_fn := w_T.lookup_func("__hash__"):
+    if w_fn := w_T.lookup_func(vm, "__hash__"):
         w_opspec = vm.fast_metacall(w_fn, [wam_obj])
         return w_opspec
 

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -31,7 +31,7 @@ def w_GETATTR(vm: "SPyVM", wam_obj: W_MetaArg, wam_name: W_MetaArg) -> W_OpImpl:
     w_T = wam_obj.w_static_T
     if w_T is B.w_dynamic:
         w_opspec = W_OpSpec(OP.w_dynamic_getattr)
-    elif w_getattribute := w_T.lookup_func(f"__getattribute__"):
+    elif w_getattribute := w_T.lookup_func(vm, f"__getattribute__"):
         w_opspec = vm.fast_metacall(w_getattribute, [wam_obj, wam_name])
     else:
         w_opspec = default_getattribute(vm, wam_obj, wam_name, name)
@@ -54,7 +54,7 @@ def w_HASATTR(vm: "SPyVM", wam_obj: W_MetaArg, wam_name: W_MetaArg) -> W_OpImpl:
     w_T = wam_obj.w_static_T
     if w_T is B.w_dynamic:
         w_opspec = W_OpSpec(OP.w_dynamic_hasattr)
-    elif w_getattribute := w_T.lookup_func("__getattribute__"):
+    elif w_getattribute := w_T.lookup_func(vm, "__getattribute__"):
         w_opspec_inner = vm.fast_metacall(w_getattribute, [wam_obj, wam_name])
         if w_opspec_inner.is_null():
             w_opspec = W_OpSpec.const(B.w_False)
@@ -114,8 +114,8 @@ def default_getattribute(
     # __dict__ by default. (__dict__ support not implemented yet ATM).
 
     w_T = wam_obj.w_static_T
-    if w_attr := w_T.lookup(name):
-        if w_get := vm.dynamic_type(w_attr).lookup_func("__get__"):
+    if w_attr := w_T.lookup(vm, name):
+        if w_get := vm.dynamic_type(w_attr).lookup_func(vm, "__get__"):
             # 1. found a descriptor on the type
             wam_attr = W_MetaArg.from_w_obj(vm, w_attr)
             return vm.fast_metacall(w_get, [wam_attr, wam_obj])
@@ -153,15 +153,15 @@ def _get_SETATTR_opspec(
         return W_OpSpec(OP.w_dynamic_setattr)
 
     # try to find a descriptor with a __set__ method
-    elif w_member := w_T.lookup(name):
+    elif w_member := w_T.lookup(vm, name):
         w_member_T = vm.dynamic_type(w_member)
-        w_set = w_member_T.lookup_func("__set__")
+        w_set = w_member_T.lookup_func(vm, "__set__")
         if w_set:
             # w_member is a descriptor! We can call its __set__
             wam_member = W_MetaArg.from_w_obj(vm, w_member)
             return vm.fast_metacall(w_set, [wam_member, wam_obj, wam_v])
 
-    elif w_setattr := w_T.lookup_func("__setattr__"):
+    elif w_setattr := w_T.lookup_func(vm, "__setattr__"):
         return vm.fast_metacall(w_setattr, [wam_obj, wam_name, wam_v])
 
     return W_OpSpec.NULL

--- a/spy/vm/modules/operator/binop.py
+++ b/spy/vm/modules/operator/binop.py
@@ -233,7 +233,7 @@ def w_ADD(vm: "SPyVM", wam_l: W_MetaArg, wam_r: W_MetaArg) -> W_OpImpl:
     w_ltype = wam_l.w_static_T
     if w_opspec := MM.get_binary_opspec("+", wam_l, wam_r):
         pass
-    elif w_add := w_ltype.lookup_func("__add__"):
+    elif w_add := w_ltype.lookup_func(vm, "__add__"):
         w_opspec = vm.fast_metacall(w_add, [wam_l, wam_r])
     else:
         w_opspec = W_OpSpec.NULL
@@ -249,7 +249,7 @@ def w_SUB(vm: "SPyVM", wam_l: W_MetaArg, wam_r: W_MetaArg) -> W_OpImpl:
     w_ltype = wam_l.w_static_T
     if w_opspec := MM.get_binary_opspec("-", wam_l, wam_r):
         pass
-    elif w_sub := w_ltype.lookup_func("__sub__"):
+    elif w_sub := w_ltype.lookup_func(vm, "__sub__"):
         w_opspec = vm.fast_metacall(w_sub, [wam_l, wam_r])
     else:
         w_opspec = W_OpSpec.NULL
@@ -265,7 +265,7 @@ def w_MUL(vm: "SPyVM", wam_l: W_MetaArg, wam_r: W_MetaArg) -> W_OpImpl:
     w_ltype = wam_l.w_static_T
     if w_opspec := MM.get_binary_opspec("*", wam_l, wam_r):
         pass
-    elif w_mul := w_ltype.lookup_func("__mul__"):
+    elif w_mul := w_ltype.lookup_func(vm, "__mul__"):
         w_opspec = vm.fast_metacall(w_mul, [wam_l, wam_r])
     else:
         w_opspec = W_OpSpec.NULL
@@ -281,7 +281,7 @@ def w_DIV(vm: "SPyVM", wam_l: W_MetaArg, wam_r: W_MetaArg) -> W_OpImpl:
     w_ltype = wam_l.w_static_T
     if w_opspec := MM.get_binary_opspec("/", wam_l, wam_r):
         pass
-    elif w_div := w_ltype.lookup_func("__div__"):
+    elif w_div := w_ltype.lookup_func(vm, "__div__"):
         w_opspec = vm.fast_metacall(w_div, [wam_l, wam_r])
     else:
         w_opspec = W_OpSpec.NULL
@@ -297,7 +297,7 @@ def w_FLOORDIV(vm: "SPyVM", wam_l: W_MetaArg, wam_r: W_MetaArg) -> W_OpImpl:
     w_ltype = wam_l.w_static_T
     if w_opspec := MM.get_binary_opspec("//", wam_l, wam_r):
         pass
-    elif w_floordiv := w_ltype.lookup_func("__floordiv__"):
+    elif w_floordiv := w_ltype.lookup_func(vm, "__floordiv__"):
         w_opspec = vm.fast_metacall(w_floordiv, [wam_l, wam_r])
     else:
         w_opspec = W_OpSpec.NULL
@@ -317,7 +317,7 @@ def w_MOD(vm: "SPyVM", wam_l: W_MetaArg, wam_r: W_MetaArg) -> W_OpImpl:
     w_ltype = wam_l.w_static_T
     if w_opspec := MM.get_binary_opspec("%", wam_l, wam_r):
         pass
-    elif w_mod := w_ltype.lookup_func("__mod__"):
+    elif w_mod := w_ltype.lookup_func(vm, "__mod__"):
         w_opspec = vm.fast_metacall(w_mod, [wam_l, wam_r])
     else:
         w_opspec = W_OpSpec.NULL
@@ -333,7 +333,7 @@ def w_LSHIFT(vm: "SPyVM", wam_l: W_MetaArg, wam_r: W_MetaArg) -> W_OpImpl:
     w_ltype = wam_l.w_static_T
     if w_opspec := MM.get_binary_opspec("<<", wam_l, wam_r):
         pass
-    elif w_lshift := w_ltype.lookup_func("__lshift__"):
+    elif w_lshift := w_ltype.lookup_func(vm, "__lshift__"):
         w_opspec = vm.fast_metacall(w_lshift, [wam_l, wam_r])
     else:
         w_opspec = W_OpSpec.NULL
@@ -353,7 +353,7 @@ def w_RSHIFT(vm: "SPyVM", wam_l: W_MetaArg, wam_r: W_MetaArg) -> W_OpImpl:
     w_ltype = wam_l.w_static_T
     if w_opspec := MM.get_binary_opspec(">>", wam_l, wam_r):
         pass
-    elif w_rshift := w_ltype.lookup_func("__rshift__"):
+    elif w_rshift := w_ltype.lookup_func(vm, "__rshift__"):
         w_opspec = vm.fast_metacall(w_rshift, [wam_l, wam_r])
     else:
         w_opspec = W_OpSpec.NULL
@@ -373,7 +373,7 @@ def w_AND(vm: "SPyVM", wam_l: W_MetaArg, wam_r: W_MetaArg) -> W_OpImpl:
     w_ltype = wam_l.w_static_T
     if w_opspec := MM.get_binary_opspec("&", wam_l, wam_r):
         pass
-    elif w_and := w_ltype.lookup_func("__and__"):
+    elif w_and := w_ltype.lookup_func(vm, "__and__"):
         w_opspec = vm.fast_metacall(w_and, [wam_l, wam_r])
     else:
         w_opspec = W_OpSpec.NULL
@@ -389,7 +389,7 @@ def w_OR(vm: "SPyVM", wam_l: W_MetaArg, wam_r: W_MetaArg) -> W_OpImpl:
     w_ltype = wam_l.w_static_T
     if w_opspec := MM.get_binary_opspec("|", wam_l, wam_r):
         pass
-    elif w_or := w_ltype.lookup_func("__or__"):
+    elif w_or := w_ltype.lookup_func(vm, "__or__"):
         w_opspec = vm.fast_metacall(w_or, [wam_l, wam_r])
     else:
         w_opspec = W_OpSpec.NULL
@@ -405,7 +405,7 @@ def w_XOR(vm: "SPyVM", wam_l: W_MetaArg, wam_r: W_MetaArg) -> W_OpImpl:
     w_ltype = wam_l.w_static_T
     if w_opspec := MM.get_binary_opspec("^", wam_l, wam_r):
         pass
-    elif w_xor := w_ltype.lookup_func("__xor__"):
+    elif w_xor := w_ltype.lookup_func(vm, "__xor__"):
         w_opspec = vm.fast_metacall(w_xor, [wam_l, wam_r])
     else:
         w_opspec = W_OpSpec.NULL
@@ -436,7 +436,7 @@ def w_EQ(vm: "SPyVM", wam_l: W_MetaArg, wam_r: W_MetaArg) -> W_OpImpl:
     w_rtype = wam_r.w_static_T
     if w_opspec := MM.get_binary_opspec("==", wam_l, wam_r):
         pass
-    elif w_eq := w_ltype.lookup_func("__eq__"):
+    elif w_eq := w_ltype.lookup_func(vm, "__eq__"):
         w_opspec = vm.fast_metacall(w_eq, [wam_l, wam_r])
     elif can_use_reference_eq(vm, w_ltype, w_rtype):
         w_opspec = W_OpSpec(OP.w_object_is)
@@ -459,7 +459,7 @@ def w_NE(vm: "SPyVM", wam_l: W_MetaArg, wam_r: W_MetaArg) -> W_OpImpl:
     w_rtype = wam_r.w_static_T
     if w_opspec := MM.get_binary_opspec("!=", wam_l, wam_r):
         pass
-    elif w_ne := w_ltype.lookup_func("__ne__"):
+    elif w_ne := w_ltype.lookup_func(vm, "__ne__"):
         w_opspec = vm.fast_metacall(w_ne, [wam_l, wam_r])
     elif can_use_reference_eq(vm, w_ltype, w_rtype):
         w_opspec = W_OpSpec(OP.w_object_isnot)
@@ -572,7 +572,7 @@ def w_LT(vm: "SPyVM", wam_l: W_MetaArg, wam_r: W_MetaArg) -> W_OpImpl:
     w_ltype = wam_l.w_static_T
     if w_opspec := MM.get_binary_opspec("<", wam_l, wam_r):
         pass
-    elif w_lt := w_ltype.lookup_func("__lt__"):
+    elif w_lt := w_ltype.lookup_func(vm, "__lt__"):
         w_opspec = vm.fast_metacall(w_lt, [wam_l, wam_r])
     else:
         w_opspec = W_OpSpec.NULL
@@ -588,7 +588,7 @@ def w_LE(vm: "SPyVM", wam_l: W_MetaArg, wam_r: W_MetaArg) -> W_OpImpl:
     w_ltype = wam_l.w_static_T
     if w_opspec := MM.get_binary_opspec("<=", wam_l, wam_r):
         pass
-    elif w_le := w_ltype.lookup_func("__le__"):
+    elif w_le := w_ltype.lookup_func(vm, "__le__"):
         w_opspec = vm.fast_metacall(w_le, [wam_l, wam_r])
     else:
         w_opspec = W_OpSpec.NULL
@@ -608,7 +608,7 @@ def w_GT(vm: "SPyVM", wam_l: W_MetaArg, wam_r: W_MetaArg) -> W_OpImpl:
     w_ltype = wam_l.w_static_T
     if w_opspec := MM.get_binary_opspec(">", wam_l, wam_r):
         pass
-    elif w_gt := w_ltype.lookup_func("__gt__"):
+    elif w_gt := w_ltype.lookup_func(vm, "__gt__"):
         w_opspec = vm.fast_metacall(w_gt, [wam_l, wam_r])
     else:
         w_opspec = W_OpSpec.NULL
@@ -624,7 +624,7 @@ def w_GE(vm: "SPyVM", wam_l: W_MetaArg, wam_r: W_MetaArg) -> W_OpImpl:
     w_ltype = wam_l.w_static_T
     if w_opspec := MM.get_binary_opspec(">=", wam_l, wam_r):
         pass
-    elif w_ge := w_ltype.lookup_func("__ge__"):
+    elif w_ge := w_ltype.lookup_func(vm, "__ge__"):
         w_opspec = vm.fast_metacall(w_ge, [wam_l, wam_r])
     else:
         w_opspec = W_OpSpec.NULL

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -39,7 +39,7 @@ def w_CALL(vm: "SPyVM", wam_obj: W_MetaArg, *args_wam: W_MetaArg) -> W_OpImpl:
 
     elif w_T is B.w_dynamic:
         w_opspec = W_OpSpec(OP.w_dynamic_call)
-    elif w_call := w_T.lookup_func("__call__"):
+    elif w_call := w_T.lookup_func(vm, "__call__"):
         w_opspec = vm.fast_metacall(w_call, newargs_wam)
 
     return typecheck_opspec(
@@ -62,7 +62,7 @@ def w_CALL_METHOD(
     meth = unwrap_name_maybe(vm, wam_meth)
 
     # if the type provides __call_method__, use it
-    if w_call_method := w_T.lookup_func("__call_method__"):
+    if w_call_method := w_T.lookup_func(vm, "__call_method__"):
         newargs_wam = [wam_obj, wam_meth] + list(args_wam)
         w_opspec = vm.fast_metacall(w_call_method, newargs_wam)
     else:
@@ -88,7 +88,7 @@ def default_callmethod(
     Default logic for call_method: look into the type dict
     """
     w_T = wam_obj.w_static_T
-    if w_func := w_T.dict_w.get(meth):
+    if w_func := w_T.lookup(vm, meth):
         # XXX: this should be turned into a proper exception, but for now we
         # cannot even write a test because we don't any way to inject
         # non-methods in the type dict

--- a/spy/vm/modules/operator/convop.py
+++ b/spy/vm/modules/operator/convop.py
@@ -86,11 +86,11 @@ def get_opspec(
     if w_opspec is not None:
         return w_opspec
 
-    elif w_conv_to := w_gotT.lookup_func("__convert_to__"):
+    elif w_conv_to := w_gotT.lookup_func(vm, "__convert_to__"):
         w_opspec = vm.fast_metacall(w_conv_to, [wam_expT, wam_gotT, wam_x])
         return w_opspec
 
-    elif w_conv_from := w_expT.lookup_func("__convert_from__"):
+    elif w_conv_from := w_expT.lookup_func(vm, "__convert_from__"):
         w_opspec = vm.fast_metacall(w_conv_from, [wam_expT, wam_gotT, wam_x])
         return w_opspec
 

--- a/spy/vm/modules/operator/itemop.py
+++ b/spy/vm/modules/operator/itemop.py
@@ -21,7 +21,7 @@ def w_GETITEM(vm: "SPyVM", wam_obj: W_MetaArg, *args_wam: W_MetaArg) -> W_OpImpl
     if isinstance(w_T, W_FuncType) and w_T.kind == "generic":
         # special case: for generic W_Funcs, "[]" means "call"
         w_opspec = w_T.pyclass.op_CALL(vm, wam_obj, *args_wam)  # type: ignore
-    elif w_getitem := w_T.lookup_func("__getitem__"):
+    elif w_getitem := w_T.lookup_func(vm, "__getitem__"):
         w_opspec = vm.fast_metacall(w_getitem, newargs_wam)
 
     return typecheck_opspec(
@@ -37,7 +37,7 @@ def w_SETITEM(vm: "SPyVM", wam_obj: W_MetaArg, *args_wam: W_MetaArg) -> W_OpImpl
     w_T = wam_obj.w_static_T
 
     newargs_wam = [wam_obj] + list(args_wam)
-    if w_setitem := w_T.lookup_func("__setitem__"):
+    if w_setitem := w_T.lookup_func(vm, "__setitem__"):
         w_opspec = vm.fast_metacall(w_setitem, newargs_wam)
 
     return typecheck_opspec(

--- a/spy/vm/modules/operator/unaryop.py
+++ b/spy/vm/modules/operator/unaryop.py
@@ -19,7 +19,7 @@ def w_NEG(vm: "SPyVM", wam_v: W_MetaArg) -> W_OpImpl:
     w_vtype = wam_v.w_static_T
     if w_opspec := MM.get_unary_opspec("-", wam_v):
         pass
-    elif w_neg := w_vtype.lookup_func("__neg__"):
+    elif w_neg := w_vtype.lookup_func(vm, "__neg__"):
         w_opspec = vm.fast_metacall(w_neg, [wam_v])
     else:
         w_opspec = W_OpSpec.NULL

--- a/spy/vm/modules/unsafe/mem.py
+++ b/spy/vm/modules/unsafe/mem.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Annotated
 
 from spy.errors import WIP
 from spy.vm.b import B
-from spy.vm.primitive import W_I32, W_Dynamic
+from spy.vm.primitive import W_I32, W_U8, W_Dynamic
 from spy.vm.str import W_Str
 from spy.vm.struct import W_Struct, W_StructType
 from spy.vm.w import W_Object, W_Type
@@ -86,6 +86,8 @@ def generic_mem_read(vm: "SPyVM", addr: int, w_T: W_Type) -> W_Object:
 
     if w_T is B.w_i32:
         return vm.wrap(vm.ll.mem.read_i32(addr))
+    elif w_T is B.w_u8:
+        return W_U8(vm.ll.mem.read_u8(addr))
     elif w_T is B.w_f64:
         return vm.wrap(vm.ll.mem.read_f64(addr))
     elif w_T is B.w_str:
@@ -116,6 +118,9 @@ def generic_mem_write(vm: "SPyVM", addr: int, w_T: W_Type, w_val: W_Object) -> N
     if w_T is B.w_i32:
         v = vm.unwrap_i32(w_val)
         vm.ll.mem.write_i32(addr, v)
+    elif w_T is B.w_u8:
+        assert isinstance(w_val, W_U8)
+        vm.ll.mem.write_u8(addr, int(w_val.value))
     elif w_T is B.w_f64:
         v = vm.unwrap_f64(w_val)
         vm.ll.mem.write_f64(addr, v)

--- a/spy/vm/modules/unsafe/misc.py
+++ b/spy/vm/modules/unsafe/misc.py
@@ -17,7 +17,7 @@ def sizeof(w_T: W_Type) -> int:
     elif isinstance(w_T, W_StructType):
         return w_T.size
     elif isinstance(w_T, W_PtrType) or w_T is B.w_str:
-        # w_str is a "spy_Str *" in C, so it's a pointer.
+        # w_str is a "spy_StrObject *" in C, so it's a pointer.
         #
         # XXX what is the right size of pointers? For wasm32 is 4 of course,
         # but for native it might be 8. Does it mean that we need to

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -523,3 +523,23 @@ def w_ptr_setfield(vm: "SPyVM", w_T: W_Type) -> W_Dynamic:
         vm.call_generic(UNSAFE.w_mem_write, [w_T], [vm.wrap(addr), w_val])
 
     return w_ptr_setfield_T
+
+
+@UNSAFE.builtin_func(color="blue", kind="metafunc")
+def w_as_StrObject(vm: "SPyVM", wam_s: W_MetaArg) -> W_OpSpec:
+    """
+    Convert an high-level `str` into low-level `gc_ptr[StrObject]`.
+
+    The struct StrObject is defined in stdlib/_str.spy.
+    """
+    w_StrObject = vm.lookup_global(FQN("_str::StrObject"))
+    assert isinstance(w_StrObject, W_StructType)
+    w_gc_ptr_StrObject = vm.getitem_w(w_gc_ptr, w_StrObject)
+    assert isinstance(w_gc_ptr_StrObject, W_PtrType)
+    GC_PTR = Annotated[W_Ptr, w_gc_ptr_StrObject]
+
+    @vm.register_builtin_func(UNSAFE.fqn)
+    def w_impl(vm: "SPyVM", w_s: W_Str) -> GC_PTR:
+        return W_Ptr(w_gc_ptr_StrObject, w_s.ptr, 1)
+
+    return W_OpSpec(w_impl, [wam_s])

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -460,7 +460,7 @@ class W_Ref(W_MemLoc):
         w_T = ref_T.w_itemT
 
         name = wam_name.blue_unwrap_str(vm)
-        w_meth = w_T.lookup(name)
+        w_meth = w_T.lookup(vm, name)
         if not isinstance(w_meth, W_ASTFunc):
             return W_OpSpec.NULL
         else:

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -538,7 +538,7 @@ def w_as_StrObject(vm: "SPyVM", wam_s: W_MetaArg) -> W_OpSpec:
     assert isinstance(w_gc_ptr_StrObject, W_PtrType)
     GC_PTR = Annotated[W_Ptr, w_gc_ptr_StrObject]
 
-    @vm.register_builtin_func(UNSAFE.fqn)
+    @vm.register_builtin_func(UNSAFE.fqn.join("as_StrObject"), "impl")
     def w_impl(vm: "SPyVM", w_s: W_Str) -> GC_PTR:
         return W_Ptr(w_gc_ptr_StrObject, w_s.ptr, 1)
 

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -269,7 +269,7 @@ class W_Object:
     def w_STR(vm: "SPyVM", wam_self: "W_MetaArg") -> "W_OpSpec":
         # default implementation: fallback to __repr__
         w_T = wam_self.w_static_T
-        if w_repr := w_T.lookup_func("__repr__"):
+        if w_repr := w_T.lookup_func(vm, "__repr__"):
             return vm.fast_metacall(w_repr, [wam_self])
 
         # this should never happen since we define __repr__ on W_Object
@@ -400,6 +400,22 @@ class W_Object:
         raise NotImplementedError("this should never be called")
 
 
+class W_LazyAttr(W_Object):
+    """
+    Special object stored in W_Type.dict_w for lazy loading stdlib methods.
+    See also __spy_lazy_attributes__.
+    """
+
+    __spy_storage_category__ = "reference"
+
+    def __init__(self, fqn: FQN) -> None:
+        self.fqn = fqn
+
+    def load(self, vm: "SPyVM") -> W_Object:
+        vm.import_(self.fqn.modname)
+        return vm.lookup_global(self.fqn)
+
+
 class W_Type(W_Object):
     """
     The default metaclass for SPy types.
@@ -511,6 +527,10 @@ class W_Type(W_Object):
                 self._init_builtin_method(value)
             elif isinstance(value, builtin_class_attr):
                 self._dict_w[value.name] = value.w_val
+
+        # process __spy_lazy_attributes__: store sentinels in dict_w
+        for name, fqn in getattr(pyclass, "__spy_lazy_attributes__", {}).items():
+            self._dict_w[name] = W_LazyAttr(fqn)
 
         # copy the content of extra_dict_w into our _dict_w
         if extra_dict_w:
@@ -679,34 +699,39 @@ class W_Type(W_Object):
             names.update(w_T.dict_w.keys())
         return names
 
-    def lookup(self, name: str) -> Optional[W_Object]:
+    def lookup(self, vm: "SPyVM", name: str) -> Optional[W_Object]:
         """
         Lookup the given attribute into the applevel dict
         """
         for w_T in self.get_mro():
             if w_obj := w_T.dict_w.get(name):
+                if isinstance(w_obj, W_LazyAttr):
+                    # always resolve through vm: W_Type is a singleton shared
+                    # across vm instances, so vm-specific objects must never
+                    # be cached back into dict_w.
+                    return w_obj.load(vm)
                 return w_obj
         return None
 
-    def lookup_func(self, name: str) -> Optional["W_Func"]:
+    def lookup_func(self, vm: "SPyVM", name: str) -> Optional["W_Func"]:
         """
         Like lookup, but ensure it's a W_Func.
         """
         from spy.vm.function import W_Func
 
-        w_obj = self.lookup(name)
+        w_obj = self.lookup(vm, name)
         if w_obj:
             assert isinstance(w_obj, W_Func)
             return w_obj
         return None
 
-    def lookup_blue_func(self, name: str) -> Optional["W_Func"]:
+    def lookup_blue_func(self, vm: "SPyVM", name: str) -> Optional["W_Func"]:
         """
         Like lookup_func, but also check that the function is blue
         """
         from spy.vm.function import W_Func
 
-        w_obj = self.lookup(name)
+        w_obj = self.lookup(vm, name)
         if w_obj:
             assert isinstance(w_obj, W_Func)
             assert w_obj.color == "blue"
@@ -757,17 +782,17 @@ class W_Type(W_Object):
         # 1. try to lookup the attribute on the metatype. If it's a
         # descriptor, call it.
         w_meta_T = vm.dynamic_type(w_T)
-        w_meta_attr = w_meta_T.lookup(name)
+        w_meta_attr = w_meta_T.lookup(vm, name)
         if w_meta_attr is not None:
-            if w_get := vm.dynamic_type(w_meta_attr).lookup_func("__get__"):
+            if w_get := vm.dynamic_type(w_meta_attr).lookup_func(vm, "__get__"):
                 wam_meta_attr = W_MetaArg.from_w_obj(vm, w_meta_attr)
                 return vm.fast_metacall(w_get, [wam_meta_attr, wam_T])
 
         # 2. Look in the __dict__ of this type and its bases
-        w_attr = w_T.lookup(name)
+        w_attr = w_T.lookup(vm, name)
         if w_attr is not None:
             # implement descriptor functionality, if any
-            if w_get := vm.dynamic_type(w_attr).lookup_func("__get__"):
+            if w_get := vm.dynamic_type(w_attr).lookup_func(vm, "__get__"):
                 raise WIP("implement me: descriptor accessed via class")
 
             # normal attribute in the class body, just return it
@@ -801,7 +826,7 @@ class W_Type(W_Object):
         assert isinstance(w_T, W_Type)
 
         # try to call __new__
-        if w_new := w_T.lookup_func("__new__"):
+        if w_new := w_T.lookup_func(vm, "__new__"):
             # this is a bit of ad-hoc logic around normal __new__ vs metafunc
             # __new__: when it's a metafunc we also want to pass the MetaArg of
             # the type itself (so that the function can reach
@@ -842,7 +867,7 @@ class W_Type(W_Object):
         w_T = wam_T.w_blueval
         assert isinstance(w_T, W_Type)
         name = wam_name.blue_unwrap_str(vm)
-        w_meth = w_T.lookup(name)
+        w_meth = w_T.lookup(vm, name)
         if w_meth is None:
             return W_OpSpec.NULL
 

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from spy.fqn import FQN
 from spy.libspy import LLSPyInstance
 from spy.vm.b import BUILTINS, OP, B
 from spy.vm.builtin import builtin_method
@@ -41,6 +42,10 @@ class W_Str(W_Object):
     """
 
     __spy_storage_category__ = "value"
+    __spy_lazy_attributes__ = {
+        "isascii": FQN("_str::methods::isascii"),
+    }
+
     vm: "SPyVM"
     ptr: int
 
@@ -87,7 +92,7 @@ class W_Str(W_Object):
             w_T = wam_arg.w_static_T
             if w_T is B.w_dynamic:
                 return W_OpSpec(OP.w_dynamic_str, [wam_arg])
-            if w_fn := w_T.lookup_func("__str__"):
+            if w_fn := w_T.lookup_func(vm, "__str__"):
                 w_opspec = vm.fast_metacall(w_fn, [wam_arg])
                 return w_opspec
 

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -11,12 +11,12 @@ if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
 
-def ll_spy_Str_new(ll: LLSPyInstance, s: str) -> int:
+def ll_str_new(ll: LLSPyInstance, s: str) -> int:
     """
-    Create a new spy_Str object inside the given LLWasmInstance, and fill it
+    Create a new spy_StrObject object inside the given LLWasmInstance, and fill it
     with the utf8-encoded content of s.
 
-    Return the corresponding 'spy_Str *'
+    Return the corresponding 'spy_StrObject *'
     """
     utf8 = s.encode("utf-8")
     length = len(utf8)
@@ -31,13 +31,13 @@ class W_Str(W_Object):
     """
     An unicode string, internally represented as UTF-8.
 
-    This is basically a 'spy_Str *', i.e. a pointer to a C struct which
+    This is basically a 'spy_StrObject *', i.e. a pointer to a C struct which
     resides in the linear memory of the VM:
         typedef struct {
             size_t length;
             int32_t hash;
             const char utf8[];
-        } spy_Str;
+        } spy_StrObject;
     """
 
     __spy_storage_category__ = "value"
@@ -45,7 +45,7 @@ class W_Str(W_Object):
     ptr: int
 
     def __init__(self, vm: "SPyVM", s: str) -> None:
-        ptr = ll_spy_Str_new(vm.ll, s)
+        ptr = ll_str_new(vm.ll, s)
         self.vm = vm
         self.ptr = ptr
 

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from spy.llwasm import LLWasmInstance
+from spy.libspy import LLSPyInstance
 from spy.vm.b import BUILTINS, OP, B
 from spy.vm.builtin import builtin_method
 from spy.vm.object import W_Object, W_Type
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
 
-def ll_spy_Str_new(ll: LLWasmInstance, s: str) -> int:
+def ll_spy_Str_new(ll: LLSPyInstance, s: str) -> int:
     """
     Create a new spy_Str object inside the given LLWasmInstance, and fill it
     with the utf8-encoded content of s.
@@ -21,7 +21,8 @@ def ll_spy_Str_new(ll: LLWasmInstance, s: str) -> int:
     utf8 = s.encode("utf-8")
     length = len(utf8)
     ptr = ll.call("spy_str_alloc", length)
-    ll.mem.write(ptr + 8, utf8)
+    utf8_ptr = ll.mem.read_i32(ptr + ll.str_layout.utf8_offset)
+    ll.mem.write(utf8_ptr, utf8)
     return ptr
 
 
@@ -56,12 +57,12 @@ class W_Str(W_Object):
         return w_res
 
     def get_length(self) -> int:
-        return self.vm.ll.mem.read_i32(self.ptr)
+        ll = self.vm.ll
+        return ll.mem.read_i32(self.ptr + ll.str_layout.length_offset)
 
     def get_utf8(self) -> bytes:
-        length = self.get_length()
-        ba = self.vm.ll.mem.read(self.ptr + 8, length)
-        return bytes(ba)
+        _, _, utf8 = self.vm.ll.read_str(self.ptr)
+        return utf8
 
     def _as_str(self) -> str:
         return self.get_utf8().decode("utf-8")

--- a/stdlib/_str.spy
+++ b/stdlib/_str.spy
@@ -1,0 +1,9 @@
+from unsafe import gc_ptr
+
+
+# this MUST stay in sync with the equivalent struct declared in str.h
+@struct
+class StrObject:
+    length: i32
+    hash: i32
+    utf8: gc_ptr[u8]

--- a/stdlib/_str.spy
+++ b/stdlib/_str.spy
@@ -1,4 +1,4 @@
-from unsafe import gc_ptr
+from unsafe import gc_ptr, as_StrObject
 
 
 # this MUST stay in sync with the equivalent struct declared in str.h
@@ -7,3 +7,28 @@ class StrObject:
     length: i32
     hash: i32
     utf8: gc_ptr[u8]
+
+
+@struct
+class methods:
+    """
+    This is a special "fake" empty struct.
+
+    It is used solely as a container for str methods defined at applevel, which are
+    referenced by W_Str.lazy_attributes.
+
+    Because of that, the 'self' must be manually annotated with the `str` type.
+    """
+
+    # each method defined here should also have a corresponding entry in
+    # W_Str.__spy_lazy_attributes__.
+
+    def isascii(self: str) -> bool:
+        ll = as_StrObject(self)
+        i = 0
+        max_ascii: u8 = 127
+        while i < ll.length:
+            if ll.utf8[i] > max_ascii:
+                return False
+            i = i + 1
+        return True


### PR DESCRIPTION
Add the necessary plumbing to write parts of `str` methods at applevel, while keeping the `str` type as builtin.

The prerequisite was to change the low-level C layout of `str`: earlier it used a flexible array member (which is not yet supported by SPy structs), now it uses an explicit `->uft8` pointer. `spy_str_alloc` still allocates everything in one allocation, so the repr is still compact.

Then we have `unsafe.as_StrObject`, which "casts" an `str` into a `gc_ptr[StrObject]`: this makes it possible to view and manipulate the low-level layout of strings from applevel.

Finally, we have "lazy attributes": this makes it possible to add applevel methods to `str.__dict__`: on the first access, they will import `stdlib/_str.spy` and resolve to the given function.

Implement `str.isascii` at applevel as an example of all of that.