### PR TITLE
Fix flaky test_zeros by zeroing array content in zeros()

### DIFF
--- a/stdlib/array.spy
+++ b/stdlib/array.spy
@@ -197,7 +197,16 @@ def zeros(DTYPE):
             ArrayT = array[DTYPE, 1]
 
             def impl(n: i32) -> ArrayT:
-                return ArrayT(n)
+                a = ArrayT(n)
+                # XXX: this loop is a temporary workaround. gc_alloc does not
+                # zero memory, so we zero the array element-by-element here.
+                # Eventually we should have a gc_alloc_zero (or similar) which
+                # returns zeroed memory, and use it for the underlying buffer.
+                i = 0
+                while i < n:
+                    a[i] = DTYPE(0)
+                    i = i + 1
+                return a
 
             return OpSpec(impl)
 


### PR DESCRIPTION
## Summary
- The `zeros` constructor in `stdlib/array.spy` was not actually zeroing the array — it just allocated a buffer via `gc_alloc`, which does not guarantee zeroed memory.
- `test_zeros` happened to pass when the underlying `malloc` returned zeroed pages, and failed otherwise (e.g. on PR #525's CI).
- Until we have a proper `gc_alloc_zero`, this PR zeroes the array element-by-element in the `zeros` constructor and adds a comment explaining the workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)