### PR TITLE
Turn `@struct` assert into WIP Error 

### DIFF
--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -412,7 +412,12 @@ class AbstractFrame:
         if classdef.kind == "struct":
             return W_StructType
         else:
-            assert False, "only @struct classes are supported for now"
+            raise SPyError.simple(
+                "W_WIP",
+                "only @struct classes are supported for now",
+                "class defined here",
+                classdef.loc,
+            )
 
     def fwdecl_ClassDef(self, classdef: ast.ClassDef) -> None:
         """


### PR DESCRIPTION
Small change - since the error that `only @struct classes are permitted` is visible to users, it's nicer to have as an Error rather than a bare assert.