### PR TITLE
Migrate manual byte/element loops to unsafe mem ops

### DIFF
--- a/spy/libspy/include/spy/unsafe.h
+++ b/spy/libspy/include/spy/unsafe.h
@@ -151,6 +151,7 @@ typedef spy_unsafe$gc_ptr__builtins$u8 spy_gc_ptr_u8;
 #ifdef SPY_DEBUG
 #  define spy_ptr_copy(dst, src, n)                                                    \
       do {                                                                             \
+          size_t _spy_nb = (size_t)(n) * sizeof(*(dst).p);                             \
           if ((size_t)(n) > (size_t)(dst).length)                                      \
               spy_panic(                                                               \
                   "PanicError", "ptr_copy dst out of bounds", __FILE__, __LINE__       \
@@ -159,7 +160,10 @@ typedef spy_unsafe$gc_ptr__builtins$u8 spy_gc_ptr_u8;
               spy_panic(                                                               \
                   "PanicError", "ptr_copy src out of bounds", __FILE__, __LINE__       \
               );                                                                       \
-          memcpy((dst).p, (src).p, (n) * sizeof(*(dst).p));                            \
+          if ((char *)(dst).p < (char *)(src).p + _spy_nb &&                           \
+              (char *)(src).p < (char *)(dst).p + _spy_nb)                             \
+              spy_panic("PanicError", "ptr_copy regions overlap", __FILE__, __LINE__); \
+          memcpy((dst).p, (src).p, _spy_nb);                                           \
       } while (0)
 #else
 #  define spy_ptr_copy(dst, src, n) memcpy((dst).p, (src).p, (n) * sizeof(*(dst).p))
@@ -184,7 +188,17 @@ typedef spy_unsafe$gc_ptr__builtins$u8 spy_gc_ptr_u8;
               spy_panic(                                                               \
                   "PanicError", "ptr_copy_slice src out of bounds", __FILE__, __LINE__ \
               );                                                                       \
-          memcpy((dst).p + (ds), (src).p + (ss), _spy_n * sizeof(*(dst).p));           \
+          {                                                                            \
+              size_t _spy_nb = (size_t)_spy_n * sizeof(*(dst).p);                      \
+              char *_spy_d = (char *)((dst).p + (ds));                                 \
+              char *_spy_s = (char *)((src).p + (ss));                                 \
+              if (_spy_d < _spy_s + _spy_nb && _spy_s < _spy_d + _spy_nb)              \
+                  spy_panic(                                                           \
+                      "PanicError", "ptr_copy_slice regions overlap", __FILE__,        \
+                      __LINE__                                                         \
+                  );                                                                   \
+              memcpy(_spy_d, _spy_s, _spy_nb);                                         \
+          }                                                                            \
       } while (0)
 #else
 #  define spy_ptr_copy_slice(dst, ds, de, src, ss, se)                                 \

--- a/spy/tests/compiler/unsafe/test_mem.py
+++ b/spy/tests/compiler/unsafe/test_mem.py
@@ -165,6 +165,30 @@ class TestMem(CompilerTest):
         with SPyError.raises("W_PanicError", match="length mismatch"):
             mod.fn_slice_mismatch()
 
+    def test_ptr_copy_overlap(self, memkind):
+        k = memkind
+        src = """
+        from unsafe import (
+            {k}_alloc as k_alloc, {k}_ptr as k_ptr,
+            ptr_copy, ptr_copy_slice,
+        )
+
+        def fn_ptr() -> i32:
+            buf: k_ptr[u8] = k_alloc[u8](4)
+            ptr_copy(buf, buf, 4)
+            return 0
+
+        def fn_slice() -> i32:
+            buf: k_ptr[u8] = k_alloc[u8](4)
+            ptr_copy_slice(buf, 0, 3, buf, 1, 4)
+            return 0
+        """.format(k=k)
+        mod = self.compile(src)
+        with SPyError.raises("W_PanicError", match="ptr_copy regions overlap"):
+            mod.fn_ptr()
+        with SPyError.raises("W_PanicError", match="ptr_copy_slice regions overlap"):
+            mod.fn_slice()
+
     def test_ptr_move(self, memkind):
         k = memkind
         src = """

--- a/spy/vm/modules/unsafe/mem.py
+++ b/spy/vm/modules/unsafe/mem.py
@@ -190,7 +190,10 @@ def w_ptr_copy(
         n = vm.unwrap_i32(w_n)
         if n > w_dst.length or n > w_src.length:
             raise SPyError("W_PanicError", "ptr_copy out of bounds")
-        vm.ll.call("_spy_memcpy", w_dst.addr, w_src.addr, n * ITEMSIZE)
+        nbytes = n * ITEMSIZE
+        if w_dst.addr < w_src.addr + nbytes and w_src.addr < w_dst.addr + nbytes:
+            raise SPyError("W_PanicError", "ptr_copy regions overlap")
+        vm.ll.call("_spy_memcpy", w_dst.addr, w_src.addr, nbytes)
 
     return W_OpSpec(w_ptr_copy_impl, [wam_dst, wam_src, wam_n])
 
@@ -242,12 +245,12 @@ def w_ptr_copy_slice(
             raise SPyError("W_PanicError", "ptr_copy_slice out of bounds")
         if src_start < 0 or src_end > w_src.length:
             raise SPyError("W_PanicError", "ptr_copy_slice out of bounds")
-        vm.ll.call(
-            "_spy_memcpy",
-            w_dst.addr + dst_start * ITEMSIZE,
-            w_src.addr + src_start * ITEMSIZE,
-            n * ITEMSIZE,
-        )
+        dst_addr = w_dst.addr + dst_start * ITEMSIZE
+        src_addr = w_src.addr + src_start * ITEMSIZE
+        nbytes = n * ITEMSIZE
+        if dst_addr < src_addr + nbytes and src_addr < dst_addr + nbytes:
+            raise SPyError("W_PanicError", "ptr_copy_slice regions overlap")
+        vm.ll.call("_spy_memcpy", dst_addr, src_addr, nbytes)
 
     return W_OpSpec(
         w_ptr_copy_slice_impl,

--- a/stdlib/_bytes.spy
+++ b/stdlib/_bytes.spy
@@ -16,6 +16,7 @@ from unsafe import (
     ptr_copy,
     ptr_copy_slice,
     memcmp,
+    memset,
     _bytes_to_BytesObject,
     _alloc_BytesObject,
     _BytesObject_to_bytes,
@@ -75,21 +76,20 @@ class methods:
         b = BytesObject.from_bytes(other)
         out = BytesObject.alloc(a.length + b.length)
         out.hash = 0
-        for ia in range(a.length):
-            out.data[ia] = a.data[ia]
-        for ib in range(b.length):
-            out.data[a.length + ib] = b.data[ib]
+        ptr_copy_slice(out.data, 0, a.length, a.data, 0, a.length)
+        ptr_copy_slice(out.data, a.length, a.length + b.length, b.data, 0, b.length)
         return BytesObject.to_bytes(out)
 
     def __mul__(self: bytes, n: i32) -> bytes:
-        a = BytesObject.from_bytes(self)
-        out = BytesObject.alloc(a.length * n)
+        ll = BytesObject.from_bytes(self)
+        out = BytesObject.alloc(ll.length * n)
         out.hash = 0
-        k = 0
-        for _ in range(n):
-            for i in range(a.length):
-                out.data[k] = a.data[i]
-                k = k + 1
+        if ll.length == 1:
+            memset(out.data, ll.data[0], n)
+        else:
+            l = ll.length
+            for i in range(n):
+                ptr_copy_slice(out.data, i * l, (i + 1) * l, ll.data, 0, l)
         return BytesObject.to_bytes(out)
 
     # XXX: __hash__ lives in C (spy_bytes_hash, called from W_Bytes.w_hash) because

--- a/stdlib/_bytes.spy
+++ b/stdlib/_bytes.spy
@@ -14,6 +14,8 @@ BytesObject.{from,to}_bytes.
 from unsafe import (
     gc_ptr,
     ptr_copy,
+    ptr_copy_slice,
+    memcmp,
     _bytes_to_BytesObject,
     _alloc_BytesObject,
     _BytesObject_to_bytes,
@@ -63,10 +65,7 @@ class methods:
         b = BytesObject.from_bytes(other)
         if a.length != b.length:
             return False
-        for i in range(a.length):
-            if a.data[i] != b.data[i]:
-                return False
-        return True
+        return memcmp(a.data, b.data, a.length) == 0
 
     def __ne__(self: bytes, other: bytes) -> bool:
         return not self.__eq__(other)

--- a/stdlib/_dict.spy
+++ b/stdlib/_dict.spy
@@ -1,4 +1,4 @@
-from unsafe import gc_alloc, gc_ptr
+from unsafe import gc_alloc, gc_ptr, ptr_set
 from operator import OpSpec
 from __spy__ import interp_dict, EmptyDictType
 
@@ -64,10 +64,7 @@ def dict(Key, Value):
         assert MIN_LOG_SIZE <= log_size
         assert log_size <= MAX_LOG_SIZE
         index = gc_alloc[i32](1 << log_size)
-        i = 0
-        while i < 1 << log_size:
-            index[i] = DKIX_EMPTY
-            i += 1
+        ptr_set(index, 0, 1 << log_size)
         return index
 
     def new_entries(log_size: i32) -> gc_ptr[Entry]:

--- a/stdlib/_list.spy
+++ b/stdlib/_list.spy
@@ -4,7 +4,7 @@ SPy list module
 A generic dynamic array implementation similar to Python's list.
 """
 
-from unsafe import gc_alloc, gc_ptr
+from unsafe import gc_alloc, gc_ptr, ptr_copy, ptr_copy_slice
 from operator import OpSpec, MetaArg
 from __spy__ import interp_list, EmptyListType
 
@@ -81,12 +81,7 @@ def list(T):
                 old_capacity = ll.capacity
                 new_capacity = old_capacity * 2
                 new_items = gc_alloc[T](new_capacity)
-
-                i = 0
-                while i < ll.length:
-                    new_items[i] = ll.items[i]
-                    i = i + 1
-
+                ptr_copy(new_items, ll.items, ll.length)
                 ll.items = new_items
                 ll.capacity = new_capacity
 
@@ -132,10 +127,8 @@ def list(T):
                 new_data.length = new_length
                 new_data.capacity = new_length + 1
                 new_data.items = gc_alloc[T](ll.capacity)
-
-                for i in range(new_length):
-                    new_data.items[i] = ll.items[indices.start + i]
-
+                ptr_copy_slice(new_data.items, 0, new_length,
+                               ll.items, indices.start, indices.start + new_length)
                 return _ListImpl.__make__(new_data)
             else:
                 new_data = gc_alloc[ListData](1)
@@ -196,10 +189,7 @@ def list(T):
                 if new_total > ll.capacity:
                     new_cap = new_total * 2
                     new_items = gc_alloc[T](new_cap)
-                    j = 0
-                    while j < ll.length:
-                        new_items[j] = ll.items[j]
-                        j = j + 1
+                    ptr_copy(new_items, ll.items, ll.length)
                     ll.items = new_items
                     ll.capacity = new_cap
 
@@ -251,12 +241,7 @@ def list(T):
                 old_capacity = ll.capacity
                 new_capacity = old_capacity * 2
                 new_items = gc_alloc[T](new_capacity)
-
-                j = 0
-                while j < ll.length:
-                    new_items[j] = ll.items[j]
-                    j = j + 1
-
+                ptr_copy(new_items, ll.items, ll.length)
                 ll.items = new_items
                 ll.capacity = new_capacity
 
@@ -273,11 +258,18 @@ def list(T):
             ll.length = 0
 
         def extend(self, other: _ListImpl) -> None:
+            ll = self.__ll__
             other_ll = other.__ll__
-            i = 0
-            while i < other_ll.length:
-                self.append(other_ll.items[i])
-                i = i + 1
+            new_length = ll.length + other_ll.length
+            if new_length > ll.capacity:
+                new_capacity = new_length * 2
+                new_items = gc_alloc[T](new_capacity)
+                ptr_copy(new_items, ll.items, ll.length)
+                ll.items = new_items
+                ll.capacity = new_capacity
+            ptr_copy_slice(ll.items, ll.length, new_length,
+                           other_ll.items, 0, other_ll.length)
+            ll.length = new_length
 
         def copy(self) -> _ListImpl:
             ll = self.__ll__
@@ -285,12 +277,7 @@ def list(T):
             new_data.length = ll.length
             new_data.capacity = ll.capacity
             new_data.items = gc_alloc[T](ll.capacity)
-
-            i = 0
-            while i < ll.length:
-                new_data.items[i] = ll.items[i]
-                i = i + 1
-
+            ptr_copy(new_data.items, ll.items, ll.length)
             return _ListImpl.__make__(new_data)
 
         def __add__(self, other: _ListImpl) -> _ListImpl:
@@ -314,10 +301,8 @@ def list(T):
 
                 i = 0
                 while i < n:
-                    j = 0
-                    while j < ll.length:
-                        new_data.items[i * ll.length + j] = ll.items[j]
-                        j = j + 1
+                    ptr_copy_slice(new_data.items, i * ll.length, (i + 1) * ll.length,
+                                   ll.items, 0, ll.length)
                     i = i + 1
 
             return _ListImpl.__make__(new_data)

--- a/stdlib/_list.spy
+++ b/stdlib/_list.spy
@@ -4,7 +4,7 @@ SPy list module
 A generic dynamic array implementation similar to Python's list.
 """
 
-from unsafe import gc_alloc, gc_ptr, ptr_copy, ptr_copy_slice
+from unsafe import gc_alloc, gc_ptr, ptr_copy, ptr_copy_slice, ptr_move_slice
 from operator import OpSpec, MetaArg
 from __spy__ import interp_list, EmptyListType
 
@@ -195,16 +195,12 @@ def list(T):
 
                 if diff > 0:
                     # shift right to make room
-                    j = ll.length - 1
-                    while j >= start + slice_len:
-                        ll.items[j + diff] = ll.items[j]
-                        j = j - 1
+                    ptr_move_slice(ll.items, start + new_len, new_total,
+                                   ll.items, start + slice_len, ll.length)
                 elif diff < 0:
                     # shift left to close gap
-                    j = start + slice_len
-                    while j < ll.length:
-                        ll.items[j + diff] = ll.items[j]
-                        j = j + 1
+                    ptr_move_slice(ll.items, start + new_len, new_total,
+                                   ll.items, start + slice_len, ll.length)
 
                 k = 0
                 while k < new_len:
@@ -223,10 +219,7 @@ def list(T):
             if i >= ll.length:
                 raise IndexError
             value = ll.items[i]
-            j = i
-            while j < ll.length - 1:
-                ll.items[j] = ll.items[j + 1]
-                j = j + 1
+            ptr_move_slice(ll.items, i, ll.length - 1, ll.items, i + 1, ll.length)
             ll.length = ll.length - 1
             return value
 
@@ -245,11 +238,7 @@ def list(T):
                 ll.items = new_items
                 ll.capacity = new_capacity
 
-            j = ll.length
-            while j > i:
-                ll.items[j] = ll.items[j - 1]
-                j = j - 1
-
+            ptr_move_slice(ll.items, i + 1, ll.length + 1, ll.items, i, ll.length)
             ll.items[i] = item
             ll.length = ll.length + 1
 
@@ -339,11 +328,7 @@ def list(T):
             if idx == -1:
                 raise ValueError
 
-            j = idx
-            while j < ll.length - 1:
-                ll.items[j] = ll.items[j + 1]
-                j = j + 1
-
+            ptr_move_slice(ll.items, idx, ll.length - 1, ll.items, idx + 1, ll.length)
             ll.length = ll.length - 1
 
         @blue.metafunc

--- a/stdlib/array.spy
+++ b/stdlib/array.spy
@@ -15,7 +15,7 @@ hardcode _array1, _array2, _array3, etc.
 """
 
 from operator import OpSpec
-from unsafe import gc_alloc, gc_ptr
+from unsafe import gc_alloc, gc_ptr, ptr_set
 
 
 @blue.generic
@@ -198,14 +198,11 @@ def zeros(DTYPE):
 
             def impl(n: i32) -> ArrayT:
                 a = ArrayT(n)
-                # XXX: this loop is a temporary workaround. gc_alloc does not
-                # zero memory, so we zero the array element-by-element here.
-                # Eventually we should have a gc_alloc_zero (or similar) which
-                # returns zeroed memory, and use it for the underlying buffer.
-                i = 0
-                while i < n:
-                    a[i] = DTYPE(0)
-                    i = i + 1
+                # XXX: this loop is a temporary workaround. gc_alloc does not zero
+                # memory, so we zero the array here.  Eventually we should have a
+                # gc_alloc_zero (or similar) which returns zeroed memory, and use it for
+                # the underlying buffer.
+                ptr_set(a.__ll__.items, 0, n)
                 return a
 
             return OpSpec(impl)


### PR DESCRIPTION
This is a relatively small but dense PR, mostly written by claude under my strict guidance.
The idea is to replace many of the the manual element-by-element loops with mem bulk functions, now that we have them.
The migration is mostly mechanical. I think we can be confident that things don't break thanks to:
1. our very good test coverage
2. lots of sanity check in interp/debug mode

In particular, this PR also adds a new sanity check for `ptr_copy`, to ensure that memory don't overlap.

What follows is the PR description written by claude.

--- 

Replace hand-rolled byte- and element-level loops in `stdlib/` with the
`unsafe` module's memory primitives. These loops went through SPy IR /
`gc_ptr` getitem-store rather than raw C intrinsics; switching them over
gives a measurable speedup in both the C backend (single intrinsic call →
vectorized libc) and the interp backend (one call instead of N).

## Changes

- `bytes.__eq__`: byte loop → `memcmp`
- `bytes.__add__`: two index loops → two `ptr_copy_slice` calls
- `bytes.__mul__`: inner byte loop → `memset` (single-byte case) or `ptr_copy_slice` per repetition
- `dict.new_index`: `while` zero-fill loop → `ptr_set`
- `array.zeros`: `while` zero-fill loop → `ptr_set`
- `list` non-overlapping copies (`append`/`insert` grow, `copy`, `_setitem_slice` grow, `_getitem_slice` step==1, `__mul__`, `extend`): → `ptr_copy` / `ptr_copy_slice`
- `list` overlapping shifts (`pop`, `insert`, `_setitem_slice` shift, `remove`): → `ptr_move_slice`

All existing tests pass unchanged across all backends.