### PR TITLE
Introduce type.__name__, __qualname__, __fqn__ and __full_fqn__

### DIFF
--- a/examples/expected_output/type_name_and_fqn.txt
+++ b/examples/expected_output/type_name_and_fqn.txt
@@ -1,0 +1,4 @@
+__full_fqn__  type_name_and_fqn::Foo[i32]::Self
+__fqn__       type_name_and_fqn::Foo[i32]
+__qualname__  type_name_and_fqn::Foo[i32]
+__name__      Foo[i32]

--- a/examples/type_name_and_fqn.spy
+++ b/examples/type_name_and_fqn.spy
@@ -1,0 +1,9 @@
+@struct
+class Foo[T]:
+    pass
+
+def main() -> None:
+    print("__full_fqn__ ", Foo[i32].__full_fqn__)
+    print("__fqn__      ", Foo[i32].__fqn__)
+    print("__qualname__ ", Foo[i32].__qualname__)
+    print("__name__     ", Foo[i32].__name__)

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -331,6 +331,10 @@ class FQN:
         human_fqn = self._resolve_aliases(vm, frozenset())
         return human_fqn._human_render()
 
+    def human_symbol_name(self, vm: Any) -> str:
+        human_fqn = self._resolve_aliases(vm, frozenset())
+        return human_fqn.symbol_name
+
     @property
     def modname(self) -> str:
         return str(self.parts[0])

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -1568,3 +1568,27 @@ class TestBasic(CompilerTest):
         """
         mod = self.compile(src)
         assert mod.foo() == 1
+
+    @only_interp
+    def test_type_name_attributes(self):
+        src = """
+        @struct
+        class Foo[T]:
+            pass
+
+        def get_name() -> str:
+            return Foo[i32].__name__
+
+        def get_qualname() -> str:
+            return Foo[i32].__qualname__
+
+        def get_fqn() -> str:
+            return Foo[i32].__fqn__
+
+        def get_full_fqn() -> str:
+            return Foo[i32].__full_fqn__
+        """
+        mod = self.compile(src)
+        assert mod.get_name() == "Foo[i32]"
+        assert mod.get_qualname() == mod.get_fqn() == "test::Foo[i32]"
+        assert mod.get_full_fqn() == "test::Foo[i32]::Self"

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -762,6 +762,44 @@ class W_Type(W_Object):
     def w_repr(vm: "SPyVM", w_self: "W_Type") -> "W_Str":
         return vm.wrap(repr(w_self))
 
+    @builtin_property("__name__")
+    @staticmethod
+    def w_get_name(vm: "SPyVM", w_self: "W_Type") -> "W_Str":
+        """
+        Equivalent to fqn.human_symbol_name().
+        """
+        return vm.wrap(w_self.fqn.human_symbol_name(vm))
+
+    @builtin_property("__qualname__")
+    @staticmethod
+    def w_get_qualname(vm: "SPyVM", w_self: "W_Type") -> "W_Str":
+        """
+        Equivalent to __fqn__ and fqn.human_name().
+
+        This is what is shown in the output of e.g. 'spy redshift'.
+        """
+        return vm.wrap(w_self.fqn.human_name(vm))
+
+    @builtin_property("__fqn__")
+    @staticmethod
+    def w_get_fqn(vm: "SPyVM", w_self: "W_Type") -> "W_Str":
+        """
+        Equivalent to __qualname__ and fqn.human_name()
+
+        This is what is shown in the output of e.g. 'spy redshift'.
+        """
+        return vm.wrap(w_self.fqn.human_name(vm))
+
+    @builtin_property("__full_fqn__")
+    @staticmethod
+    def w_get_full_fqn(vm: "SPyVM", w_self: "W_Type") -> "W_Str":
+        """
+        Equivalent to str(fqn).
+
+        This is what is shown in the output of e.g. 'spy redshift --full-fqn'.
+        """
+        return vm.wrap(str(w_self.fqn))
+
     # this is the equivalent of CPython's typeobject.c:type_getattro
     @builtin_method("__getattribute__", color="blue", kind="metafunc")
     @staticmethod


### PR DESCRIPTION
They are all derived by the fqn, with varying grades of precision. It
is not possible to do a 1:1 mapping to what CPython shows but we tried
to give reasonable results for `__name__` and `__qualname__`.

`__fqn__` and `__full_fqn__` are new and should be preferred.

The easiest way to explain the difference is to look at a concrete example (see also test_basic::test_type_name_attributes):

It is easier to explain with an example:

```python
@struct
class Foo[T]:
    pass

def main() -> None:
    print("__full_fqn__ ", Foo[i32].__full_fqn__)
    print("__fqn__      ", Foo[i32].__fqn__)
    print("__qualname__ ", Foo[i32].__qualname__)
    print("__name__     ", Foo[i32].__name__)
```

```
❯ spy /tmp/x.spy 
__full_fqn__  x::Foo[i32]::Self
__fqn__       x::Foo[i32]
__qualname__  x::Foo[i32]
__name__      Foo[i32]
```

`x:Foo[i32]::Self` is the most complete name used internally. It's what `spy redshift` uses to show types/function names when you pass `__full_fqn__`.

`__fqn__` is the "human readable" version of it. The biggest difference is that it honors generics, so you get `x::Foo[i32]` instead.  `__qualname__` is just an alias to it.

`__name__` is like `__qualname__` but without the module name. It's a bit different than CPython because it includes the qualifiers (e.g. `Foo[i32]` instead of `Foo`) but I think it's good to include them in e.g. error messages.