### PR TITLE
Improve applevel implementation of str

### DIFF
--- a/spy/libspy/include/spy/str.h
+++ b/spy/libspy/include/spy/str.h
@@ -50,12 +50,12 @@ SPY_PTR_FUNCTIONS(gc, spy_unsafe$gc_ptr___str$StrObject, spy_StrObject)
 typedef spy_unsafe$gc_ptr___str$StrObject spy_gc_ptr_StrObject;
 
 static inline spy_gc_ptr_StrObject
-spy_unsafe$as_StrObject$impl(spy_StrObject *s) {
+spy_unsafe$_str_to_StrObject$impl(spy_StrObject *s) {
     return spy_unsafe$gc_ptr___str$StrObject_from_addr(s);
 }
 
 static inline spy_StrObject *
-spy_unsafe$from_StrObject$impl(spy_gc_ptr_StrObject p) {
+spy_unsafe$_StrObject_to_str$impl(spy_gc_ptr_StrObject p) {
     return p.p;
 }
 
@@ -91,7 +91,7 @@ _spy_StrObject_Layout WASM_EXPORT(_spy_StrObject_layout)(void);
 spy_StrObject *WASM_EXPORT(spy_str_alloc)(size_t length);
 
 static inline spy_gc_ptr_StrObject
-spy_unsafe$alloc_StrObject$impl(int32_t length) {
+spy_unsafe$_alloc_StrObject$impl(int32_t length) {
     return spy_unsafe$gc_ptr___str$StrObject_from_addr(spy_str_alloc((size_t)length));
 }
 

--- a/spy/libspy/include/spy/str.h
+++ b/spy/libspy/include/spy/str.h
@@ -54,6 +54,11 @@ spy_unsafe$as_StrObject$impl(spy_StrObject *s) {
     return spy_unsafe$gc_ptr___str$StrObject_from_addr(s);
 }
 
+static inline spy_StrObject *
+spy_unsafe$from_StrObject$impl(spy_gc_ptr_StrObject p) {
+    return p.p;
+}
+
 /* SPY_STR_LITERAL(N, "content") is a struct initializer for spy_StrObject,
    useful for static globals and for-test literals. There are two versions
    depending on whether spy_gc_ptr_u8 carries a length (SPY_DEBUG). */
@@ -84,6 +89,11 @@ typedef struct {
 _spy_StrObject_Layout WASM_EXPORT(_spy_StrObject_layout)(void);
 
 spy_StrObject *WASM_EXPORT(spy_str_alloc)(size_t length);
+
+static inline spy_gc_ptr_StrObject
+spy_unsafe$alloc_StrObject$impl(int32_t length) {
+    return spy_unsafe$gc_ptr___str$StrObject_from_addr(spy_str_alloc((size_t)length));
+}
 
 spy_StrObject *WASM_EXPORT(spy_str_add)(spy_StrObject *a, spy_StrObject *b);
 

--- a/spy/tests/compiler/test_str.py
+++ b/spy/tests/compiler/test_str.py
@@ -263,6 +263,17 @@ class TestStr(CompilerTest):
         assert mod.isascii("hello")
         assert not mod.isascii("àèìòù")
 
+    def test_upper(self):
+        src = """
+        def upper(s: str) -> str:
+            return s.upper()
+        """
+        mod = self.compile(src)
+        assert mod.upper("hello") == "HELLO"
+        assert mod.upper("Hello World") == "HELLO WORLD"
+        assert mod.upper("ABC123") == "ABC123"
+        assert mod.upper("") == ""
+
     def test_str_replace(self):
         mod = self.compile("""
         def foo(s: str, old: str, new: str) -> str:

--- a/spy/tests/compiler/unsafe/test_ptr.py
+++ b/spy/tests/compiler/unsafe/test_ptr.py
@@ -643,15 +643,15 @@ class TestUnsafePtr(CompilerTest):
 
     def test_as_StrObject(self):
         mod = self.compile("""
-        from unsafe import as_StrObject
+        from unsafe import _str_to_StrObject
         from _str import StrObject
 
         def get_length(s: str) -> i32:
-            data = as_StrObject(s)
+            data = _str_to_StrObject(s)
             return data.length
 
         def get_byte(s: str, i: i32) -> u8:
-            data = as_StrObject(s)
+            data = _str_to_StrObject(s)
             return data.utf8[i]
         """)
         assert mod.get_length("hello") == 5

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -543,3 +543,38 @@ def w_as_StrObject(vm: "SPyVM", wam_s: W_MetaArg) -> W_OpSpec:
         return W_Ptr(w_gc_ptr_StrObject, w_s.ptr, 1)
 
     return W_OpSpec(w_impl, [wam_s])
+
+
+@UNSAFE.builtin_func(color="blue", kind="metafunc")
+def w_alloc_StrObject(vm: "SPyVM", wam_length: W_MetaArg) -> W_OpSpec:
+    """
+    Allocate a fresh StrObject (with utf8 buffer of `length` bytes) and return a
+    `gc_ptr[StrObject]`. The dual of `from_StrObject`.
+    """
+    w_StrObject = vm.lookup_global(FQN("_str::StrObject"))
+    assert isinstance(w_StrObject, W_StructType)
+    w_gc_ptr_StrObject = vm.getitem_w(w_gc_ptr, w_StrObject)
+    assert isinstance(w_gc_ptr_StrObject, W_PtrType)
+    GC_PTR = Annotated[W_Ptr, w_gc_ptr_StrObject]
+
+    @vm.register_builtin_func(UNSAFE.fqn.join("alloc_StrObject"), "impl")
+    def w_impl(vm: "SPyVM", w_length: W_I32) -> GC_PTR:
+        length = vm.unwrap_i32(w_length)
+        addr = vm.ll.call("spy_str_alloc", length)
+        return W_Ptr(w_gc_ptr_StrObject, addr, 1)
+
+    return W_OpSpec(w_impl, [wam_length])
+
+
+@UNSAFE.builtin_func(color="blue", kind="metafunc")
+def w_from_StrObject(vm: "SPyVM", wam_p: W_MetaArg) -> W_OpSpec:
+    """
+    Convert a low-level `gc_ptr[StrObject]` back into a high-level `str`. The dual
+    of `as_StrObject`.
+    """
+
+    @vm.register_builtin_func(UNSAFE.fqn.join("from_StrObject"), "impl")
+    def w_impl(vm: "SPyVM", w_p: W_Ptr) -> W_Str:
+        return W_Str.from_ptr(vm, w_p.addr)
+
+    return W_OpSpec(w_impl, [wam_p])

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -526,7 +526,7 @@ def w_ptr_setfield(vm: "SPyVM", w_T: W_Type) -> W_Dynamic:
 
 
 @UNSAFE.builtin_func(color="blue", kind="metafunc")
-def w_as_StrObject(vm: "SPyVM", wam_s: W_MetaArg) -> W_OpSpec:
+def w__str_to_StrObject(vm: "SPyVM", wam_s: W_MetaArg) -> W_OpSpec:
     """
     Convert an high-level `str` into low-level `gc_ptr[StrObject]`.
 
@@ -538,7 +538,7 @@ def w_as_StrObject(vm: "SPyVM", wam_s: W_MetaArg) -> W_OpSpec:
     assert isinstance(w_gc_ptr_StrObject, W_PtrType)
     GC_PTR = Annotated[W_Ptr, w_gc_ptr_StrObject]
 
-    @vm.register_builtin_func(UNSAFE.fqn.join("as_StrObject"), "impl")
+    @vm.register_builtin_func(UNSAFE.fqn.join("_str_to_StrObject"), "impl")
     def w_impl(vm: "SPyVM", w_s: W_Str) -> GC_PTR:
         return W_Ptr(w_gc_ptr_StrObject, w_s.ptr, 1)
 
@@ -546,10 +546,10 @@ def w_as_StrObject(vm: "SPyVM", wam_s: W_MetaArg) -> W_OpSpec:
 
 
 @UNSAFE.builtin_func(color="blue", kind="metafunc")
-def w_alloc_StrObject(vm: "SPyVM", wam_length: W_MetaArg) -> W_OpSpec:
+def w__alloc_StrObject(vm: "SPyVM", wam_length: W_MetaArg) -> W_OpSpec:
     """
     Allocate a fresh StrObject (with utf8 buffer of `length` bytes) and return a
-    `gc_ptr[StrObject]`. The dual of `from_StrObject`.
+    `gc_ptr[StrObject]`. The dual of `_StrObject_to_str`.
     """
     w_StrObject = vm.lookup_global(FQN("_str::StrObject"))
     assert isinstance(w_StrObject, W_StructType)
@@ -557,7 +557,7 @@ def w_alloc_StrObject(vm: "SPyVM", wam_length: W_MetaArg) -> W_OpSpec:
     assert isinstance(w_gc_ptr_StrObject, W_PtrType)
     GC_PTR = Annotated[W_Ptr, w_gc_ptr_StrObject]
 
-    @vm.register_builtin_func(UNSAFE.fqn.join("alloc_StrObject"), "impl")
+    @vm.register_builtin_func(UNSAFE.fqn.join("_alloc_StrObject"), "impl")
     def w_impl(vm: "SPyVM", w_length: W_I32) -> GC_PTR:
         length = vm.unwrap_i32(w_length)
         addr = vm.ll.call("spy_str_alloc", length)
@@ -567,13 +567,13 @@ def w_alloc_StrObject(vm: "SPyVM", wam_length: W_MetaArg) -> W_OpSpec:
 
 
 @UNSAFE.builtin_func(color="blue", kind="metafunc")
-def w_from_StrObject(vm: "SPyVM", wam_p: W_MetaArg) -> W_OpSpec:
+def w__StrObject_to_str(vm: "SPyVM", wam_p: W_MetaArg) -> W_OpSpec:
     """
     Convert a low-level `gc_ptr[StrObject]` back into a high-level `str`. The dual
-    of `as_StrObject`.
+    of `_str_to_StrObject`.
     """
 
-    @vm.register_builtin_func(UNSAFE.fqn.join("from_StrObject"), "impl")
+    @vm.register_builtin_func(UNSAFE.fqn.join("_StrObject_to_str"), "impl")
     def w_impl(vm: "SPyVM", w_p: W_Ptr) -> W_Str:
         return W_Str.from_ptr(vm, w_p.addr)
 

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -44,6 +44,7 @@ class W_Str(W_Object):
     __spy_storage_category__ = "value"
     __spy_lazy_attributes__ = {
         "isascii": FQN("_str::methods::isascii"),
+        "upper": FQN("_str::methods::upper"),
     }
 
     vm: "SPyVM"

--- a/stdlib/_str.spy
+++ b/stdlib/_str.spy
@@ -81,15 +81,14 @@ class methods:
         ll = StrObject.from_str(self)
         llnew = StrObject.alloc(ll.length)
         llnew.hash = 0
-        lo: u8 = 97  # 'a'
-        hi: u8 = 122  # 'z'
-        delta: u8 = 32
-        i = 0
-        while i < ll.length:
+        # we don't have bytes literal yet, quick workaround
+        A = u8(65)
+        a = u8(97)
+        z = u8(122)
+        for i in range(ll.length):
             ch = ll.utf8[i]
-            if lo <= ch and ch <= hi:
-                llnew.utf8[i] = ch - delta
+            if a <= ch and ch <= z:
+                llnew.utf8[i] = ch - (a - A)
             else:
                 llnew.utf8[i] = ch
-            i = i + 1
         return StrObject.to_str(llnew)

--- a/stdlib/_str.spy
+++ b/stdlib/_str.spy
@@ -1,4 +1,18 @@
-from unsafe import gc_ptr, as_StrObject, alloc_StrObject, from_StrObject
+"""
+This module contains the applevel part of the `str` type.
+
+At the C level, `str` is defined by the spy_StrObject struct and related helper
+functions defined in str.h and str.c
+
+At interp level, the W_Str type is defined in vm/str.py.
+
+Finally, some of the methods are implemented at applevel in this file.
+
+The StrObject struct defined here MUST stay in sync with the one defined in C. It is
+possible to cast between str and gc_ptr[StrObject] using StrObject.{from,to}_str.
+"""
+
+from unsafe import gc_ptr, _str_to_StrObject, _alloc_StrObject, _StrObject_to_str
 
 
 # this MUST stay in sync with the equivalent struct declared in str.h
@@ -7,6 +21,35 @@ class StrObject:
     length: i32
     hash: i32
     utf8: gc_ptr[u8]
+
+    @staticmethod
+    def alloc(n: i32) -> gc_ptr[StrObject]:
+        """
+        Allocate a new StrObject AND the its utf8 buffer.
+        If you want a split allocation, you must gc_malloc[StrObject] manually.
+        """
+        return _alloc_StrObject(n)
+
+    @staticmethod
+    def from_str(s: str) -> gc_ptr[StrObject]:
+        """
+        Cast `s` into its low level gc_ptr[StrObject].
+
+        This is just a cast and the returned ptr points to the same area of memory as
+        `s`. You must be careful NOT to modify the content, else as modifications are
+        visible from the outside.
+        """
+        return _str_to_StrObject(s)
+
+    @staticmethod
+    def to_str(ll: gc_ptr[StrObject]) -> str:
+        """
+        Cast a `ll` into a high level `str`.
+
+        Once a newly-allocated StrObject is casted to `str`, it should be considered
+        "locked" and immutable.
+        """
+        return _StrObject_to_str(ll)
 
 
 @struct
@@ -24,7 +67,7 @@ class methods:
     # W_Str.__spy_lazy_attributes__.
 
     def isascii(self: str) -> bool:
-        ll = as_StrObject(self)
+        ll = StrObject.from_str(self)
         i = 0
         max_ascii: u8 = 127
         while i < ll.length:
@@ -35,10 +78,10 @@ class methods:
 
     def upper(self: str) -> str:
         # XXX: this works only for ASCII strings but it's good enough for now
-        ll = as_StrObject(self)
-        llnew = alloc_StrObject(ll.length)
+        ll = StrObject.from_str(self)
+        llnew = StrObject.alloc(ll.length)
         llnew.hash = 0
-        lo: u8 = 97   # 'a'
+        lo: u8 = 97  # 'a'
         hi: u8 = 122  # 'z'
         delta: u8 = 32
         i = 0
@@ -49,4 +92,4 @@ class methods:
             else:
                 llnew.utf8[i] = ch
             i = i + 1
-        return from_StrObject(llnew)
+        return StrObject.to_str(llnew)

--- a/stdlib/_str.spy
+++ b/stdlib/_str.spy
@@ -1,4 +1,4 @@
-from unsafe import gc_ptr, as_StrObject
+from unsafe import gc_ptr, as_StrObject, alloc_StrObject, from_StrObject
 
 
 # this MUST stay in sync with the equivalent struct declared in str.h
@@ -32,3 +32,21 @@ class methods:
                 return False
             i = i + 1
         return True
+
+    def upper(self: str) -> str:
+        # XXX: this works only for ASCII strings but it's good enough for now
+        ll = as_StrObject(self)
+        llnew = alloc_StrObject(ll.length)
+        llnew.hash = 0
+        lo: u8 = 97   # 'a'
+        hi: u8 = 122  # 'z'
+        delta: u8 = 32
+        i = 0
+        while i < ll.length:
+            ch = ll.utf8[i]
+            if lo <= ch and ch <= hi:
+                llnew.utf8[i] = ch - delta
+            else:
+                llnew.utf8[i] = ch
+            i = i + 1
+        return from_StrObject(llnew)


### PR DESCRIPTION
- Add `_alloc_StrObject` and `_StrObject_to_str`: combined, they make it possible to manually allocate and initialize a `str` object from applevel
- add docstrings and improve the general useability of `_str.spy`
- implement `str.upper` at applevel