### PR TITLE
Fix dict_iterator

### DIFF
--- a/spy/tests/stdlib/test_dict.py
+++ b/spy/tests/stdlib/test_dict.py
@@ -127,20 +127,22 @@ class TestDict(CompilerTest):
         src = """
         from _dict import dict
 
-        def test() -> int:
+        def test() -> tuple[int, int]:
             d = dict[i32, i32]()
             d[10] = -1
             d[20] = -1
             d[30] = -1
             it = d.__fastiter__()
+            count = 0
             total = 0
             while it.__continue_iteration__():
-                total = total + it.__item__()
+                count += 1
+                total += it.__item__()
                 it = it.__next__()
-            return total
+            return count, total
         """
         mod = self.compile(src)
-        assert mod.test() == 60
+        assert mod.test() == (3, 60)
 
     def test_for_loop(self):
         src = """

--- a/spy/tests/stdlib/test_dict.py
+++ b/spy/tests/stdlib/test_dict.py
@@ -321,3 +321,21 @@ class TestDict(CompilerTest):
         x = mod.foo()
         assert x[0] == 1
         assert x[1] == 1000
+
+    def test_iter_after_delete(self):
+        src = """
+        def test() -> i32:
+            visited = 0
+            for i in range(1, 4):
+                d = {1: 1, 2: 2, 3: 3}  # literals!
+                d.__delitem__(i)
+                for k in d:
+                    visited += 1
+            d = {1: 1}
+            d.__delitem__(1)
+            for k3 in d:
+                visited += 1
+            return visited
+        """
+        mod = self.compile(src)
+        assert mod.test() == 2 * 3

--- a/spy/vm/struct.py
+++ b/spy/vm/struct.py
@@ -432,22 +432,13 @@ def unwrap_dict(vm: "SPyVM", w_dict: W_Object) -> dict[Any, Any]:
     w_it = vm.call_w(w_fastiter, [w_dict], color="red")
     w_it_T = vm.dynamic_type(w_it)
     w_continue_iteration = vm.lookup_global(w_it_T.fqn.join("__continue_iteration__"))
-    is_continue = vm.call_w(w_continue_iteration, [w_it], color="red")
+    w_item_method = vm.lookup_global(w_it_T.fqn.join("__item__"))
     w_next = vm.lookup_global(w_it_T.fqn.join("__next__"))
-    w_it = vm.call_w(w_next, [w_it], color="red")
 
-    while vm.unwrap_bool(is_continue):
-        w_it_T = vm.dynamic_type(w_it)
-        w_item_method = vm.lookup_global(w_it_T.fqn.join("__item__"))
+    while vm.unwrap_bool(vm.call_w(w_continue_iteration, [w_it], color="red")):
         w_key = vm.call_w(w_item_method, [w_it], color="red")
         w_val = vm.getitem_w(w_dict, w_key, color="red")
-        result[vm.unwrap(w_key)] = vm.unwrap(w_val)  # append key,value
-
-        w_next = vm.lookup_global(w_it_T.fqn.join("__next__"))
+        result[vm.unwrap(w_key)] = vm.unwrap(w_val)
         w_it = vm.call_w(w_next, [w_it], color="red")
-        w_continue_iteration = vm.lookup_global(
-            w_it_T.fqn.join("__continue_iteration__")
-        )
-        is_continue = vm.call_w(w_continue_iteration, [w_it], color="red")
 
     return result

--- a/stdlib/_dict.spy
+++ b/stdlib/_dict.spy
@@ -194,6 +194,11 @@ def dict(Key, Value):
         data.length = data.length - 1
         return deleted_value
 
+    def next_nonempty(data: gc_ptr[DictData], i: i32) -> i32:
+        while i <= data.length and data.entries[i].empty:
+            i += 1
+        return i
+
     @struct
     class dict_iterator:
         data: gc_ptr[DictData]
@@ -202,7 +207,7 @@ def dict(Key, Value):
         # todo: detect dict size change during iteration
 
         def __next__(self) -> dict_iterator:
-            return dict_iterator(self.data, self.i + 1)
+            return dict_iterator(self.data, next_nonempty(self.data, self.i + 1))
 
         def __item__(self) -> Key:
             return self.data.entries[self.i].key
@@ -300,7 +305,7 @@ def dict(Key, Value):
             return data.length
 
         def __fastiter__(self) -> dict_iterator:
-            return dict_iterator(self.__ll__, 0)
+            return dict_iterator(self.__ll__, next_nonempty(self.__ll__, 0))
 
         def keys(self) -> _dict:
             return self

--- a/stdlib/_dict.spy
+++ b/stdlib/_dict.spy
@@ -203,6 +203,8 @@ def dict(Key, Value):
         # todo: detect dict size change during iteration
 
         def __next__(self) -> dict_iterator:
+            # entries are always compact, we don't need to check for empty slots
+            # also see swap_last_entry_with() in delete()
             return dict_iterator(self.data, self.i + 1)
 
         def __item__(self) -> Key:

--- a/stdlib/_dict.spy
+++ b/stdlib/_dict.spy
@@ -125,6 +125,7 @@ def dict(Key, Value):
         return data.index[position]
 
     def insert_entry(entries: gc_ptr[Entry], ix: i32, key: Key, value: Value) -> None:
+        assert ix > 0  # zero is reserved for empty node
         entries[ix].key = key
         entries[ix].value = value
         entries[ix].empty = 0
@@ -194,11 +195,6 @@ def dict(Key, Value):
         data.length = data.length - 1
         return deleted_value
 
-    def next_nonempty(data: gc_ptr[DictData], i: i32) -> i32:
-        while i <= data.length and data.entries[i].empty:
-            i += 1
-        return i
-
     @struct
     class dict_iterator:
         data: gc_ptr[DictData]
@@ -207,7 +203,7 @@ def dict(Key, Value):
         # todo: detect dict size change during iteration
 
         def __next__(self) -> dict_iterator:
-            return dict_iterator(self.data, next_nonempty(self.data, self.i + 1))
+            return dict_iterator(self.data, self.i + 1)
 
         def __item__(self) -> Key:
             return self.data.entries[self.i].key
@@ -305,7 +301,8 @@ def dict(Key, Value):
             return data.length
 
         def __fastiter__(self) -> dict_iterator:
-            return dict_iterator(self.__ll__, next_nonempty(self.__ll__, 0))
+            # the first entry is always empty, so we skip it
+            return dict_iterator(self.__ll__, 1)
 
         def keys(self) -> _dict:
             return self


### PR DESCRIPTION
dict_iterator was buggy because it didn't skip empty entries. So far
the tests worked by chance because they were reading empty items whose
key/value was 0 by chance.

The fix uncovers and existing bug in unwrap_dict. Fix it.
