### PR TITLE
Rename ptr_set to ptr_setbytes and update examples/3_low_level/mem.spy after ptr_* and ptr_*_slice

### DIFF
--- a/examples/3_low_level/mem.spy
+++ b/examples/3_low_level/mem.spy
@@ -1,78 +1,111 @@
 """
 Things to notice:
-  - memset, memcpy, memmove, memcmp all operate on ptr[u8] buffers
-  - they provide the same semantics as their C counterparts
+  - ptr_copy, ptr_move, ptr_set, ptr_cmp are the primary mem ops; they work
+    on ptr[T] for any type T, and count is expressed in items, not bytes
+  - each op has a _slice variant that avoids the need for pointer arithmetic:
+      ptr_copy_slice(dst, dstart, dend, src, sstart, send)
+  - ptr_copy panics on overlapping regions; use ptr_move when regions may overlap
   - bounds are checked at runtime: out-of-bounds access panics
-  - memcpy is faster but requires non-overlapping buffers;
-    memmove is safe for overlapping regions
-  - gc_alloc is used here: the GC handles memory release automatically
+  - gc_alloc is used here; the GC handles memory release automatically
+
+Note: memcpy, memmove, memset, memcmp are byte-only shims (ptr[u8]/ptr[i8])
+that mirror the C standard library.
 """
 
-from unsafe import gc_alloc, gc_ptr, memset, memcpy, memmove, memcmp
+from unsafe import (
+    gc_alloc,
+    gc_ptr,
+    ptr_copy,
+    ptr_copy_slice,
+    ptr_cmp,
+    ptr_cmp_slice,
+    ptr_move,
+    ptr_move_slice,
+    ptr_set,
+    ptr_set_slice,
+)
 
 
-def demo_memset() -> None:
-    buf: gc_ptr[u8] = gc_alloc[u8](4)
-    memset(buf, 7, 4)
-    # all bytes are now 7
+def demo_ptr_set() -> None:
+    buf = gc_alloc[u8](4)
+    ptr_set(buf, 7, 4)
     total: i32 = buf[0] + buf[1] + buf[2] + buf[3]
     assert total == 28
 
+    # _slice variant: only fill a sub-range [1, 3)
+    buf2 = gc_alloc[u8](4)
+    ptr_set(buf2, 0, 4)
+    ptr_set_slice(buf2, 1, 3, 5)
+    assert buf2[0] == u8(0)
+    assert buf2[1] == u8(5)
+    assert buf2[2] == u8(5)
+    assert buf2[3] == u8(0)
 
-def demo_memcpy() -> None:
-    src: gc_ptr[u8] = gc_alloc[u8](4)
-    dst: gc_ptr[u8] = gc_alloc[u8](4)
+
+def demo_ptr_copy() -> None:
+    src = gc_alloc[u8](4)
+    dst = gc_alloc[u8](4)
 
     src[0] = 10
     src[1] = 20
     src[2] = 30
     src[3] = 40
 
-    memcpy(dst, src, 4)
-
+    ptr_copy(dst, src, 4)
     total: i32 = dst[0] + dst[1] + dst[2] + dst[3]
     assert total == 100
 
-
-# The canonical use case for memmove over memcpy is overlapping regions, e.g.:
-#
-#   memmove(buf + 2, buf, 3)  # shift 3 bytes forward by 2 positions
-#
-# This requires pointer arithmetic (buf + 2), which is not yet supported in SPy.
-# For non-overlapping buffers memmove and memcpy are interchangeable.
-def demo_memmove() -> None:
-    src: gc_ptr[u8] = gc_alloc[u8](4)
-    dst: gc_ptr[u8] = gc_alloc[u8](4)
-
-    src[0] = 1
-    src[1] = 2
-    src[2] = 3
-    src[3] = 4
-
-    memmove(dst, src, 4)
-
-    assert dst[0] == u8(1)
-    assert dst[1] == u8(2)
-    assert dst[2] == u8(3)
-    assert dst[3] == u8(4)
+    # _slice variant: copy src[1:3] into dst[2:4]
+    dst2 = gc_alloc[u8](4)
+    ptr_set(dst2, 0, 4)
+    ptr_copy_slice(dst2, 2, 4, src, 1, 3)
+    assert dst2[0] == u8(0)
+    assert dst2[1] == u8(0)
+    assert dst2[2] == u8(20)
+    assert dst2[3] == u8(30)
 
 
-def demo_memcmp() -> None:
-    a: gc_ptr[u8] = gc_alloc[u8](3)
-    b: gc_ptr[u8] = gc_alloc[u8](3)
+def demo_ptr_move() -> None:
+    # ptr_move_slice allows shifting data within a buffer using overlapping
+    # regions, without needing pointer arithmetic
+    buf = gc_alloc[u8](6)
+    buf[0] = 1
+    buf[1] = 2
+    buf[2] = 3
+    buf[3] = 0
+    buf[4] = 0
+    buf[5] = 0
 
-    memset(a, 42, 3)
-    memset(b, 42, 3)
-    assert memcmp(a, b, 3) == 0  # buffers are equal
+    # shift buf[0:3] into buf[2:5] (overlapping)
+    ptr_move_slice(buf, 2, 5, buf, 0, 3)
 
-    b[2] = 99
-    result: i32 = memcmp(a, b, 3)
-    assert result < 0  # a < b lexicographically
+    assert buf[2] == u8(1)
+    assert buf[3] == u8(2)
+    assert buf[4] == u8(3)
+
+
+def demo_ptr_cmp() -> None:
+    a = gc_alloc[u8](4)
+    b = gc_alloc[u8](4)
+
+    ptr_set(a, 42, 4)
+    ptr_set(b, 42, 4)
+    assert ptr_cmp(a, b, 4) == 0  # equal
+
+    b[3] = 99
+    assert ptr_cmp(a, b, 4) < 0
+
+    # _slice variant: compare only the middle two bytes
+    a[1] = 7
+    a[2] = 7
+    b[1] = 7
+    b[2] = 7
+    assert ptr_cmp_slice(a, 1, 3, b, 1, 3) == 0
 
 
 def main() -> None:
-    demo_memset()
-    demo_memcpy()
-    demo_memmove()
-    demo_memcmp()
+    demo_ptr_set()
+    demo_ptr_copy()
+    demo_ptr_move()
+    demo_ptr_cmp()
     print("all assertions passed")

--- a/examples/3_low_level/mem.spy
+++ b/examples/3_low_level/mem.spy
@@ -1,6 +1,6 @@
 """
 Things to notice:
-  - ptr_copy, ptr_move, ptr_set, ptr_cmp are the primary mem ops; they work
+  - ptr_copy, ptr_move, ptr_setbytes, ptr_cmp are the primary mem ops; they work
     on ptr[T] for any type T, and count is expressed in items, not bytes
   - each op has a _slice variant that avoids the need for pointer arithmetic:
       ptr_copy_slice(dst, dstart, dend, src, sstart, send)
@@ -21,29 +21,29 @@ from unsafe import (
     ptr_cmp_slice,
     ptr_move,
     ptr_move_slice,
-    ptr_set,
-    ptr_set_slice,
+    ptr_setbytes,
+    ptr_setbytes_slice,
 )
 
 
-def demo_ptr_set() -> None:
-    # ptr_set broadcasts a byte value across n*sizeof(T) bytes;
+def demo_ptr_setbytes() -> None:
+    # ptr_setbytes broadcasts a byte value across n*sizeof(T) bytes;
     # for T longer than u8 it is mainly useful for zeroing memory
     buf = gc_alloc[i32](4)
-    ptr_set(buf, 0, 4)
+    ptr_setbytes(buf, 0, 4)
     total = buf[0] + buf[1] + buf[2] + buf[3]
     assert total == 0
 
     # for u8 buffers, any byte value works as expected
     bytes_buf = gc_alloc[u8](4)
-    ptr_set(bytes_buf, 7, 4)
+    ptr_setbytes(bytes_buf, 7, 4)
     total = bytes_buf[0] + bytes_buf[1] + bytes_buf[2] + bytes_buf[3]
     assert total == 28
 
     # _slice variant: only fill a sub-range [1, 3)
     buf2 = gc_alloc[u8](4)
-    ptr_set(buf2, 0, 4)
-    ptr_set_slice(buf2, 1, 3, 5)
+    ptr_setbytes(buf2, 0, 4)
+    ptr_setbytes_slice(buf2, 1, 3, 5)
     assert buf2[0] == u8(0)
     assert buf2[1] == u8(5)
     assert buf2[2] == u8(5)
@@ -65,7 +65,7 @@ def demo_ptr_copy() -> None:
 
     # _slice variant: copy src[1:3] into dst[2:4]
     dst2 = gc_alloc[i32](4)
-    ptr_set(dst2, 0, 4)
+    ptr_setbytes(dst2, 0, 4)
     ptr_copy_slice(dst2, 2, 4, src, 1, 3)
     assert dst2[0] == 0
     assert dst2[1] == 0
@@ -96,8 +96,8 @@ def demo_ptr_cmp() -> None:
     a = gc_alloc[i32](4)
     b = gc_alloc[i32](4)
 
-    ptr_set(a, 42, 4)
-    ptr_set(b, 42, 4)
+    ptr_setbytes(a, 42, 4)
+    ptr_setbytes(b, 42, 4)
     assert ptr_cmp(a, b, 4) == 0  # equal
 
     b[3] = 99
@@ -112,7 +112,7 @@ def demo_ptr_cmp() -> None:
 
 
 def main() -> None:
-    demo_ptr_set()
+    demo_ptr_setbytes()
     demo_ptr_copy()
     demo_ptr_move()
     demo_ptr_cmp()

--- a/examples/3_low_level/mem.spy
+++ b/examples/3_low_level/mem.spy
@@ -27,9 +27,17 @@ from unsafe import (
 
 
 def demo_ptr_set() -> None:
-    buf = gc_alloc[u8](4)
-    ptr_set(buf, 7, 4)
-    total: i32 = buf[0] + buf[1] + buf[2] + buf[3]
+    # ptr_set broadcasts a byte value across n*sizeof(T) bytes;
+    # for T longer than u8 it is mainly useful for zeroing memory
+    buf = gc_alloc[i32](4)
+    ptr_set(buf, 0, 4)
+    total = buf[0] + buf[1] + buf[2] + buf[3]
+    assert total == 0
+
+    # for u8 buffers, any byte value works as expected
+    bytes_buf = gc_alloc[u8](4)
+    ptr_set(bytes_buf, 7, 4)
+    total = bytes_buf[0] + bytes_buf[1] + bytes_buf[2] + bytes_buf[3]
     assert total == 28
 
     # _slice variant: only fill a sub-range [1, 3)
@@ -43,8 +51,8 @@ def demo_ptr_set() -> None:
 
 
 def demo_ptr_copy() -> None:
-    src = gc_alloc[u8](4)
-    dst = gc_alloc[u8](4)
+    src = gc_alloc[i32](4)
+    dst = gc_alloc[i32](4)
 
     src[0] = 10
     src[1] = 20
@@ -56,19 +64,19 @@ def demo_ptr_copy() -> None:
     assert total == 100
 
     # _slice variant: copy src[1:3] into dst[2:4]
-    dst2 = gc_alloc[u8](4)
+    dst2 = gc_alloc[i32](4)
     ptr_set(dst2, 0, 4)
     ptr_copy_slice(dst2, 2, 4, src, 1, 3)
-    assert dst2[0] == u8(0)
-    assert dst2[1] == u8(0)
-    assert dst2[2] == u8(20)
-    assert dst2[3] == u8(30)
+    assert dst2[0] == 0
+    assert dst2[1] == 0
+    assert dst2[2] == 20
+    assert dst2[3] == 30
 
 
 def demo_ptr_move() -> None:
     # ptr_move_slice allows shifting data within a buffer using overlapping
     # regions, without needing pointer arithmetic
-    buf = gc_alloc[u8](6)
+    buf = gc_alloc[i32](6)
     buf[0] = 1
     buf[1] = 2
     buf[2] = 3
@@ -79,14 +87,14 @@ def demo_ptr_move() -> None:
     # shift buf[0:3] into buf[2:5] (overlapping)
     ptr_move_slice(buf, 2, 5, buf, 0, 3)
 
-    assert buf[2] == u8(1)
-    assert buf[3] == u8(2)
-    assert buf[4] == u8(3)
+    assert buf[2] == 1
+    assert buf[3] == 2
+    assert buf[4] == 3
 
 
 def demo_ptr_cmp() -> None:
-    a = gc_alloc[u8](4)
-    b = gc_alloc[u8](4)
+    a = gc_alloc[i32](4)
+    b = gc_alloc[i32](4)
 
     ptr_set(a, 42, 4)
     ptr_set(b, 42, 4)

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -613,8 +613,8 @@ class CFuncWriter:
             "spy_ptr_move_slice",
             "spy_ptr_cmp",
             "spy_ptr_cmp_slice",
-            "spy_ptr_set",
-            "spy_ptr_set_slice",
+            "spy_ptr_setbytes",
+            "spy_ptr_setbytes_slice",
         )
         c_args = [self.fmt_expr(arg) for arg in call.args]
         return C.Call(cfunc, c_args)

--- a/spy/libspy/include/spy/unsafe.h
+++ b/spy/libspy/include/spy/unsafe.h
@@ -141,7 +141,7 @@ SPY_PTR_FUNCTIONS(gc, spy_unsafe$gc_ptr__builtins$u8, uint8_t)
 // short alias for manual use
 typedef spy_unsafe$gc_ptr__builtins$u8 spy_gc_ptr_u8;
 
-/* ptr_copy/ptr_move/ptr_set/ptr_cmp macros for the C backend.
+/* ptr_copy/ptr_move/ptr_setbytes/ptr_cmp macros for the C backend.
    In SPY_DEBUG they check bounds via the .length field; in SPY_RELEASE they
    expand to bare libc calls with zero overhead.
 
@@ -246,28 +246,28 @@ typedef spy_unsafe$gc_ptr__builtins$u8 spy_gc_ptr_u8;
 #endif
 
 #ifdef SPY_DEBUG
-#  define spy_ptr_set(dst, value, n)                                                   \
+#  define spy_ptr_setbytes(dst, value, n)                                                   \
       do {                                                                             \
           if ((size_t)(n) > (size_t)(dst).length)                                      \
-              spy_panic("PanicError", "ptr_set out of bounds", __FILE__, __LINE__);    \
+              spy_panic("PanicError", "ptr_setbytes out of bounds", __FILE__, __LINE__);    \
           memset((dst).p, (value), (n) * sizeof(*(dst).p));                            \
       } while (0)
 #else
-#  define spy_ptr_set(dst, value, n) memset((dst).p, (value), (n) * sizeof(*(dst).p))
+#  define spy_ptr_setbytes(dst, value, n) memset((dst).p, (value), (n) * sizeof(*(dst).p))
 #endif
 
 #ifdef SPY_DEBUG
-#  define spy_ptr_set_slice(dst, ds, de, value)                                        \
+#  define spy_ptr_setbytes_slice(dst, ds, de, value)                                        \
       do {                                                                             \
           ptrdiff_t _spy_n = (de) - (ds);                                              \
           if (_spy_n < 0 || (ds) < 0 || (de) > (dst).length)                           \
               spy_panic(                                                               \
-                  "PanicError", "ptr_set_slice out of bounds", __FILE__, __LINE__      \
+                  "PanicError", "ptr_setbytes_slice out of bounds", __FILE__, __LINE__      \
               );                                                                       \
           memset((dst).p + (ds), (value), _spy_n * sizeof(*(dst).p));                  \
       } while (0)
 #else
-#  define spy_ptr_set_slice(dst, ds, de, value)                                        \
+#  define spy_ptr_setbytes_slice(dst, ds, de, value)                                        \
       memset((dst).p + (ds), (value), ((de) - (ds)) * sizeof(*(dst).p))
 #endif
 

--- a/spy/tests/compiler/unsafe/test_mem.py
+++ b/spy/tests/compiler/unsafe/test_mem.py
@@ -291,17 +291,17 @@ class TestMem(CompilerTest):
         with SPyError.raises("W_PanicError", match="length mismatch"):
             mod.fn_slice_mismatch()
 
-    def test_ptr_set(self, memkind):
+    def test_ptr_setbytes(self, memkind):
         k = memkind
         src = """
         from unsafe import (
             {k}_alloc as k_alloc, {k}_ptr as k_ptr,
-            ptr_set, ptr_set_slice,
+            ptr_setbytes, ptr_setbytes_slice,
         )
 
         def fn_ptr() -> i32:
             buf: k_ptr[u8] = k_alloc[u8](4)
-            ptr_set(buf, 7, 4)
+            ptr_setbytes(buf, 7, 4)
             return buf[0] + buf[1] + buf[2] + buf[3]
 
         def fn_slice() -> i32:
@@ -310,20 +310,20 @@ class TestMem(CompilerTest):
             buf[1] = 0
             buf[2] = 0
             buf[3] = 0
-            ptr_set_slice(buf, 1, 3, 7)
+            ptr_setbytes_slice(buf, 1, 3, 7)
             return i32(buf[0])*1000 + i32(buf[1])*100 + i32(buf[2])*10 + i32(buf[3])
         """.format(k=k)
         mod = self.compile(src)
         assert mod.fn_ptr() == 28
         assert mod.fn_slice() == 700 + 70
 
-    def test_ptr_set_not_a_ptr(self):
+    def test_ptr_setbytes_not_a_ptr(self):
         src = """
-        from unsafe import ptr_set
+        from unsafe import ptr_setbytes
 
         def foo() -> i32:
             x: i32 = 0
-            ptr_set(x, 0, 4)
+            ptr_setbytes(x, 0, 4)
             return 0
         """
         errors = expect_errors(
@@ -332,22 +332,22 @@ class TestMem(CompilerTest):
         )
         self.compile_raises(src, "foo", errors)
 
-    def test_ptr_set_out_of_bounds(self, memkind):
+    def test_ptr_setbytes_out_of_bounds(self, memkind):
         k = memkind
         src = """
         from unsafe import (
             {k}_alloc as k_alloc, {k}_ptr as k_ptr,
-            ptr_set, ptr_set_slice,
+            ptr_setbytes, ptr_setbytes_slice,
         )
 
         def fn_ptr() -> i32:
             buf: k_ptr[u8] = k_alloc[u8](4)
-            ptr_set(buf, 0, 10)
+            ptr_setbytes(buf, 0, 10)
             return 0
 
         def fn_slice() -> i32:
             buf: k_ptr[u8] = k_alloc[u8](4)
-            ptr_set_slice(buf, 0, 10, 0)
+            ptr_setbytes_slice(buf, 0, 10, 0)
             return 0
         """.format(k=k)
         mod = self.compile(src)
@@ -361,21 +361,21 @@ class TestMem(CompilerTest):
         src = """
         from unsafe import (
             {k}_alloc as k_alloc, {k}_ptr as k_ptr,
-            ptr_set, ptr_cmp, ptr_cmp_slice,
+            ptr_setbytes, ptr_cmp, ptr_cmp_slice,
         )
 
         def fn_ptr_eq() -> i32:
             a: k_ptr[u8] = k_alloc[u8](4)
             b: k_ptr[u8] = k_alloc[u8](4)
-            ptr_set(a, 42, 4)
-            ptr_set(b, 42, 4)
+            ptr_setbytes(a, 42, 4)
+            ptr_setbytes(b, 42, 4)
             return ptr_cmp(a, b, 4)
 
         def fn_ptr_lt() -> i32:
             a: k_ptr[u8] = k_alloc[u8](4)
             b: k_ptr[u8] = k_alloc[u8](4)
-            ptr_set(a, 1, 4)
-            ptr_set(b, 2, 4)
+            ptr_setbytes(a, 1, 4)
+            ptr_setbytes(b, 2, 4)
             r: i32 = ptr_cmp(a, b, 4)
             if r < 0:
                 return -1
@@ -397,8 +397,8 @@ class TestMem(CompilerTest):
         def fn_slice_lt() -> i32:
             a: k_ptr[u8] = k_alloc[u8](4)
             b: k_ptr[u8] = k_alloc[u8](4)
-            ptr_set(a, 1, 4)
-            ptr_set(b, 2, 4)
+            ptr_setbytes(a, 1, 4)
+            ptr_setbytes(b, 2, 4)
             r: i32 = ptr_cmp_slice(a, 0, 2, b, 0, 2)
             if r < 0:
                 return -1
@@ -564,7 +564,7 @@ class TestMem(CompilerTest):
         errors = expect_errors(
             "mismatched types",
             ("expected ptr[u8] or ptr[i8], got `unsafe::raw_ptr[i32]`", "buf"),
-            ("help: use `ptr_set` instead", "buf"),
+            ("help: use `ptr_setbytes` instead", "buf"),
         )
         self.compile_raises(src, "foo", errors)
 

--- a/spy/vm/modules/unsafe/mem.py
+++ b/spy/vm/modules/unsafe/mem.py
@@ -145,10 +145,10 @@ def w_memset(
     memset(dst, value, n): write the byte `value` to the first `n` bytes of `dst`.
 
     Mirrors C's memset: only accepts ptr[u8] or ptr[i8]; for any other ptr[T]
-    use ptr_set instead.
+    use ptr_setbytes instead.
     """
-    _check_byte_ptr(vm, wam_dst, "ptr_set")
-    return vm.fast_metacall(UNSAFE.w_ptr_set, [wam_dst, wam_value, wam_n])
+    _check_byte_ptr(vm, wam_dst, "ptr_setbytes")
+    return vm.fast_metacall(UNSAFE.w_ptr_setbytes, [wam_dst, wam_value, wam_n])
 
 
 @UNSAFE.builtin_func(color="blue", kind="metafunc")
@@ -346,11 +346,11 @@ def w_ptr_move_slice(
 
 
 @UNSAFE.builtin_func(color="blue", kind="metafunc")
-def w_ptr_set(
+def w_ptr_setbytes(
     vm: "SPyVM", wam_dst: W_MetaArg, wam_value: W_MetaArg, wam_n: W_MetaArg
 ) -> W_OpSpec:
     """
-    ptr_set(dst, value, n): write the byte `value` to the first `n` items of `dst`.
+    ptr_setbytes(dst, value, n): write the byte `value` to the first `n` items of `dst`.
 
     `n` is the number of ITEMS (not bytes); the underlying memset writes
     `n * sizeof(T)` bytes. `value` is interpreted as a byte and broadcast to
@@ -360,21 +360,21 @@ def w_ptr_set(
     w_dst_T = _check_ptr(vm, wam_dst)
     DST = Annotated[W_Ptr, w_dst_T]
     ITEMSIZE = sizeof(w_dst_T.w_itemT)
-    ns = UNSAFE.w_ptr_set.compute_inner_ns([w_dst_T])
-    irtag = IRTag("unsafe.memop", cfunc="spy_ptr_set")
+    ns = UNSAFE.w_ptr_setbytes.compute_inner_ns([w_dst_T])
+    irtag = IRTag("unsafe.memop", cfunc="spy_ptr_setbytes")
 
     @vm.register_builtin_func(ns, "impl", irtag=irtag)
-    def w_ptr_set_impl(vm: "SPyVM", w_dst: DST, w_value: W_U8, w_n: W_I32) -> None:
+    def w_ptr_setbytes_impl(vm: "SPyVM", w_dst: DST, w_value: W_U8, w_n: W_I32) -> None:
         n = vm.unwrap_i32(w_n)
         if n > w_dst.length:
-            raise SPyError("W_PanicError", "ptr_set out of bounds")
+            raise SPyError("W_PanicError", "ptr_setbytes out of bounds")
         vm.ll.call("_spy_memset", w_dst.addr, int(w_value.value), n * ITEMSIZE)
 
-    return W_OpSpec(w_ptr_set_impl, [wam_dst, wam_value, wam_n])
+    return W_OpSpec(w_ptr_setbytes_impl, [wam_dst, wam_value, wam_n])
 
 
 @UNSAFE.builtin_func(color="blue", kind="metafunc")
-def w_ptr_set_slice(
+def w_ptr_setbytes_slice(
     vm: "SPyVM",
     wam_dst: W_MetaArg,
     wam_dst_start: W_MetaArg,
@@ -382,19 +382,19 @@ def w_ptr_set_slice(
     wam_value: W_MetaArg,
 ) -> W_OpSpec:
     """
-    ptr_set_slice(dst, dst_start, dst_end, value): write the byte `value`
+    ptr_setbytes_slice(dst, dst_start, dst_end, value): write the byte `value`
     to dst[dst_start:dst_end].
 
-    Like ptr_set, but writes only the given slice instead of the prefix.
+    Like ptr_setbytes, but writes only the given slice instead of the prefix.
     """
     w_dst_T = _check_ptr(vm, wam_dst)
     DST = Annotated[W_Ptr, w_dst_T]
     ITEMSIZE = sizeof(w_dst_T.w_itemT)
-    ns = UNSAFE.w_ptr_set_slice.compute_inner_ns([w_dst_T])
-    irtag = IRTag("unsafe.memop", cfunc="spy_ptr_set_slice")
+    ns = UNSAFE.w_ptr_setbytes_slice.compute_inner_ns([w_dst_T])
+    irtag = IRTag("unsafe.memop", cfunc="spy_ptr_setbytes_slice")
 
     @vm.register_builtin_func(ns, "impl", irtag=irtag)
-    def w_ptr_set_slice_impl(
+    def w_ptr_setbytes_slice_impl(
         vm: "SPyVM",
         w_dst: DST,
         w_dst_start: W_I32,
@@ -405,7 +405,7 @@ def w_ptr_set_slice(
         dst_end = vm.unwrap_i32(w_dst_end)
         n = dst_end - dst_start
         if n < 0 or dst_start < 0 or dst_end > w_dst.length:
-            raise SPyError("W_PanicError", "ptr_set_slice out of bounds")
+            raise SPyError("W_PanicError", "ptr_setbytes_slice out of bounds")
         vm.ll.call(
             "_spy_memset",
             w_dst.addr + dst_start * ITEMSIZE,
@@ -414,7 +414,7 @@ def w_ptr_set_slice(
         )
 
     return W_OpSpec(
-        w_ptr_set_slice_impl, [wam_dst, wam_dst_start, wam_dst_end, wam_value]
+        w_ptr_setbytes_slice_impl, [wam_dst, wam_dst_start, wam_dst_end, wam_value]
     )
 
 

--- a/stdlib/_dict.spy
+++ b/stdlib/_dict.spy
@@ -1,4 +1,4 @@
-from unsafe import gc_alloc, gc_ptr, ptr_set
+from unsafe import gc_alloc, gc_ptr, ptr_setbytes
 from operator import OpSpec
 from __spy__ import interp_dict, EmptyDictType
 
@@ -64,7 +64,7 @@ def dict(Key, Value):
         assert MIN_LOG_SIZE <= log_size
         assert log_size <= MAX_LOG_SIZE
         index = gc_alloc[i32](1 << log_size)
-        ptr_set(index, 0, 1 << log_size)
+        ptr_setbytes(index, 0, 1 << log_size)
         return index
 
     def new_entries(log_size: i32) -> gc_ptr[Entry]:

--- a/stdlib/array.spy
+++ b/stdlib/array.spy
@@ -15,7 +15,7 @@ hardcode _array1, _array2, _array3, etc.
 """
 
 from operator import OpSpec
-from unsafe import gc_alloc, gc_ptr, ptr_set
+from unsafe import gc_alloc, gc_ptr, ptr_setbytes
 
 
 @blue.generic
@@ -202,7 +202,7 @@ def zeros(DTYPE):
                 # memory, so we zero the array here.  Eventually we should have a
                 # gc_alloc_zero (or similar) which returns zeroed memory, and use it for
                 # the underlying buffer.
-                ptr_set(a.__ll__.items, 0, n)
+                ptr_setbytes(a.__ll__.items, 0, n)
                 return a
 
             return OpSpec(impl)


### PR DESCRIPTION
Adapt mem.spy after https://github.com/spylang/spy/pull/552 and rename `ptr_set` to `ptr_setbytes` after discussion on Discord.

I finally chose `ptr_setbytes` and not `ptr_fillbytes`. It was a bit difficult to choose since both names are very similar and nearly as good. I found `ptr_setbytes` slightly easier to read, slightly shorter and I like the fact that the `set` of `memset` is kept.