### PR TITLE
Improve ImportError messages

### DIFF
--- a/spy/analyze/importing.py
+++ b/spy/analyze/importing.py
@@ -8,6 +8,7 @@ import py.path
 
 from spy import ast
 from spy.analyze.scope import ScopeAnalyzer
+from spy.errors import SPyError
 from spy.fqn import FQN
 from spy.parser import Parser
 from spy.textbuilder import ColorFormatter
@@ -102,6 +103,7 @@ class ImportAnalyzer:
 
     def __init__(self, vm: "SPyVM", modname: str, use_spyc: bool = True) -> None:
         self.vm = vm
+        self.root = modname
         self.queue = deque([modname])
         self.mods: dict[str, MODULE] = {}
         self.deps: dict[str, OrderedSet[str]] = {}  # modname -> list_of_imports
@@ -297,6 +299,21 @@ class ImportAnalyzer:
             mod = self.mods[modname]
             if isinstance(mod, ast.Module):
                 self.import_one(modname, mod)
+            elif mod is None and modname == self.root:
+                # The root module couldn't be found. For non-root modules this
+                # is reported by ModFrame.exec_Import (which has the `import`
+                # statement to point at), but nothing imports the root, so we
+                # report it here instead.
+                self.import_error_not_found(modname)
+
+    def import_error_not_found(self, modname: str) -> None:
+        if self.vm.find_file_on_path(modname) is not None:
+            # the file exists, so it must be a .py (a .spy would have been
+            # parsed during parse_all)
+            msg = f"file `{modname}.py` exists, but py files cannot be imported"
+        else:
+            msg = f"module `{modname}` does not exist"
+        raise SPyError("W_ImportError", msg)
 
     def import_one(self, modname: str, mod: ast.Module) -> None:
         assert mod.symtable is not None

--- a/spy/analyze/importing.py
+++ b/spy/analyze/importing.py
@@ -118,6 +118,26 @@ class ImportAnalyzer:
         assert isinstance(mod, ast.Module)
         return mod
 
+    def find_file_on_path(self, modname: str) -> Optional[py.path.local]:
+        # XXX for now we assume that we find the module as a single file in
+        # the only vm.path entry. Eventually we will need a proper import
+        # mechanism and support for packages
+        #
+        # We search dir by dir, and within a dir .spy wins over .py. The
+        # caller is expected to check the extension of the result: a .py file
+        # cannot be imported, but we return it anyway so that the caller can
+        # produce a good error message. Note that a .py found in an earlier
+        # dir shadows a .spy in a later dir.
+        assert self.vm.path, "vm.path not set"
+        for d in self.vm.path:
+            f = py.path.local(d).join(f"{modname}.spy")
+            if f.exists():
+                return f
+            py_f = f.new(ext=".py")
+            if py_f.exists():
+                return py_f
+        return None
+
     def _get_spyc(self, spyfile: py.path.local) -> py.path.local:
         """
         Get the path to the cache file for a given .spy file.
@@ -212,7 +232,7 @@ class ImportAnalyzer:
                 w_mod = self.vm.modules_w[modname]
                 self.mods[modname] = w_mod
 
-            elif (spyfile := self.vm.find_file_on_path(modname)) and (
+            elif (spyfile := self.find_file_on_path(modname)) and (
                 spyfile.ext == ".spy"
             ):
                 # Initialize the dependency list for this module
@@ -311,7 +331,7 @@ class ImportAnalyzer:
                 assert False
 
     def raise_import_error(self, modname: str) -> None:
-        f = self.vm.find_file_on_path(modname)
+        f = self.find_file_on_path(modname)
         if f is not None and f.ext == ".py":
             msg = f"file `{modname}.py` exists, but py files cannot be imported"
         else:

--- a/spy/analyze/importing.py
+++ b/spy/analyze/importing.py
@@ -496,13 +496,14 @@ class ImportAnalyzer:
         self.record_import(self.cur_modname, imp.ref.modname, node=imp)
 
     def record_import(
-        self, cur_modname: str, modname: str, *, node: ast.Import
+        self, cur_modname: str, modname: str, *, node: ast.Import | None
     ) -> None:
         if modname == "builtins":
             return
         self.deps[cur_modname].add(modname)
         self.queue.append(modname)
         # remember the first Import node which referenced this module
-        self.importers.setdefault(modname, node)
+        if node is not None:
+            self.importers.setdefault(modname, node)
 
     # ===========================================================

--- a/spy/analyze/importing.py
+++ b/spy/analyze/importing.py
@@ -209,7 +209,9 @@ class ImportAnalyzer:
                 w_mod = self.vm.modules_w[modname]
                 self.mods[modname] = w_mod
 
-            elif spyfile := self.vm.find_file_on_path(modname):
+            elif (spyfile := self.vm.find_file_on_path(modname)) and (
+                spyfile.ext == ".spy"
+            ):
                 # Initialize the dependency list for this module
                 if modname not in self.deps:
                     self.deps[modname] = OrderedSet()

--- a/spy/analyze/importing.py
+++ b/spy/analyze/importing.py
@@ -103,10 +103,11 @@ class ImportAnalyzer:
 
     def __init__(self, vm: "SPyVM", modname: str, use_spyc: bool = True) -> None:
         self.vm = vm
-        self.root = modname
         self.queue = deque([modname])
         self.mods: dict[str, MODULE] = {}
         self.deps: dict[str, OrderedSet[str]] = {}  # modname -> list_of_imports
+        # modname -> first ast.Import that referenced it
+        self.importers: dict[str, ast.Import] = {}
         self.cur_modname: Optional[str] = None
         self.cached_mods: dict[str, py.path.local] = {}  # modname -> cache file path
         self.cache_errors: list[CacheError] = []  # List of all cache errors
@@ -224,7 +225,7 @@ class ImportAnalyzer:
                 # record implicit imports
                 assert mod.symtable is not None
                 for imp_modname in mod.symtable.implicit_imports:
-                    self.record_import(modname, imp_modname)
+                    self.record_import(modname, imp_modname, node=None)
 
                 # record explicit imports
                 self.cur_modname = modname
@@ -293,27 +294,37 @@ class ImportAnalyzer:
         return result
 
     def import_all(self) -> None:
+        from spy.vm.module import W_Module
+
         assert self.mods, "call .parse_all() first"
         import_list = self.get_import_list()
         for modname in import_list:
             mod = self.mods[modname]
             if isinstance(mod, ast.Module):
                 self.import_one(modname, mod)
-            elif mod is None and modname == self.root:
-                # The root module couldn't be found. For non-root modules this
-                # is reported by ModFrame.exec_Import (which has the `import`
-                # statement to point at), but nothing imports the root, so we
-                # report it here instead.
-                self.import_error_not_found(modname)
+            elif isinstance(mod, W_Module):
+                pass  # already imported, nothing to do
+            elif mod is None:
+                # not found, raise ImportError
+                self.raise_import_error(modname)
+            else:
+                assert False
 
-    def import_error_not_found(self, modname: str) -> None:
-        if self.vm.find_file_on_path(modname) is not None:
-            # the file exists, so it must be a .py (a .spy would have been
-            # parsed during parse_all)
+    def raise_import_error(self, modname: str) -> None:
+        f = self.vm.find_file_on_path(modname)
+        if f is not None and f.ext == ".py":
             msg = f"file `{modname}.py` exists, but py files cannot be imported"
         else:
             msg = f"module `{modname}` does not exist"
-        raise SPyError("W_ImportError", msg)
+
+        imp = self.importers.get(modname)
+        if imp is None:
+            # nobody imported this module via an `import` statement: it's
+            # either the root module or an implicit import (which has no node)
+            raise SPyError("W_ImportError", msg)
+        err = SPyError("W_ImportError", f"cannot import `{imp.ref.spy_name()}`")
+        err.add("error", msg, loc=imp.loc)
+        raise err
 
     def import_one(self, modname: str, mod: ast.Module) -> None:
         assert mod.symtable is not None
@@ -462,12 +473,16 @@ class ImportAnalyzer:
 
     def visit_Import(self, imp: ast.Import) -> None:
         assert self.cur_modname is not None
-        self.record_import(self.cur_modname, imp.ref.modname)
+        self.record_import(self.cur_modname, imp.ref.modname, node=imp)
 
-    def record_import(self, cur_modname: str, modname: str) -> None:
+    def record_import(
+        self, cur_modname: str, modname: str, *, node: ast.Import
+    ) -> None:
         if modname == "builtins":
             return
         self.deps[cur_modname].add(modname)
         self.queue.append(modname)
+        # remember the first Import node which referenced this module
+        self.importers.setdefault(modname, node)
 
     # ===========================================================

--- a/spy/tests/compiler/test_importing.py
+++ b/spy/tests/compiler/test_importing.py
@@ -47,6 +47,25 @@ class TestImporting(CompilerTest):
             from mymodule import x
             """)
 
+    def test_py_shadows_spy(self):
+        # a .py in an earlier vm.path dir shadows a .spy in a later one, so
+        # the import fails even though a .spy exists
+        otherdir = self.tmpdir.join("otherdir").ensure(dir=True)
+        self.vm.path.insert(0, str(otherdir))
+        otherdir.join("mymodule.py").write("x = 42")
+        self.write_file("mymodule.spy", "x: i32 = 100")
+        ctx = expect_errors(
+            "cannot import `mymodule.x`",
+            (
+                "file `mymodule.py` exists, but py files cannot be imported",
+                "from mymodule import x",
+            ),
+        )
+        with ctx:
+            self.compile("""
+            from mymodule import x
+            """)
+
     def test_function_in_other_module(self):
         src = """
         def get_delta() -> i32:

--- a/spy/tests/compiler/test_importing.py
+++ b/spy/tests/compiler/test_importing.py
@@ -1,3 +1,4 @@
+from spy.errors import SPyError
 from spy.tests.support import CompilerTest, expect_errors, only_interp
 
 
@@ -65,6 +66,18 @@ class TestImporting(CompilerTest):
             self.compile("""
             from mymodule import x
             """)
+
+    @only_interp
+    def test_import_missing_root_module(self):
+        with SPyError.raises("W_ImportError", match="module `xxx` does not exist"):
+            self.vm.import_("xxx")
+
+    @only_interp
+    def test_import_py_root_module(self):
+        self.write_file("mymodule.py", "x = 42")
+        msg = "file `mymodule.py` exists, but py files cannot be imported"
+        with SPyError.raises("W_ImportError", match=msg):
+            self.vm.import_("mymodule")
 
     def test_function_in_other_module(self):
         src = """

--- a/spy/tests/test_import_analyzer.py
+++ b/spy/tests/test_import_analyzer.py
@@ -26,6 +26,14 @@ class TestImportAnalyzer:
             f.setmtime(f.mtime() + mtime_delta)
         return f
 
+    def test_find_file_on_path(self):
+        analyzer = ImportAnalyzer(self.vm, "main")
+        self.tmpdir.join("main.spy").write("x: i32 = 42\n")
+        assert analyzer.find_file_on_path("main") == self.tmpdir.join("main.spy")
+        assert analyzer.find_file_on_path("nonexistent") is None
+        self.tmpdir.join("py.py").write("i = 42\n")
+        assert analyzer.find_file_on_path("py") == self.tmpdir.join("py.py")
+
     def test_simple_import(self):
         src = """
         x: i32 = 42

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -259,19 +259,6 @@ class TestVM:
         with pytest.raises(ValueError, match="'builtins::x' already exists"):
             vm.add_global(fqn, vm.wrap(43))
 
-    def test_get_filename(self, tmpdir):
-        vm = SPyVM()
-        vm.path = [str(tmpdir)]
-        spy_file = tmpdir.join("main.spy")
-        spy_file.write("x: i32 = 42\n")
-
-        filename = vm.find_file_on_path("main")
-        assert filename == tmpdir.join("main.spy")
-        assert vm.find_file_on_path("nonexistent") is None
-        py_file = tmpdir.join("py.py")
-        py_file.write("i = 42\n")
-        assert vm.find_file_on_path("py") == tmpdir.join("py.py")
-
     def test_wrap_list(self):
         from spy.vm.struct import unwrap_list
 

--- a/spy/tests/vm/test_vm.py
+++ b/spy/tests/vm/test_vm.py
@@ -270,8 +270,7 @@ class TestVM:
         assert vm.find_file_on_path("nonexistent") is None
         py_file = tmpdir.join("py.py")
         py_file.write("i = 42\n")
-        assert vm.find_file_on_path("py") is None
-        assert vm.find_file_on_path("py", allow_py_files=True) == tmpdir.join("py.py")
+        assert vm.find_file_on_path("py") == tmpdir.join("py.py")
 
     def test_wrap_list(self):
         from spy.vm.struct import unwrap_list

--- a/spy/vm/modframe.py
+++ b/spy/vm/modframe.py
@@ -120,37 +120,35 @@ class ModFrame(AbstractFrame):
         assert sym.impref == imp.ref
         w_val = self.vm.lookup_ImportRef(imp.ref)
         if w_val is not None:
-            # import successfull
+            # import successful
             w_T = self.vm.dynamic_type(w_val)
             self.declare_local(sym.name, "blue", w_T, imp.loc)
             self.store_local(sym.name, w_val)
             return
 
-        # import failed
+        if imp.ref.modname not in self.vm.modules_w:
+            # the module exists as a file (otherwise check_imports would have
+            # caught it) but is not loaded yet: this is a circular import,
+            # which is not yet supported.
+            err = SPyError(
+                "W_ImportError",
+                f"cannot import `{imp.ref.spy_name()}`",
+            )
+            err.add("error", f"module `{imp.ref.modname}` does not exist", loc=imp.loc)
+            err.add("note", "this is likely a circular import (WIP)", loc=imp.loc)
+            raise err
+
+        # if we are here, the module was imported but lookup_ImportRef failed: it must
+        # be a missing attribute on the module
+        assert imp.ref.modname in self.vm.modules_w, "FIXME: circular imports"
         err = SPyError(
             "W_ImportError",
             f"cannot import `{imp.ref.spy_name()}`",
         )
-        if imp.ref.modname not in self.vm.modules_w:
-            # See if there is a matching .py file
-            f = self.vm.find_file_on_path(imp.ref.modname)
-            if f is not None and f.ext == ".py":
-                err.add(
-                    "error",
-                    f"file `{imp.ref.modname}.py` exists, but py files cannot be imported",
-                    loc=imp.loc,
-                )
-            else:
-                # module not found
-                err.add(
-                    "error", f"module `{imp.ref.modname}` does not exist", loc=imp.loc
-                )
-        else:
-            # attribute not found
-            err.add(
-                "error",
-                f"attribute `{imp.ref.attr}` does not exist "
-                + f"in module `{imp.ref.modname}`",
-                loc=imp.loc_asname,
-            )
+        err.add(
+            "error",
+            f"attribute `{imp.ref.attr}` does not exist "
+            + f"in module `{imp.ref.modname}`",
+            loc=imp.loc_asname,
+        )
         raise err

--- a/spy/vm/modframe.py
+++ b/spy/vm/modframe.py
@@ -133,7 +133,8 @@ class ModFrame(AbstractFrame):
         )
         if imp.ref.modname not in self.vm.modules_w:
             # See if there is a matching .py file
-            if self.vm.find_file_on_path(imp.ref.modname, allow_py_files=True):
+            f = self.vm.find_file_on_path(imp.ref.modname)
+            if f is not None and f.ext == ".py":
                 err.add(
                     "error",
                     f"file `{imp.ref.modname}.py` exists, but py files cannot be imported",

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -170,22 +170,25 @@ class SPyVM:
         w_mod = self.modules_w[modname]
         return w_mod
 
-    def find_file_on_path(
-        self, modname: str, allow_py_files: bool = False
-    ) -> Optional[py.path.local]:
+    def find_file_on_path(self, modname: str) -> Optional[py.path.local]:
         # XXX for now we assume that we find the module as a single file in
         # the only vm.path entry. Eventually we will need a proper import
         # mechanism and support for packages
+        #
+        # We search dir by dir, and within a dir .spy wins over .py. The
+        # caller is expected to check the extension of the result: a .py file
+        # cannot be imported, but we return it anyway so that the caller can
+        # produce a good error message. Note that a .py found in an earlier
+        # dir shadows a .spy in a later dir.
         assert self.path, "vm.path not set"
         for d in self.path:
             # XXX write test for this
             f = py.path.local(d).join(f"{modname}.spy")
             if f.exists():
                 return f
-            if allow_py_files:
-                py_f = f.new(ext=".py")
-                if py_f.exists():
-                    return py_f
+            py_f = f.new(ext=".py")
+            if py_f.exists():
+                return py_f
 
         return None
 

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -4,7 +4,6 @@ from types import FunctionType
 from typing import Any, Callable, Iterable, Optional, Sequence, Union, overload
 
 import fixedint
-import py.path
 
 from spy import ROOT, ast, libspy
 from spy.analyze.symtable import Color, ImportRef, SymTable, maybe_blue
@@ -169,28 +168,6 @@ class SPyVM:
         importer.import_all()
         w_mod = self.modules_w[modname]
         return w_mod
-
-    def find_file_on_path(self, modname: str) -> Optional[py.path.local]:
-        # XXX for now we assume that we find the module as a single file in
-        # the only vm.path entry. Eventually we will need a proper import
-        # mechanism and support for packages
-        #
-        # We search dir by dir, and within a dir .spy wins over .py. The
-        # caller is expected to check the extension of the result: a .py file
-        # cannot be imported, but we return it anyway so that the caller can
-        # produce a good error message. Note that a .py found in an earlier
-        # dir shadows a .spy in a later dir.
-        assert self.path, "vm.path not set"
-        for d in self.path:
-            # XXX write test for this
-            f = py.path.local(d).join(f"{modname}.spy")
-            if f.exists():
-                return f
-            py_f = f.new(ext=".py")
-            if py_f.exists():
-                return py_f
-
-        return None
 
     def redshift(self, error_mode: ErrorMode) -> None:
         """


### PR DESCRIPTION
Improve import system in various ways.
First of all, this changes the .py/.spy behavior.
The old way was:
  - first scan `vm.path` to find a .spy file
  - IF not found, scan it again to fine a .py file. If a .py file is found, raise `"file `mymodule.py` exists, but py files cannot be imported`

The new way is:
  - scan directories of vm.path one by one. For each dir:
  - if a .spy file is there, use it
  - if a .py file is there, raise the error

This means that a .py file "shadows" a .spy file which comes later in the path, but I think it's a better choice and leads to less surprises. Moreover, it helps to simplify the logic which is a nice plus. Happy to revisit the decision later if needed.

As a by-product of this change, we also fix the problem that caused the error message `...but py files cannot be imported` spuriously, even when the actual problem was something else.

Also, we now add a note when an import error is caused by a (likely) circular import, which is not fully supported yet.

Finally, we did a general refactoring/simplification of the code in `ImportAnalyzer`. In particular, `ImportError` is now raised by `ImportAnalyzer` itself.