### PR TITLE
fix(parser): support untyped global var/const

### DIFF
--- a/spy/parser.py
+++ b/spy/parser.py
@@ -506,18 +506,22 @@ class Parser:
         return spy.ast.Return(py_node.loc, value)
 
     def from_py_global_Assign(self, py_node: py_ast.Assign) -> spy.ast.VarDef:
-        assign = self.from_py_stmt_Assign(py_node)
-        assert isinstance(assign, spy.ast.Assign)
+        stmt = self.from_py_stmt_Assign(py_node)
+        # `var x = ...` and `const x = ...` are already lowered to VarDef
+        # by from_py_stmt_Assign; only bare `x = ...` returns Assign.
+        if isinstance(stmt, spy.ast.VarDef):
+            return stmt
+        assert isinstance(stmt, spy.ast.Assign)
         assert len(py_node.targets) == 1
         assert isinstance(py_node.targets[0], py_ast.Name)
-        assert isinstance(assign.target, spy.ast.SingleTarget)
+        assert isinstance(stmt.target, spy.ast.SingleTarget)
         varkind, _ = parse_var_name(py_node.targets[0].id)
         vardef = spy.ast.VarDef(
             loc=py_node.loc,
             kind=varkind,
-            name=assign.target.name,
+            name=stmt.target.name,
             type=spy.ast.Auto(loc=py_node.loc),
-            value=assign.value,
+            value=stmt.value,
         )
         return vardef
 

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -689,6 +689,37 @@ class TestParser:
         """
         self.assert_dump(mod, expected)
 
+    def test_global_VarDef_without_type(self):
+        mod = self.parse("""
+        var c = 43
+        const d = 44
+        """)
+        expected = f"""
+        Module(
+            filename='{self.tmpdir}/test.spy',
+            docstring=None,
+            decls=[
+                GlobalVarDef(
+                    vardef=VarDef(
+                        kind='var',
+                        name=StrConst(value='c'),
+                        type=Auto(),
+                        value=Constant(value=43),
+                    ),
+                ),
+                GlobalVarDef(
+                    vardef=VarDef(
+                        kind='const',
+                        name=StrConst(value='d'),
+                        type=Auto(),
+                        value=Constant(value=44),
+                    ),
+                ),
+            ],
+        )
+        """
+        self.assert_dump(mod, expected)
+
     def test_List(self):
         mod = self.parse("""
         def foo() -> None:

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -702,17 +702,17 @@ class TestParser:
                 GlobalVarDef(
                     vardef=VarDef(
                         kind='var',
-                        name=StrConst(value='c'),
+                        name=StrLiteral(value='c'),
                         type=Auto(),
-                        value=Constant(value=43),
+                        value=Literal(value=43),
                     ),
                 ),
                 GlobalVarDef(
                     vardef=VarDef(
                         kind='const',
-                        name=StrConst(value='d'),
+                        name=StrLiteral(value='d'),
                         type=Auto(),
-                        value=Constant(value=44),
+                        value=Literal(value=44),
                     ),
                 ),
             ],


### PR DESCRIPTION
Fixes #501.

Per @antocuni in the issue: `from_py_stmt_Assign` already returns a `VarDef` for `var x = ...` / `const x = ...`, so `from_py_global_Assign` now uses that directly instead of asserting `Assign`.