### PR TITLE
playground: avoid SystemExit being turned into an error

### DIFF
--- a/playground/main.py
+++ b/playground/main.py
@@ -180,7 +180,12 @@ def run_spy_file_with_args(argv: list[str]):
     with open(display_filename(), "w") as f:
         f.write(text)
 
-    spy.cli.app(argv)
+    # This try/except avoids SystemExit being turned into an error.
+    # No such issue with Firefox but this is useful for others browsers.
+    try:
+        spy.cli.app(argv)
+    except SystemExit:
+        pass
 
 
 def run_click(event):


### PR DESCRIPTION
Fixes #566 

Actually the try/except removed in https://github.com/spylang/spy/pull/555 was useful.