### PR TITLE
draft: Generic class type alias

### DIFF
--- a/examples/myarray.spy
+++ b/examples/myarray.spy
@@ -35,14 +35,18 @@ Note that the name of the concrete type is always "Self".
 
 @struct
 class Array1d[DTYPE]:
+
+    # just a local type alias
+    type ArrData = ArrayData[DTYPE]
+
     # this struct is a thin zero-cost wrapper around the "__ll__" pointer. The actual data is heap-allocated.
-    __ll__: gc_ptr[ArrayData[DTYPE]]
+    __ll__: gc_ptr[ArrData]
 
     # note: here, Self corresponds to the concrete type Array1d[DTYPE].
 
     def __new__(length: i32) -> Self:
         # a pointer towards the array data
-        ll = gc_alloc[ArrayData[DTYPE]](1)
+        ll = gc_alloc[ArrData](1)
         ll.length = length
         ll.capacity = length
         ll.items = gc_alloc[DTYPE](length)

--- a/spy/analyze/scope.py
+++ b/spy/analyze/scope.py
@@ -372,6 +372,10 @@ class ScopeAnalyzer:
         self.inner_scopes[gclassdef] = inner_scope
         for arg in gclassdef.args:
             self.define_name(arg.name, "const", "blue-param", arg.loc, arg.type.loc)
+        for alias in gclassdef.type_aliases:
+            self.define_name(
+                alias.name.value, "const", "type-alias", alias.loc, alias.value.loc
+            )
         self.define_name("Self", "const", "classdef", loc, loc)
         self.define_name("@return", "var", "auto", loc, loc)
         self.declare(gclassdef.inner)
@@ -548,6 +552,8 @@ class ScopeAnalyzer:
             self.flatten(arg)
         inner_scope = self.by_generic_classdef(gclassdef)
         self.push_scope(inner_scope)
+        for alias in gclassdef.type_aliases:
+            self.flatten(alias.value)
         self.flatten_ClassDef(gclassdef.inner)
         self.pop_scope()
         gclassdef.symtable = inner_scope

--- a/spy/analyze/symtable.py
+++ b/spy/analyze/symtable.py
@@ -43,6 +43,7 @@ VarKindOrigin = Literal[
     "class-field",   # class field declarations are always "var"
     "red-param",     # parameters of red functions are "var"
     "blue-param",    # parameters of blue functions are "const"
+    "type-alias",    # `type X = ...` inside a GenericClassDef
 ]  # fmt: skip
 
 # each ScopeKind corresponds to a different Frame for evaluation: ModFrame, ClassFrame,

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -632,6 +632,20 @@ class ClassDef(Stmt):
 
 
 @astnode
+class TypeAlias(Stmt):
+    """
+    A type alias inside a GenericClassDef body, e.g.:
+
+        type ptr_T = gc_ptr[DTYPE]
+
+    Only valid inside a GenericClassDef; the parser rejects it elsewhere.
+    """
+
+    name: StrConst
+    value: "Expr"
+
+
+@astnode
 class GenericClassDef(Stmt):
     """
     If you have this:
@@ -642,10 +656,15 @@ class GenericClassDef(Stmt):
             y: T
 
     Then GenericClassDef represents the "outer" function. Its argument list contains "T".
+
+    Type aliases (e.g. `type ptr_T = gc_ptr[DTYPE]`) are stored separately in
+    `type_aliases` rather than in `inner.body`, since they belong to the outer
+    (blue) scope, not to the struct body.
     """
 
     name: str
     args: list[FuncArg]
+    type_aliases: list[TypeAlias]
     inner: ClassDef
     symtable: Any = field(repr=False, default=None)
 

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -364,7 +364,8 @@ class Parser:
         # generic arguments: class Cls[T]()
         if py_classdef.type_params:
             generic_args = self._parse_type_params(py_classdef)
-            type_aliases, inner_classdef = self._parse_py_generic_classdef(py_classdef)
+            type_aliases: list[spy.ast.TypeAlias] = []
+            inner_classdef = self._parse_py_classdef(py_classdef, type_aliases)
             inner_classdef.name = "Self"
             return spy.ast.GenericClassDef(
                 loc=py_classdef.loc,
@@ -376,60 +377,6 @@ class Parser:
 
         return self._parse_py_classdef(py_classdef)
 
-    def _parse_py_generic_classdef(
-        self, py_classdef: py_ast.ClassDef
-    ) -> tuple[list[spy.ast.TypeAlias], spy.ast.ClassDef]:
-        """
-        Parse a generic class body, separating `type X = ...` aliases from
-        field declarations. Returns (type_aliases, inner_classdef).
-        """
-        docstring, py_class_body = self.get_docstring_maybe(py_classdef.body)
-
-        type_aliases: list[spy.ast.TypeAlias] = []
-        body: list[spy.ast.Stmt] = []
-        for py_stmt in py_class_body:
-            if isinstance(py_stmt, py_ast.TypeAlias):
-                name_node = py_stmt.name
-                assert isinstance(name_node, py_ast.Name)
-                type_aliases.append(
-                    spy.ast.TypeAlias(
-                        loc=py_stmt.loc,
-                        name=spy.ast.StrConst(
-                            loc=name_node.loc, value=name_node.id
-                        ),
-                        value=self.from_py_expr(py_stmt.value),
-                    )
-                )
-            elif isinstance(py_stmt, py_ast.AnnAssign):
-                body.append(self.from_py_AnnAssign(py_stmt))
-            else:
-                body.append(self.from_py_stmt(py_stmt))
-
-        # determine kind from decorators (same logic as _parse_py_classdef)
-        struct_loc: Optional[Loc] = None
-        for py_deco in py_classdef.decorator_list:
-            if is_py_Name(py_deco, "struct"):
-                struct_loc = py_deco.loc
-            else:
-                self.error(
-                    "class decorators not supported yet",
-                    "this is not supported",
-                    py_deco.loc,
-                )
-        kind: spy.ast.ClassKind = "struct" if struct_loc else "class"
-
-        body_loc = py_classdef.loc
-        loc = body_loc.replace(line_end=body_loc.line_start, col_end=-1)
-        inner = spy.ast.ClassDef(
-            loc=loc,
-            body_loc=body_loc,
-            name=py_classdef.name,
-            kind=kind,
-            body=body,
-            docstring=docstring,
-        )
-        return type_aliases, inner
-
     def from_py_stmt_TypeAlias(self, py_node: py_ast.TypeAlias) -> spy.ast.Stmt:
         self.error(
             "`type` aliases are only supported inside generic classes",
@@ -437,9 +384,22 @@ class Parser:
             py_node.loc,
         )
 
-    def _parse_py_classdef(self, py_classdef: py_ast.ClassDef) -> spy.ast.ClassDef:
-        # decorators are not supported yet, but @struct and @typelif are
-        # special-cased
+    def _parse_py_classdef(
+        self,
+        py_classdef: py_ast.ClassDef,
+        type_aliases: Optional[list[spy.ast.TypeAlias]] = None,
+    ) -> spy.ast.ClassDef:
+        """
+        Parse a ClassDef node.
+
+        If `type_aliases` is provided, `type X = ...` statements in the body
+        are collected there instead of the returned ClassDef body.  This is
+        used when parsing the inner class of a GenericClassDef, where type
+        aliases belong to the outer (blue) scope.
+        When `type_aliases` is None, encountering a TypeAlias raises an error
+        via the normal from_py_stmt dispatch.
+        """
+        # decorators are not supported yet, but @struct is special-cased
         struct_loc: Optional[Loc] = None
         for py_deco in py_classdef.decorator_list:
             if is_py_Name(py_deco, "struct"):
@@ -451,11 +411,7 @@ class Parser:
                     py_deco.loc,
                 )
 
-        kind: spy.ast.ClassKind
-        if struct_loc:
-            kind = "struct"
-        else:
-            kind = "class"
+        kind: spy.ast.ClassKind = "struct" if struct_loc else "class"
 
         docstring, py_class_body = self.get_docstring_maybe(py_classdef.body)
 
@@ -463,7 +419,17 @@ class Parser:
         # validation is delegated to ClassFrame
         body: list[spy.ast.Stmt] = []
         for py_stmt in py_class_body:
-            if isinstance(py_stmt, py_ast.AnnAssign):
+            if type_aliases is not None and isinstance(py_stmt, py_ast.TypeAlias):
+                name_node = py_stmt.name
+                assert isinstance(name_node, py_ast.Name)
+                type_aliases.append(
+                    spy.ast.TypeAlias(
+                        loc=py_stmt.loc,
+                        name=spy.ast.StrConst(loc=name_node.loc, value=name_node.id),
+                        value=self.from_py_expr(py_stmt.value),
+                    )
+                )
+            elif isinstance(py_stmt, py_ast.AnnAssign):
                 body.append(self.from_py_AnnAssign(py_stmt))
             else:
                 body.append(self.from_py_stmt(py_stmt))

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -364,16 +364,78 @@ class Parser:
         # generic arguments: class Cls[T]()
         if py_classdef.type_params:
             generic_args = self._parse_type_params(py_classdef)
-            inner_classdef = self._parse_py_classdef(py_classdef)
+            type_aliases, inner_classdef = self._parse_py_generic_classdef(py_classdef)
             inner_classdef.name = "Self"
             return spy.ast.GenericClassDef(
                 loc=py_classdef.loc,
                 name=py_classdef.name,
                 args=generic_args,
+                type_aliases=type_aliases,
                 inner=inner_classdef,
             )
 
         return self._parse_py_classdef(py_classdef)
+
+    def _parse_py_generic_classdef(
+        self, py_classdef: py_ast.ClassDef
+    ) -> tuple[list[spy.ast.TypeAlias], spy.ast.ClassDef]:
+        """
+        Parse a generic class body, separating `type X = ...` aliases from
+        field declarations. Returns (type_aliases, inner_classdef).
+        """
+        docstring, py_class_body = self.get_docstring_maybe(py_classdef.body)
+
+        type_aliases: list[spy.ast.TypeAlias] = []
+        body: list[spy.ast.Stmt] = []
+        for py_stmt in py_class_body:
+            if isinstance(py_stmt, py_ast.TypeAlias):
+                name_node = py_stmt.name
+                assert isinstance(name_node, py_ast.Name)
+                type_aliases.append(
+                    spy.ast.TypeAlias(
+                        loc=py_stmt.loc,
+                        name=spy.ast.StrConst(
+                            loc=name_node.loc, value=name_node.id
+                        ),
+                        value=self.from_py_expr(py_stmt.value),
+                    )
+                )
+            elif isinstance(py_stmt, py_ast.AnnAssign):
+                body.append(self.from_py_AnnAssign(py_stmt))
+            else:
+                body.append(self.from_py_stmt(py_stmt))
+
+        # determine kind from decorators (same logic as _parse_py_classdef)
+        struct_loc: Optional[Loc] = None
+        for py_deco in py_classdef.decorator_list:
+            if is_py_Name(py_deco, "struct"):
+                struct_loc = py_deco.loc
+            else:
+                self.error(
+                    "class decorators not supported yet",
+                    "this is not supported",
+                    py_deco.loc,
+                )
+        kind: spy.ast.ClassKind = "struct" if struct_loc else "class"
+
+        body_loc = py_classdef.loc
+        loc = body_loc.replace(line_end=body_loc.line_start, col_end=-1)
+        inner = spy.ast.ClassDef(
+            loc=loc,
+            body_loc=body_loc,
+            name=py_classdef.name,
+            kind=kind,
+            body=body,
+            docstring=docstring,
+        )
+        return type_aliases, inner
+
+    def from_py_stmt_TypeAlias(self, py_node: py_ast.TypeAlias) -> spy.ast.Stmt:
+        self.error(
+            "`type` aliases are only supported inside generic classes",
+            "not supported here",
+            py_node.loc,
+        )
 
     def _parse_py_classdef(self, py_classdef: py_ast.ClassDef) -> spy.ast.ClassDef:
         # decorators are not supported yet, but @struct and @typelif are

--- a/spy/tests/compiler/test_blue_generic.py
+++ b/spy/tests/compiler/test_blue_generic.py
@@ -173,3 +173,15 @@ class TestBlueGeneric(CompilerTest):
         assert w_list.fqn.human_name(self.vm) == "list[i32]"
         assert w_dict.fqn.human_name(self.vm) == "dict[i32, str]"
         assert w_tuple.fqn.human_name(self.vm) == "tuple[i32, str, f64]"
+
+    def test_generic_class_with_TypeAlias(self):
+        mod = self.compile("""
+        @struct
+        class Wrapper[T]:
+            type value_T = T
+            value: value_T
+
+        def foo() -> i32:
+            return Wrapper[i32](42).value
+        """)
+        assert mod.foo() == 42

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -442,6 +442,7 @@ class TestParser:
                     kind='simple',
                 ),
             ],
+            type_aliases=[],
             inner=ClassDef(
                 name='Self',
                 kind='struct',

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -459,6 +459,59 @@ class TestParser:
         """
         self.assert_dump(classdef, expected)
 
+    def test_GenericClassDef_with_TypeAlias(self):
+        mod = self.parse("""
+        @struct
+        class ArrayData[DTYPE]:
+            type ptr_T = gc_ptr[DTYPE]
+            length: i32
+            items: ptr_T
+        """)
+        classdef = mod.get_generic_classdef("ArrayData")
+        expected = """
+        GenericClassDef(
+            name='ArrayData',
+            args=[
+                FuncArg(
+                    name='DTYPE',
+                    type=Auto(),
+                    kind='simple',
+                ),
+            ],
+            type_aliases=[
+                TypeAlias(
+                    name=StrConst(value='ptr_T'),
+                    value=GetItem(
+                        value=Name(id='gc_ptr'),
+                        args=[
+                            Name(id='DTYPE'),
+                        ],
+                    ),
+                ),
+            ],
+            inner=ClassDef(
+                name='Self',
+                kind='struct',
+                docstring=None,
+                body=[
+                    VarDef(
+                        kind=None,
+                        name=StrConst(value='length'),
+                        type=Name(id='i32'),
+                        value=None,
+                    ),
+                    VarDef(
+                        kind=None,
+                        name=StrConst(value='items'),
+                        type=Name(id='ptr_T'),
+                        value=None,
+                    ),
+                ],
+            ),
+        )
+        """
+        self.assert_dump(classdef, expected)
+
     def test_blue_metafunc_FuncDef(self):
         mod = self.parse("""
         @blue.metafunc

--- a/spy/tests/test_scope.py
+++ b/spy/tests/test_scope.py
@@ -491,6 +491,33 @@ class TestScopeAnalyzer:
             "T": MatchSymbol("T", "const", "blue-param", level=1),
         }
 
+    def test_generic_class_with_TypeAlias(self):
+        scopes = self.analyze("""
+        @struct
+        class ArrayData[DTYPE]:
+            type ptr_T = gc_ptr[DTYPE]
+            length: i32
+            items: ptr_T
+        """)
+        gclassdef = self.mod.get_generic_classdef("ArrayData")
+        scope = scopes.by_generic_classdef(gclassdef)
+        assert scope.name == "test::ArrayData"
+        assert scope.color == "blue"
+        assert scope._symbols == {
+            "DTYPE": MatchSymbol("DTYPE", "const", "blue-param"),
+            "ptr_T": MatchSymbol("ptr_T", "const", "type-alias"),
+            "Self": MatchSymbol("Self", "const", "classdef"),
+            "@return": MatchSymbol("@return", "var", "auto"),
+        }
+
+        inner_scope = scopes.by_classdef(gclassdef.inner)
+        assert inner_scope._symbols == {
+            "length": MatchSymbol("length", "var", "class-field"),
+            "items": MatchSymbol("items", "var", "class-field"),
+            "DTYPE": MatchSymbol("DTYPE", "const", "blue-param", level=1),
+            "ptr_T": MatchSymbol("ptr_T", "const", "type-alias", level=1),
+        }
+
     def test_vararg(self):
         scopes = self.analyze("""
         def foo(a: i32, *args: str) -> None:

--- a/spy/tests/test_scope.py
+++ b/spy/tests/test_scope.py
@@ -503,20 +503,21 @@ class TestScopeAnalyzer:
         scope = scopes.by_generic_classdef(gclassdef)
         assert scope.name == "test::ArrayData"
         assert scope.color == "blue"
-        assert scope._symbols == {
-            "DTYPE": MatchSymbol("DTYPE", "const", "blue-param"),
-            "ptr_T": MatchSymbol("ptr_T", "const", "type-alias"),
-            "Self": MatchSymbol("Self", "const", "classdef"),
-            "@return": MatchSymbol("@return", "var", "auto"),
-        }
+        assert scope._symbols["DTYPE"] == MatchSymbol("DTYPE", "const", "blue-param")
+        assert scope._symbols["ptr_T"] == MatchSymbol("ptr_T", "const", "type-alias")
+        assert scope._symbols["Self"] == MatchSymbol("Self", "const", "classdef")
+        assert scope._symbols["@return"] == MatchSymbol("@return", "var", "auto")
 
         inner_scope = scopes.by_classdef(gclassdef.inner)
-        assert inner_scope._symbols == {
-            "length": MatchSymbol("length", "var", "class-field"),
-            "items": MatchSymbol("items", "var", "class-field"),
-            "DTYPE": MatchSymbol("DTYPE", "const", "blue-param", level=1),
-            "ptr_T": MatchSymbol("ptr_T", "const", "type-alias", level=1),
-        }
+        assert inner_scope._symbols["length"] == MatchSymbol(
+            "length", "var", "class-field"
+        )
+        assert inner_scope._symbols["items"] == MatchSymbol(
+            "items", "var", "class-field"
+        )
+        assert inner_scope._symbols["ptr_T"] == MatchSymbol(
+            "ptr_T", "const", "type-alias", level=1
+        )
 
     def test_vararg(self):
         scopes = self.analyze("""

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -467,6 +467,20 @@ class AbstractFrame:
         loc = gclassdef.loc
         assert gclassdef.symtable is not None
 
+        # desugar each `type X = expr` alias into a synthetic `const X = expr`
+        # VarDef, which will be evaluated before the inner ClassDef
+        alias_stmts: list[ast.Stmt] = []
+        for alias in gclassdef.type_aliases:
+            alias_stmts.append(
+                ast.VarDef(
+                    loc=alias.loc,
+                    kind="const",
+                    name=alias.name,
+                    type=ast.Auto(alias.loc),
+                    value=alias.value,
+                )
+            )
+
         # build synthetic return: return Self
         impl_symbol = gclassdef.symtable.lookup("Self")
         return_stmt = ast.Return(
@@ -483,7 +497,7 @@ class AbstractFrame:
             return_type=ast.Auto(loc),
             defaults=[],
             docstring=None,
-            body=[gclassdef.inner, return_stmt],
+            body=alias_stmts + [gclassdef.inner, return_stmt],
             decorators=[],
             symtable=gclassdef.symtable,
         )


### PR DESCRIPTION
For my loop fusion demo, I see that we need a syntax compatible with generic struct for

```
@blue.generic
def LazySin(DTYPE, NDIM, ARG_TYPE):
    A = ndarray[DTYPE, NDIM]

    @struct
    class Self:
```

I propose to support

```python
@struct
class LazySin[DTYPE, NDIM, ARG_TYPE]:
    type A = ndarray[DTYPE, NDIM]
```

(just syntactic sugar for the former). This PR is an implementation of that. Good shape but not yet ready for review.

Done with Claude under my supervision.
