### PR TITLE
Simplify magic_py_parse

### DIFF
--- a/spy/ast_dump.py
+++ b/spy/ast_dump.py
@@ -85,8 +85,6 @@ class Dumper(TextBuilder):
         name = "py:" + node.__class__.__name__
         fields = list(node.__class__._fields)
         fields = [f for f in fields if f not in self.fields_to_ignore]
-        if isinstance(node, py_ast.Name):
-            fields.append("spy_varkind")
         # Use turquoise text_color to distinguish from blue in colorize command
         self._dump_node(node, name, fields, text_color="turquoise")
 

--- a/spy/magic_py_parse.py
+++ b/spy/magic_py_parse.py
@@ -7,6 +7,14 @@ The goal is be able to parse lines such as:
 
 We want to reuse the Python parser, but the lines above is not valid syntax.
 
+The idea is to convert the code above into:
+    var·x: i32 = 0
+    const·y: i32 = 0
+
+'·' is U+00B7 MIDDLE DOT, which is a valid unicode char for an indentifier. This means
+that 'var·x' will be parsed as a single valide NAME token by Python, and then the SPy
+parser will be able to special case it later.
+
 The idea is the following:
 
 1. tokenize the source
@@ -14,14 +22,11 @@ The idea is the following:
 2. search for pairs of NAMEs starting with 'var' (from the point of view of
    the tokenizer, 'var' is a plain NAME)
 
-3. remove the 'var' token, and keep track of the location in which it was seen
+3. replace 'var name' with 'var·name'
 
 4. turn back the (modified) tokens into source code
 
 5. parse the generated source code into an AST
-
-6. add a new field "is_var: bool" to all ast.Name nodes, using the infos
-   gathered at point (3)
 
 It is important to make sure that whitespace is preserved as much as possible,
 because we want the AST to contain location info which match the actual file
@@ -30,24 +35,12 @@ does exactly that.
 """
 
 import ast as py_ast
-from dataclasses import dataclass
 from io import BytesIO
 from tokenize import NAME, TokenError, TokenInfo, tokenize
-from typing import Literal
 
 from spy.errors import SPyError
 from spy.location import Loc
 from spy.vendored import untokenize
-
-VarKind = Literal["var", "const"]
-
-
-@dataclass(frozen=True)
-class LocInfo:
-    lineno: int
-    end_lineno: int
-    col_offset: int
-    end_col_offset: int
 
 
 def magic_py_parse(src: str, filename: str = "<string>") -> py_ast.Module:
@@ -55,25 +48,14 @@ def magic_py_parse(src: str, filename: str = "<string>") -> py_ast.Module:
     Like ast.parse, but supports the new "var" and "const" syntax. See the module
     docstring for more info.
     """
-    src2, varkind_locs = preprocess(src, filename)
+    src2 = preprocess(src, filename)
     try:
-        py_mod = py_ast.parse(src2, filename=filename)
+        return py_ast.parse(src2, filename=filename)
     except SyntaxError as e:
         lineno = e.lineno or 1
         loc = Loc(filename, lineno, lineno, 0, -1)
         # this happens e.g. if we have an incomplete `if`, see test_magic_py_parse_error
         raise SPyError.simple("W_ParseError", e.msg, "", loc)
-
-    for node in py_ast.walk(py_mod):
-        if isinstance(node, py_ast.Name):
-            assert node.end_lineno is not None
-            assert node.end_col_offset is not None
-            loc_info = LocInfo(
-                node.lineno, node.end_lineno, node.col_offset, node.end_col_offset
-            )
-            node.spy_varkind = varkind_locs.get(loc_info)
-
-    return py_mod
 
 
 def get_tokens(src: str) -> list[TokenInfo]:
@@ -81,9 +63,7 @@ def get_tokens(src: str) -> list[TokenInfo]:
     return list(tokenize(readline))
 
 
-def preprocess(
-    src: str, filename: str = "<string>"
-) -> tuple[str, dict[LocInfo, VarKind]]:
+def preprocess(src: str, filename: str = "<string>") -> str:
     try:
         tokens = get_tokens(src)
     except (SyntaxError, TokenError) as e:
@@ -98,43 +78,25 @@ def preprocess(
     newtokens = []
     i = 0
     N = len(tokens)
-    varkind_locs: dict[LocInfo, VarKind] = {}
 
     while i < N - 1:
         tok0 = tokens[i]
         tok1 = tokens[i + 1]
         if tok0.type == NAME and tok0.string in ("var", "const") and tok1.type == NAME:
-            varkind: VarKind = tok0.string  # type: ignore
-            # tok0 is 'var'
-            # tok1 is the name
-            # basically, we want to turn:
-            #     var x: i32 = 100
-            # into:
-            #     x    : i32 = 100
-            #
-            # so that the Locs in the final AST maps to the correct places in
-            # the original source code.
+            # merge `var x` (or `const x`) into a single NAME token `var·x`
+            # (resp. `const·x`), preserving the original column offsets by
+            # padding the gap with U+00B7 MIDDLE DOT chars.
             var_l0, var_c0 = tok0.start
             var_l1, var_c1 = tok0.end
             name_l0, name_c0 = tok1.start
             name_l1, name_c1 = tok1.end
             assert var_l0 == var_l1 == name_l0 == name_l1, "multiline var not supported"
-            spaces = " " * (name_c0 - var_c0)
-            newtok = TokenInfo(
-                NAME, tok1.string + spaces, tok0.start, tok1.end, tok1.line
-            )
+            dots = "·" * (name_c0 - var_c1)  # U+00B7 MIDDLE DOT
+            newstring = tok0.string + dots + tok1.string
+            newtok = TokenInfo(NAME, newstring, tok0.start, tok1.end, tok1.line)
             newtokens.append(newtok)
-            # compute the location info of the future ast.Name
-            loc_info = LocInfo(
-                lineno=var_l0,
-                end_lineno=var_l0,
-                col_offset=var_c0,
-                end_col_offset=var_c0 + len(tok1.string),
-            )
-            varkind_locs[loc_info] = varkind
             i += 1
         else:
             newtokens.append(tok0)
         i += 1
-    src2 = untokenize.untokenize(newtokens)
-    return src2, varkind_locs
+    return untokenize.untokenize(newtokens)

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -20,6 +20,18 @@ def is_py_Name(py_expr: py_ast.expr, expected: str) -> bool:
     return isinstance(py_expr, py_ast.Name) and py_expr.id == expected
 
 
+def parse_var_name(id: str) -> tuple[Optional[str], str]:
+    """
+    Split a possibly-merged var name like 'var·x' or 'const···y' into
+    (varkind, real_name). Returns (None, id) for plain names.
+    """
+    MIDDLE_DOT = "·"
+    if MIDDLE_DOT not in id:
+        return None, id
+    parts = id.split(MIDDLE_DOT)
+    return parts[0], parts[-1]
+
+
 def parse_special_decorator(py_expr: py_ast.expr) -> Optional[str]:
     """
     If the decorator is a simple @name or @name.attr, return them as
@@ -486,7 +498,7 @@ class Parser:
         assert isinstance(assign, spy.ast.Assign)
         assert len(py_node.targets) == 1
         assert isinstance(py_node.targets[0], py_ast.Name)
-        varkind = py_node.targets[0].spy_varkind
+        varkind, _ = parse_var_name(py_node.targets[0].id)
         vardef = spy.ast.VarDef(
             loc=py_node.loc,
             kind=varkind,
@@ -507,7 +519,7 @@ class Parser:
         # non-name target
         assert isinstance(py_node.target, py_ast.Name), "WTF?"
 
-        varkind = py_node.target.spy_varkind
+        varkind, real_name = parse_var_name(py_node.target.id)
         value = None
         if py_node.value is not None:
             value = self.from_py_expr(py_node.value)
@@ -515,7 +527,7 @@ class Parser:
         vardef = spy.ast.VarDef(
             loc=py_node.loc,
             kind=varkind,
-            name=spy.ast.StrConst(py_node.target.loc, py_node.target.id),
+            name=spy.ast.StrConst(py_node.target.loc, real_name),
             type=self.from_py_expr(py_node.annotation),
             value=value,
         )
@@ -530,12 +542,13 @@ class Parser:
             self.unsupported(py_node, "assign to multiple targets")
         py_target = py_node.targets[0]
         if isinstance(py_target, py_ast.Name):
-            if py_target.spy_varkind is not None:
+            varkind, real_name = parse_var_name(py_target.id)
+            if varkind is not None:
                 # "var x = 0" is a VarDef, not an Assign
                 return spy.ast.VarDef(
                     loc=py_node.loc,
-                    kind=py_target.spy_varkind,
-                    name=spy.ast.StrConst(py_target.loc, py_target.id),
+                    kind=varkind,
+                    name=spy.ast.StrConst(py_target.loc, real_name),
                     type=spy.ast.Auto(loc=py_node.loc),
                     value=self.from_py_expr(py_node.value),
                 )
@@ -543,7 +556,7 @@ class Parser:
                 # "x = 0" is an Assign
                 return spy.ast.Assign(
                     loc=py_node.loc,
-                    target=spy.ast.StrConst(py_target.loc, py_target.id),
+                    target=spy.ast.StrConst(py_target.loc, real_name),
                     value=self.from_py_expr(py_node.value),
                 )
         elif isinstance(py_target, py_ast.Attribute):

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -3,12 +3,13 @@
 # ================================================================
 
 import ast as py_ast
+import re
 import textwrap
 from types import NoneType
 from typing import NoReturn, Optional
 
 import spy.ast
-from spy.analyze.symtable import ImportRef
+from spy.analyze.symtable import ImportRef, VarKind
 from spy.errors import SPyError
 from spy.fqn import FQN
 from spy.location import Loc
@@ -20,16 +21,23 @@ def is_py_Name(py_expr: py_ast.expr, expected: str) -> bool:
     return isinstance(py_expr, py_ast.Name) and py_expr.id == expected
 
 
-def parse_var_name(id: str) -> tuple[Optional[str], str]:
+# match things like:
+#   var·x
+#   var····x
+#   const·x
+#   etc.
+_VAR_NAME_RE = re.compile(r"^(var|const)·+(.+)$")
+
+
+def parse_var_name(id: str) -> tuple[Optional[VarKind], str]:
     """
     Split a possibly-merged var name like 'var·x' or 'const···y' into
     (varkind, real_name). Returns (None, id) for plain names.
     """
-    MIDDLE_DOT = "·"
-    if MIDDLE_DOT not in id:
+    m = _VAR_NAME_RE.match(id)
+    if m is None:
         return None, id
-    parts = id.split(MIDDLE_DOT)
-    return parts[0], parts[-1]
+    return m.group(1), m.group(2)  # type: ignore[return-value]
 
 
 def parse_special_decorator(py_expr: py_ast.expr) -> Optional[str]:

--- a/spy/tests/test_magic_py_parse.py
+++ b/spy/tests/test_magic_py_parse.py
@@ -1,6 +1,6 @@
+import ast as py_ast
 import textwrap
 
-from spy.ast_dump import dump
 from spy.magic_py_parse import magic_py_parse, preprocess
 from spy.parser import Parser
 from spy.tests.support import expect_errors
@@ -10,7 +10,7 @@ def test_preprocess_plain():
     src1 = textwrap.dedent("""
     x: i32 = 100
     """)
-    src2, varkind_locs = preprocess(src1)
+    src2 = preprocess(src1)
     assert src1 == src2
 
 
@@ -19,14 +19,12 @@ def test_preprocess_var():
     var x: i32 = 100
     var    y     : i32 = 200
     """)
-    src2, varkind_locs = preprocess(src1)
+    src2 = preprocess(src1)
     expected = textwrap.dedent("""
-    x    : i32 = 100
-    y            : i32 = 200
+    var·x: i32 = 100
+    var····y     : i32 = 200
     """)
     assert src2 == expected
-    assert len(varkind_locs) == 2
-    assert list(varkind_locs.values()) == ["var", "var"]
 
 
 def test_preprocess_const():
@@ -34,14 +32,12 @@ def test_preprocess_const():
     const x: i32 = 100
     const    y     : i32 = 200
     """)
-    src2, varkind_locs = preprocess(src1)
+    src2 = preprocess(src1)
     expected = textwrap.dedent("""
-    x      : i32 = 100
-    y              : i32 = 200
+    const·x: i32 = 100
+    const····y     : i32 = 200
     """)
     assert src2 == expected
-    assert len(varkind_locs) == 2
-    assert list(varkind_locs.values()) == ["const", "const"]
 
 
 def test_magic_py_parse():
@@ -52,33 +48,10 @@ def test_magic_py_parse():
 
     """)
     py_mod = magic_py_parse(src)
-    dumped = dump(py_mod, use_colors=False)
-    expected = textwrap.dedent("""
-    py:Module(
-        body=[
-            py:AnnAssign(
-                target=py:Name(id='x', ctx=py:Store(), spy_varkind='var'),
-                annotation=py:Name(id='i32', ctx=py:Load(), spy_varkind=None),
-                value=py:Constant(value=100, kind=None),
-                simple=1,
-            ),
-            py:AnnAssign(
-                target=py:Name(id='y', ctx=py:Store(), spy_varkind='const'),
-                annotation=py:Name(id='i32', ctx=py:Load(), spy_varkind=None),
-                value=py:Constant(value=200, kind=None),
-                simple=1,
-            ),
-            py:AnnAssign(
-                target=py:Name(id='z', ctx=py:Store(), spy_varkind=None),
-                annotation=py:Name(id='i32', ctx=py:Load(), spy_varkind=None),
-                value=py:Constant(value=300, kind=None),
-                simple=1,
-            ),
-        ],
-        type_ignores=[],
-    )
-    """)
-    assert dumped.strip() == expected.strip()
+    targets = [
+        stmt.target.id for stmt in py_mod.body if isinstance(stmt, py_ast.AnnAssign)
+    ]
+    assert targets == ["var·x", "const·y", "z"]
 
 
 def test_magic_py_parse_error(tmpdir):

--- a/spy/tests/test_magic_py_parse.py
+++ b/spy/tests/test_magic_py_parse.py
@@ -49,7 +49,9 @@ def test_magic_py_parse():
     """)
     py_mod = magic_py_parse(src)
     targets = [
-        stmt.target.id for stmt in py_mod.body if isinstance(stmt, py_ast.AnnAssign)
+        stmt.target.id
+        for stmt in py_mod.body
+        if isinstance(stmt, py_ast.AnnAssign) and isinstance(stmt.target, py_ast.Name)
     ]
     assert targets == ["var·x", "const·y", "z"]
 

--- a/stubs/ast.pyi
+++ b/stubs/ast.pyi
@@ -1142,9 +1142,6 @@ class Name(expr):
         __match_args__ = ("id", "ctx")
     id: _Identifier
     ctx: expr_context  # Not present in Python < 3.13 if not passed to `__init__`
-    # <spy>
-    spy_varkind: Optional[Literal["var", "const"]]
-    # </spy>
 
     def __init__(self, id: _Identifier, ctx: expr_context = ..., **kwargs: Unpack[_Attributes]) -> None: ...
 


### PR DESCRIPTION
Greatly simplify `magic_py_parse`. The ultimate goal is to be able to re-use the python parser also with this spy-specific syntax:
```python
var x = 1
const y = 2
```

The old way detected `var x`, replaced with a single `x` and kept a side table with info about whether this particular NAME was by chance a `var/const`, and the location info.

The new approach is much simpler: the code above becomes:
```python
var·x = 1
const·y = 2
```

The `·` is "U+00B7 MIDDLE DOT", and Python considers it a valid char for an identifier. This means that `var·x` is seen as a single identifier, so the python parser parses it correctly, and then the SPy parser detect this special name.

As usual, special care is needed to ensure that the source location of the rewritten file are kept the same as in the original. E.g.:
```
    var x: i32 = 100
    var    y     : i32 = 200
```

becomes:
```
    var·x: i32 = 100
    var····y     : i32 = 200
```