### PR TITLE
Implement str.encode and bytes.decode

### DIFF
--- a/spy/tests/compiler/__spy__/test_misc.py
+++ b/spy/tests/compiler/__spy__/test_misc.py
@@ -1,6 +1,7 @@
 import pytest
 
-from spy.tests.support import CompilerTest
+from spy.errors import SPyError
+from spy.tests.support import CompilerTest, only_interp
 
 
 class TestMisc(CompilerTest):
@@ -41,3 +42,35 @@ class TestMisc(CompilerTest):
         """
         mod = self.compile(src)
         assert mod.foo() == "red"
+
+    @only_interp
+    def test_lookup_fqn(self):
+        src = """
+        from __spy__ import lookup_fqn
+
+        def foo() -> str:
+            bar = lookup_fqn('test::bar')
+            return bar() + '-foo'
+        """
+        self.write_file("y.spy", src)
+        #
+        mod = self.compile("""
+        from y import foo
+
+        def bar() -> str:
+            return 'bar'
+
+        def main() -> str:
+            return foo() + '-main'
+        """)
+        assert mod.main() == "bar-foo-main"
+
+    @only_interp
+    def test_lookup_fqn_not_found(self):
+        src = """
+        from __spy__ import lookup_fqn
+
+        w_x = lookup_fqn("test::does_not_exist")
+        """
+        with SPyError.raises("W_ValueError", match="FQN not found"):
+            self.compile(src)

--- a/spy/tests/compiler/test_bytes.py
+++ b/spy/tests/compiler/test_bytes.py
@@ -1,3 +1,4 @@
+from spy.errors import SPyError
 from spy.tests.support import CompilerTest, only_interp
 
 
@@ -106,3 +107,31 @@ class TestBytes(CompilerTest):
         result = mod.foo()
         assert result != 0
         assert result == mod.foo()
+
+    def test_decode(self):
+        src = """
+        def decode(b: bytes) -> str:
+            return b.decode("utf-8")
+        """
+        mod = self.compile(src)
+        assert mod.decode(b"hello") == "hello"
+        assert mod.decode(b"") == ""
+        assert mod.decode("àèìòù".encode("utf-8")) == "àèìòù"
+
+    def test_decode_unsupported(self):
+        src = """
+        def decode(b: bytes, enc: str) -> str:
+            return b.decode(enc)
+        """
+        mod = self.compile(src)
+        with SPyError.raises("W_ValueError"):
+            mod.decode(b"x", "ascii")
+
+    def test_encode_decode_roundtrip(self):
+        src = """
+        def roundtrip(s: str) -> str:
+            return s.encode("utf-8").decode("utf-8")
+        """
+        mod = self.compile(src)
+        assert mod.roundtrip("hello world") == "hello world"
+        assert mod.roundtrip("àèìòù") == "àèìòù"

--- a/spy/tests/compiler/test_str.py
+++ b/spy/tests/compiler/test_str.py
@@ -1,7 +1,7 @@
 import re
 
 from spy.errors import SPyError
-from spy.tests.support import CompilerTest, skip_backends
+from spy.tests.support import CompilerTest, only_interp, skip_backends
 
 
 class TestStr(CompilerTest):
@@ -430,3 +430,22 @@ class TestStr(CompilerTest):
         # assert mod.foo("abc", "", "-", 0) == "abc"  # count not supported
         # assert mod.foo("abc", "ab", "--", 0) == "abc"  # count not supported
         assert mod.foo("abc", "xy", "--") == "abc"
+
+    def test_encode(self):
+        src = """
+        def encode(s: str) -> bytes:
+            return s.encode("utf-8")
+        """
+        mod = self.compile(src)
+        assert mod.encode("hello") == b"hello"
+        assert mod.encode("") == b""
+        assert mod.encode("àèìòù") == "àèìòù".encode("utf-8")
+
+    def test_encode_unsupported(self):
+        src = """
+        def encode(s: str, enc: str) -> bytes:
+            return s.encode(enc)
+        """
+        mod = self.compile(src)
+        with SPyError.raises("W_ValueError"):
+            mod.encode("x", "ascii")

--- a/spy/vm/bytes.py
+++ b/spy/vm/bytes.py
@@ -48,6 +48,7 @@ class W_Bytes(W_Object):
         "__add__": FQN("_bytes::methods::__add__"),
         "__mul__": FQN("_bytes::methods::__mul__"),
         "__repr__": FQN("_bytes::methods::__repr__"),
+        "decode": FQN("_bytes::methods::decode"),
     }
 
     vm: "SPyVM"

--- a/spy/vm/modules/__spy__/misc.py
+++ b/spy/vm/modules/__spy__/misc.py
@@ -132,7 +132,9 @@ def w__stdout_write(vm: "SPyVM", w_s: W_Str) -> None:
 @SPY.builtin_func(color="blue")
 def w_lookup_fqn(vm: "SPyVM", w_s: W_Str) -> W_Dynamic:
     fqn_str = vm.unwrap_str(w_s)
-    w_val = vm.lookup_global_maybe(FQN(fqn_str))
+    fqn = FQN(fqn_str)
+    vm.import_(fqn.modname)
+    w_val = vm.lookup_global_maybe(fqn)
     if w_val is None:
         raise SPyError("W_ValueError", f"FQN not found: {fqn_str}")
     return w_val

--- a/spy/vm/modules/__spy__/misc.py
+++ b/spy/vm/modules/__spy__/misc.py
@@ -7,7 +7,7 @@ from spy.vm.builtin import builtin_method
 from spy.vm.function import W_ASTFunc, W_Func
 from spy.vm.object import W_Object
 from spy.vm.opspec import W_MetaArg, W_OpSpec
-from spy.vm.primitive import W_Bool
+from spy.vm.primitive import W_Bool, W_Dynamic
 from spy.vm.str import W_Str
 
 from . import SPY, interp_list
@@ -127,3 +127,12 @@ def w_force_inline(vm: "SPyVM", w_func: W_Object) -> W_Object:
 @SPY.builtin_func
 def w__stdout_write(vm: "SPyVM", w_s: W_Str) -> None:
     sys.stdout.write(vm.unwrap(w_s))
+
+
+@SPY.builtin_func(color="blue")
+def w_lookup_fqn(vm: "SPyVM", w_s: W_Str) -> W_Dynamic:
+    fqn_str = vm.unwrap_str(w_s)
+    w_val = vm.lookup_global_maybe(FQN(fqn_str))
+    if w_val is None:
+        raise SPyError("W_ValueError", f"FQN not found: {fqn_str}")
+    return w_val

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -45,6 +45,7 @@ class W_Str(W_Object):
     __spy_lazy_attributes__ = {
         "isascii": FQN("_str::methods::isascii"),
         "upper": FQN("_str::methods::upper"),
+        "encode": FQN("_str::methods::encode"),
     }
 
     vm: "SPyVM"

--- a/stdlib/_bytes.spy
+++ b/stdlib/_bytes.spy
@@ -13,6 +13,7 @@ BytesObject.{from,to}_bytes.
 
 from unsafe import (
     gc_ptr,
+    memcpy,
     _bytes_to_BytesObject,
     _alloc_BytesObject,
     _BytesObject_to_bytes,
@@ -95,6 +96,16 @@ class methods:
     # XXX: __hash__ lives in C (spy_bytes_hash, called from W_Bytes.w_hash) because
     # FNV-1a requires wrapping i32 multiply, which is not yet available at applevel.
     # Once SPy gains wrapping arithmetic primitives, port it here.
+
+    def decode(self: bytes, encoding: str) -> str:
+        if encoding != "utf-8":
+            raise ValueError("only 'utf-8' encoding is supported")
+        ll = BytesObject.from_bytes(self)
+        out = StrObject.alloc(ll.length)
+        out.hash = 0
+        if ll.length > 0:
+            memcpy(out.utf8, ll.data, ll.length)
+        return StrObject.to_str(out)
 
     def __repr__(self: bytes) -> str:
         ll = BytesObject.from_bytes(self)

--- a/stdlib/_str.spy
+++ b/stdlib/_str.spy
@@ -12,7 +12,15 @@ The StrObject struct defined here MUST stay in sync with the one defined in C. I
 possible to cast between str and gc_ptr[StrObject] using StrObject.{from,to}_str.
 """
 
-from unsafe import gc_ptr, _str_to_StrObject, _alloc_StrObject, _StrObject_to_str
+from unsafe import (
+    gc_ptr,
+    memcpy,
+    _str_to_StrObject,
+    _alloc_StrObject,
+    _StrObject_to_str,
+)
+from unsafe import _alloc_BytesObject, _BytesObject_to_bytes
+from __spy__ import lookup_fqn
 
 
 # this MUST stay in sync with the equivalent struct declared in str.h
@@ -66,6 +74,19 @@ class methods:
     # each method defined here should also have a corresponding entry in
     # W_Str.__spy_lazy_attributes__.
 
+    def encode(self: str, encoding: str) -> bytes:
+        # we don't support circular imports and function-level imports. This is a hacky
+        # workaround for 'from _bytes import BytesObject'
+        BytesObject = lookup_fqn("_bytes::BytesObject")
+        if encoding != "utf-8":
+            raise ValueError("only 'utf-8' encoding is supported")
+        ll = StrObject.from_str(self)
+        out = _alloc_BytesObject(ll.length)
+        out.hash = 0
+        if ll.length > 0:
+            memcpy(out.data, ll.utf8, ll.length)
+        return _BytesObject_to_bytes(out)
+
     def isascii(self: str) -> bool:
         ll = StrObject.from_str(self)
         i = 0
@@ -83,8 +104,8 @@ class methods:
         llnew.hash = 0
         for i in range(ll.length):
             ch = ll.utf8[i]
-            if ord(b'a') <= ch and ch <= ord(b'z'):
-                llnew.utf8[i] = ch - (ord(b'a') - ord(b'A'))
+            if ord(b"a") <= ch and ch <= ord(b"z"):
+                llnew.utf8[i] = ch - (ord(b"a") - ord(b"A"))
             else:
                 llnew.utf8[i] = ch
         return StrObject.to_str(llnew)


### PR DESCRIPTION
- Implement `bytes.decode()`. Only utf-8 supported and it's "fake" (it doesn't validate).
- Implement `str.encode()`. Only utf-8 supported.
- Add `__spy__.lookup_fqn` as a workaround for circular imports