### PR TITLE
Generalize unsafe memops to ptr[T] and add slice variants

### DIFF
--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -558,7 +558,7 @@ class CFuncWriter:
             return self.fmt_generic_call(fqn, call)
 
         elif irtag.tag == "unsafe.memop":
-            # memcpy, memmove, etc.
+            # ptr_copy, ptr_move, etc.
             return self.fmt_memop(fqn, call, irtag)
 
         else:
@@ -606,6 +606,6 @@ class CFuncWriter:
 
     def fmt_memop(self, fqn: FQN, call: ast.Call, irtag: IRTag) -> C.Expr:
         cfunc = irtag.data["cfunc"]
-        assert cfunc in ("spy_memcpy", "spy_memmove", "spy_memcmp", "spy_memset")
+        assert cfunc in ("spy_ptr_copy", "spy_ptr_move", "spy_ptr_cmp", "spy_ptr_set")
         c_args = [self.fmt_expr(arg) for arg in call.args]
         return C.Call(cfunc, c_args)

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -610,8 +610,11 @@ class CFuncWriter:
             "spy_ptr_copy",
             "spy_ptr_copy_slice",
             "spy_ptr_move",
+            "spy_ptr_move_slice",
             "spy_ptr_cmp",
+            "spy_ptr_cmp_slice",
             "spy_ptr_set",
+            "spy_ptr_set_slice",
         )
         c_args = [self.fmt_expr(arg) for arg in call.args]
         return C.Call(cfunc, c_args)

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -606,6 +606,12 @@ class CFuncWriter:
 
     def fmt_memop(self, fqn: FQN, call: ast.Call, irtag: IRTag) -> C.Expr:
         cfunc = irtag.data["cfunc"]
-        assert cfunc in ("spy_ptr_copy", "spy_ptr_move", "spy_ptr_cmp", "spy_ptr_set")
+        assert cfunc in (
+            "spy_ptr_copy",
+            "spy_ptr_copy_slice",
+            "spy_ptr_move",
+            "spy_ptr_cmp",
+            "spy_ptr_set",
+        )
         c_args = [self.fmt_expr(arg) for arg in call.args]
         return C.Call(cfunc, c_args)

--- a/spy/libspy/include/spy/unsafe.h
+++ b/spy/libspy/include/spy/unsafe.h
@@ -209,6 +209,29 @@ typedef spy_unsafe$gc_ptr__builtins$u8 spy_gc_ptr_u8;
 #endif
 
 #ifdef SPY_DEBUG
+#  define spy_ptr_move_slice(dst, ds, de, src, ss, se)                                 \
+      do {                                                                             \
+          ptrdiff_t _spy_n = (de) - (ds);                                              \
+          if (_spy_n != (se) - (ss))                                                   \
+              spy_panic(                                                               \
+                  "PanicError", "ptr_move_slice length mismatch", __FILE__, __LINE__   \
+              );                                                                       \
+          if (_spy_n < 0 || (ds) < 0 || (de) > (dst).length)                           \
+              spy_panic(                                                               \
+                  "PanicError", "ptr_move_slice dst out of bounds", __FILE__, __LINE__ \
+              );                                                                       \
+          if ((ss) < 0 || (se) > (src).length)                                         \
+              spy_panic(                                                               \
+                  "PanicError", "ptr_move_slice src out of bounds", __FILE__, __LINE__ \
+              );                                                                       \
+          memmove((dst).p + (ds), (src).p + (ss), _spy_n * sizeof(*(dst).p));          \
+      } while (0)
+#else
+#  define spy_ptr_move_slice(dst, ds, de, src, ss, se)                                 \
+      memmove((dst).p + (ds), (src).p + (ss), ((de) - (ds)) * sizeof(*(dst).p))
+#endif
+
+#ifdef SPY_DEBUG
 #  define spy_ptr_set(dst, value, n)                                                   \
       do {                                                                             \
           if ((size_t)(n) > (size_t)(dst).length)                                      \
@@ -217,6 +240,21 @@ typedef spy_unsafe$gc_ptr__builtins$u8 spy_gc_ptr_u8;
       } while (0)
 #else
 #  define spy_ptr_set(dst, value, n) memset((dst).p, (value), (n) * sizeof(*(dst).p))
+#endif
+
+#ifdef SPY_DEBUG
+#  define spy_ptr_set_slice(dst, ds, de, value)                                        \
+      do {                                                                             \
+          ptrdiff_t _spy_n = (de) - (ds);                                              \
+          if (_spy_n < 0 || (ds) < 0 || (de) > (dst).length)                           \
+              spy_panic(                                                               \
+                  "PanicError", "ptr_set_slice out of bounds", __FILE__, __LINE__      \
+              );                                                                       \
+          memset((dst).p + (ds), (value), _spy_n * sizeof(*(dst).p));                  \
+      } while (0)
+#else
+#  define spy_ptr_set_slice(dst, ds, de, value)                                        \
+      memset((dst).p + (ds), (value), ((de) - (ds)) * sizeof(*(dst).p))
 #endif
 
 // spy_ptr_cmp needs to yield a value; ternary chain works on all compilers.
@@ -232,6 +270,30 @@ typedef spy_unsafe$gc_ptr__builtins$u8 spy_gc_ptr_u8;
            : memcmp((a).p, (b).p, (n) * sizeof(*(a).p)))
 #else
 #  define spy_ptr_cmp(a, b, n) memcmp((a).p, (b).p, (n) * sizeof(*(a).p))
+#endif
+
+// spy_ptr_cmp_slice yields a value too; same ternary trick.
+#ifdef SPY_DEBUG
+#  define spy_ptr_cmp_slice(a, as_, ae, b, bs, be)                                     \
+      (((ae) - (as_)) != ((be) - (bs))                                                 \
+           ? (spy_panic(                                                               \
+                  "PanicError", "ptr_cmp_slice length mismatch", __FILE__, __LINE__    \
+              ),                                                                       \
+              0)                                                                       \
+       : ((ae) - (as_)) < 0 || (as_) < 0 || (ae) > (a).length                          \
+           ? (spy_panic(                                                               \
+                  "PanicError", "ptr_cmp_slice a out of bounds", __FILE__, __LINE__    \
+              ),                                                                       \
+              0)                                                                       \
+       : (bs) < 0 || (be) > (b).length                                                 \
+           ? (spy_panic(                                                               \
+                  "PanicError", "ptr_cmp_slice b out of bounds", __FILE__, __LINE__    \
+              ),                                                                       \
+              0)                                                                       \
+           : memcmp((a).p + (as_), (b).p + (bs), ((ae) - (as_)) * sizeof(*(a).p)))
+#else
+#  define spy_ptr_cmp_slice(a, as_, ae, b, bs, be)                                     \
+      memcmp((a).p + (as_), (b).p + (bs), ((ae) - (as_)) * sizeof(*(a).p))
 #endif
 
 #endif /* SPY_UNSAFE_H */

--- a/spy/libspy/include/spy/unsafe.h
+++ b/spy/libspy/include/spy/unsafe.h
@@ -144,6 +144,7 @@ typedef spy_unsafe$gc_ptr__builtins$u8 spy_gc_ptr_u8;
 /* memcpy/memmove/memset/memcmp macros for the C backend.
    In SPY_DEBUG they check bounds via the .length field; in SPY_RELEASE they
    expand to bare libc calls with zero overhead. */
+/* In all the macros below, `n` is the number of ITEMS, not bytes. */
 #ifdef SPY_DEBUG
 #  define spy_memcpy(dst, src, n)                                                      \
       do {                                                                             \
@@ -151,10 +152,10 @@ typedef spy_unsafe$gc_ptr__builtins$u8 spy_gc_ptr_u8;
               spy_panic("PanicError", "memcpy dst out of bounds", __FILE__, __LINE__); \
           if ((size_t)(n) > (size_t)(src).length)                                      \
               spy_panic("PanicError", "memcpy src out of bounds", __FILE__, __LINE__); \
-          memcpy((dst).p, (src).p, (n));                                               \
+          memcpy((dst).p, (src).p, (n) * sizeof(*(dst).p));                            \
       } while (0)
 #else
-#  define spy_memcpy(dst, src, n) memcpy((dst).p, (src).p, (n))
+#  define spy_memcpy(dst, src, n) memcpy((dst).p, (src).p, (n) * sizeof(*(dst).p))
 #endif
 
 #ifdef SPY_DEBUG
@@ -168,10 +169,10 @@ typedef spy_unsafe$gc_ptr__builtins$u8 spy_gc_ptr_u8;
               spy_panic(                                                               \
                   "PanicError", "memmove src out of bounds", __FILE__, __LINE__        \
               );                                                                       \
-          memmove((dst).p, (src).p, (n));                                              \
+          memmove((dst).p, (src).p, (n) * sizeof(*(dst).p));                           \
       } while (0)
 #else
-#  define spy_memmove(dst, src, n) memmove((dst).p, (src).p, (n))
+#  define spy_memmove(dst, src, n) memmove((dst).p, (src).p, (n) * sizeof(*(dst).p))
 #endif
 
 #ifdef SPY_DEBUG
@@ -179,10 +180,10 @@ typedef spy_unsafe$gc_ptr__builtins$u8 spy_gc_ptr_u8;
       do {                                                                             \
           if ((size_t)(n) > (size_t)(dst).length)                                      \
               spy_panic("PanicError", "memset out of bounds", __FILE__, __LINE__);     \
-          memset((dst).p, (value), (n));                                               \
+          memset((dst).p, (value), (n) * sizeof(*(dst).p));                            \
       } while (0)
 #else
-#  define spy_memset(dst, value, n) memset((dst).p, (value), (n))
+#  define spy_memset(dst, value, n) memset((dst).p, (value), (n) * sizeof(*(dst).p))
 #endif
 
 // spy_memcmp needs to yield a value; ternary chain works on all compilers.
@@ -195,9 +196,9 @@ typedef spy_unsafe$gc_ptr__builtins$u8 spy_gc_ptr_u8;
        : (size_t)(n) > (size_t)(b).length                                              \
            ? (spy_panic("PanicError", "memcmp b out of bounds", __FILE__, __LINE__),   \
               0)                                                                       \
-           : memcmp((a).p, (b).p, (n)))
+           : memcmp((a).p, (b).p, (n) * sizeof(*(a).p)))
 #else
-#  define spy_memcmp(a, b, n) memcmp((a).p, (b).p, (n))
+#  define spy_memcmp(a, b, n) memcmp((a).p, (b).p, (n) * sizeof(*(a).p))
 #endif
 
 #endif /* SPY_UNSAFE_H */

--- a/spy/libspy/include/spy/unsafe.h
+++ b/spy/libspy/include/spy/unsafe.h
@@ -141,64 +141,71 @@ SPY_PTR_FUNCTIONS(gc, spy_unsafe$gc_ptr__builtins$u8, uint8_t)
 // short alias for manual use
 typedef spy_unsafe$gc_ptr__builtins$u8 spy_gc_ptr_u8;
 
-/* memcpy/memmove/memset/memcmp macros for the C backend.
+/* ptr_copy/ptr_move/ptr_set/ptr_cmp macros for the C backend.
    In SPY_DEBUG they check bounds via the .length field; in SPY_RELEASE they
-   expand to bare libc calls with zero overhead. */
-/* In all the macros below, `n` is the number of ITEMS, not bytes. */
-#ifdef SPY_DEBUG
-#  define spy_memcpy(dst, src, n)                                                      \
-      do {                                                                             \
-          if ((size_t)(n) > (size_t)(dst).length)                                      \
-              spy_panic("PanicError", "memcpy dst out of bounds", __FILE__, __LINE__); \
-          if ((size_t)(n) > (size_t)(src).length)                                      \
-              spy_panic("PanicError", "memcpy src out of bounds", __FILE__, __LINE__); \
-          memcpy((dst).p, (src).p, (n) * sizeof(*(dst).p));                            \
-      } while (0)
-#else
-#  define spy_memcpy(dst, src, n) memcpy((dst).p, (src).p, (n) * sizeof(*(dst).p))
-#endif
+   expand to bare libc calls with zero overhead.
 
+   Unlike C's memcpy/memmove/memset/memcmp, `n` is the number of ITEMS, not
+   bytes — matching Rust's ptr::copy{,_nonoverlapping}, Java's
+   System.arraycopy, C#'s Array.Copy, and Go's copy. */
 #ifdef SPY_DEBUG
-#  define spy_memmove(dst, src, n)                                                     \
+#  define spy_ptr_copy(dst, src, n)                                                    \
       do {                                                                             \
           if ((size_t)(n) > (size_t)(dst).length)                                      \
               spy_panic(                                                               \
-                  "PanicError", "memmove dst out of bounds", __FILE__, __LINE__        \
+                  "PanicError", "ptr_copy dst out of bounds", __FILE__, __LINE__       \
               );                                                                       \
           if ((size_t)(n) > (size_t)(src).length)                                      \
               spy_panic(                                                               \
-                  "PanicError", "memmove src out of bounds", __FILE__, __LINE__        \
+                  "PanicError", "ptr_copy src out of bounds", __FILE__, __LINE__       \
+              );                                                                       \
+          memcpy((dst).p, (src).p, (n) * sizeof(*(dst).p));                            \
+      } while (0)
+#else
+#  define spy_ptr_copy(dst, src, n) memcpy((dst).p, (src).p, (n) * sizeof(*(dst).p))
+#endif
+
+#ifdef SPY_DEBUG
+#  define spy_ptr_move(dst, src, n)                                                    \
+      do {                                                                             \
+          if ((size_t)(n) > (size_t)(dst).length)                                      \
+              spy_panic(                                                               \
+                  "PanicError", "ptr_move dst out of bounds", __FILE__, __LINE__       \
+              );                                                                       \
+          if ((size_t)(n) > (size_t)(src).length)                                      \
+              spy_panic(                                                               \
+                  "PanicError", "ptr_move src out of bounds", __FILE__, __LINE__       \
               );                                                                       \
           memmove((dst).p, (src).p, (n) * sizeof(*(dst).p));                           \
       } while (0)
 #else
-#  define spy_memmove(dst, src, n) memmove((dst).p, (src).p, (n) * sizeof(*(dst).p))
+#  define spy_ptr_move(dst, src, n) memmove((dst).p, (src).p, (n) * sizeof(*(dst).p))
 #endif
 
 #ifdef SPY_DEBUG
-#  define spy_memset(dst, value, n)                                                    \
+#  define spy_ptr_set(dst, value, n)                                                   \
       do {                                                                             \
           if ((size_t)(n) > (size_t)(dst).length)                                      \
-              spy_panic("PanicError", "memset out of bounds", __FILE__, __LINE__);     \
+              spy_panic("PanicError", "ptr_set out of bounds", __FILE__, __LINE__);    \
           memset((dst).p, (value), (n) * sizeof(*(dst).p));                            \
       } while (0)
 #else
-#  define spy_memset(dst, value, n) memset((dst).p, (value), (n) * sizeof(*(dst).p))
+#  define spy_ptr_set(dst, value, n) memset((dst).p, (value), (n) * sizeof(*(dst).p))
 #endif
 
-// spy_memcmp needs to yield a value; ternary chain works on all compilers.
+// spy_ptr_cmp needs to yield a value; ternary chain works on all compilers.
 // spy_panic is NORETURN so the ", 0" arms are dead code but satisfy the type.
 #ifdef SPY_DEBUG
-#  define spy_memcmp(a, b, n)                                                          \
+#  define spy_ptr_cmp(a, b, n)                                                         \
       ((size_t)(n) > (size_t)(a).length                                                \
-           ? (spy_panic("PanicError", "memcmp a out of bounds", __FILE__, __LINE__),   \
+           ? (spy_panic("PanicError", "ptr_cmp a out of bounds", __FILE__, __LINE__),  \
               0)                                                                       \
        : (size_t)(n) > (size_t)(b).length                                              \
-           ? (spy_panic("PanicError", "memcmp b out of bounds", __FILE__, __LINE__),   \
+           ? (spy_panic("PanicError", "ptr_cmp b out of bounds", __FILE__, __LINE__),  \
               0)                                                                       \
            : memcmp((a).p, (b).p, (n) * sizeof(*(a).p)))
 #else
-#  define spy_memcmp(a, b, n) memcmp((a).p, (b).p, (n) * sizeof(*(a).p))
+#  define spy_ptr_cmp(a, b, n) memcmp((a).p, (b).p, (n) * sizeof(*(a).p))
 #endif
 
 #endif /* SPY_UNSAFE_H */

--- a/spy/libspy/include/spy/unsafe.h
+++ b/spy/libspy/include/spy/unsafe.h
@@ -165,6 +165,32 @@ typedef spy_unsafe$gc_ptr__builtins$u8 spy_gc_ptr_u8;
 #  define spy_ptr_copy(dst, src, n) memcpy((dst).p, (src).p, (n) * sizeof(*(dst).p))
 #endif
 
+/* ptr_copy_slice(dst, dst_start, dst_end, src, src_start, src_end):
+   copy items in src[src_start:src_end] to dst[dst_start:dst_end].
+   Both slices must have the same length; bounds are checked in SPY_DEBUG. */
+#ifdef SPY_DEBUG
+#  define spy_ptr_copy_slice(dst, ds, de, src, ss, se)                                 \
+      do {                                                                             \
+          ptrdiff_t _spy_n = (de) - (ds);                                              \
+          if (_spy_n != (se) - (ss))                                                   \
+              spy_panic(                                                               \
+                  "PanicError", "ptr_copy_slice length mismatch", __FILE__, __LINE__   \
+              );                                                                       \
+          if (_spy_n < 0 || (ds) < 0 || (de) > (dst).length)                           \
+              spy_panic(                                                               \
+                  "PanicError", "ptr_copy_slice dst out of bounds", __FILE__, __LINE__ \
+              );                                                                       \
+          if ((ss) < 0 || (se) > (src).length)                                         \
+              spy_panic(                                                               \
+                  "PanicError", "ptr_copy_slice src out of bounds", __FILE__, __LINE__ \
+              );                                                                       \
+          memcpy((dst).p + (ds), (src).p + (ss), _spy_n * sizeof(*(dst).p));           \
+      } while (0)
+#else
+#  define spy_ptr_copy_slice(dst, ds, de, src, ss, se)                                 \
+      memcpy((dst).p + (ds), (src).p + (ss), ((de) - (ds)) * sizeof(*(dst).p))
+#endif
+
 #ifdef SPY_DEBUG
 #  define spy_ptr_move(dst, src, n)                                                    \
       do {                                                                             \

--- a/spy/tests/compiler/unsafe/test_mem.py
+++ b/spy/tests/compiler/unsafe/test_mem.py
@@ -300,3 +300,130 @@ class TestMem(CompilerTest):
         mod = self.compile(src)
         with SPyError.raises("W_PanicError", match="out of bounds"):
             mod.foo()
+
+    def test_memcpy(self, memkind):
+        k = memkind
+        src = """
+        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, memcpy
+
+        def foo() -> i32:
+            src: k_ptr[u8] = k_alloc[u8](4)
+            dst: k_ptr[u8] = k_alloc[u8](4)
+            src[0] = 10
+            src[1] = 20
+            src[2] = 30
+            src[3] = 40
+            memcpy(dst, src, 4)
+            return dst[0] + dst[1] + dst[2] + dst[3]
+        """.format(k=k)
+        mod = self.compile(src)
+        assert mod.foo() == 100
+
+    def test_memcpy_i32_rejected(self):
+        src = """
+        from unsafe import raw_alloc, raw_ptr, memcpy
+
+        def foo() -> i32:
+            buf: raw_ptr[i32] = raw_alloc[i32](4)
+            memcpy(buf, buf, 4)
+            return 0
+        """
+        errors = expect_errors(
+            "mismatched types",
+            ("expected ptr[u8] or ptr[i8], got `unsafe::raw_ptr[i32]`", "buf"),
+            ("help: use `ptr_copy` instead", "buf"),
+        )
+        self.compile_raises(src, "foo", errors)
+
+    def test_memmove(self, memkind):
+        k = memkind
+        src = """
+        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, memmove
+
+        def foo() -> i32:
+            src: k_ptr[u8] = k_alloc[u8](4)
+            dst: k_ptr[u8] = k_alloc[u8](4)
+            src[0] = 10
+            src[1] = 20
+            src[2] = 30
+            src[3] = 40
+            memmove(dst, src, 4)
+            return dst[0] + dst[1] + dst[2] + dst[3]
+        """.format(k=k)
+        mod = self.compile(src)
+        assert mod.foo() == 100
+
+    def test_memmove_i32_rejected(self):
+        src = """
+        from unsafe import raw_alloc, raw_ptr, memmove
+
+        def foo() -> i32:
+            buf: raw_ptr[i32] = raw_alloc[i32](4)
+            memmove(buf, buf, 4)
+            return 0
+        """
+        errors = expect_errors(
+            "mismatched types",
+            ("expected ptr[u8] or ptr[i8], got `unsafe::raw_ptr[i32]`", "buf"),
+            ("help: use `ptr_move` instead", "buf"),
+        )
+        self.compile_raises(src, "foo", errors)
+
+    def test_memset(self, memkind):
+        k = memkind
+        src = """
+        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, memset
+
+        def foo() -> i32:
+            buf: k_ptr[u8] = k_alloc[u8](4)
+            memset(buf, 7, 4)
+            return buf[0] + buf[1] + buf[2] + buf[3]
+        """.format(k=k)
+        mod = self.compile(src)
+        assert mod.foo() == 28
+
+    def test_memset_i32_rejected(self):
+        src = """
+        from unsafe import raw_alloc, raw_ptr, memset
+
+        def foo() -> i32:
+            buf: raw_ptr[i32] = raw_alloc[i32](4)
+            memset(buf, 0, 4)
+            return 0
+        """
+        errors = expect_errors(
+            "mismatched types",
+            ("expected ptr[u8] or ptr[i8], got `unsafe::raw_ptr[i32]`", "buf"),
+            ("help: use `ptr_set` instead", "buf"),
+        )
+        self.compile_raises(src, "foo", errors)
+
+    def test_memcmp(self, memkind):
+        k = memkind
+        src = """
+        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, memset, memcmp
+
+        def foo() -> i32:
+            a: k_ptr[u8] = k_alloc[u8](4)
+            b: k_ptr[u8] = k_alloc[u8](4)
+            memset(a, 42, 4)
+            memset(b, 42, 4)
+            return memcmp(a, b, 4)
+        """.format(k=k)
+        mod = self.compile(src)
+        assert mod.foo() == 0
+
+    def test_memcmp_i32_rejected(self):
+        src = """
+        from unsafe import raw_alloc, raw_ptr, memcmp
+
+        def foo() -> i32:
+            buf: raw_ptr[i32] = raw_alloc[i32](4)
+            return memcmp(buf, buf, 4)
+        """
+        errors = expect_errors(
+            "mismatched types",
+            ("expected ptr[u8] or ptr[i8], got `unsafe::raw_ptr[i32]`", "buf"),
+            ("help: use `ptr_cmp` instead", "buf"),
+        )
+        self.compile_raises(src, "foo", errors)

--- a/spy/tests/compiler/unsafe/test_mem.py
+++ b/spy/tests/compiler/unsafe/test_mem.py
@@ -44,20 +44,70 @@ class TestMem(CompilerTest):
         mod = self.compile(src)
         assert mod.foo() == 6
 
-    def test_memcpy_wrong_itemtype(self):
+    def test_memcpy_not_a_ptr(self):
         src = """
-        from unsafe import raw_alloc, raw_ptr, memcpy
+        from unsafe import memcpy
 
         def foo() -> i32:
-            buf: raw_ptr[i32] = raw_alloc[i32](4)
-            memcpy(buf, buf, 4)
+            x: i32 = 0
+            memcpy(x, x, 4)
             return 0
         """
         errors = expect_errors(
             "mismatched types",
-            ("expected ptr[u8], got `unsafe::raw_ptr[i32]`", "buf"),
+            ("expected ptr[T], got `i32`", "x"),
         )
         self.compile_raises(src, "foo", errors)
+
+    def test_memcpy_incompatible_ptrs(self):
+        src = """
+        from unsafe import raw_alloc, raw_ptr, memcpy
+
+        def foo() -> i32:
+            a: raw_ptr[i32] = raw_alloc[i32](4)
+            b: raw_ptr[u8] = raw_alloc[u8](4)
+            memcpy(a, b, 4)
+            return 0
+        """
+        errors = expect_errors(
+            "mismatched types",
+            ("`unsafe::raw_ptr[i32]`", "a"),
+            ("`unsafe::raw_ptr[u8]`", "b"),
+        )
+        self.compile_raises(src, "foo", errors)
+
+    def test_memcpy_i32(self, memkind):
+        k = memkind
+        src = """
+        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, memcpy
+
+        def foo() -> i32:
+            src: k_ptr[i32] = k_alloc[i32](4)
+            dst: k_ptr[i32] = k_alloc[i32](4)
+            src[0] = 100
+            src[1] = 200
+            src[2] = 300
+            src[3] = 400
+            memcpy(dst, src, 4)
+            return dst[0] + dst[1] + dst[2] + dst[3]
+        """.format(k=k)
+        mod = self.compile(src)
+        assert mod.foo() == 1000
+
+    def test_memcpy_i32_out_of_bounds(self, memkind):
+        k = memkind
+        src = """
+        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, memcpy
+
+        def foo() -> i32:
+            src: k_ptr[i32] = k_alloc[i32](4)
+            dst: k_ptr[i32] = k_alloc[i32](4)
+            memcpy(dst, src, 10)
+            return 0
+        """.format(k=k)
+        mod = self.compile(src)
+        with SPyError.raises("W_PanicError", match="out of bounds"):
+            mod.foo()
 
     def test_memcpy_out_of_bounds(self, memkind):
         k = memkind
@@ -92,18 +142,35 @@ class TestMem(CompilerTest):
         mod = self.compile(src)
         assert mod.foo() == 100
 
-    def test_memmove_wrong_itemtype(self):
+    def test_memmove_not_a_ptr(self):
         src = """
-        from unsafe import raw_alloc, raw_ptr, memmove
+        from unsafe import memmove
 
         def foo() -> i32:
-            buf: raw_ptr[i32] = raw_alloc[i32](4)
-            memmove(buf, buf, 4)
+            x: i32 = 0
+            memmove(x, x, 4)
             return 0
         """
         errors = expect_errors(
             "mismatched types",
-            ("expected ptr[u8], got `unsafe::raw_ptr[i32]`", "buf"),
+            ("expected ptr[T], got `i32`", "x"),
+        )
+        self.compile_raises(src, "foo", errors)
+
+    def test_memmove_incompatible_ptrs(self):
+        src = """
+        from unsafe import raw_alloc, raw_ptr, memmove
+
+        def foo() -> i32:
+            a: raw_ptr[i32] = raw_alloc[i32](4)
+            b: raw_ptr[u8] = raw_alloc[u8](4)
+            memmove(a, b, 4)
+            return 0
+        """
+        errors = expect_errors(
+            "mismatched types",
+            ("`unsafe::raw_ptr[i32]`", "a"),
+            ("`unsafe::raw_ptr[u8]`", "b"),
         )
         self.compile_raises(src, "foo", errors)
 
@@ -135,18 +202,18 @@ class TestMem(CompilerTest):
         mod = self.compile(src)
         assert mod.foo() == 28
 
-    def test_memset_wrong_itemtype(self):
+    def test_memset_not_a_ptr(self):
         src = """
-        from unsafe import raw_alloc, raw_ptr, memset
+        from unsafe import memset
 
         def foo() -> i32:
-            buf: raw_ptr[i32] = raw_alloc[i32](4)
-            memset(buf, 0, 4)
+            x: i32 = 0
+            memset(x, 0, 4)
             return 0
         """
         errors = expect_errors(
             "mismatched types",
-            ("expected ptr[u8], got `unsafe::raw_ptr[i32]`", "buf"),
+            ("expected ptr[T], got `i32`", "x"),
         )
         self.compile_raises(src, "foo", errors)
 
@@ -190,17 +257,33 @@ class TestMem(CompilerTest):
         assert mod.foo() == 0
         assert mod.bar() == -1
 
-    def test_memcmp_wrong_itemtype(self):
+    def test_memcmp_not_a_ptr(self):
+        src = """
+        from unsafe import memcmp
+
+        def foo() -> i32:
+            x: i32 = 0
+            return memcmp(x, x, 4)
+        """
+        errors = expect_errors(
+            "mismatched types",
+            ("expected ptr[T], got `i32`", "x"),
+        )
+        self.compile_raises(src, "foo", errors)
+
+    def test_memcmp_incompatible_ptrs(self):
         src = """
         from unsafe import raw_alloc, raw_ptr, memcmp
 
         def foo() -> i32:
-            buf: raw_ptr[i32] = raw_alloc[i32](4)
-            return memcmp(buf, buf, 4)
+            a: raw_ptr[i32] = raw_alloc[i32](4)
+            b: raw_ptr[u8] = raw_alloc[u8](4)
+            return memcmp(a, b, 4)
         """
         errors = expect_errors(
             "mismatched types",
-            ("expected ptr[u8], got `unsafe::raw_ptr[i32]`", "buf"),
+            ("`unsafe::raw_ptr[i32]`", "a"),
+            ("`unsafe::raw_ptr[u8]`", "b"),
         )
         self.compile_raises(src, "foo", errors)
 

--- a/spy/tests/compiler/unsafe/test_mem.py
+++ b/spy/tests/compiler/unsafe/test_mem.py
@@ -168,9 +168,12 @@ class TestMem(CompilerTest):
     def test_ptr_move(self, memkind):
         k = memkind
         src = """
-        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, ptr_move
+        from unsafe import (
+            {k}_alloc as k_alloc, {k}_ptr as k_ptr,
+            ptr_move, ptr_move_slice,
+        )
 
-        def foo() -> i32:
+        def fn_ptr() -> i32:
             src: k_ptr[u8] = k_alloc[u8](4)
             dst: k_ptr[u8] = k_alloc[u8](4)
             src[0] = 10
@@ -179,9 +182,24 @@ class TestMem(CompilerTest):
             src[3] = 40
             ptr_move(dst, src, 4)
             return dst[0] + dst[1] + dst[2] + dst[3]
+
+        def fn_slice() -> i32:
+            src: k_ptr[u8] = k_alloc[u8](4)
+            dst: k_ptr[u8] = k_alloc[u8](4)
+            src[0] = 10
+            src[1] = 20
+            src[2] = 30
+            src[3] = 40
+            dst[0] = 0
+            dst[1] = 0
+            dst[2] = 0
+            dst[3] = 0
+            ptr_move_slice(dst, 2, 4, src, 1, 3)
+            return i32(dst[0])*1000 + i32(dst[1])*100 + i32(dst[2])*10 + i32(dst[3])
         """.format(k=k)
         mod = self.compile(src)
-        assert mod.foo() == 100
+        assert mod.fn_ptr() == 100
+        assert mod.fn_slice() == 200 + 30
 
     def test_ptr_move_not_a_ptr(self):
         src = """
@@ -218,30 +236,62 @@ class TestMem(CompilerTest):
     def test_ptr_move_out_of_bounds(self, memkind):
         k = memkind
         src = """
-        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, ptr_move
+        from unsafe import (
+            {k}_alloc as k_alloc, {k}_ptr as k_ptr,
+            ptr_move, ptr_move_slice,
+        )
 
-        def foo() -> i32:
+        def fn_ptr() -> i32:
             src: k_ptr[u8] = k_alloc[u8](4)
             dst: k_ptr[u8] = k_alloc[u8](4)
             ptr_move(dst, src, 10)
             return 0
+
+        def fn_slice() -> i32:
+            src: k_ptr[u8] = k_alloc[u8](4)
+            dst: k_ptr[u8] = k_alloc[u8](4)
+            ptr_move_slice(dst, 0, 10, src, 0, 10)
+            return 0
+
+        def fn_slice_mismatch() -> i32:
+            src: k_ptr[u8] = k_alloc[u8](4)
+            dst: k_ptr[u8] = k_alloc[u8](4)
+            ptr_move_slice(dst, 0, 3, src, 0, 2)
+            return 0
         """.format(k=k)
         mod = self.compile(src)
         with SPyError.raises("W_PanicError", match="out of bounds"):
-            mod.foo()
+            mod.fn_ptr()
+        with SPyError.raises("W_PanicError", match="out of bounds"):
+            mod.fn_slice()
+        with SPyError.raises("W_PanicError", match="length mismatch"):
+            mod.fn_slice_mismatch()
 
     def test_ptr_set(self, memkind):
         k = memkind
         src = """
-        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, ptr_set
+        from unsafe import (
+            {k}_alloc as k_alloc, {k}_ptr as k_ptr,
+            ptr_set, ptr_set_slice,
+        )
 
-        def foo() -> i32:
+        def fn_ptr() -> i32:
             buf: k_ptr[u8] = k_alloc[u8](4)
             ptr_set(buf, 7, 4)
             return buf[0] + buf[1] + buf[2] + buf[3]
+
+        def fn_slice() -> i32:
+            buf: k_ptr[u8] = k_alloc[u8](4)
+            buf[0] = 0
+            buf[1] = 0
+            buf[2] = 0
+            buf[3] = 0
+            ptr_set_slice(buf, 1, 3, 7)
+            return i32(buf[0])*1000 + i32(buf[1])*100 + i32(buf[2])*10 + i32(buf[3])
         """.format(k=k)
         mod = self.compile(src)
-        assert mod.foo() == 28
+        assert mod.fn_ptr() == 28
+        assert mod.fn_slice() == 700 + 70
 
     def test_ptr_set_not_a_ptr(self):
         src = """
@@ -261,30 +311,43 @@ class TestMem(CompilerTest):
     def test_ptr_set_out_of_bounds(self, memkind):
         k = memkind
         src = """
-        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, ptr_set
+        from unsafe import (
+            {k}_alloc as k_alloc, {k}_ptr as k_ptr,
+            ptr_set, ptr_set_slice,
+        )
 
-        def foo() -> i32:
+        def fn_ptr() -> i32:
             buf: k_ptr[u8] = k_alloc[u8](4)
             ptr_set(buf, 0, 10)
+            return 0
+
+        def fn_slice() -> i32:
+            buf: k_ptr[u8] = k_alloc[u8](4)
+            ptr_set_slice(buf, 0, 10, 0)
             return 0
         """.format(k=k)
         mod = self.compile(src)
         with SPyError.raises("W_PanicError", match="out of bounds"):
-            mod.foo()
+            mod.fn_ptr()
+        with SPyError.raises("W_PanicError", match="out of bounds"):
+            mod.fn_slice()
 
     def test_ptr_cmp(self, memkind):
         k = memkind
         src = """
-        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, ptr_set, ptr_cmp
+        from unsafe import (
+            {k}_alloc as k_alloc, {k}_ptr as k_ptr,
+            ptr_set, ptr_cmp, ptr_cmp_slice,
+        )
 
-        def foo() -> i32:
+        def fn_ptr_eq() -> i32:
             a: k_ptr[u8] = k_alloc[u8](4)
             b: k_ptr[u8] = k_alloc[u8](4)
             ptr_set(a, 42, 4)
             ptr_set(b, 42, 4)
             return ptr_cmp(a, b, 4)
 
-        def bar() -> i32:
+        def fn_ptr_lt() -> i32:
             a: k_ptr[u8] = k_alloc[u8](4)
             b: k_ptr[u8] = k_alloc[u8](4)
             ptr_set(a, 1, 4)
@@ -293,10 +356,35 @@ class TestMem(CompilerTest):
             if r < 0:
                 return -1
             return 1
+
+        def fn_slice_eq() -> i32:
+            a: k_ptr[u8] = k_alloc[u8](4)
+            b: k_ptr[u8] = k_alloc[u8](4)
+            a[0] = 1
+            a[1] = 7
+            a[2] = 7
+            a[3] = 9
+            b[0] = 2
+            b[1] = 7
+            b[2] = 7
+            b[3] = 8
+            return ptr_cmp_slice(a, 1, 3, b, 1, 3)
+
+        def fn_slice_lt() -> i32:
+            a: k_ptr[u8] = k_alloc[u8](4)
+            b: k_ptr[u8] = k_alloc[u8](4)
+            ptr_set(a, 1, 4)
+            ptr_set(b, 2, 4)
+            r: i32 = ptr_cmp_slice(a, 0, 2, b, 0, 2)
+            if r < 0:
+                return -1
+            return 1
         """.format(k=k)
         mod = self.compile(src)
-        assert mod.foo() == 0
-        assert mod.bar() == -1
+        assert mod.fn_ptr_eq() == 0
+        assert mod.fn_ptr_lt() == -1
+        assert mod.fn_slice_eq() == 0
+        assert mod.fn_slice_lt() == -1
 
     def test_ptr_cmp_not_a_ptr(self):
         src = """
@@ -331,16 +419,33 @@ class TestMem(CompilerTest):
     def test_ptr_cmp_out_of_bounds(self, memkind):
         k = memkind
         src = """
-        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, ptr_cmp
+        from unsafe import (
+            {k}_alloc as k_alloc, {k}_ptr as k_ptr,
+            ptr_cmp, ptr_cmp_slice,
+        )
 
-        def foo() -> i32:
+        def fn_ptr() -> i32:
             a: k_ptr[u8] = k_alloc[u8](4)
             b: k_ptr[u8] = k_alloc[u8](4)
             return ptr_cmp(a, b, 10)
+
+        def fn_slice() -> i32:
+            a: k_ptr[u8] = k_alloc[u8](4)
+            b: k_ptr[u8] = k_alloc[u8](4)
+            return ptr_cmp_slice(a, 0, 10, b, 0, 10)
+
+        def fn_slice_mismatch() -> i32:
+            a: k_ptr[u8] = k_alloc[u8](4)
+            b: k_ptr[u8] = k_alloc[u8](4)
+            return ptr_cmp_slice(a, 0, 3, b, 0, 2)
         """.format(k=k)
         mod = self.compile(src)
         with SPyError.raises("W_PanicError", match="out of bounds"):
-            mod.foo()
+            mod.fn_ptr()
+        with SPyError.raises("W_PanicError", match="out of bounds"):
+            mod.fn_slice()
+        with SPyError.raises("W_PanicError", match="length mismatch"):
+            mod.fn_slice_mismatch()
 
     def test_memcpy(self, memkind):
         k = memkind

--- a/spy/tests/compiler/unsafe/test_mem.py
+++ b/spy/tests/compiler/unsafe/test_mem.py
@@ -10,10 +10,10 @@ def memkind(request):
 
 
 class TestMem(CompilerTest):
-    def test_memcpy(self, memkind):
+    def test_ptr_copy(self, memkind):
         k = memkind
         src = """
-        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, memcpy
+        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, ptr_copy
 
         def foo() -> i32:
             src: k_ptr[u8] = k_alloc[u8](4)
@@ -22,15 +22,15 @@ class TestMem(CompilerTest):
             src[1] = 20
             src[2] = 30
             src[3] = 40
-            memcpy(dst, src, 4)
+            ptr_copy(dst, src, 4)
             return dst[0] + dst[1] + dst[2] + dst[3]
         """.format(k=k)
         mod = self.compile(src)
         assert mod.foo() == 100
 
-    def test_memcpy_mixed_memkind(self):
+    def test_ptr_copy_mixed_memkind(self):
         src = """
-        from unsafe import raw_alloc, raw_ptr, gc_alloc, gc_ptr, memcpy
+        from unsafe import raw_alloc, raw_ptr, gc_alloc, gc_ptr, ptr_copy
 
         def foo() -> i32:
             src: raw_ptr[u8] = raw_alloc[u8](3)
@@ -38,19 +38,19 @@ class TestMem(CompilerTest):
             src[0] = 1
             src[1] = 2
             src[2] = 3
-            memcpy(dst, src, 3)
+            ptr_copy(dst, src, 3)
             return dst[0] + dst[1] + dst[2]
         """
         mod = self.compile(src)
         assert mod.foo() == 6
 
-    def test_memcpy_not_a_ptr(self):
+    def test_ptr_copy_not_a_ptr(self):
         src = """
-        from unsafe import memcpy
+        from unsafe import ptr_copy
 
         def foo() -> i32:
             x: i32 = 0
-            memcpy(x, x, 4)
+            ptr_copy(x, x, 4)
             return 0
         """
         errors = expect_errors(
@@ -59,14 +59,14 @@ class TestMem(CompilerTest):
         )
         self.compile_raises(src, "foo", errors)
 
-    def test_memcpy_incompatible_ptrs(self):
+    def test_ptr_copy_incompatible_ptrs(self):
         src = """
-        from unsafe import raw_alloc, raw_ptr, memcpy
+        from unsafe import raw_alloc, raw_ptr, ptr_copy
 
         def foo() -> i32:
             a: raw_ptr[i32] = raw_alloc[i32](4)
             b: raw_ptr[u8] = raw_alloc[u8](4)
-            memcpy(a, b, 4)
+            ptr_copy(a, b, 4)
             return 0
         """
         errors = expect_errors(
@@ -76,10 +76,10 @@ class TestMem(CompilerTest):
         )
         self.compile_raises(src, "foo", errors)
 
-    def test_memcpy_i32(self, memkind):
+    def test_ptr_copy_i32(self, memkind):
         k = memkind
         src = """
-        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, memcpy
+        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, ptr_copy
 
         def foo() -> i32:
             src: k_ptr[i32] = k_alloc[i32](4)
@@ -88,46 +88,46 @@ class TestMem(CompilerTest):
             src[1] = 200
             src[2] = 300
             src[3] = 400
-            memcpy(dst, src, 4)
+            ptr_copy(dst, src, 4)
             return dst[0] + dst[1] + dst[2] + dst[3]
         """.format(k=k)
         mod = self.compile(src)
         assert mod.foo() == 1000
 
-    def test_memcpy_i32_out_of_bounds(self, memkind):
+    def test_ptr_copy_i32_out_of_bounds(self, memkind):
         k = memkind
         src = """
-        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, memcpy
+        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, ptr_copy
 
         def foo() -> i32:
             src: k_ptr[i32] = k_alloc[i32](4)
             dst: k_ptr[i32] = k_alloc[i32](4)
-            memcpy(dst, src, 10)
+            ptr_copy(dst, src, 10)
             return 0
         """.format(k=k)
         mod = self.compile(src)
         with SPyError.raises("W_PanicError", match="out of bounds"):
             mod.foo()
 
-    def test_memcpy_out_of_bounds(self, memkind):
+    def test_ptr_copy_out_of_bounds(self, memkind):
         k = memkind
         src = """
-        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, memcpy
+        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, ptr_copy
 
         def foo() -> i32:
             src: k_ptr[u8] = k_alloc[u8](4)
             dst: k_ptr[u8] = k_alloc[u8](4)
-            memcpy(dst, src, 10)
+            ptr_copy(dst, src, 10)
             return 0
         """.format(k=k)
         mod = self.compile(src)
         with SPyError.raises("W_PanicError", match="out of bounds"):
             mod.foo()
 
-    def test_memmove(self, memkind):
+    def test_ptr_move(self, memkind):
         k = memkind
         src = """
-        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, memmove
+        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, ptr_move
 
         def foo() -> i32:
             src: k_ptr[u8] = k_alloc[u8](4)
@@ -136,19 +136,19 @@ class TestMem(CompilerTest):
             src[1] = 20
             src[2] = 30
             src[3] = 40
-            memmove(dst, src, 4)
+            ptr_move(dst, src, 4)
             return dst[0] + dst[1] + dst[2] + dst[3]
         """.format(k=k)
         mod = self.compile(src)
         assert mod.foo() == 100
 
-    def test_memmove_not_a_ptr(self):
+    def test_ptr_move_not_a_ptr(self):
         src = """
-        from unsafe import memmove
+        from unsafe import ptr_move
 
         def foo() -> i32:
             x: i32 = 0
-            memmove(x, x, 4)
+            ptr_move(x, x, 4)
             return 0
         """
         errors = expect_errors(
@@ -157,14 +157,14 @@ class TestMem(CompilerTest):
         )
         self.compile_raises(src, "foo", errors)
 
-    def test_memmove_incompatible_ptrs(self):
+    def test_ptr_move_incompatible_ptrs(self):
         src = """
-        from unsafe import raw_alloc, raw_ptr, memmove
+        from unsafe import raw_alloc, raw_ptr, ptr_move
 
         def foo() -> i32:
             a: raw_ptr[i32] = raw_alloc[i32](4)
             b: raw_ptr[u8] = raw_alloc[u8](4)
-            memmove(a, b, 4)
+            ptr_move(a, b, 4)
             return 0
         """
         errors = expect_errors(
@@ -174,41 +174,41 @@ class TestMem(CompilerTest):
         )
         self.compile_raises(src, "foo", errors)
 
-    def test_memmove_out_of_bounds(self, memkind):
+    def test_ptr_move_out_of_bounds(self, memkind):
         k = memkind
         src = """
-        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, memmove
+        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, ptr_move
 
         def foo() -> i32:
             src: k_ptr[u8] = k_alloc[u8](4)
             dst: k_ptr[u8] = k_alloc[u8](4)
-            memmove(dst, src, 10)
+            ptr_move(dst, src, 10)
             return 0
         """.format(k=k)
         mod = self.compile(src)
         with SPyError.raises("W_PanicError", match="out of bounds"):
             mod.foo()
 
-    def test_memset(self, memkind):
+    def test_ptr_set(self, memkind):
         k = memkind
         src = """
-        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, memset
+        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, ptr_set
 
         def foo() -> i32:
             buf: k_ptr[u8] = k_alloc[u8](4)
-            memset(buf, 7, 4)
+            ptr_set(buf, 7, 4)
             return buf[0] + buf[1] + buf[2] + buf[3]
         """.format(k=k)
         mod = self.compile(src)
         assert mod.foo() == 28
 
-    def test_memset_not_a_ptr(self):
+    def test_ptr_set_not_a_ptr(self):
         src = """
-        from unsafe import memset
+        from unsafe import ptr_set
 
         def foo() -> i32:
             x: i32 = 0
-            memset(x, 0, 4)
+            ptr_set(x, 0, 4)
             return 0
         """
         errors = expect_errors(
@@ -217,38 +217,38 @@ class TestMem(CompilerTest):
         )
         self.compile_raises(src, "foo", errors)
 
-    def test_memset_out_of_bounds(self, memkind):
+    def test_ptr_set_out_of_bounds(self, memkind):
         k = memkind
         src = """
-        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, memset
+        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, ptr_set
 
         def foo() -> i32:
             buf: k_ptr[u8] = k_alloc[u8](4)
-            memset(buf, 0, 10)
+            ptr_set(buf, 0, 10)
             return 0
         """.format(k=k)
         mod = self.compile(src)
         with SPyError.raises("W_PanicError", match="out of bounds"):
             mod.foo()
 
-    def test_memcmp(self, memkind):
+    def test_ptr_cmp(self, memkind):
         k = memkind
         src = """
-        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, memset, memcmp
+        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, ptr_set, ptr_cmp
 
         def foo() -> i32:
             a: k_ptr[u8] = k_alloc[u8](4)
             b: k_ptr[u8] = k_alloc[u8](4)
-            memset(a, 42, 4)
-            memset(b, 42, 4)
-            return memcmp(a, b, 4)
+            ptr_set(a, 42, 4)
+            ptr_set(b, 42, 4)
+            return ptr_cmp(a, b, 4)
 
         def bar() -> i32:
             a: k_ptr[u8] = k_alloc[u8](4)
             b: k_ptr[u8] = k_alloc[u8](4)
-            memset(a, 1, 4)
-            memset(b, 2, 4)
-            r: i32 = memcmp(a, b, 4)
+            ptr_set(a, 1, 4)
+            ptr_set(b, 2, 4)
+            r: i32 = ptr_cmp(a, b, 4)
             if r < 0:
                 return -1
             return 1
@@ -257,13 +257,13 @@ class TestMem(CompilerTest):
         assert mod.foo() == 0
         assert mod.bar() == -1
 
-    def test_memcmp_not_a_ptr(self):
+    def test_ptr_cmp_not_a_ptr(self):
         src = """
-        from unsafe import memcmp
+        from unsafe import ptr_cmp
 
         def foo() -> i32:
             x: i32 = 0
-            return memcmp(x, x, 4)
+            return ptr_cmp(x, x, 4)
         """
         errors = expect_errors(
             "mismatched types",
@@ -271,14 +271,14 @@ class TestMem(CompilerTest):
         )
         self.compile_raises(src, "foo", errors)
 
-    def test_memcmp_incompatible_ptrs(self):
+    def test_ptr_cmp_incompatible_ptrs(self):
         src = """
-        from unsafe import raw_alloc, raw_ptr, memcmp
+        from unsafe import raw_alloc, raw_ptr, ptr_cmp
 
         def foo() -> i32:
             a: raw_ptr[i32] = raw_alloc[i32](4)
             b: raw_ptr[u8] = raw_alloc[u8](4)
-            return memcmp(a, b, 4)
+            return ptr_cmp(a, b, 4)
         """
         errors = expect_errors(
             "mismatched types",
@@ -287,15 +287,15 @@ class TestMem(CompilerTest):
         )
         self.compile_raises(src, "foo", errors)
 
-    def test_memcmp_out_of_bounds(self, memkind):
+    def test_ptr_cmp_out_of_bounds(self, memkind):
         k = memkind
         src = """
-        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, memcmp
+        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, ptr_cmp
 
         def foo() -> i32:
             a: k_ptr[u8] = k_alloc[u8](4)
             b: k_ptr[u8] = k_alloc[u8](4)
-            return memcmp(a, b, 10)
+            return ptr_cmp(a, b, 10)
         """.format(k=k)
         mod = self.compile(src)
         with SPyError.raises("W_PanicError", match="out of bounds"):

--- a/spy/tests/compiler/unsafe/test_mem.py
+++ b/spy/tests/compiler/unsafe/test_mem.py
@@ -13,9 +13,12 @@ class TestMem(CompilerTest):
     def test_ptr_copy(self, memkind):
         k = memkind
         src = """
-        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, ptr_copy
+        from unsafe import (
+            {k}_alloc as k_alloc, {k}_ptr as k_ptr,
+            ptr_copy, ptr_copy_slice,
+        )
 
-        def foo() -> i32:
+        def fn_ptr() -> i32:
             src: k_ptr[u8] = k_alloc[u8](4)
             dst: k_ptr[u8] = k_alloc[u8](4)
             src[0] = 10
@@ -24,9 +27,25 @@ class TestMem(CompilerTest):
             src[3] = 40
             ptr_copy(dst, src, 4)
             return dst[0] + dst[1] + dst[2] + dst[3]
+
+        def fn_slice() -> i32:
+            src: k_ptr[u8] = k_alloc[u8](4)
+            dst: k_ptr[u8] = k_alloc[u8](4)
+            src[0] = 10
+            src[1] = 20
+            src[2] = 30
+            src[3] = 40
+            dst[0] = 0
+            dst[1] = 0
+            dst[2] = 0
+            dst[3] = 0
+            # copy src[1:3] into dst[2:4]
+            ptr_copy_slice(dst, 2, 4, src, 1, 3)
+            return i32(dst[0])*1000 + i32(dst[1])*100 + i32(dst[2])*10 + i32(dst[3])
         """.format(k=k)
         mod = self.compile(src)
-        assert mod.foo() == 100
+        assert mod.fn_ptr() == 100
+        assert mod.fn_slice() == 200 + 30  # dst[2]=20, dst[3]=30; rest=0
 
     def test_ptr_copy_mixed_memkind(self):
         src = """
@@ -79,9 +98,12 @@ class TestMem(CompilerTest):
     def test_ptr_copy_i32(self, memkind):
         k = memkind
         src = """
-        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, ptr_copy
+        from unsafe import (
+            {k}_alloc as k_alloc, {k}_ptr as k_ptr,
+            ptr_copy, ptr_copy_slice,
+        )
 
-        def foo() -> i32:
+        def fn_ptr() -> i32:
             src: k_ptr[i32] = k_alloc[i32](4)
             dst: k_ptr[i32] = k_alloc[i32](4)
             src[0] = 100
@@ -90,39 +112,58 @@ class TestMem(CompilerTest):
             src[3] = 400
             ptr_copy(dst, src, 4)
             return dst[0] + dst[1] + dst[2] + dst[3]
-        """.format(k=k)
-        mod = self.compile(src)
-        assert mod.foo() == 1000
 
-    def test_ptr_copy_i32_out_of_bounds(self, memkind):
-        k = memkind
-        src = """
-        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, ptr_copy
-
-        def foo() -> i32:
+        def fn_slice() -> i32:
             src: k_ptr[i32] = k_alloc[i32](4)
             dst: k_ptr[i32] = k_alloc[i32](4)
-            ptr_copy(dst, src, 10)
-            return 0
+            src[0] = 100
+            src[1] = 200
+            src[2] = 300
+            src[3] = 400
+            dst[0] = 0
+            dst[1] = 0
+            dst[2] = 0
+            dst[3] = 0
+            ptr_copy_slice(dst, 2, 4, src, 1, 3)
+            return dst[0] + dst[1] + dst[2] + dst[3]
         """.format(k=k)
         mod = self.compile(src)
-        with SPyError.raises("W_PanicError", match="out of bounds"):
-            mod.foo()
+        assert mod.fn_ptr() == 1000
+        assert mod.fn_slice() == 500  # dst[2]=200, dst[3]=300
 
     def test_ptr_copy_out_of_bounds(self, memkind):
         k = memkind
         src = """
-        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, ptr_copy
+        from unsafe import (
+            {k}_alloc as k_alloc, {k}_ptr as k_ptr,
+            ptr_copy, ptr_copy_slice,
+        )
 
-        def foo() -> i32:
-            src: k_ptr[u8] = k_alloc[u8](4)
-            dst: k_ptr[u8] = k_alloc[u8](4)
+        def fn_ptr() -> i32:
+            src: k_ptr[i32] = k_alloc[i32](4)
+            dst: k_ptr[i32] = k_alloc[i32](4)
             ptr_copy(dst, src, 10)
+            return 0
+
+        def fn_slice() -> i32:
+            src: k_ptr[i32] = k_alloc[i32](4)
+            dst: k_ptr[i32] = k_alloc[i32](4)
+            ptr_copy_slice(dst, 0, 10, src, 0, 10)
+            return 0
+
+        def fn_slice_mismatch() -> i32:
+            src: k_ptr[i32] = k_alloc[i32](4)
+            dst: k_ptr[i32] = k_alloc[i32](4)
+            ptr_copy_slice(dst, 0, 3, src, 0, 2)
             return 0
         """.format(k=k)
         mod = self.compile(src)
         with SPyError.raises("W_PanicError", match="out of bounds"):
-            mod.foo()
+            mod.fn_ptr()
+        with SPyError.raises("W_PanicError", match="out of bounds"):
+            mod.fn_slice()
+        with SPyError.raises("W_PanicError", match="length mismatch"):
+            mod.fn_slice_mismatch()
 
     def test_ptr_move(self, memkind):
         k = memkind

--- a/spy/vm/modules/unsafe/mem.py
+++ b/spy/vm/modules/unsafe/mem.py
@@ -110,6 +110,13 @@ def _check_byte_ptr(vm: "SPyVM", wam: W_MetaArg, ptr_op: str) -> W_PtrType:
 def w_memcpy(
     vm: "SPyVM", wam_dst: W_MetaArg, wam_src: W_MetaArg, wam_n: W_MetaArg
 ) -> W_OpSpec:
+    """
+    memcpy(dst, src, n): copy `n` bytes from `src` to `dst`.
+
+    Mirrors C's memcpy: only accepts ptr[u8] or ptr[i8]; for any other ptr[T]
+    use ptr_copy instead. The two regions must NOT overlap (use memmove for
+    that).
+    """
     _check_byte_ptr(vm, wam_dst, "ptr_copy")
     _check_byte_ptr(vm, wam_src, "ptr_copy")
     return vm.fast_metacall(UNSAFE.w_ptr_copy, [wam_dst, wam_src, wam_n])
@@ -119,6 +126,12 @@ def w_memcpy(
 def w_memmove(
     vm: "SPyVM", wam_dst: W_MetaArg, wam_src: W_MetaArg, wam_n: W_MetaArg
 ) -> W_OpSpec:
+    """
+    memmove(dst, src, n): copy `n` bytes from `src` to `dst`, allowing overlap.
+
+    Mirrors C's memmove: only accepts ptr[u8] or ptr[i8]; for any other ptr[T]
+    use ptr_move instead.
+    """
     _check_byte_ptr(vm, wam_dst, "ptr_move")
     _check_byte_ptr(vm, wam_src, "ptr_move")
     return vm.fast_metacall(UNSAFE.w_ptr_move, [wam_dst, wam_src, wam_n])
@@ -128,6 +141,12 @@ def w_memmove(
 def w_memset(
     vm: "SPyVM", wam_dst: W_MetaArg, wam_value: W_MetaArg, wam_n: W_MetaArg
 ) -> W_OpSpec:
+    """
+    memset(dst, value, n): write the byte `value` to the first `n` bytes of `dst`.
+
+    Mirrors C's memset: only accepts ptr[u8] or ptr[i8]; for any other ptr[T]
+    use ptr_set instead.
+    """
     _check_byte_ptr(vm, wam_dst, "ptr_set")
     return vm.fast_metacall(UNSAFE.w_ptr_set, [wam_dst, wam_value, wam_n])
 
@@ -136,6 +155,12 @@ def w_memset(
 def w_memcmp(
     vm: "SPyVM", wam_a: W_MetaArg, wam_b: W_MetaArg, wam_n: W_MetaArg
 ) -> W_OpSpec:
+    """
+    memcmp(a, b, n): compare the first `n` bytes of `a` and `b`.
+
+    Returns 0 if equal, <0 if a<b, >0 if a>b. Mirrors C's memcmp: only accepts
+    ptr[u8] or ptr[i8]; for any other ptr[T] use ptr_cmp instead.
+    """
     _check_byte_ptr(vm, wam_a, "ptr_cmp")
     _check_byte_ptr(vm, wam_b, "ptr_cmp")
     return vm.fast_metacall(UNSAFE.w_ptr_cmp, [wam_a, wam_b, wam_n])
@@ -145,6 +170,14 @@ def w_memcmp(
 def w_ptr_copy(
     vm: "SPyVM", wam_dst: W_MetaArg, wam_src: W_MetaArg, wam_n: W_MetaArg
 ) -> W_OpSpec:
+    """
+    ptr_copy(dst, src, n): copy `n` items from `src` to `dst`.
+
+    Both `src` and `dst` must be ptr[T] for the same item type T (memkinds may
+    differ). Unlike C's memcpy, `n` is the number of ITEMS, not bytes —
+    matching Rust's ptr::copy_nonoverlapping, Java's System.arraycopy, etc.
+    The two regions must NOT overlap (use ptr_move for that).
+    """
     w_dst_T, w_src_T = _check_ptrs_match(vm, wam_dst, wam_src)
     DST = Annotated[W_Ptr, w_dst_T]
     SRC = Annotated[W_Ptr, w_src_T]
@@ -172,6 +205,13 @@ def w_ptr_copy_slice(
     wam_src_start: W_MetaArg,
     wam_src_end: W_MetaArg,
 ) -> W_OpSpec:
+    """
+    ptr_copy_slice(dst, dst_start, dst_end, src, src_start, src_end):
+    copy items from src[src_start:src_end] into dst[dst_start:dst_end].
+
+    Both slices must have the same length, both endpoints must be in bounds,
+    and the two regions must NOT overlap (use ptr_move_slice for that).
+    """
     w_dst_T, w_src_T = _check_ptrs_match(vm, wam_dst, wam_src)
     DST = Annotated[W_Ptr, w_dst_T]
     SRC = Annotated[W_Ptr, w_src_T]
@@ -219,6 +259,12 @@ def w_ptr_copy_slice(
 def w_ptr_move(
     vm: "SPyVM", wam_dst: W_MetaArg, wam_src: W_MetaArg, wam_n: W_MetaArg
 ) -> W_OpSpec:
+    """
+    ptr_move(dst, src, n): copy `n` items from `src` to `dst`, allowing overlap.
+
+    Like ptr_copy, but the two regions are allowed to overlap. `n` is the
+    number of ITEMS, not bytes.
+    """
     w_dst_T, w_src_T = _check_ptrs_match(vm, wam_dst, wam_src)
     DST = Annotated[W_Ptr, w_dst_T]
     SRC = Annotated[W_Ptr, w_src_T]
@@ -246,6 +292,13 @@ def w_ptr_move_slice(
     wam_src_start: W_MetaArg,
     wam_src_end: W_MetaArg,
 ) -> W_OpSpec:
+    """
+    ptr_move_slice(dst, dst_start, dst_end, src, src_start, src_end):
+    copy items from src[src_start:src_end] into dst[dst_start:dst_end],
+    allowing overlap.
+
+    Like ptr_copy_slice, but the two regions are allowed to overlap.
+    """
     w_dst_T, w_src_T = _check_ptrs_match(vm, wam_dst, wam_src)
     DST = Annotated[W_Ptr, w_dst_T]
     SRC = Annotated[W_Ptr, w_src_T]
@@ -293,6 +346,14 @@ def w_ptr_move_slice(
 def w_ptr_set(
     vm: "SPyVM", wam_dst: W_MetaArg, wam_value: W_MetaArg, wam_n: W_MetaArg
 ) -> W_OpSpec:
+    """
+    ptr_set(dst, value, n): write the byte `value` to the first `n` items of `dst`.
+
+    `n` is the number of ITEMS (not bytes); the underlying memset writes
+    `n * sizeof(T)` bytes. `value` is interpreted as a byte and broadcast to
+    every byte in the region — this is mostly useful for zeroing memory or
+    initializing ptr[u8]/ptr[i8].
+    """
     w_dst_T = _check_ptr(vm, wam_dst)
     DST = Annotated[W_Ptr, w_dst_T]
     ITEMSIZE = sizeof(w_dst_T.w_itemT)
@@ -317,6 +378,12 @@ def w_ptr_set_slice(
     wam_dst_end: W_MetaArg,
     wam_value: W_MetaArg,
 ) -> W_OpSpec:
+    """
+    ptr_set_slice(dst, dst_start, dst_end, value): write the byte `value`
+    to dst[dst_start:dst_end].
+
+    Like ptr_set, but writes only the given slice instead of the prefix.
+    """
     w_dst_T = _check_ptr(vm, wam_dst)
     DST = Annotated[W_Ptr, w_dst_T]
     ITEMSIZE = sizeof(w_dst_T.w_itemT)
@@ -352,6 +419,14 @@ def w_ptr_set_slice(
 def w_ptr_cmp(
     vm: "SPyVM", wam_a: W_MetaArg, wam_b: W_MetaArg, wam_n: W_MetaArg
 ) -> W_OpSpec:
+    """
+    ptr_cmp(a, b, n): byte-compare the first `n` items of `a` and `b`.
+
+    Returns 0 if equal, <0 if a<b, >0 if a>b. `n` is the number of ITEMS, not
+    bytes; the comparison is byte-wise (like memcmp), so the result is
+    meaningful for ptr[u8]/ptr[i8] and for plain-data structs but not for
+    types whose representation has padding or alternate equal forms.
+    """
     w_a_T, w_b_T = _check_ptrs_match(vm, wam_a, wam_b)
     A = Annotated[W_Ptr, w_a_T]
     B_ = Annotated[W_Ptr, w_b_T]
@@ -380,6 +455,13 @@ def w_ptr_cmp_slice(
     wam_b_start: W_MetaArg,
     wam_b_end: W_MetaArg,
 ) -> W_OpSpec:
+    """
+    ptr_cmp_slice(a, a_start, a_end, b, b_start, b_end): byte-compare
+    a[a_start:a_end] and b[b_start:b_end].
+
+    Like ptr_cmp, but compares the given slices. Both slices must have the
+    same length.
+    """
     w_a_T, w_b_T = _check_ptrs_match(vm, wam_a, wam_b)
     A = Annotated[W_Ptr, w_a_T]
     B_ = Annotated[W_Ptr, w_b_T]

--- a/spy/vm/modules/unsafe/mem.py
+++ b/spy/vm/modules/unsafe/mem.py
@@ -57,28 +57,47 @@ def w_gc_alloc(vm: "SPyVM", w_T: W_Type) -> W_Dynamic:
     return w_fn
 
 
-def _check_ptr_u8(vm: "SPyVM", wam: W_MetaArg) -> W_PtrType:
+def _check_ptr(vm: "SPyVM", wam: W_MetaArg) -> W_PtrType:
     """
-    Validate that a W_MetaArg is statically typed as ptr[u8] (any memkind).
+    Validate that a W_MetaArg is statically typed as ptr[T] (any memkind, any T).
     Raises W_TypeError on failure.
     """
     w_T = wam.w_static_T
-    if isinstance(w_T, W_PtrType) and w_T.w_itemT is B.w_u8:
+    if isinstance(w_T, W_PtrType):
         return w_T
     t = w_T.fqn.human_name(vm)
-    err = SPyError("W_TypeError", f"mismatched types")
-    err.add("error", f"expected ptr[u8], got `{t}`", loc=wam.loc)
+    err = SPyError("W_TypeError", "mismatched types")
+    err.add("error", f"expected ptr[T], got `{t}`", loc=wam.loc)
     raise err
+
+
+def _check_ptrs_match(
+    vm: "SPyVM", wam_a: W_MetaArg, wam_b: W_MetaArg
+) -> tuple[W_PtrType, W_PtrType]:
+    """
+    Validate that both wams are ptr[T] for the SAME T (memkinds may differ).
+    Raises W_TypeError on failure.
+    """
+    w_a_T = _check_ptr(vm, wam_a)
+    w_b_T = _check_ptr(vm, wam_b)
+    if w_a_T.w_itemT is not w_b_T.w_itemT:
+        a_t = w_a_T.fqn.human_name(vm)
+        b_t = w_b_T.fqn.human_name(vm)
+        err = SPyError("W_TypeError", "mismatched types")
+        err.add("error", f"`{a_t}`", loc=wam_a.loc)
+        err.add("error", f"`{b_t}`", loc=wam_b.loc)
+        raise err
+    return w_a_T, w_b_T
 
 
 @UNSAFE.builtin_func(color="blue", kind="metafunc")
 def w_memcpy(
     vm: "SPyVM", wam_dst: W_MetaArg, wam_src: W_MetaArg, wam_n: W_MetaArg
 ) -> W_OpSpec:
-    w_dst_T = _check_ptr_u8(vm, wam_dst)
-    w_src_T = _check_ptr_u8(vm, wam_src)
+    w_dst_T, w_src_T = _check_ptrs_match(vm, wam_dst, wam_src)
     DST = Annotated[W_Ptr, w_dst_T]
     SRC = Annotated[W_Ptr, w_src_T]
+    ITEMSIZE = sizeof(w_dst_T.w_itemT)
     ns = UNSAFE.w_memcpy.compute_inner_ns([w_dst_T, w_src_T])
     irtag = IRTag("unsafe.memop", cfunc="spy_memcpy")
 
@@ -87,7 +106,7 @@ def w_memcpy(
         n = vm.unwrap_i32(w_n)
         if n > w_dst.length or n > w_src.length:
             raise SPyError("W_PanicError", "memcpy out of bounds")
-        vm.ll.call("_spy_memcpy", w_dst.addr, w_src.addr, n)
+        vm.ll.call("_spy_memcpy", w_dst.addr, w_src.addr, n * ITEMSIZE)
 
     return W_OpSpec(w_memcpy_impl, [wam_dst, wam_src, wam_n])
 
@@ -96,10 +115,10 @@ def w_memcpy(
 def w_memmove(
     vm: "SPyVM", wam_dst: W_MetaArg, wam_src: W_MetaArg, wam_n: W_MetaArg
 ) -> W_OpSpec:
-    w_dst_T = _check_ptr_u8(vm, wam_dst)
-    w_src_T = _check_ptr_u8(vm, wam_src)
+    w_dst_T, w_src_T = _check_ptrs_match(vm, wam_dst, wam_src)
     DST = Annotated[W_Ptr, w_dst_T]
     SRC = Annotated[W_Ptr, w_src_T]
+    ITEMSIZE = sizeof(w_dst_T.w_itemT)
     ns = UNSAFE.w_memmove.compute_inner_ns([w_dst_T, w_src_T])
     irtag = IRTag("unsafe.memop", cfunc="spy_memmove")
 
@@ -108,7 +127,7 @@ def w_memmove(
         n = vm.unwrap_i32(w_n)
         if n > w_dst.length or n > w_src.length:
             raise SPyError("W_PanicError", "memmove out of bounds")
-        vm.ll.call("_spy_memmove", w_dst.addr, w_src.addr, n)
+        vm.ll.call("_spy_memmove", w_dst.addr, w_src.addr, n * ITEMSIZE)
 
     return W_OpSpec(w_memmove_impl, [wam_dst, wam_src, wam_n])
 
@@ -117,8 +136,9 @@ def w_memmove(
 def w_memset(
     vm: "SPyVM", wam_dst: W_MetaArg, wam_value: W_MetaArg, wam_n: W_MetaArg
 ) -> W_OpSpec:
-    w_dst_T = _check_ptr_u8(vm, wam_dst)
+    w_dst_T = _check_ptr(vm, wam_dst)
     DST = Annotated[W_Ptr, w_dst_T]
+    ITEMSIZE = sizeof(w_dst_T.w_itemT)
     ns = UNSAFE.w_memset.compute_inner_ns([w_dst_T])
     irtag = IRTag("unsafe.memop", cfunc="spy_memset")
 
@@ -127,7 +147,7 @@ def w_memset(
         n = vm.unwrap_i32(w_n)
         if n > w_dst.length:
             raise SPyError("W_PanicError", "memset out of bounds")
-        vm.ll.call("_spy_memset", w_dst.addr, int(w_value.value), n)
+        vm.ll.call("_spy_memset", w_dst.addr, int(w_value.value), n * ITEMSIZE)
 
     return W_OpSpec(w_memset_impl, [wam_dst, wam_value, wam_n])
 
@@ -136,10 +156,10 @@ def w_memset(
 def w_memcmp(
     vm: "SPyVM", wam_a: W_MetaArg, wam_b: W_MetaArg, wam_n: W_MetaArg
 ) -> W_OpSpec:
-    w_a_T = _check_ptr_u8(vm, wam_a)
-    w_b_T = _check_ptr_u8(vm, wam_b)
+    w_a_T, w_b_T = _check_ptrs_match(vm, wam_a, wam_b)
     A = Annotated[W_Ptr, w_a_T]
     B_ = Annotated[W_Ptr, w_b_T]
+    ITEMSIZE = sizeof(w_a_T.w_itemT)
     ns = UNSAFE.w_memcmp.compute_inner_ns([w_a_T, w_b_T])
     irtag = IRTag("unsafe.memop", cfunc="spy_memcmp")
 
@@ -148,7 +168,7 @@ def w_memcmp(
         n = vm.unwrap_i32(w_n)
         if n > w_a.length or n > w_b.length:
             raise SPyError("W_PanicError", "memcmp out of bounds")
-        result = vm.ll.call("_spy_memcmp", w_a.addr, w_b.addr, n)
+        result = vm.ll.call("_spy_memcmp", w_a.addr, w_b.addr, n * ITEMSIZE)
         return vm.wrap(result)
 
     return W_OpSpec(w_memcmp_impl, [wam_a, wam_b, wam_n])

--- a/spy/vm/modules/unsafe/mem.py
+++ b/spy/vm/modules/unsafe/mem.py
@@ -90,6 +90,57 @@ def _check_ptrs_match(
     return w_a_T, w_b_T
 
 
+def _check_byte_ptr(vm: "SPyVM", wam: W_MetaArg, ptr_op: str) -> W_PtrType:
+    """
+    Validate that a W_MetaArg is statically typed as ptr[u8] or ptr[i8].
+    Used by the memcpy/memmove/memset/memcmp shims, which mirror C's byte-
+    oriented mem* and only accept byte-sized item types.
+    """
+    w_T = _check_ptr(vm, wam)
+    if w_T.w_itemT is not B.w_u8 and w_T.w_itemT is not B.w_i8:
+        t = w_T.fqn.human_name(vm)
+        err = SPyError("W_TypeError", "mismatched types")
+        err.add("error", f"expected ptr[u8] or ptr[i8], got `{t}`", loc=wam.loc)
+        err.add("note", f"help: use `{ptr_op}` instead", loc=wam.loc)
+        raise err
+    return w_T
+
+
+@UNSAFE.builtin_func(color="blue", kind="metafunc")
+def w_memcpy(
+    vm: "SPyVM", wam_dst: W_MetaArg, wam_src: W_MetaArg, wam_n: W_MetaArg
+) -> W_OpSpec:
+    _check_byte_ptr(vm, wam_dst, "ptr_copy")
+    _check_byte_ptr(vm, wam_src, "ptr_copy")
+    return vm.fast_metacall(UNSAFE.w_ptr_copy, [wam_dst, wam_src, wam_n])
+
+
+@UNSAFE.builtin_func(color="blue", kind="metafunc")
+def w_memmove(
+    vm: "SPyVM", wam_dst: W_MetaArg, wam_src: W_MetaArg, wam_n: W_MetaArg
+) -> W_OpSpec:
+    _check_byte_ptr(vm, wam_dst, "ptr_move")
+    _check_byte_ptr(vm, wam_src, "ptr_move")
+    return vm.fast_metacall(UNSAFE.w_ptr_move, [wam_dst, wam_src, wam_n])
+
+
+@UNSAFE.builtin_func(color="blue", kind="metafunc")
+def w_memset(
+    vm: "SPyVM", wam_dst: W_MetaArg, wam_value: W_MetaArg, wam_n: W_MetaArg
+) -> W_OpSpec:
+    _check_byte_ptr(vm, wam_dst, "ptr_set")
+    return vm.fast_metacall(UNSAFE.w_ptr_set, [wam_dst, wam_value, wam_n])
+
+
+@UNSAFE.builtin_func(color="blue", kind="metafunc")
+def w_memcmp(
+    vm: "SPyVM", wam_a: W_MetaArg, wam_b: W_MetaArg, wam_n: W_MetaArg
+) -> W_OpSpec:
+    _check_byte_ptr(vm, wam_a, "ptr_cmp")
+    _check_byte_ptr(vm, wam_b, "ptr_cmp")
+    return vm.fast_metacall(UNSAFE.w_ptr_cmp, [wam_a, wam_b, wam_n])
+
+
 @UNSAFE.builtin_func(color="blue", kind="metafunc")
 def w_ptr_copy(
     vm: "SPyVM", wam_dst: W_MetaArg, wam_src: W_MetaArg, wam_n: W_MetaArg

--- a/spy/vm/modules/unsafe/mem.py
+++ b/spy/vm/modules/unsafe/mem.py
@@ -91,87 +91,87 @@ def _check_ptrs_match(
 
 
 @UNSAFE.builtin_func(color="blue", kind="metafunc")
-def w_memcpy(
+def w_ptr_copy(
     vm: "SPyVM", wam_dst: W_MetaArg, wam_src: W_MetaArg, wam_n: W_MetaArg
 ) -> W_OpSpec:
     w_dst_T, w_src_T = _check_ptrs_match(vm, wam_dst, wam_src)
     DST = Annotated[W_Ptr, w_dst_T]
     SRC = Annotated[W_Ptr, w_src_T]
     ITEMSIZE = sizeof(w_dst_T.w_itemT)
-    ns = UNSAFE.w_memcpy.compute_inner_ns([w_dst_T, w_src_T])
-    irtag = IRTag("unsafe.memop", cfunc="spy_memcpy")
+    ns = UNSAFE.w_ptr_copy.compute_inner_ns([w_dst_T, w_src_T])
+    irtag = IRTag("unsafe.memop", cfunc="spy_ptr_copy")
 
     @vm.register_builtin_func(ns, "impl", irtag=irtag)
-    def w_memcpy_impl(vm: "SPyVM", w_dst: DST, w_src: SRC, w_n: W_I32) -> None:
+    def w_ptr_copy_impl(vm: "SPyVM", w_dst: DST, w_src: SRC, w_n: W_I32) -> None:
         n = vm.unwrap_i32(w_n)
         if n > w_dst.length or n > w_src.length:
-            raise SPyError("W_PanicError", "memcpy out of bounds")
+            raise SPyError("W_PanicError", "ptr_copy out of bounds")
         vm.ll.call("_spy_memcpy", w_dst.addr, w_src.addr, n * ITEMSIZE)
 
-    return W_OpSpec(w_memcpy_impl, [wam_dst, wam_src, wam_n])
+    return W_OpSpec(w_ptr_copy_impl, [wam_dst, wam_src, wam_n])
 
 
 @UNSAFE.builtin_func(color="blue", kind="metafunc")
-def w_memmove(
+def w_ptr_move(
     vm: "SPyVM", wam_dst: W_MetaArg, wam_src: W_MetaArg, wam_n: W_MetaArg
 ) -> W_OpSpec:
     w_dst_T, w_src_T = _check_ptrs_match(vm, wam_dst, wam_src)
     DST = Annotated[W_Ptr, w_dst_T]
     SRC = Annotated[W_Ptr, w_src_T]
     ITEMSIZE = sizeof(w_dst_T.w_itemT)
-    ns = UNSAFE.w_memmove.compute_inner_ns([w_dst_T, w_src_T])
-    irtag = IRTag("unsafe.memop", cfunc="spy_memmove")
+    ns = UNSAFE.w_ptr_move.compute_inner_ns([w_dst_T, w_src_T])
+    irtag = IRTag("unsafe.memop", cfunc="spy_ptr_move")
 
     @vm.register_builtin_func(ns, "impl", irtag=irtag)
-    def w_memmove_impl(vm: "SPyVM", w_dst: DST, w_src: SRC, w_n: W_I32) -> None:
+    def w_ptr_move_impl(vm: "SPyVM", w_dst: DST, w_src: SRC, w_n: W_I32) -> None:
         n = vm.unwrap_i32(w_n)
         if n > w_dst.length or n > w_src.length:
-            raise SPyError("W_PanicError", "memmove out of bounds")
+            raise SPyError("W_PanicError", "ptr_move out of bounds")
         vm.ll.call("_spy_memmove", w_dst.addr, w_src.addr, n * ITEMSIZE)
 
-    return W_OpSpec(w_memmove_impl, [wam_dst, wam_src, wam_n])
+    return W_OpSpec(w_ptr_move_impl, [wam_dst, wam_src, wam_n])
 
 
 @UNSAFE.builtin_func(color="blue", kind="metafunc")
-def w_memset(
+def w_ptr_set(
     vm: "SPyVM", wam_dst: W_MetaArg, wam_value: W_MetaArg, wam_n: W_MetaArg
 ) -> W_OpSpec:
     w_dst_T = _check_ptr(vm, wam_dst)
     DST = Annotated[W_Ptr, w_dst_T]
     ITEMSIZE = sizeof(w_dst_T.w_itemT)
-    ns = UNSAFE.w_memset.compute_inner_ns([w_dst_T])
-    irtag = IRTag("unsafe.memop", cfunc="spy_memset")
+    ns = UNSAFE.w_ptr_set.compute_inner_ns([w_dst_T])
+    irtag = IRTag("unsafe.memop", cfunc="spy_ptr_set")
 
     @vm.register_builtin_func(ns, "impl", irtag=irtag)
-    def w_memset_impl(vm: "SPyVM", w_dst: DST, w_value: W_U8, w_n: W_I32) -> None:
+    def w_ptr_set_impl(vm: "SPyVM", w_dst: DST, w_value: W_U8, w_n: W_I32) -> None:
         n = vm.unwrap_i32(w_n)
         if n > w_dst.length:
-            raise SPyError("W_PanicError", "memset out of bounds")
+            raise SPyError("W_PanicError", "ptr_set out of bounds")
         vm.ll.call("_spy_memset", w_dst.addr, int(w_value.value), n * ITEMSIZE)
 
-    return W_OpSpec(w_memset_impl, [wam_dst, wam_value, wam_n])
+    return W_OpSpec(w_ptr_set_impl, [wam_dst, wam_value, wam_n])
 
 
 @UNSAFE.builtin_func(color="blue", kind="metafunc")
-def w_memcmp(
+def w_ptr_cmp(
     vm: "SPyVM", wam_a: W_MetaArg, wam_b: W_MetaArg, wam_n: W_MetaArg
 ) -> W_OpSpec:
     w_a_T, w_b_T = _check_ptrs_match(vm, wam_a, wam_b)
     A = Annotated[W_Ptr, w_a_T]
     B_ = Annotated[W_Ptr, w_b_T]
     ITEMSIZE = sizeof(w_a_T.w_itemT)
-    ns = UNSAFE.w_memcmp.compute_inner_ns([w_a_T, w_b_T])
-    irtag = IRTag("unsafe.memop", cfunc="spy_memcmp")
+    ns = UNSAFE.w_ptr_cmp.compute_inner_ns([w_a_T, w_b_T])
+    irtag = IRTag("unsafe.memop", cfunc="spy_ptr_cmp")
 
     @vm.register_builtin_func(ns, "impl", irtag=irtag)
-    def w_memcmp_impl(vm: "SPyVM", w_a: A, w_b: B_, w_n: W_I32) -> W_I32:
+    def w_ptr_cmp_impl(vm: "SPyVM", w_a: A, w_b: B_, w_n: W_I32) -> W_I32:
         n = vm.unwrap_i32(w_n)
         if n > w_a.length or n > w_b.length:
-            raise SPyError("W_PanicError", "memcmp out of bounds")
+            raise SPyError("W_PanicError", "ptr_cmp out of bounds")
         result = vm.ll.call("_spy_memcmp", w_a.addr, w_b.addr, n * ITEMSIZE)
         return vm.wrap(result)
 
-    return W_OpSpec(w_memcmp_impl, [wam_a, wam_b, wam_n])
+    return W_OpSpec(w_ptr_cmp_impl, [wam_a, wam_b, wam_n])
 
 
 @UNSAFE.builtin_func(color="blue")

--- a/spy/vm/modules/unsafe/mem.py
+++ b/spy/vm/modules/unsafe/mem.py
@@ -237,6 +237,59 @@ def w_ptr_move(
 
 
 @UNSAFE.builtin_func(color="blue", kind="metafunc")
+def w_ptr_move_slice(
+    vm: "SPyVM",
+    wam_dst: W_MetaArg,
+    wam_dst_start: W_MetaArg,
+    wam_dst_end: W_MetaArg,
+    wam_src: W_MetaArg,
+    wam_src_start: W_MetaArg,
+    wam_src_end: W_MetaArg,
+) -> W_OpSpec:
+    w_dst_T, w_src_T = _check_ptrs_match(vm, wam_dst, wam_src)
+    DST = Annotated[W_Ptr, w_dst_T]
+    SRC = Annotated[W_Ptr, w_src_T]
+    ITEMSIZE = sizeof(w_dst_T.w_itemT)
+    ns = UNSAFE.w_ptr_move_slice.compute_inner_ns([w_dst_T, w_src_T])
+    irtag = IRTag("unsafe.memop", cfunc="spy_ptr_move_slice")
+
+    @vm.register_builtin_func(ns, "impl", irtag=irtag)
+    def w_ptr_move_slice_impl(
+        vm: "SPyVM",
+        w_dst: DST,
+        w_dst_start: W_I32,
+        w_dst_end: W_I32,
+        w_src: SRC,
+        w_src_start: W_I32,
+        w_src_end: W_I32,
+    ) -> None:
+        dst_start = vm.unwrap_i32(w_dst_start)
+        dst_end = vm.unwrap_i32(w_dst_end)
+        src_start = vm.unwrap_i32(w_src_start)
+        src_end = vm.unwrap_i32(w_src_end)
+        n = dst_end - dst_start
+        if n != src_end - src_start:
+            raise SPyError("W_PanicError", "ptr_move_slice length mismatch")
+        if n < 0:
+            raise SPyError("W_PanicError", "ptr_move_slice out of bounds")
+        if dst_start < 0 or dst_end > w_dst.length:
+            raise SPyError("W_PanicError", "ptr_move_slice out of bounds")
+        if src_start < 0 or src_end > w_src.length:
+            raise SPyError("W_PanicError", "ptr_move_slice out of bounds")
+        vm.ll.call(
+            "_spy_memmove",
+            w_dst.addr + dst_start * ITEMSIZE,
+            w_src.addr + src_start * ITEMSIZE,
+            n * ITEMSIZE,
+        )
+
+    return W_OpSpec(
+        w_ptr_move_slice_impl,
+        [wam_dst, wam_dst_start, wam_dst_end, wam_src, wam_src_start, wam_src_end],
+    )
+
+
+@UNSAFE.builtin_func(color="blue", kind="metafunc")
 def w_ptr_set(
     vm: "SPyVM", wam_dst: W_MetaArg, wam_value: W_MetaArg, wam_n: W_MetaArg
 ) -> W_OpSpec:
@@ -254,6 +307,45 @@ def w_ptr_set(
         vm.ll.call("_spy_memset", w_dst.addr, int(w_value.value), n * ITEMSIZE)
 
     return W_OpSpec(w_ptr_set_impl, [wam_dst, wam_value, wam_n])
+
+
+@UNSAFE.builtin_func(color="blue", kind="metafunc")
+def w_ptr_set_slice(
+    vm: "SPyVM",
+    wam_dst: W_MetaArg,
+    wam_dst_start: W_MetaArg,
+    wam_dst_end: W_MetaArg,
+    wam_value: W_MetaArg,
+) -> W_OpSpec:
+    w_dst_T = _check_ptr(vm, wam_dst)
+    DST = Annotated[W_Ptr, w_dst_T]
+    ITEMSIZE = sizeof(w_dst_T.w_itemT)
+    ns = UNSAFE.w_ptr_set_slice.compute_inner_ns([w_dst_T])
+    irtag = IRTag("unsafe.memop", cfunc="spy_ptr_set_slice")
+
+    @vm.register_builtin_func(ns, "impl", irtag=irtag)
+    def w_ptr_set_slice_impl(
+        vm: "SPyVM",
+        w_dst: DST,
+        w_dst_start: W_I32,
+        w_dst_end: W_I32,
+        w_value: W_U8,
+    ) -> None:
+        dst_start = vm.unwrap_i32(w_dst_start)
+        dst_end = vm.unwrap_i32(w_dst_end)
+        n = dst_end - dst_start
+        if n < 0 or dst_start < 0 or dst_end > w_dst.length:
+            raise SPyError("W_PanicError", "ptr_set_slice out of bounds")
+        vm.ll.call(
+            "_spy_memset",
+            w_dst.addr + dst_start * ITEMSIZE,
+            int(w_value.value),
+            n * ITEMSIZE,
+        )
+
+    return W_OpSpec(
+        w_ptr_set_slice_impl, [wam_dst, wam_dst_start, wam_dst_end, wam_value]
+    )
 
 
 @UNSAFE.builtin_func(color="blue", kind="metafunc")
@@ -276,6 +368,58 @@ def w_ptr_cmp(
         return vm.wrap(result)
 
     return W_OpSpec(w_ptr_cmp_impl, [wam_a, wam_b, wam_n])
+
+
+@UNSAFE.builtin_func(color="blue", kind="metafunc")
+def w_ptr_cmp_slice(
+    vm: "SPyVM",
+    wam_a: W_MetaArg,
+    wam_a_start: W_MetaArg,
+    wam_a_end: W_MetaArg,
+    wam_b: W_MetaArg,
+    wam_b_start: W_MetaArg,
+    wam_b_end: W_MetaArg,
+) -> W_OpSpec:
+    w_a_T, w_b_T = _check_ptrs_match(vm, wam_a, wam_b)
+    A = Annotated[W_Ptr, w_a_T]
+    B_ = Annotated[W_Ptr, w_b_T]
+    ITEMSIZE = sizeof(w_a_T.w_itemT)
+    ns = UNSAFE.w_ptr_cmp_slice.compute_inner_ns([w_a_T, w_b_T])
+    irtag = IRTag("unsafe.memop", cfunc="spy_ptr_cmp_slice")
+
+    @vm.register_builtin_func(ns, "impl", irtag=irtag)
+    def w_ptr_cmp_slice_impl(
+        vm: "SPyVM",
+        w_a: A,
+        w_a_start: W_I32,
+        w_a_end: W_I32,
+        w_b: B_,
+        w_b_start: W_I32,
+        w_b_end: W_I32,
+    ) -> W_I32:
+        a_start = vm.unwrap_i32(w_a_start)
+        a_end = vm.unwrap_i32(w_a_end)
+        b_start = vm.unwrap_i32(w_b_start)
+        b_end = vm.unwrap_i32(w_b_end)
+        n = a_end - a_start
+        if n != b_end - b_start:
+            raise SPyError("W_PanicError", "ptr_cmp_slice length mismatch")
+        if n < 0 or a_start < 0 or a_end > w_a.length:
+            raise SPyError("W_PanicError", "ptr_cmp_slice out of bounds")
+        if b_start < 0 or b_end > w_b.length:
+            raise SPyError("W_PanicError", "ptr_cmp_slice out of bounds")
+        result = vm.ll.call(
+            "_spy_memcmp",
+            w_a.addr + a_start * ITEMSIZE,
+            w_b.addr + b_start * ITEMSIZE,
+            n * ITEMSIZE,
+        )
+        return vm.wrap(result)
+
+    return W_OpSpec(
+        w_ptr_cmp_slice_impl,
+        [wam_a, wam_a_start, wam_a_end, wam_b, wam_b_start, wam_b_end],
+    )
 
 
 @UNSAFE.builtin_func(color="blue")

--- a/spy/vm/modules/unsafe/mem.py
+++ b/spy/vm/modules/unsafe/mem.py
@@ -163,6 +163,59 @@ def w_ptr_copy(
 
 
 @UNSAFE.builtin_func(color="blue", kind="metafunc")
+def w_ptr_copy_slice(
+    vm: "SPyVM",
+    wam_dst: W_MetaArg,
+    wam_dst_start: W_MetaArg,
+    wam_dst_end: W_MetaArg,
+    wam_src: W_MetaArg,
+    wam_src_start: W_MetaArg,
+    wam_src_end: W_MetaArg,
+) -> W_OpSpec:
+    w_dst_T, w_src_T = _check_ptrs_match(vm, wam_dst, wam_src)
+    DST = Annotated[W_Ptr, w_dst_T]
+    SRC = Annotated[W_Ptr, w_src_T]
+    ITEMSIZE = sizeof(w_dst_T.w_itemT)
+    ns = UNSAFE.w_ptr_copy_slice.compute_inner_ns([w_dst_T, w_src_T])
+    irtag = IRTag("unsafe.memop", cfunc="spy_ptr_copy_slice")
+
+    @vm.register_builtin_func(ns, "impl", irtag=irtag)
+    def w_ptr_copy_slice_impl(
+        vm: "SPyVM",
+        w_dst: DST,
+        w_dst_start: W_I32,
+        w_dst_end: W_I32,
+        w_src: SRC,
+        w_src_start: W_I32,
+        w_src_end: W_I32,
+    ) -> None:
+        dst_start = vm.unwrap_i32(w_dst_start)
+        dst_end = vm.unwrap_i32(w_dst_end)
+        src_start = vm.unwrap_i32(w_src_start)
+        src_end = vm.unwrap_i32(w_src_end)
+        n = dst_end - dst_start
+        if n != src_end - src_start:
+            raise SPyError("W_PanicError", "ptr_copy_slice length mismatch")
+        if n < 0:
+            raise SPyError("W_PanicError", "ptr_copy_slice out of bounds")
+        if dst_start < 0 or dst_end > w_dst.length:
+            raise SPyError("W_PanicError", "ptr_copy_slice out of bounds")
+        if src_start < 0 or src_end > w_src.length:
+            raise SPyError("W_PanicError", "ptr_copy_slice out of bounds")
+        vm.ll.call(
+            "_spy_memcpy",
+            w_dst.addr + dst_start * ITEMSIZE,
+            w_src.addr + src_start * ITEMSIZE,
+            n * ITEMSIZE,
+        )
+
+    return W_OpSpec(
+        w_ptr_copy_slice_impl,
+        [wam_dst, wam_dst_start, wam_dst_end, wam_src, wam_src_start, wam_src_end],
+    )
+
+
+@UNSAFE.builtin_func(color="blue", kind="metafunc")
 def w_ptr_move(
     vm: "SPyVM", wam_dst: W_MetaArg, wam_src: W_MetaArg, wam_n: W_MetaArg
 ) -> W_OpSpec:

--- a/stdlib/_bytes.spy
+++ b/stdlib/_bytes.spy
@@ -13,7 +13,7 @@ BytesObject.{from,to}_bytes.
 
 from unsafe import (
     gc_ptr,
-    memcpy,
+    ptr_copy,
     _bytes_to_BytesObject,
     _alloc_BytesObject,
     _BytesObject_to_bytes,
@@ -104,7 +104,7 @@ class methods:
         out = StrObject.alloc(ll.length)
         out.hash = 0
         if ll.length > 0:
-            memcpy(out.utf8, ll.data, ll.length)
+            ptr_copy(out.utf8, ll.data, ll.length)
         return StrObject.to_str(out)
 
     def __repr__(self: bytes) -> str:

--- a/stdlib/_str.spy
+++ b/stdlib/_str.spy
@@ -14,7 +14,7 @@ possible to cast between str and gc_ptr[StrObject] using StrObject.{from,to}_str
 
 from unsafe import (
     gc_ptr,
-    memcpy,
+    ptr_copy,
     _str_to_StrObject,
     _alloc_StrObject,
     _StrObject_to_str,
@@ -84,7 +84,7 @@ class methods:
         out = _alloc_BytesObject(ll.length)
         out.hash = 0
         if ll.length > 0:
-            memcpy(out.data, ll.utf8, ll.length)
+            ptr_copy(out.data, ll.utf8, ll.length)
         return _BytesObject_to_bytes(out)
 
     def isascii(self: str) -> bool:


### PR DESCRIPTION
`unsafe.memcpy` worked only on `ptr[u8]`. We wanted to make it available also on generic `ptr[T]`, but this poses a problem: the `count` argument is naturally expressed in *items*, but the C memcpy takes *bytes*.
Using the `memcpy` name with a slightly different semantic for the `count` argument would be confusing.

The solution is:
  - add `ptr_copy`, `ptr_move`, `ptr_set`, `ptr_cmp`: these works for all ptr types. The naming is inspired by rust `ptr::copy` and C++ `std::copy`.
  - `memcpy` & co. works only for i8/u8 and are small shims over `ptr_copy` & co

Moreover, we `ptr_copy_slice` & co. The slice version takes (ptr, start, end) for both src and dst.
