### PR TITLE
Docs for `@blue.generic` and Generic Class syntax

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
   - contributing.md
   - Language features:
     - howto/main_function.md
+    - howto/generics.md
   - API Reference:
     - api_reference/python_builtins.md
     - api_reference/spy_builtins.md

--- a/docs/src/howto/generics.md
+++ b/docs/src/howto/generics.md
@@ -1,0 +1,85 @@
+title: Generic Functions and Types
+---
+
+<!-- See https://github.com/spylang/spy/pull/519 and https://github.com/spylang/spy/pull/448-->
+
+
+
+Geneic 
+
+
+### Generic Functions
+
+Functions decorated with [@blue.generic](../api_reference/spy_builtins.md#bluegeneric) are called with `[]` brackets instead of parentheses. These *may* be used anywhere, but they are intended to help create functions that look like [PEP 695](https://peps.python.org/pep-0695/) functions with type parameters:
+
+```python
+  @blue.generic
+  def add(T):
+      def impl(x:T, y: T) -> T:
+          return x + y
+      return impl
+
+  def main() -> None:
+      print(add[i32](1, 2))
+      print(add[str]('hello ', 'world'))
+```
+
+### Generic Types
+
+`struct` classes may also be constructed with a type parameter, which is.... At an implementation level, the class syntax syntactic sugar:
+
+```py
+@struct
+class MyList[T]:
+    inner: list[T]
+
+# ^^^ is syntactic sugar for vvv
+
+@blue.generic
+def MyList(T):
+    @struct
+    class Self:
+        inner: list[T]
+
+    return Self
+```
+
+### \_\_origin\_\_
+
+Objects in SPy have an `__origin__` attribute, which defaults to `None`. When a `type` or `function` defined inside a `blue.generic` function is returned, it's `__origin__` is set to that generic function (if it wasn't already set by something else).
+
+```py
+@blue.generic
+def adder(T):
+    @struct
+    class impl:
+         ...
+
+    return impl
+
+
+assert adder[T].__origin__ is adder
+```
+
+This is a straightforward way to identify that `MyList[T]` is a 'specialised' version of `MyList` on the type `T`.
+
+This also works with generic classes:
+
+```py
+@struct
+class MyType[T]:
+    inner: list[T]
+
+assert MyList[T].__origin__ is MyList
+```
+
+
+<!-- 
+
+The __origin__ is set ONLY:
+
+upon returning something from a @blue.generic function
+if the returned value was defined INSIDE the function
+if the __origin__ has not been set already
+
+-->

--- a/docs/src/howto/generics.md
+++ b/docs/src/howto/generics.md
@@ -18,7 +18,7 @@ def main() -> None:
     print(add[str]('hello ', 'world'))
 ```
 
-Like all functions marked `@blue`, the generic function is guarenteed to be executed at compile-time. We can see in the redshifted version of the above code that `add()` no longer appears, but the two specialized versions of it remain:
+Like all functions marked `@blue`, the generic function is guaranteed to be executed at compile-time. We can see in the redshifted version of the above code that `add()` no longer appears, but the two specialized versions of it remain:
 
 <!-- Colorful code formatted by ansi2html -->
 <style type="text/css">

--- a/docs/src/howto/generics.md
+++ b/docs/src/howto/generics.md
@@ -7,16 +7,41 @@ title: Generic Functions and Types
 Functions decorated with [@blue.generic](../api_reference/spy_builtins.md#bluegeneric) are called with `[]` brackets instead of parentheses. These *may* be used anywhere, but they are intended to help create functions that look like [PEP 695](https://peps.python.org/pep-0695/) functions with type parameters:
 
 ```python
-  @blue.generic
-  def add(T):
-      def impl(x:T, y: T) -> T:
-          return x + y
-      return impl
+@blue.generic
+def add(T):
+    def impl(x:T, y: T) -> T:
+        return x + y
+    return impl
 
-  def main() -> None:
-      print(add[i32](1, 2))
-      print(add[str]('hello ', 'world'))
+def main() -> None:
+    print(add[i32](1, 2))
+    print(add[str]('hello ', 'world'))
 ```
+
+Like all functions marked `@blue`, the generic function is guarenteed to be executed at compile-time. We can see in the redshifted version of the above code that `add()` no longer appears, but the two specialized versions of it remain:
+
+<!-- Colorful code formatted by ansi2html -->
+<style type="text/css">
+.ansi2html-content { display: block; white-space: pre-wrap; word-wrap: break-word; font-size: .85em; padding:1.1em; corner-radius: 0.1em}
+.ansi1 { font-weight: bold; }
+.ansi32 { color: #00aa00; }
+.ansi33 { color: #aa5500; }
+.ansi34 { color: #0000aa; }
+.ansi35 { color: #E850A8; }
+</style>
+<div class="body_background" style="background-color:rgb(245, 245, 245);">
+<pre class="ansi2html-content">
+<span class="ansi1 ansi34">def</span> main() -&gt; <span class="ansi1 ansi34">None</span>:
+    <span class="ansi1 ansi35">`_print::println[i32]::p`</span>(<span class="ansi1 ansi35">`t::add[i32]::impl`</span>(<span class="ansi1 ansi33">1</span>, <span class="ansi1 ansi33">2</span>))
+    <span class="ansi1 ansi35">`_print::println[str]::p`</span>(<span class="ansi1 ansi35">`t::add[str]::impl`</span>(<span class="ansi1 ansi32">'hello '</span>, <span class="ansi1 ansi32">'world'</span>))
+
+<span class="ansi1 ansi34">def</span> <span class="ansi1 ansi35">`t::add[i32]::impl`</span>(x: <span class="ansi1 ansi35">i32</span>, y: <span class="ansi1 ansi35">i32</span>) -&gt; <span class="ansi1 ansi35">i32</span>:
+    <span class="ansi1 ansi34">return</span> x + y
+
+<span class="ansi1 ansi34">def</span> <span class="ansi1 ansi35">`t::add[str]::impl`</span>(x: <span class="ansi1 ansi35">str</span>, y: <span class="ansi1 ansi35">str</span>) -&gt; <span class="ansi1 ansi35">str</span>:
+    <span class="ansi1 ansi34">return</span> <span class="ansi1 ansi35">`operator::str_add`</span>(x, y)
+</pre>
+</div>
 
 ### Generic Types
 
@@ -60,7 +85,7 @@ def main() -> None:
 
 ### `__origin__`
 
-Objects in SPy have an `__origin__` attribute, which defaults to `None`. When a `type` or `function` defined inside a `blue.generic` function is returned, it's `__origin__` is set to that generic function (if it wasn't already set by something else).
+The `__origin__` attribute of SPy objects carries information about the generic function which created them, if any. When `blue.generic` defines a `type` or `function` and returns it, the returned object has it's `__origin__` is set to the generic function:
 
 ```py
 @blue.generic
@@ -75,7 +100,9 @@ def adder(T):
 assert adder[T].__origin__ is adder
 ```
 
-This is a straightforward way to identify that `MyList[T]` is a 'specialised' version of `MyList` on the type `T`.
+This is a straightforward way to identify that, for example, `MyList[T]` is a 'specialised' version of `MyList` on the type `T`.
+
+(The default value for `__origin__` is None. If the object returned by a generic function already has a non-`None` origin, that origin will *not* be overwritten.)
 
 This also works with generic classes:
 

--- a/docs/src/howto/generics.md
+++ b/docs/src/howto/generics.md
@@ -26,6 +26,8 @@ Functions decorated with [@blue.generic](../api_reference/spy_builtins.md#bluege
 @struct
 class MyList[T]:
     inner: list[T]
+    other_param_1: ...
+    other_param_2: ...
 
 # ^^^ is syntactic sugar for vvv
 
@@ -34,6 +36,8 @@ def MyList(T):
     @struct
     class Self:
         inner: list[T]
+        other_param_1: ...
+        other_param_2: ...
 
     return Self
 ```
@@ -42,18 +46,19 @@ In use, this looks like:
 
 ```py
 @struct
-class MyList[T]:
-    inner: list[T]
+class MyAnnotatedList[T]:
+    name: str
+    data: list[T]
 
-  def main() -> None:
-    my_int_list = MyList[i32]()
-    my_int_list.append(123)
+def main() -> None:
+    my_int_list = MyList[i32]("profits", [])
+    my_int_list.data.append(1)
 
-    my_str_list = MyList[str]()
-    my_str_list.extend(["hello", "world"])
+    my_str_list = MyList[str]("words", ["hello", "world"])
+    my_str_list.data.extend(["and", "goodbye"])
 ```
 
-### \_\_origin\_\_
+### `__origin__`
 
 Objects in SPy have an `__origin__` attribute, which defaults to `None`. When a `type` or `function` defined inside a `blue.generic` function is returned, it's `__origin__` is set to that generic function (if it wasn't already set by something else).
 
@@ -81,14 +86,3 @@ class MyType[T]:
 
 assert MyList[T].__origin__ is MyList
 ```
-
-
-<!-- 
-
-The __origin__ is set ONLY:
-
-upon returning something from a @blue.generic function
-if the returned value was defined INSIDE the function
-if the __origin__ has not been set already
-
--->

--- a/docs/src/howto/generics.md
+++ b/docs/src/howto/generics.md
@@ -23,7 +23,6 @@ Like all functions marked `@blue`, the generic function is guarenteed to be exec
 <!-- Colorful code formatted by ansi2html -->
 <style type="text/css">
 .ansi2html-content { display: block; white-space: pre-wrap; word-wrap: break-word; font-size: .85em; padding:1.1em; corner-radius: 0.1em}
-.ansi1 { font-weight: bold; }
 .ansi32 { color: #00aa00; }
 .ansi33 { color: #aa5500; }
 .ansi34 { color: #0000aa; }
@@ -31,15 +30,15 @@ Like all functions marked `@blue`, the generic function is guarenteed to be exec
 </style>
 <div class="body_background" style="background-color:rgb(245, 245, 245);">
 <pre class="ansi2html-content">
-<span class="ansi1 ansi34">def</span> main() -&gt; <span class="ansi1 ansi34">None</span>:
-    <span class="ansi1 ansi35">`_print::println[i32]::p`</span>(<span class="ansi1 ansi35">`t::add[i32]::impl`</span>(<span class="ansi1 ansi33">1</span>, <span class="ansi1 ansi33">2</span>))
-    <span class="ansi1 ansi35">`_print::println[str]::p`</span>(<span class="ansi1 ansi35">`t::add[str]::impl`</span>(<span class="ansi1 ansi32">'hello '</span>, <span class="ansi1 ansi32">'world'</span>))
+<span class="ansi34">def</span> main() -&gt; <span class="ansi34">None</span>:
+    <span class="ansi35">`_print::println[i32]::p`</span>(<span class="ansi35">`t::add[i32]::impl`</span>(<span class="ansi33">1</span>, <span class="ansi33">2</span>))
+    <span class="ansi35">`_print::println[str]::p`</span>(<span class="ansi35">`t::add[str]::impl`</span>(<span class="ansi32">'hello '</span>, <span class="ansi32">'world'</span>))
 
-<span class="ansi1 ansi34">def</span> <span class="ansi1 ansi35">`t::add[i32]::impl`</span>(x: <span class="ansi1 ansi35">i32</span>, y: <span class="ansi1 ansi35">i32</span>) -&gt; <span class="ansi1 ansi35">i32</span>:
-    <span class="ansi1 ansi34">return</span> x + y
+<span class="ansi34">def</span> <span class="ansi35">`t::add[i32]::impl`</span>(x: <span class="ansi35">i32</span>, y: <span class="ansi35">i32</span>) -&gt; <span class="ansi35">i32</span>:
+    <span class="ansi34">return</span> x + y
 
-<span class="ansi1 ansi34">def</span> <span class="ansi1 ansi35">`t::add[str]::impl`</span>(x: <span class="ansi1 ansi35">str</span>, y: <span class="ansi1 ansi35">str</span>) -&gt; <span class="ansi1 ansi35">str</span>:
-    <span class="ansi1 ansi34">return</span> <span class="ansi1 ansi35">`operator::str_add`</span>(x, y)
+<span class="ansi34">def</span> <span class="ansi35">`t::add[str]::impl`</span>(x: <span class="ansi35">str</span>, y: <span class="ansi35">str</span>) -&gt; <span class="ansi35">str</span>:
+    <span class="ansi34">return</span> <span class="ansi35">`operator::str_add`</span>(x, y)
 </pre>
 </div>
 
@@ -71,15 +70,15 @@ In use, this looks like:
 
 ```py
 @struct
-class MyAnnotatedList[T]:
+class MyNamedList[T]:
     name: str
     data: list[T]
 
 def main() -> None:
-    my_int_list = MyList[i32]("profits", [])
-    my_int_list.data.append(1)
+    my_int_list = MyNamedList[i32]("profits", [])
+    my_int_list.data.append(1_000_000)
 
-    my_str_list = MyList[str]("words", ["hello", "world"])
+    my_str_list = MyNamedList[str]("words", ["hello", "world"])
     my_str_list.data.extend(["and", "goodbye"])
 ```
 
@@ -97,19 +96,21 @@ def adder(T):
     return impl
 
 
-assert adder[T].__origin__ is adder
+def main() -> None:
+    assert adder[T].__origin__ is adder
 ```
 
 This is a straightforward way to identify that, for example, `MyList[T]` is a 'specialised' version of `MyList` on the type `T`.
 
 (The default value for `__origin__` is None. If the object returned by a generic function already has a non-`None` origin, that origin will *not* be overwritten.)
 
-This also works with generic classes:
+This also works with the generic class syntax:
 
 ```py
 @struct
-class MyType[T]:
+class MyList[T]:
     inner: list[T]
 
-assert MyList[T].__origin__ is MyList
+def main() -> None:
+    assert MyList[i32].__origin__ is MyList
 ```

--- a/docs/src/howto/generics.md
+++ b/docs/src/howto/generics.md
@@ -42,9 +42,9 @@ Like all functions marked `@blue`, the generic function is guarenteed to be exec
 </pre>
 </div>
 
-### Generic Types
+### Generic Class Syntax
 
-`struct` classes may also be created with one or more parameters in `[]` brackets. This is different from passing superclasses inside of `()` parentheses; rather, this is syntactic sugar for a generic function with an inner `struct` class than can make use of those parameters:
+`@struct` classes may also be created with one or more parameters in `[]` brackets. This is different from passing superclasses inside of `()` parentheses; rather, this is syntactic sugar for a generic function with an inner `@struct` class than can make use of those parameters:
 
 ```py
 @struct
@@ -53,7 +53,7 @@ class MyList[T]:
     other_param_1: ...
     other_param_2: ...
 
-# ^^^ is syntactic sugar for vvv
+# ↑ is syntactic sugar for ↓
 
 @blue.generic
 def MyList(T):
@@ -82,6 +82,8 @@ def main() -> None:
     my_str_list.data.extend(["and", "goodbye"])
 ```
 
+For a larger example, see the `myarray` example [on GitHub](https://github.com/spylang/spy/blob/main/examples/myarray.spy) or [run it in the SPy Playground](https://spylang.github.io/spy/#code=eJydVcFO40AMvecrrHBpdiGiwHKoFsRKcOCCkOCyQlVkEqed3XQmmplQytevJ5OmkzZIK6oeEnv8bL9nT-I4jp6XwgD_lSRQJdglwUoZC1i8ocypAHrHVV2Rcd6nxw0YBSXqNIruLQjnWZG0pg18RSPy9iDCgiRpkQNqjRuwm5qi6EFZ4oNowVjd5JxEE9RoDKd53cAbVg3nmYiUUshVLahI0ijmIqNSqxU00mBJLqnSFhZ5hlWl8mP3VFsdRdGNh43yijHhl8t8ixZfbp9_P97NZxHwryK5sMsZiPOz9j3HGnNhNzuLsLQysw61i2XweEvWtjOfhQ1_GubLbKTF3LLdNAvUUCqu6OaVO0q7gKigclfUpAVOfFHbwtuCWtgnqkrvGyt6vPDPi3ceTbbRsgUOlXC6SVz14udK5nyUWslcd1itcWMgdoFxJ8cY09NiwPMRo3F0J7TDcQYJH6TVSe4mbK2xrknzEKhGFm3yOMuqKstiqJWQlnQKz2xlWhusoGDWHNCSsD5ppUdLRdpm83F93_vSdxQcgeS-Z4yg6bhlgtvVmkytZMEjrEYYGPaWeiCnZJZJWmfZJNAmgZPrPeWOuO-uGcZfoy78qvi1cC3tRK7gqp_qwxYm0yQ4mvq0HOEfQtd2Mkad7YCEiTx818YuheAzp_3beikqngb4uR3F3hPCvoj5IGqLI-A7THtrMIhplq3wLzkWq2RHrZsLWUwMnzj2t8IM_Lo4gh_4qpoNWTMey83AroEyoOn6KiRmWP0RV2TEB68BUcE30QkUqnmtyA9DFzKIcMKHJAeUf4OzYfvl3mnmZ5h-BHB6kO0z1cLAZK8rvkE3fHsLY4Vc-IvhQJmhVoHKW-bGaw3UDrQ_OHqovVesH8Iea_9AQEbYYnQwyS99pa6YdlbGt6R_duUES7wg64B4BP24id0mtxz_36SJbsLGSNMoDMG9LOj9Tmv-LPQOvwghg0FhZrQw3oev7cKXKhwu9htf_K62FQo52UuPWVkptE7U7Y1ZXl7wpXWadH4hB17uZT65CJ0vp_N-9jvL1FnOQsuZs5yHlnNnuQgsaXd9_EhGjJfeyF9nZoQ_Rxrlgti6I6TWfH7SgYt5Ev0DKx6k_A==)
+
 ### `__origin__`
 
 The `__origin__` attribute of SPy objects carries information about the generic function which created them, if any. When `blue.generic` defines a `type` or `function` and returns it, the returned object has it's `__origin__` is set to the generic function:
@@ -102,9 +104,9 @@ def main() -> None:
 
 This is a straightforward way to identify that, for example, `MyList[T]` is a 'specialised' version of `MyList` on the type `T`.
 
-(The default value for `__origin__` is None. If the object returned by a generic function already has a non-`None` origin, that origin will *not* be overwritten.)
+(The default value for `__origin__` is `None`. If the object returned by a generic function already has a non-`None` origin, that origin will *not* be overwritten.)
 
-This also works with the generic class syntax:
+The `__origin__` functions identically with the Generic Class syntax described above:
 
 ```py
 @struct

--- a/docs/src/howto/generics.md
+++ b/docs/src/howto/generics.md
@@ -1,12 +1,6 @@
 title: Generic Functions and Types
 ---
-
 <!-- See https://github.com/spylang/spy/pull/519 and https://github.com/spylang/spy/pull/448-->
-
-
-
-Geneic 
-
 
 ### Generic Functions
 
@@ -26,7 +20,7 @@ Functions decorated with [@blue.generic](../api_reference/spy_builtins.md#bluege
 
 ### Generic Types
 
-`struct` classes may also be constructed with a type parameter, which is.... At an implementation level, the class syntax syntactic sugar:
+`struct` classes may also be created with one or more parameters in `[]` brackets. This is different from passing superclasses inside of `()` parentheses; rather, this is syntactic sugar for a generic function with an inner `struct` class than can make use of those parameters:
 
 ```py
 @struct
@@ -42,6 +36,21 @@ def MyList(T):
         inner: list[T]
 
     return Self
+```
+
+In use, this looks like:
+
+```py
+@struct
+class MyList[T]:
+    inner: list[T]
+
+  def main() -> None:
+    my_int_list = MyList[i32]()
+    my_int_list.append(123)
+
+    my_str_list = MyList[str]()
+    my_str_list.extend(["hello", "world"])
 ```
 
 ### \_\_origin\_\_


### PR DESCRIPTION
Here's an attempt at some documentation on `@blue.generic`, and the generic class syntax just merged in #448 (yay!)

Like some of the other docs, this page probably does a little more 'storytelling' than it finally wants to - when there are broader conceptual pages on "What is Redshifting" etc., this can probably get tighter. =)

It also felt a bit odd to be documenting decoratings on `@struct` classes when there's not currently a page for that - another project for the near future.