### PR TITLE
fix playground: do not print traceback for SystemExit

### DIFF
--- a/examples/1_high_level/exit_code.spy
+++ b/examples/1_high_level/exit_code.spy
@@ -1,3 +1,10 @@
+"""
+Things to notice:
+  - `main()` can take `argv` as a `list[str]` and can return an `i32` exit code
+  - the exit code is propagated to the OS
+  - `argv` contains the script/executable name and the script arguments
+"""
+
 def main(argv: list[str]) -> i32:
     print("argv:")
     for arg in argv:

--- a/playground/main.py
+++ b/playground/main.py
@@ -32,13 +32,6 @@ console.log("[Python] SPy imports complete")
 libspy.LIBSPY_WASM = str(URL.new("./libspy.mjs", document.baseURI))
 
 
-def spy_main(argv):
-    try:
-        spy.cli.app(argv)
-    except SystemExit:
-        pass
-
-
 # =========== GUI code ==========
 
 
@@ -152,7 +145,7 @@ def run_spy_file_with_args(argv: list[str]):
     with open(display_filename, "w") as f:
         f.write(text)
 
-    spy_main(argv)
+    spy.cli.app(argv)
 
 
 def run_click(event):

--- a/playground/pyscript.toml
+++ b/playground/pyscript.toml
@@ -4,6 +4,7 @@ packages = [ "micropip"]
 [files]
 "pyscript.toml" = ""
 "hello_add.spy" = "examples/1_high_level/"
+"exit_code.spy" = "examples/1_high_level/"
 "bluefunc_pi.spy" = "examples/2_metaprogramming/"
 "bluefunc_adder.spy" = "examples/2_metaprogramming/"
 "point.spy" = "examples/3_low_level/"

--- a/spy/cli/_runners.py
+++ b/spy/cli/_runners.py
@@ -29,13 +29,15 @@ GLOBAL_VM: Optional[SPyVM] = None
 
 async def _pyodide_main(user_func: Callable, args: "Base_Args") -> None:
     """
-    For some reasons, it seems that pyodide doesn't print exceptions
-    uncaught exceptions which escapes an asyncio task. This is a small wrapper
-    to ensure that we display a proper traceback in that case
+    For some reasons, it seems that pyodide doesn't print uncaught exceptions
+    which escapes an asyncio task. This is a small wrapper to ensure that we
+    display a proper traceback in that case.
     """
     try:
         await _run_command(user_func, args)
-    except BaseException:
+    except BaseException as exc:
+        if isinstance(exc, SystemExit):
+            return
         traceback.print_exc()
 
 


### PR DESCRIPTION
Fixes #535.

~~It seems that we don't actually need to call `sys.exit(0)` at the end of `execute_spy_main`.~~
