### PR TITLE
unsafe.sizeof: support f32 and u32

### DIFF
--- a/spy/tests/compiler/unsafe/test_sizeof.py
+++ b/spy/tests/compiler/unsafe/test_sizeof.py
@@ -1,19 +1,12 @@
-import pytest
-
 from spy.vm.b import B
 from spy.vm.modules.unsafe.misc import sizeof
 
 
-@pytest.mark.parametrize(
-    "w_T, expected",
-    [
-        (B.w_i8, 1),
-        (B.w_u8, 1),
-        (B.w_i32, 4),
-        (B.w_u32, 4),
-        (B.w_f32, 4),
-        (B.w_f64, 8),
-    ],
-)
-def test_sizeof_primitives(w_T, expected):
-    assert sizeof(w_T) == expected
+def test_sizeof_primitives():
+    assert sizeof(B.w_bool) == 1
+    assert sizeof(B.w_i8) == 1
+    assert sizeof(B.w_u8) == 1
+    assert sizeof(B.w_i32) == 4
+    assert sizeof(B.w_u32) == 4
+    assert sizeof(B.w_f32) == 4
+    assert sizeof(B.w_f64) == 8

--- a/spy/tests/compiler/unsafe/test_sizeof.py
+++ b/spy/tests/compiler/unsafe/test_sizeof.py
@@ -1,0 +1,19 @@
+import pytest
+
+from spy.vm.b import B
+from spy.vm.modules.unsafe.misc import sizeof
+
+
+@pytest.mark.parametrize(
+    "w_T, expected",
+    [
+        (B.w_i8, 1),
+        (B.w_u8, 1),
+        (B.w_i32, 4),
+        (B.w_u32, 4),
+        (B.w_f32, 4),
+        (B.w_f64, 8),
+    ],
+)
+def test_sizeof_primitives(w_T, expected):
+    assert sizeof(w_T) == expected

--- a/spy/vm/modules/unsafe/misc.py
+++ b/spy/vm/modules/unsafe/misc.py
@@ -8,7 +8,7 @@ def sizeof(w_T: W_Type) -> int:
     from spy.vm.modules.unsafe.ptr import W_PtrType
     from spy.vm.struct import W_StructType
 
-    if w_T in (B.w_i8, B.w_u8):
+    if w_T in (B.w_bool, B.w_i8, B.w_u8):
         return 1
     elif w_T in (B.w_i32, B.w_u32, B.w_f32):
         return 4

--- a/spy/vm/modules/unsafe/misc.py
+++ b/spy/vm/modules/unsafe/misc.py
@@ -10,7 +10,7 @@ def sizeof(w_T: W_Type) -> int:
 
     if w_T in (B.w_i8, B.w_u8):
         return 1
-    elif w_T is B.w_i32:
+    elif w_T in (B.w_i32, B.w_u32, B.w_f32):
         return 4
     elif w_T is B.w_f64:
         return 8


### PR DESCRIPTION
Also added unit test for sizeof of all primitive numeric types.

(Patch created with AI assistance.)