### PR TITLE
[GHA] Preview-docs-deploy should succeed if the docs haven't changed

### DIFF
--- a/.github/workflows/docs-preview-deploy.yml
+++ b/.github/workflows/docs-preview-deploy.yml
@@ -72,6 +72,7 @@ jobs:
 
       - name: Commit artifact
         working-directory: /tmp/spy-docs
+        continue-on-error: true
         run: |
           git add pr-preview
           git commit -m "Added preview build for PR ${{ steps.pr.outputs.pr_number }}"


### PR DESCRIPTION
Small change - the docs-previews get rebuilt for any new commits in a relevant PR, but if that commit didn't actually cause the outputted docs to change, the `docs-previews-deploy` action would fail when it tried to create a new commit with no changes. Ths should allow that job to succeed, even if creating that commit fails.

Fixes #534 