### PR TITLE
Move several str methods from C to applevel

### DIFF
--- a/spy/libspy/include/spy/str.h
+++ b/spy/libspy/include/spy/str.h
@@ -97,12 +97,6 @@ spy_unsafe$_alloc_StrObject$impl(int32_t length) {
 
 spy_StrObject *WASM_EXPORT(spy_str_add)(spy_StrObject *a, spy_StrObject *b);
 
-spy_StrObject *WASM_EXPORT(spy_str_replace)(
-    spy_StrObject *original,
-    spy_StrObject *old,
-    spy_StrObject *new_str
-);
-
 spy_StrObject *WASM_EXPORT(spy_str_mul)(spy_StrObject *a, int32_t b);
 
 bool WASM_EXPORT(spy_str_eq)(spy_StrObject *a, spy_StrObject *b);
@@ -126,7 +120,6 @@ int32_t WASM_EXPORT(spy_str_hash)(spy_StrObject *s);
 #define spy_operator$str_eq spy_str_eq
 #define spy_operator$str_ne spy_str_ne
 #define spy_operator$str_to_complex128 spy_str_to_complex128
-#define spy_builtins$str$replace spy_str_replace
 #define spy_builtins$str$__getitem__ spy_str_getitem
 #define spy_builtins$str$__len__ spy_str_len
 #define spy_builtins$str$__str__ spy_str_identity

--- a/spy/libspy/include/spy/str.h
+++ b/spy/libspy/include/spy/str.h
@@ -95,10 +95,6 @@ spy_unsafe$_alloc_StrObject$impl(int32_t length) {
     return spy_unsafe$gc_ptr___str$StrObject_from_addr(spy_str_alloc((size_t)length));
 }
 
-spy_StrObject *WASM_EXPORT(spy_str_add)(spy_StrObject *a, spy_StrObject *b);
-
-spy_StrObject *WASM_EXPORT(spy_str_mul)(spy_StrObject *a, int32_t b);
-
 bool WASM_EXPORT(spy_str_eq)(spy_StrObject *a, spy_StrObject *b);
 
 static inline bool
@@ -106,20 +102,11 @@ spy_str_ne(spy_StrObject *a, spy_StrObject *b) {
     return !spy_str_eq(a, b);
 }
 
-// XXX: should we introduce a separate type Char?
-spy_StrObject *WASM_EXPORT(spy_str_getitem)(spy_StrObject *s, int32_t i);
-
-int32_t WASM_EXPORT(spy_str_len)(spy_StrObject *s);
-
 int32_t WASM_EXPORT(spy_str_hash)(spy_StrObject *s);
 
-#define spy_operator$str_add spy_str_add
-#define spy_operator$str_mul spy_str_mul
 #define spy_operator$str_eq spy_str_eq
 #define spy_operator$str_ne spy_str_ne
 #define spy_operator$str_to_complex128 spy_str_to_complex128
-#define spy_builtins$str$__getitem__ spy_str_getitem
-#define spy_builtins$str$__len__ spy_str_len
 #define spy_builtins$str$__str__ spy_str_identity
 
 static inline spy_StrObject *

--- a/spy/libspy/include/spy/str.h
+++ b/spy/libspy/include/spy/str.h
@@ -111,8 +111,6 @@ spy_StrObject *WASM_EXPORT(spy_str_getitem)(spy_StrObject *s, int32_t i);
 
 int32_t WASM_EXPORT(spy_str_len)(spy_StrObject *s);
 
-spy_StrObject *WASM_EXPORT(spy_str_repr)(spy_StrObject *s);
-
 int32_t WASM_EXPORT(spy_str_hash)(spy_StrObject *s);
 
 #define spy_operator$str_add spy_str_add
@@ -123,7 +121,6 @@ int32_t WASM_EXPORT(spy_str_hash)(spy_StrObject *s);
 #define spy_builtins$str$__getitem__ spy_str_getitem
 #define spy_builtins$str$__len__ spy_str_len
 #define spy_builtins$str$__str__ spy_str_identity
-#define spy_builtins$str$__repr__ spy_str_repr
 
 static inline spy_StrObject *
 spy_str_identity(spy_StrObject *s) {

--- a/spy/libspy/src/str.c
+++ b/spy/libspy/src/str.c
@@ -41,67 +41,6 @@ spy_str_add(spy_StrObject *a, spy_StrObject *b) {
 }
 
 spy_StrObject *
-spy_str_replace(spy_StrObject *original, spy_StrObject *old, spy_StrObject *new_str) {
-    size_t orig_len = original->length;
-    size_t old_len = old->length;
-    size_t new_len = new_str->length;
-
-    if (old_len == 0) {
-        // when old_len is empty insert new_str before each byte and after the last
-        size_t result_len = orig_len + (orig_len + 1) * new_len;
-        spy_StrObject *res = spy_str_alloc(result_len);
-        char *buf = (char *)spy_StrObject_UTF8(res);
-        for (size_t i = 0; i < orig_len; i++) {
-            memcpy(buf, spy_StrObject_UTF8(new_str), new_len);
-            buf += new_len;
-            buf[0] = spy_StrObject_UTF8(original)[i];
-            buf++;
-        }
-        memcpy(buf, spy_StrObject_UTF8(new_str), new_len);
-        return res;
-    }
-
-    // First pass -> count occurrences
-    size_t count = 0;
-    const char *p = (const char *)spy_StrObject_UTF8(original);
-    const char *end = p + orig_len;
-    while (p <= end - old_len) {
-        if (memcmp(p, spy_StrObject_UTF8(old), old_len) == 0) {
-            count++;
-            p += old_len;
-        } else {
-            p++;
-        }
-    }
-
-    if (count == 0) {
-        // Return the original string when no occurrences are found
-        spy_StrObject *res = spy_str_alloc(orig_len);
-        memcpy((char *)spy_StrObject_UTF8(res), spy_StrObject_UTF8(original), orig_len);
-        return res;
-    }
-
-    // Second pass -> build the result
-    size_t result_len = orig_len + count * (new_len - old_len);
-    spy_StrObject *res = spy_str_alloc(result_len);
-    char *buf = (char *)spy_StrObject_UTF8(res);
-    p = (const char *)spy_StrObject_UTF8(original);
-    while (p <= end - old_len) {
-        if (memcmp(p, spy_StrObject_UTF8(old), old_len) == 0) {
-            memcpy(buf, spy_StrObject_UTF8(new_str), new_len);
-            buf += new_len;
-            p += old_len;
-        } else {
-            *buf++ = *p++;
-        }
-    }
-    // Copy remaining bytes
-    size_t remaining = end - p;
-    memcpy(buf, p, remaining);
-    return res;
-}
-
-spy_StrObject *
 spy_str_mul(spy_StrObject *a, int32_t b) {
     size_t l = a->length * b;
     spy_StrObject *res = spy_str_alloc(l);

--- a/spy/libspy/src/str.c
+++ b/spy/libspy/src/str.c
@@ -30,55 +30,11 @@ spy_str_alloc(size_t length) {
     return res;
 }
 
-spy_StrObject *
-spy_str_add(spy_StrObject *a, spy_StrObject *b) {
-    size_t l = a->length + b->length;
-    spy_StrObject *res = spy_str_alloc(l);
-    char *buf = (char *)spy_StrObject_UTF8(res);
-    memcpy(buf, spy_StrObject_UTF8(a), a->length);
-    memcpy(buf + a->length, spy_StrObject_UTF8(b), b->length);
-    return res;
-}
-
-spy_StrObject *
-spy_str_mul(spy_StrObject *a, int32_t b) {
-    size_t l = a->length * b;
-    spy_StrObject *res = spy_str_alloc(l);
-    char *buf = (char *)spy_StrObject_UTF8(res);
-    for (int i = 0; i < b; i++) {
-        memcpy(buf, spy_StrObject_UTF8(a), a->length);
-        buf += a->length;
-    }
-    return res;
-}
-
 bool
 spy_str_eq(spy_StrObject *a, spy_StrObject *b) {
     if (a->length != b->length)
         return false;
     return memcmp(spy_StrObject_UTF8(a), spy_StrObject_UTF8(b), a->length) == 0;
-}
-
-spy_StrObject *
-spy_str_getitem(spy_StrObject *s, int32_t i) {
-    // XXX this is wrong: it should return a code point
-    size_t l = s->length;
-    if (i < 0) {
-        i += l;
-    }
-    if (i >= l || i < 0) {
-        spy_panic("IndexError", "string index out of bound", __FILE__, __LINE__);
-        return NULL;
-    }
-    spy_StrObject *res = spy_str_alloc(1);
-    char *buf = (char *)spy_StrObject_UTF8(res);
-    buf[0] = spy_StrObject_UTF8(s)[i];
-    return res;
-}
-
-int32_t
-spy_str_len(spy_StrObject *s) {
-    return (int32_t)s->length;
 }
 
 int32_t

--- a/spy/libspy/src/str.c
+++ b/spy/libspy/src/str.c
@@ -81,66 +81,6 @@ spy_str_len(spy_StrObject *s) {
     return (int32_t)s->length;
 }
 
-spy_StrObject *
-spy_str_repr(spy_StrObject *s) {
-    // Choose quote character: use double quotes if string contains ' but not "
-    char quote = '\'';
-    for (size_t i = 0; i < s->length; i++) {
-        if (spy_StrObject_UTF8(s)[i] == '\'') {
-            quote = '"';
-        }
-        if (spy_StrObject_UTF8(s)[i] == '"') {
-            quote = '\'';
-            break;
-        }
-    }
-
-    // First pass: calculate the output length
-    size_t out_len = 2; // for the surrounding quotes
-    for (size_t i = 0; i < s->length; i++) {
-        unsigned char c = (unsigned char)spy_StrObject_UTF8(s)[i];
-        if (c == '\\' || c == quote) {
-            out_len += 2;
-        } else if (c == '\n' || c == '\r' || c == '\t') {
-            out_len += 2;
-        } else if (c < 0x20) {
-            out_len += 4; // \xNN
-        } else {
-            out_len += 1;
-        }
-    }
-
-    // Second pass: fill the buffer
-    spy_StrObject *res = spy_str_alloc(out_len);
-    char *buf = (char *)spy_StrObject_UTF8(res);
-    *buf++ = quote;
-    for (size_t i = 0; i < s->length; i++) {
-        unsigned char c = (unsigned char)spy_StrObject_UTF8(s)[i];
-        if (c == '\\') {
-            *buf++ = '\\';
-            *buf++ = '\\';
-        } else if (c == quote) {
-            *buf++ = '\\';
-            *buf++ = quote;
-        } else if (c == '\n') {
-            *buf++ = '\\';
-            *buf++ = 'n';
-        } else if (c == '\r') {
-            *buf++ = '\\';
-            *buf++ = 'r';
-        } else if (c == '\t') {
-            *buf++ = '\\';
-            *buf++ = 't';
-        } else if (c < 0x20) {
-            buf += sprintf(buf, "\\x%02x", c);
-        } else {
-            *buf++ = c;
-        }
-    }
-    *buf++ = quote;
-    return res;
-}
-
 int32_t
 spy_str_hash(spy_StrObject *s) {
     if (s->hash != 0)

--- a/spy/tests/compiler/test_str.py
+++ b/spy/tests/compiler/test_str.py
@@ -20,6 +20,19 @@ class TestStr(CompilerTest):
         """)
         assert mod.foo() == "hello àèìòù"
 
+    def test_empty_str_as_StrObject(self):
+        src = """
+        from unsafe import _str_to_StrObject
+        from _str import StrObject
+
+        def get_length(s: str) -> i32:
+            data = _str_to_StrObject(s)
+            utf8 = data.utf8
+            return data.length
+        """
+        mod = self.compile(src)
+        assert mod.get_length("") == 0
+
     def test_add(self):
         mod = self.compile("""
         def foo() -> str:

--- a/spy/tests/test_cli.py
+++ b/spy/tests/test_cli.py
@@ -294,8 +294,8 @@ class TestMain:
     def test_execute_pyodide(self):
         # pyodide under node cannot access /tmp/, so we cannot try to execute
         # files which we wrote to self.tmpdir. Instead, let's try to execute
-        # examples/hello.spy
-        hello_spy = spy.ROOT.dirpath().join("examples", "hello.spy")
+        # examples/1_high_level/hello.spy
+        hello_spy = spy.ROOT.dirpath().join("examples", "1_high_level", "hello.spy")
         assert hello_spy.exists()
         res, stdout = self.run_external(PYODIDE_EXE, hello_spy)
         assert stdout == "Hello world!\n"

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -340,7 +340,7 @@ class TestDoppler:
             return x + y
 
         def `test::add[str]::impl`(x: str, y: str) -> str:
-            return `operator::str_add`(x, y)
+            return `_str::methods::__add__`(x, y)
         """)
 
     def test_store_outer_var(self):

--- a/spy/tests/test_libspy.py
+++ b/spy/tests/test_libspy.py
@@ -47,9 +47,6 @@ class TestLibSPy(CTest):
         #
         ptr_W = ll.call("mk_W")
         assert ll.read_str(ptr_W) == (5, 0, b"world")
-        #
-        ptr_HW = ll.call("spy_str_add", ptr_H, ptr_W)
-        assert ll.read_str(ptr_HW) == (11, 0, b"hello world")
 
     def test_debug_log(self):
         src = r"""

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -241,6 +241,12 @@ class W_Func(W_Object):
 
     _pure_fqns = {
         FQN("builtins::type::__new__"),
+        FQN("_str::methods::__add__"),
+        FQN("_str::methods::__mul__"),
+        FQN("_str::methods::__getitem__"),
+        FQN("_str::methods::__len__"),
+        FQN("_str::methods::__repr__"),
+        FQN("_str::methods::replace"),
     }
 
     def compute_inner_ns(self, args_w: Sequence[W_Object]) -> FQN:

--- a/spy/vm/modules/operator/binop.py
+++ b/spy/vm/modules/operator/binop.py
@@ -189,8 +189,6 @@ for num_t in ["i32", "f64"]:
     MM.register("!=", num_t, "complex128", OP.w_complex128_ne)
 
 # str ops
-MM.register("+",  "str", "str", OP.w_str_add)
-MM.register("*",  "str", "i32", OP.w_str_mul)
 MM.register("==", "str", "str", OP.w_str_eq)
 MM.register("!=", "str", "str", OP.w_str_ne)
 

--- a/spy/vm/modules/operator/opimpl_str.py
+++ b/spy/vm/modules/operator/opimpl_str.py
@@ -11,22 +11,6 @@ if TYPE_CHECKING:
 
 
 @OP.builtin_func
-def w_str_add(vm: "SPyVM", w_a: W_Str, w_b: W_Str) -> W_Str:
-    assert isinstance(w_a, W_Str)
-    assert isinstance(w_b, W_Str)
-    ptr_c = vm.ll.call("spy_str_add", w_a.ptr, w_b.ptr)
-    return W_Str.from_ptr(vm, ptr_c)
-
-
-@OP.builtin_func
-def w_str_mul(vm: "SPyVM", w_a: W_Str, w_b: W_I32) -> W_Str:
-    assert isinstance(w_a, W_Str)
-    assert isinstance(w_b, W_I32)
-    ptr_c = vm.ll.call("spy_str_mul", w_a.ptr, w_b.value)
-    return W_Str.from_ptr(vm, ptr_c)
-
-
-@OP.builtin_func
 def w_str_eq(vm: "SPyVM", w_a: W_Str, w_b: W_Str) -> W_Bool:
     assert isinstance(w_a, W_Str)
     assert isinstance(w_b, W_Str)

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -223,7 +223,7 @@ class W_MemLoc(W_Object):
         if addr == 0:
             assert length == 0
         else:
-            assert length >= 1
+            assert length >= 0
         self.w_T = w_T
         self.addr = fixedint.Int32(addr)
         self.length = fixedint.Int32(length)

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -47,6 +47,7 @@ class W_Str(W_Object):
         "upper": FQN("_str::methods::upper"),
         "encode": FQN("_str::methods::encode"),
         "replace": FQN("_str::methods::replace"),
+        "__repr__": FQN("_str::methods::__repr__"),
     }
 
     vm: "SPyVM"
@@ -124,10 +125,3 @@ class W_Str(W_Object):
     @staticmethod
     def w_str(vm: "SPyVM", w_s: "W_Str") -> "W_Str":
         return w_s
-
-    @builtin_method("__repr__")
-    @staticmethod
-    def w_repr(vm: "SPyVM", w_s: "W_Str") -> "W_Str":
-        assert isinstance(w_s, W_Str)
-        ptr = vm.ll.call("spy_str_repr", w_s.ptr)
-        return W_Str.from_ptr(vm, ptr)

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -46,6 +46,7 @@ class W_Str(W_Object):
         "isascii": FQN("_str::methods::isascii"),
         "upper": FQN("_str::methods::upper"),
         "encode": FQN("_str::methods::encode"),
+        "replace": FQN("_str::methods::replace"),
     }
 
     vm: "SPyVM"
@@ -130,11 +131,3 @@ class W_Str(W_Object):
         assert isinstance(w_s, W_Str)
         ptr = vm.ll.call("spy_str_repr", w_s.ptr)
         return W_Str.from_ptr(vm, ptr)
-
-    @builtin_method("replace")
-    @staticmethod
-    def w_replace(
-        vm: "SPyVM", w_original: "W_Str", w_old: "W_Str", w_new: "W_Str"
-    ) -> "W_Str":
-        ptr_c = vm.ll.call("spy_str_replace", w_original.ptr, w_old.ptr, w_new.ptr)
-        return W_Str.from_ptr(vm, ptr_c)

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -48,6 +48,10 @@ class W_Str(W_Object):
         "encode": FQN("_str::methods::encode"),
         "replace": FQN("_str::methods::replace"),
         "__repr__": FQN("_str::methods::__repr__"),
+        "__len__": FQN("_str::methods::__len__"),
+        "__getitem__": FQN("_str::methods::__getitem__"),
+        "__add__": FQN("_str::methods::__add__"),
+        "__mul__": FQN("_str::methods::__mul__"),
     }
 
     vm: "SPyVM"
@@ -105,21 +109,6 @@ class W_Str(W_Object):
                 "W_TypeError", f"cannot call str(`{t}`)", f"this is `{t}`", wam_arg.loc
             )
         return W_OpSpec.NULL
-
-    @builtin_method("__getitem__")
-    @staticmethod
-    def w_getitem(vm: "SPyVM", w_s: "W_Str", w_i: W_I32) -> "W_Str":
-        assert isinstance(w_s, W_Str)
-        assert isinstance(w_i, W_I32)
-        ptr_c = vm.ll.call("spy_str_getitem", w_s.ptr, w_i.value)
-        return W_Str.from_ptr(vm, ptr_c)
-
-    @builtin_method("__len__")
-    @staticmethod
-    def w_len(vm: "SPyVM", w_s: "W_Str") -> W_I32:
-        assert isinstance(w_s, W_Str)
-        length = vm.ll.call("spy_str_len", w_s.ptr)
-        return vm.wrap(length)
 
     @builtin_method("__str__")
     @staticmethod

--- a/stdlib/_str.spy
+++ b/stdlib/_str.spy
@@ -76,6 +76,41 @@ class methods:
     # each method defined here should also have a corresponding entry in
     # W_Str.__spy_lazy_attributes__.
 
+    def __len__(self: str) -> i32:
+        ll = StrObject.from_str(self)
+        return ll.length
+
+    def __getitem__(self: str, i: i32) -> str:
+        # XXX this is wrong: it should return a code point
+        ll = StrObject.from_str(self)
+        n = ll.length
+        if i < 0:
+            i = i + n
+        if i < 0 or i >= n:
+            raise IndexError("string index out of bound")
+        out = StrObject.alloc(1)
+        out.hash = 0
+        out.utf8[0] = ll.utf8[i]
+        return StrObject.to_str(out)
+
+    def __add__(self: str, other: str) -> str:
+        a = StrObject.from_str(self)
+        b = StrObject.from_str(other)
+        out = StrObject.alloc(a.length + b.length)
+        out.hash = 0
+        ptr_copy_slice(out.utf8, 0, a.length, a.utf8, 0, a.length)
+        ptr_copy_slice(out.utf8, a.length, a.length + b.length, b.utf8, 0, b.length)
+        return StrObject.to_str(out)
+
+    def __mul__(self: str, n: i32) -> str:
+        ll = StrObject.from_str(self)
+        out = StrObject.alloc(ll.length * n)
+        out.hash = 0
+        l = ll.length
+        for i in range(n):
+            ptr_copy_slice(out.utf8, i * l, (i + 1) * l, ll.utf8, 0, l)
+        return StrObject.to_str(out)
+
     def encode(self: str, encoding: str) -> bytes:
         # we don't support circular imports and function-level imports. This is a hacky
         # workaround for 'from _bytes import BytesObject'

--- a/stdlib/_str.spy
+++ b/stdlib/_str.spy
@@ -99,6 +99,92 @@ class methods:
             i = i + 1
         return True
 
+    def __repr__(self: str) -> str:
+        ll = StrObject.from_str(self)
+        # Choose quote: ' by default, but " if the string contains ' but not "
+        single = ord(b"'")
+        double = ord(b'"')
+        quote = single
+        for i in range(ll.length):
+            ci = ll.utf8[i]
+            if ci == single:
+                quote = double
+            if ci == double:
+                quote = single
+                # found ", stop scanning since ' wins on conflict
+                # (matches C behaviour: it 'break's here)
+                break
+
+        # First pass: compute the output length
+        out_len: i32 = 2  # surrounding quotes
+        for m in range(ll.length):
+            c = ll.utf8[m]
+            if c == ord(b"\\") or c == quote:
+                out_len = out_len + 2
+            elif c == ord(b"\n") or c == ord(b"\r") or c == ord(b"\t"):
+                out_len = out_len + 2
+            elif c < ord(b" "):
+                out_len = out_len + 4  # \xNN
+            else:
+                out_len = out_len + 1
+
+        # Second pass: fill the buffer
+        out = StrObject.alloc(out_len)
+        out.hash = 0
+        j: i32 = 0
+        out.utf8[j] = quote
+        j = j + 1
+        for k in range(ll.length):
+            c2 = ll.utf8[k]
+            if c2 == ord(b"\\"):
+                out.utf8[j] = ord(b"\\")
+                j = j + 1
+                out.utf8[j] = ord(b"\\")
+                j = j + 1
+            elif c2 == quote:
+                out.utf8[j] = ord(b"\\")
+                j = j + 1
+                out.utf8[j] = quote
+                j = j + 1
+            elif c2 == ord(b"\n"):
+                out.utf8[j] = ord(b"\\")
+                j = j + 1
+                out.utf8[j] = ord(b"n")
+                j = j + 1
+            elif c2 == ord(b"\r"):
+                out.utf8[j] = ord(b"\\")
+                j = j + 1
+                out.utf8[j] = ord(b"r")
+                j = j + 1
+            elif c2 == ord(b"\t"):
+                out.utf8[j] = ord(b"\\")
+                j = j + 1
+                out.utf8[j] = ord(b"t")
+                j = j + 1
+            elif c2 < ord(b" "):
+                # \xNN hex escape
+                out.utf8[j] = ord(b"\\")
+                j = j + 1
+                out.utf8[j] = ord(b"x")
+                j = j + 1
+                hi: i32 = i32(c2) >> 4
+                lo: i32 = i32(c2) & 15
+                if hi < 10:
+                    out.utf8[j] = u8(hi) + ord(b"0")
+                else:
+                    out.utf8[j] = u8(hi - 10) + ord(b"a")
+                j = j + 1
+                if lo < 10:
+                    out.utf8[j] = u8(lo) + ord(b"0")
+                else:
+                    out.utf8[j] = u8(lo - 10) + ord(b"a")
+                j = j + 1
+            else:
+                out.utf8[j] = c2
+                j = j + 1
+        out.utf8[j] = quote
+        return StrObject.to_str(out)
+
     def replace(self: str, old: str, new: str) -> str:
         ll_orig = StrObject.from_str(self)
         ll_old = StrObject.from_str(old)

--- a/stdlib/_str.spy
+++ b/stdlib/_str.spy
@@ -15,6 +15,8 @@ possible to cast between str and gc_ptr[StrObject] using StrObject.{from,to}_str
 from unsafe import (
     gc_ptr,
     ptr_copy,
+    ptr_copy_slice,
+    ptr_cmp_slice,
     _str_to_StrObject,
     _alloc_StrObject,
     _StrObject_to_str,
@@ -96,6 +98,80 @@ class methods:
                 return False
             i = i + 1
         return True
+
+    def replace(self: str, old: str, new: str) -> str:
+        ll_orig = StrObject.from_str(self)
+        ll_old = StrObject.from_str(old)
+        ll_new = StrObject.from_str(new)
+        orig_len = ll_orig.length
+        old_len = ll_old.length
+        new_len = ll_new.length
+
+        if old_len == 0:
+            # insert `new` before each byte and after the last
+            result_len = orig_len + (orig_len + 1) * new_len
+            res = StrObject.alloc(result_len)
+            res.hash = 0
+            pos: i32 = 0
+            for i in range(orig_len):
+                if new_len > 0:
+                    ptr_copy_slice(
+                        res.utf8, pos, pos + new_len, ll_new.utf8, 0, new_len
+                    )
+                    pos = pos + new_len
+                res.utf8[pos] = ll_orig.utf8[i]
+                pos = pos + 1
+            if new_len > 0:
+                ptr_copy_slice(res.utf8, pos, pos + new_len, ll_new.utf8, 0, new_len)
+            return StrObject.to_str(res)
+
+        # First pass: count occurrences
+        count: i32 = 0
+        i = 0
+        while i <= orig_len - old_len:
+            if (
+                ptr_cmp_slice(ll_orig.utf8, i, i + old_len, ll_old.utf8, 0, old_len)
+                == 0
+            ):
+                count = count + 1
+                i = i + old_len
+            else:
+                i = i + 1
+
+        if count == 0:
+            # Return the original string when no occurrences are found
+            res = StrObject.alloc(orig_len)
+            res.hash = 0
+            if orig_len > 0:
+                ptr_copy(res.utf8, ll_orig.utf8, orig_len)
+            return StrObject.to_str(res)
+
+        # Second pass: build the result
+        result_len = orig_len + count * (new_len - old_len)
+        res = StrObject.alloc(result_len)
+        res.hash = 0
+        pos = 0
+        i = 0
+        while i <= orig_len - old_len:
+            c = ptr_cmp_slice(ll_orig.utf8, i, i + old_len, ll_old.utf8, 0, old_len)
+            if c == 0:  # found
+                if new_len > 0:
+                    ptr_copy_slice(
+                        res.utf8, pos, pos + new_len, ll_new.utf8, 0, new_len
+                    )
+                    pos = pos + new_len
+                i = i + old_len
+            else:
+                res.utf8[pos] = ll_orig.utf8[i]
+                pos = pos + 1
+                i = i + 1
+        # Copy remaining tail
+        remaining = orig_len - i
+        if remaining > 0:
+            ptr_copy_slice(
+                res.utf8, pos, pos + remaining, ll_orig.utf8, i, i + remaining
+            )
+        return StrObject.to_str(res)
 
     def upper(self: str) -> str:
         # XXX: this works only for ASCII strings but it's good enough for now


### PR DESCRIPTION
Now we have enough machinery around to move most str methods to _str.spy.
I decided to leave `str_eq`/`str_ne` in C mostly for performance reasons: I admit it's just a gut feeling, but I suppose that `==` is the most common operation on strings.

What follows is the summary as written by claude.

---

Migrates `replace`, `__repr__`, `__add__`, `__mul__`, `__getitem__`, and `__len__` for the `str` type from C (`spy/libspy/src/str.c`) to applevel SPy code in `stdlib/_str.spy`, mirroring the pattern already used by `bytes`.

The interp-level wrappers in `spy/vm/str.py` and the corresponding `OP.w_str_add`/`w_str_mul` operator implementations are removed. `+` and `*` on `str` now dispatch via the `__add__`/`__mul__` lazy attributes (same path as `bytes`), and the explicit `MM.register("+", "str", "str", ...)` / `MM.register("*", "str", "i32", ...)` entries in `binop.py` are removed.

The new applevel methods are added to `W_Func._pure_fqns` so that constant-folding on blue arguments still works (preserving the previous behavior of the operator-level functions).

`__eq__` / `__ne__` stay in C for performance reasons.
