### PR TITLE
Add docstrings and reorganize playground examples

### DIFF
--- a/examples/1_high_level/collections.spy
+++ b/examples/1_high_level/collections.spy
@@ -1,16 +1,16 @@
 """
 Things to notice:
-  - tuples, dicts, and lists work as in Python
-  - types are inferred from usage: `a = (2, "SPy")` gives a `tuple[i32, str]`
-  - heterogeneous tuples are fully supported; dict and list require uniform types
-  - the length and element types of tuples must be known at compile time
-  - after redshift, collection operations are specialized and dispatch-free
+  - Tuples, dicts, and lists work as in Python.
+  - Types are inferred from usage: `a = (2, "SPy")` gives a `tuple[i32, str]`.
+  - Heterogeneous tuples are fully supported; dict and list require uniform types.
+  - The length and element types of tuples must be known at compile time.
+  - After redshift, collection operations are specialized and dispatch-free.
 
 Notes:
-  - for use inside blue functions, `interp_` variants exist:
-    `from __spy__ import interp_tuple, interp_list, interp_dict`
-  - the static versions are still missing many methods, but they are implemented
-    in SPy's own standard library, so contributions are welcome and relatively easy
+  - For use inside blue functions, `interp_` variants exist:
+    `from __spy__ import interp_tuple, interp_list, interp_dict`.
+  - The static versions are still missing many methods, but they are implemented
+    in SPy's own standard library, so contributions are welcome and relatively easy.
 """
 
 

--- a/examples/1_high_level/collections.spy
+++ b/examples/1_high_level/collections.spy
@@ -1,3 +1,12 @@
+"""
+Things to notice:
+  - tuples, dicts, and lists work as in Python
+  - types are inferred from usage: `a = (2, "SPy")` gives a `tuple[i32, str]`
+  - heterogeneous tuples are fully supported; dict and list require uniform types
+  - after redshift, collection operations are specialized and dispatch-free
+"""
+
+
 def main() -> None:
     a = (2, "SPy")
     print(a[0])

--- a/examples/1_high_level/collections.spy
+++ b/examples/1_high_level/collections.spy
@@ -3,12 +3,17 @@ Things to notice:
   - Tuples, dicts, and lists work as in Python.
   - Types are inferred from usage: `a = (2, "SPy")` gives a `tuple[i32, str]`.
   - Heterogeneous tuples are fully supported; dict and list require uniform types.
-  - The length and element types of tuples must be known at compile time.
+  - The length and element types of tuples must be known at compile time;
+    `tuple[T, ...]` is not supported yet (but will be).
   - After redshift, collection operations are specialized and dispatch-free.
 
 Notes:
-  - For use inside blue functions, `interp_` variants exist:
+
+  - `interp_` variants without type limitations exist:
     `from __spy__ import interp_tuple, interp_list, interp_dict`.
+    For example, `interp_list[dynamic](1, "a", int)` is supported.
+    However, they can only be used in blue functions if you want to be able to build.
+
   - The static versions are still missing many methods, but they are implemented
     in SPy's own standard library, so contributions are welcome and relatively easy.
 """

--- a/examples/1_high_level/collections.spy
+++ b/examples/1_high_level/collections.spy
@@ -3,7 +3,14 @@ Things to notice:
   - tuples, dicts, and lists work as in Python
   - types are inferred from usage: `a = (2, "SPy")` gives a `tuple[i32, str]`
   - heterogeneous tuples are fully supported; dict and list require uniform types
+  - the length and element types of tuples must be known at compile time
   - after redshift, collection operations are specialized and dispatch-free
+
+Notes:
+  - for use inside blue functions, `interp_` variants exist:
+    `from __spy__ import interp_tuple, interp_list, interp_dict`
+  - the static versions are still missing many methods, but they are implemented
+    in SPy's own standard library, so contributions are welcome and relatively easy
 """
 
 

--- a/examples/1_high_level/exit_code.spy
+++ b/examples/1_high_level/exit_code.spy
@@ -1,8 +1,8 @@
 """
 Things to notice:
-  - `main()` can take `argv` as a `list[str]` and can return an `i32` exit code
-  - the exit code is propagated to the OS
-  - `argv` contains the script/executable name and the script arguments
+  - `main()` can take `argv` as a `list[str]` and can return an `i32` exit code.
+  - The exit code is propagated to the OS.
+  - `argv` contains the script/executable name and the script arguments.
 """
 
 

--- a/examples/1_high_level/exit_code.spy
+++ b/examples/1_high_level/exit_code.spy
@@ -5,6 +5,7 @@ Things to notice:
   - `argv` contains the script/executable name and the script arguments
 """
 
+
 def main(argv: list[str]) -> i32:
     print("argv:")
     for arg in argv:

--- a/examples/1_high_level/factorial.spy
+++ b/examples/1_high_level/factorial.spy
@@ -1,9 +1,9 @@
 """
 Things to notice:
   - `i32` is a concrete 32-bit integer type (unlike Python's arbitrary-precision `int`)
-  - SPy primitive types include i8, i16, i32, i64, u8, u16, u32, u64, f32, f64
+  - SPy primitive types include i8, i16, i32, u8, u16, u32, f32, f64
   - `for` loops and `range()` work as in Python
-  - after redshift, the loop is compiled to efficient C code with no boxing
+  - after redshift, the for loop is compiled to efficient code without runtime dispatch and boxing
 """
 
 import time

--- a/examples/1_high_level/factorial.spy
+++ b/examples/1_high_level/factorial.spy
@@ -1,9 +1,9 @@
 """
 Things to notice:
-  - `i32` is a concrete 32-bit integer type (unlike Python's arbitrary-precision `int`)
-  - SPy primitive types include i8, i16, i32, u8, u16, u32, f32, f64
-  - `for` loops and `range()` work as in Python
-  - after redshift, the for loop is compiled to efficient code without runtime dispatch and boxing
+  - `i32` is a concrete 32-bit integer type (unlike Python's arbitrary-precision `int`).
+  - SPy primitive types include i8, i16, i32, u8, u16, u32, f32, f64.
+  - `for` loops and `range()` work as in Python.
+  - After redshift, the for loop is compiled to efficient code without runtime dispatch and boxing.
 """
 
 import time

--- a/examples/1_high_level/factorial.spy
+++ b/examples/1_high_level/factorial.spy
@@ -1,3 +1,11 @@
+"""
+Things to notice:
+  - `i32` is a concrete 32-bit integer type (unlike Python's arbitrary-precision `int`)
+  - SPy primitive types include i8, i16, i32, i64, u8, u16, u32, u64, f32, f64
+  - `for` loops and `range()` work as in Python
+  - after redshift, the loop is compiled to efficient C code with no boxing
+"""
+
 import time
 
 

--- a/examples/1_high_level/fibo.spy
+++ b/examples/1_high_level/fibo.spy
@@ -1,9 +1,16 @@
 """
 Things to notice:
-  - `int` is SPy's arbitrary-precision integer (like Python's), distinct from `i32`
+  - currently, `int` is just an alias to `i32`
   - recursive functions work as in Python, with full type inference on return values
   - timing shows the speedup from compilation vs CPython interpretation
-  - in SPy, main() does not need to be explicitely called
+  - in SPy, main() does not need to be explicitly called
+
+Note: SPy's performance comes from the compiler, not the interpreter. The interpreter
+is currently much slower than CPython — the goal is to reach CPython speed, but this
+is not yet achieved. The plan to get there is to implement the SPy interpreter in SPy
+itself, so that it can be compiled. To get compiled performance in the meantime,
+install SPy locally and run `spy build -x fibo.spy`. The playground does not yet
+support `spy build`.
 """
 
 from time import time

--- a/examples/1_high_level/fibo.spy
+++ b/examples/1_high_level/fibo.spy
@@ -1,9 +1,9 @@
 """
 Things to notice:
-  - currently, `int` is just an alias to `i32`
-  - recursive functions work as in Python, with full type inference on return values
-  - timing shows the speedup from compilation vs CPython interpretation
-  - in SPy, main() does not need to be explicitly called
+  - Currently, `int` is just an alias to `i32`.
+  - Recursive functions work as in Python, with full type inference on return values.
+  - Timing shows the speedup from compilation vs CPython interpretation.
+  - In SPy, `main()` does not need to be explicitly called.
 
 Note: SPy's performance comes from the compiler, not the interpreter. The interpreter
 is currently much slower than CPython — the goal is to reach CPython speed, but this

--- a/examples/1_high_level/fibo.spy
+++ b/examples/1_high_level/fibo.spy
@@ -1,3 +1,11 @@
+"""
+Things to notice:
+  - `int` is SPy's arbitrary-precision integer (like Python's), distinct from `i32`
+  - recursive functions work as in Python, with full type inference on return values
+  - timing shows the speedup from compilation vs CPython interpretation
+  - in SPy, main() does not need to be explicitely called
+"""
+
 from time import time
 
 
@@ -16,4 +24,5 @@ def main() -> None:
     print("#", str(t_end - t_start), "s")
 
 
+# uncomment this line to run with a Python interpreter
 # main()

--- a/examples/1_high_level/fileio.spy
+++ b/examples/1_high_level/fileio.spy
@@ -1,3 +1,10 @@
+"""
+Things to notice:
+  - `open()`, `write()`, `close()`, and iteration over lines work as in Python
+  - context managers (`with`) are not yet supported (but it's in the roadmap)
+"""
+
+
 def main() -> None:
     f = open("/tmp/foo.txt", "w")
     for i in range(10):

--- a/examples/1_high_level/fileio.spy
+++ b/examples/1_high_level/fileio.spy
@@ -1,7 +1,7 @@
 """
 Things to notice:
-  - `open()`, `write()`, `close()`, and iteration over lines work as in Python
-  - context managers (`with`) are not yet supported (but in the roadmap)
+  - `open()`, `write()`, `close()`, and iteration over lines work as in Python.
+  - Context managers (`with`) are not yet supported (but in the roadmap).
 """
 
 

--- a/examples/1_high_level/fileio.spy
+++ b/examples/1_high_level/fileio.spy
@@ -1,7 +1,7 @@
 """
 Things to notice:
   - `open()`, `write()`, `close()`, and iteration over lines work as in Python
-  - context managers (`with`) are not yet supported (but it's in the roadmap)
+  - context managers (`with`) are not yet supported (but in the roadmap)
 """
 
 

--- a/examples/1_high_level/hello.spy
+++ b/examples/1_high_level/hello.spy
@@ -1,12 +1,24 @@
 """
-Things to notice:
-  - every SPy program defines `main()` as its entry point
-  - `spy execute hello.spy` runs the program
-  - `spy colorize hello.spy` shows syntax highlighting (blue/red coloring)
-  - `spy redshift hello.spy` shows the fully compiled, type-specialized output
-  - `spy redshift --c hello.spy` emits C code
-"""
+## About the playground:
 
+The playground presents example files organized in 4 categories. You can discover
+SPy by following the proposed progression from left to right.
+
+You can use the `spy` CLI in the playground by typing a command in the input bar
+and pressing Enter or the Run button, or by clicking one of the shortcut buttons
+below the editor. These buttons correspond to the most useful commands for running
+and inspecting the compilation pipeline:
+
+  - `spy execute hello.spy`             run the program (interpreted)
+  - `spy colorize hello.spy`            show code with blue/red coloring
+  - `spy redshift hello.spy`            show the redshifted typed AST (as code)
+  - `spy redshift --execute hello.spy`  run the redshifted AST (interpreted)
+  - `spy build --cdump hello.spy`       emit C code
+
+Things to notice:
+  - Every SPy program defines `main()` as its entry point.
+    SPy libraries do not need a `main()` function.
+"""
 
 def main() -> None:
     print("Hello world!")

--- a/examples/1_high_level/hello.spy
+++ b/examples/1_high_level/hello.spy
@@ -1,2 +1,12 @@
+"""
+Things to notice:
+  - every SPy program defines `main()` as its entry point
+  - `spy execute hello.spy` runs the program
+  - `spy colorize hello.spy` shows syntax highlighting (blue/red coloring)
+  - `spy redshift hello.spy` shows the fully compiled, type-specialized output
+  - `spy redshift --c hello.spy` emits C code
+"""
+
+
 def main() -> None:
     print("Hello world!")

--- a/examples/1_high_level/hello.spy
+++ b/examples/1_high_level/hello.spy
@@ -20,5 +20,6 @@ Things to notice:
     SPy libraries do not need a `main()` function.
 """
 
+
 def main() -> None:
     print("Hello world!")

--- a/examples/1_high_level/hello_add.spy
+++ b/examples/1_high_level/hello_add.spy
@@ -1,13 +1,18 @@
 """
 Things to notice:
-  - "red" functions require signature
-  - after "redshift", print is specialized
+  - red functions require signature
+  - after redshift, print is specialized
+  - press the `redshift` button and study the output — this is a good first
+    example to understand what redshift does
 
 Redshift is the compilation phase during which SPy applies:
   - partial evaluation of all blue expressions and functions,
   - concretization of all generic types,
   - static dispatch of all function calls, and
   - type checking.
+
+The distinction between "blue" (compile-time) and "red" (runtime) is central
+to SPy and will be explained in the next examples.
 """
 
 

--- a/examples/1_high_level/hello_add.spy
+++ b/examples/1_high_level/hello_add.spy
@@ -1,6 +1,6 @@
 """
 Things to notice:
-  - Red functions require signature.
+  - Red functions require type annotations.
   - After redshift, print is specialized.
   - Press the `redshift` button and study the output — this is a good first
     example to understand what redshift does.

--- a/examples/1_high_level/hello_add.spy
+++ b/examples/1_high_level/hello_add.spy
@@ -1,9 +1,9 @@
 """
 Things to notice:
-  - red functions require signature
-  - after redshift, print is specialized
-  - press the `redshift` button and study the output — this is a good first
-    example to understand what redshift does
+  - Red functions require signature.
+  - After redshift, print is specialized.
+  - Press the `redshift` button and study the output — this is a good first
+    example to understand what redshift does.
 
 Redshift is the compilation phase during which SPy applies:
   - partial evaluation of all blue expressions and functions,

--- a/examples/1_high_level/hello_add.spy
+++ b/examples/1_high_level/hello_add.spy
@@ -1,8 +1,13 @@
 """
 Things to notice:
-  - functions require signature
-  - after redshift, print is specialized
-  - with spy redshift --full-fqn, you can see that lookups are resolved early
+  - "red" functions require signature
+  - after "redshift", print is specialized
+
+Redshift is the compilation phase during which SPy applies:
+  - partial evaluation of all blue expressions and functions,
+  - concretization of all generic types,
+  - static dispatch of all function calls, and
+  - type checking.
 """
 
 

--- a/examples/1_high_level/str_bytes.spy
+++ b/examples/1_high_level/str_bytes.spy
@@ -1,10 +1,13 @@
 """
 Things to notice:
-  - str supports: +, *, ==, !=, [], len(), replace(), upper(), isascii()
+  - str supports: +, *, ==, !=, [], len(), replace(), upper(), isascii(), ...
   - str can be converted to numeric types with explicit casts: i32(s), f64(s), ...
   - bytes literals use b'...' syntax
-  - bytes supports: len(), [], ==, !=, +, *, repr()
+  - bytes supports: len(), [], ==, !=, +, *, repr(), ...
   - ord() works on single-character str or bytes literals
+
+Warning: str and bytes are still missing many methods, but they can be implemented
+in SPy's own standard library, so contributions are welcome and relatively easy.
 """
 
 

--- a/examples/1_high_level/str_bytes.spy
+++ b/examples/1_high_level/str_bytes.spy
@@ -2,9 +2,9 @@
 Things to notice:
   - str supports: +, *, ==, !=, [], len(), replace(), upper(), isascii(), ...
   - str can be converted to numeric types with explicit casts: i32(s), f64(s), ...
-  - bytes literals use b'...' syntax
+  - bytes literals use b'...' syntax.
   - bytes supports: len(), [], ==, !=, +, *, repr(), ...
-  - ord() works on single-character str or bytes literals
+  - `ord()` works on single-character str or bytes literals.
 
 Warning: str and bytes are still missing many methods, but they can be implemented
 in SPy's own standard library, so contributions are welcome and relatively easy.

--- a/examples/1_high_level/var_const.spy
+++ b/examples/1_high_level/var_const.spy
@@ -1,12 +1,12 @@
 """
 Things to notice:
-  - module-level assignments are blue and immutable (const) by default
-  - `var` declares a mutable global variable — reassignment is then allowed
+  - Module-level assignments are blue and immutable (const) by default.
+  - `var` declares a mutable global variable — reassignment is then allowed.
   - `var` globals are especially useful for mutable pointers (e.g. gc_ptr[T])
-    which appear in low-level and advanced examples
+    which appear in low-level and advanced examples.
   - `const` inside a function declares a local blue constant: it is fully
-    resolved at redshift time and inlined as a literal (run `spy redshift` to see)
-  - local variables assigned only once with literals or blue variables are by default blue
+    resolved at redshift time and inlined as a literal (run `spy redshift` to see).
+  - Local variables assigned only once with literals or blue variables are by default blue.
 """
 
 from __spy__ import COLOR

--- a/examples/1_high_level/var_const.spy
+++ b/examples/1_high_level/var_const.spy
@@ -1,0 +1,48 @@
+"""
+Things to notice:
+  - module-level assignments are blue and immutable (const) by default
+  - `var` declares a mutable global variable — reassignment is then allowed
+  - `var` globals are especially useful for mutable pointers (e.g. gc_ptr[T])
+    which appear in low-level and advanced examples
+  - `const` inside a function declares a local blue constant: it is fully
+    resolved at redshift time and inlined as a literal (run `spy redshift` to see)
+  - local variables assigned only once with literals or blue variables are by default blue
+"""
+
+from __spy__ import COLOR
+
+
+# plain module-level assignment: immutable (const) by default
+N: i32 = 10
+
+# `var` makes the global mutable
+var counter: i32 = 0
+
+
+def increment() -> None:
+    counter = counter + 1
+
+
+def main() -> None:
+    # `const` declares a local blue constant, resolved at redshift time
+    const LIMIT = 5
+    # LIMIT = 6  # would raise: "x is const" — uncomment to see the error
+
+    LIMIT2 = 10
+    LIMIT3 = LIMIT + LIMIT2
+    LIMIT4 = LIMIT + LIMIT2
+
+    print("COLOR(LIMIT)", COLOR(LIMIT))    # blue
+    print("COLOR(LIMIT2)", COLOR(LIMIT2))  # blue
+    print("COLOR(LIMIT3)", COLOR(LIMIT3))  # blue
+    print("COLOR(LIMIT4)", COLOR(LIMIT4))  # red
+
+    LIMIT4 = 10
+
+    print("N+1:", N+1)
+    # N = 20  # would raise: "x is const" — uncomment to see the error
+
+    print("counter:", counter)
+    for i in range(LIMIT):
+        increment()
+    print("counter:", counter)

--- a/examples/1_high_level/var_const.spy
+++ b/examples/1_high_level/var_const.spy
@@ -1,9 +1,17 @@
 """
-Things to notice:
-  - Module-level assignments are blue and immutable (const) by default.
+This example presents the only deviance from Python's grammar in SPy,
+associated with two keywords, `var` and `const`.
+
+It is in particular related to a notable semantics difference for module-level code:
+after imports, the modules are frozen (immutable) and module-level assignments create
+by default blue and immutable (const) variables.
+
+However:
   - `var` declares a mutable global variable — reassignment is then allowed.
   - `var` globals are especially useful for mutable pointers (e.g. gc_ptr[T])
     which appear in low-level and advanced examples.
+
+Local variables are by default var and red, with two exceptions:
   - `const` inside a function declares a local blue constant: it is fully
     resolved at redshift time and inlined as a literal (run `spy redshift` to see).
   - Local variables assigned only once with literals or blue variables are by default blue.
@@ -28,11 +36,14 @@ def main() -> None:
     const LIMIT = 5
     # LIMIT = 6  # would raise: "x is const" — uncomment to see the error
 
+    # equivalent to `const LIMIT2 = 10`
     LIMIT2 = 10              # blue, since assigned once
+    # (if a name is assigned only once outside a loop, it's tagged as const)
+    # however, no error would be raised if a developer adds another `LIMIT2 = ...`
 
     # this is getting advanced, don't worry if it's not clear yet
     LIMIT3 = LIMIT + LIMIT2  # also blue, since LIMIT and LIMIT2 are blue
-    LIMIT4 = LIMIT + LIMIT2  # red because of the next assignment
+    LIMIT4 = LIMIT + LIMIT2  # var and red because of the next assignment
 
     print("COLOR(LIMIT)", COLOR(LIMIT))    # blue
     print("COLOR(LIMIT2)", COLOR(LIMIT2))  # blue

--- a/examples/1_high_level/var_const.spy
+++ b/examples/1_high_level/var_const.spy
@@ -28,9 +28,9 @@ def main() -> None:
     const LIMIT = 5
     # LIMIT = 6  # would raise: "x is const" — uncomment to see the error
 
-    LIMIT2 = 10
-    LIMIT3 = LIMIT + LIMIT2
-    LIMIT4 = LIMIT + LIMIT2
+    LIMIT2 = 10              # blue, since assigned once
+    LIMIT3 = LIMIT + LIMIT2  # also blue
+    LIMIT4 = LIMIT + LIMIT2  # red because of the next assignment
 
     print("COLOR(LIMIT)", COLOR(LIMIT))    # blue
     print("COLOR(LIMIT2)", COLOR(LIMIT2))  # blue

--- a/examples/1_high_level/var_const.spy
+++ b/examples/1_high_level/var_const.spy
@@ -29,7 +29,9 @@ def main() -> None:
     # LIMIT = 6  # would raise: "x is const" — uncomment to see the error
 
     LIMIT2 = 10              # blue, since assigned once
-    LIMIT3 = LIMIT + LIMIT2  # also blue
+
+    # this is getting advanced, don't worry if it's not clear yet
+    LIMIT3 = LIMIT + LIMIT2  # also blue, since LIMIT and LIMIT2 are blue
     LIMIT4 = LIMIT + LIMIT2  # red because of the next assignment
 
     print("COLOR(LIMIT)", COLOR(LIMIT))    # blue

--- a/examples/2_metaprogramming/blue_generic.spy
+++ b/examples/2_metaprogramming/blue_generic.spy
@@ -1,3 +1,13 @@
+"""
+Things to notice:
+  - `def add[T](...)` is syntactic sugar for `@blue.generic def add(T): ...`
+  - generic functions are called with `[]` for the type parameter, `()` for values
+  - `@blue.generic` functions are resolved entirely at redshift time:
+    each `add[i32]` and `add[str]` becomes a separate specialized red function
+  - `add2` shows the explicit desugaring — both forms are equivalent
+"""
+
+
 def add[T](x: T, y: T) -> T:
     return x + y
 

--- a/examples/2_metaprogramming/blue_generic.spy
+++ b/examples/2_metaprogramming/blue_generic.spy
@@ -21,10 +21,8 @@ def add2(T):
     return impl
 
 
-"""
-Functions decorated with @blue.generic are called using square brackets [] instead of parentheses ().
-Other than that, they are identical to other blue functions.
-"""
+# Functions decorated with @blue.generic are called using square brackets [] instead of parentheses ().
+# Other than that, they are identical to other blue functions.
 
 
 def main() -> None:

--- a/examples/2_metaprogramming/blue_generic.spy
+++ b/examples/2_metaprogramming/blue_generic.spy
@@ -1,7 +1,7 @@
 """
 Things to notice:
   - `def add[T](...)` is syntactic sugar for `@blue.generic def add(T): ...`
-  - generic functions are called with `[]` for the type parameter, `()` for values
+  - generic functions are called with `[]` for the parameters, `()` for values
   - `@blue.generic` functions are resolved entirely at redshift time:
     each `add[i32]` and `add[str]` becomes a separate specialized red function
   - `add2` shows the explicit desugaring — both forms are equivalent
@@ -12,13 +12,19 @@ def add[T](x: T, y: T) -> T:
     return x + y
 
 
-# the function above is syntax sugar for this
+# the function above is syntax sugar for this, i.e. a @blue.generic function factory
 @blue.generic
 def add2(T):
     def impl(x: T, y: T) -> T:
         return x + y
 
     return impl
+
+
+"""
+Functions decorated with @blue.generic are called using square brackets [] instead of parentheses ().
+Other than that, they are identical to other blue functions.
+"""
 
 
 def main() -> None:

--- a/examples/2_metaprogramming/blue_generic.spy
+++ b/examples/2_metaprogramming/blue_generic.spy
@@ -1,10 +1,10 @@
 """
 Things to notice:
-  - `def add[T](...)` is syntactic sugar for `@blue.generic def add(T): ...`
-  - generic functions are called with `[]` for the parameters, `()` for values
+  - `def add[T](...)` is syntactic sugar for `@blue.generic def add(T): ...`.
+  - Generic functions are called with `[]` for the parameters, `()` for values.
   - `@blue.generic` functions are resolved entirely at redshift time:
-    each `add[i32]` and `add[str]` becomes a separate specialized red function
-  - `add2` shows the explicit desugaring — both forms are equivalent
+    each `add[i32]` and `add[str]` becomes a separate specialized red function.
+  - `add2` shows the explicit desugaring — both forms are equivalent.
 """
 
 

--- a/examples/2_metaprogramming/bluefunc_adder.spy
+++ b/examples/2_metaprogramming/bluefunc_adder.spy
@@ -1,13 +1,13 @@
 """
 Things to notice:
-  - @blue funcs are completely resolved at redshift time
-  - make_adder is not present in the redshifted or .c file
-  - signatures in blue functions are optional
-  - parameters can be a type to get generics but other types can be used
-    (here i32 and float)
-  - generic functions with the [] syntax are just syntactic sugar for a
-    `@blue.generic` function factory
-  - redshift inserts type conversions
+  - @blue funcs are completely resolved at redshift time.
+  - `make_adder` is not present in the redshifted or .c file.
+  - signatures in blue functions are optional.
+  - Parameters can be a type to get generics but other types can be used
+    (here i32 and float).
+  - Generic functions with the [] syntax are just syntactic sugar for a
+    `@blue.generic` function factory.
+  - Redshift inserts type conversions.
 """
 
 

--- a/examples/2_metaprogramming/bluefunc_adder.spy
+++ b/examples/2_metaprogramming/bluefunc_adder.spy
@@ -2,7 +2,7 @@
 Things to notice:
   - @blue funcs are completely resolved at redshift time.
   - `make_adder` is not present in the redshifted or .c file.
-  - signatures in blue functions are optional.
+  - Type annotations in blue functions are optional and default to `dynamic`.
   - Parameters can be a type to get generics but other types can be used
     (here i32 and float).
   - Generic functions with the [] syntax are just syntactic sugar for a

--- a/examples/2_metaprogramming/bluefunc_adder.spy
+++ b/examples/2_metaprogramming/bluefunc_adder.spy
@@ -2,8 +2,11 @@
 Things to notice:
   - @blue funcs are completely resolved at redshift time
   - make_adder is not present in the redshifted or .c file
-  - types in blue functions are optional
-  - you can pass a type to get generics
+  - signatures in blue functions are optional
+  - parameters can be a type to get generics but other types can be used
+    (here i32 and float)
+  - generic functions with the [] syntax are just syntactic sugar for a
+    `@blue.generic` function factory
   - redshift inserts type conversions
 """
 
@@ -11,20 +14,6 @@ Things to notice:
 def make_adder[T, x](y: T) -> T:
     return x + y
 
-
-"""
-This generic function is just syntactic sugar for
-
-@blue.generic
-def make_adder(T, x):
-    def _impl(y: T) -> T:
-        return x + y
-
-    return _impl
-
-Functions decorated with @blue.generic are called using square brackets [] instead of parentheses ().
-Other than that, they are identical to other blue functions.
-"""
 
 add_4 = make_adder[i32, 4]
 add_pi = make_adder[f64, 3.1415]

--- a/examples/2_metaprogramming/bluefunc_pi.spy
+++ b/examples/2_metaprogramming/bluefunc_pi.spy
@@ -1,8 +1,8 @@
 """
 Things to notice:
-  - @blue funcs are completely resolved at redshift time
-  - get_pi is not present in the redshifted or .c file
-  - types in blue functions are optional
+  - @blue funcs are completely resolved at redshift time.
+  - `get_pi` is not present in the redshifted or .c file.
+  - Signatures in blue functions are optional.
 
 Note: `redshift --linearize` "linearises" the `__block__`, which can give
 simpler output for the print calls with more than one argument.

--- a/examples/2_metaprogramming/bluefunc_pi.spy
+++ b/examples/2_metaprogramming/bluefunc_pi.spy
@@ -2,7 +2,7 @@
 Things to notice:
   - @blue funcs are completely resolved at redshift time.
   - `get_pi` is not present in the redshifted or .c file.
-  - Signatures in blue functions are optional.
+  - Type annotations in blue functions are optional and default to `dynamic`.
 
 Note: `redshift --linearize` "linearises" the `__block__`, which can give
 simpler output for the print calls with more than one argument.

--- a/examples/2_metaprogramming/bluefunc_pi.spy
+++ b/examples/2_metaprogramming/bluefunc_pi.spy
@@ -4,8 +4,8 @@ Things to notice:
   - get_pi is not present in the redshifted or .c file
   - types in blue functions are optional
 
-Note: `redshift --linearize` gives simpler output for the print calls with
-more than one argument.
+Note: `redshift --linearize` "linearises" the `__block__`, which can give
+simpler output for the print calls with more than one argument.
 """
 
 

--- a/examples/2_metaprogramming/deco.spy
+++ b/examples/2_metaprogramming/deco.spy
@@ -1,6 +1,6 @@
 """
 Things to notice:
-  - `@blue` decorators are applied entirely at redshift time.
+  - `@blue` decorators are applied entirely at import time.
   - `double` wraps `inc` at compile time: the resulting `inc` in red code
     is already the doubled version — `double` itself disappears from the output.
   - This is the SPy equivalent of zero-cost compile-time code generation.

--- a/examples/2_metaprogramming/deco.spy
+++ b/examples/2_metaprogramming/deco.spy
@@ -1,3 +1,13 @@
+"""
+Things to notice:
+  - `@blue` decorators are applied entirely at redshift time
+  - `double` wraps `inc` at compile time: the resulting `inc` in red code
+    is already the doubled version — `double` itself disappears from the output
+  - this is the SPy equivalent of zero-cost compile-time code generation
+  - blue decorator functions do not need type annotations
+"""
+
+
 @blue
 def double(fn):
     def inner(x: i32) -> i32:

--- a/examples/2_metaprogramming/deco.spy
+++ b/examples/2_metaprogramming/deco.spy
@@ -1,10 +1,10 @@
 """
 Things to notice:
-  - `@blue` decorators are applied entirely at redshift time
+  - `@blue` decorators are applied entirely at redshift time.
   - `double` wraps `inc` at compile time: the resulting `inc` in red code
-    is already the doubled version — `double` itself disappears from the output
-  - this is the SPy equivalent of zero-cost compile-time code generation
-  - blue decorator functions do not need type annotations
+    is already the doubled version — `double` itself disappears from the output.
+  - This is the SPy equivalent of zero-cost compile-time code generation.
+  - Blue decorator functions do not need type annotations.
 """
 
 

--- a/examples/2_metaprogramming/metafunc.spy
+++ b/examples/2_metaprogramming/metafunc.spy
@@ -1,3 +1,12 @@
+"""
+Things to notice:
+  - `@blue.metafunc` allows dispatch on the *static type* of arguments at redshift time
+  - `m_x.static_type` gives the compile-time type of the argument — no runtime cost
+  - each call site gets a specialized implementation; unsupported types raise TypeError
+    at redshift time, not at runtime
+  - this is how SPy's built-in `print` is implemented internally
+"""
+
 from operator import OpSpec
 
 

--- a/examples/2_metaprogramming/metafunc.spy
+++ b/examples/2_metaprogramming/metafunc.spy
@@ -1,16 +1,16 @@
 """
 Things to notice:
   - `@blue.metafunc` defines a function that runs at redshift time to dispatch
-    on the static types of its arguments — no runtime cost
-  - arguments prefixed with `m_` are MetaArgs: they carry information known at
-    redshift time, in particular `m_x.static_type` and `m_x.color`
-  - each call site gets a specialized implementation, depending on the MetaArgs
-  - the metafunc returns an `OpSpec`, which describes which red function will be
-    called at runtime and with which arguments
+    on the static types of its arguments — no runtime cost.
+  - Arguments prefixed with `m_` are MetaArgs: they carry information known at
+    redshift time, in particular `m_x.static_type` and `m_x.color`.
+  - Each call site gets a specialized implementation, depending on the MetaArgs.
+  - The metafunc returns an `OpSpec`, which describes which red function will be
+    called at runtime and with which arguments.
   - `OpSpec(func)` is the simple form: `func` will be called with the original
-    arguments as-is
-  - unsupported types raise `TypeError` at redshift time, not at runtime
-  - this is how SPy's built-in `print` is implemented internally
+    arguments as-is.
+  - Unsupported types raise `TypeError` at redshift time, not at runtime.
+  - This is how SPy's built-in `print` is implemented internally.
 
 Note on `OpSpec` — the return value of metafuncs:
   - `OpSpec(func)`: simple form — `func` is called with the original arguments

--- a/examples/2_metaprogramming/metafunc.spy
+++ b/examples/2_metaprogramming/metafunc.spy
@@ -1,10 +1,23 @@
 """
 Things to notice:
-  - `@blue.metafunc` allows dispatch on the *static type* of arguments at redshift time
-  - `m_x.static_type` gives the compile-time type of the argument — no runtime cost
-  - each call site gets a specialized implementation; unsupported types raise TypeError
-    at redshift time, not at runtime
+  - `@blue.metafunc` defines a function that runs at redshift time to dispatch
+    on the static types of its arguments — no runtime cost
+  - arguments prefixed with `m_` are MetaArgs: they carry information known at
+    redshift time, in particular `m_x.static_type` and `m_x.color`
+  - each call site gets a specialized implementation, depending on the MetaArgs
+  - the metafunc returns an `OpSpec`, which describes which red function will be
+    called at runtime and with which arguments
+  - `OpSpec(func)` is the simple form: `func` will be called with the original
+    arguments as-is
+  - unsupported types raise `TypeError` at redshift time, not at runtime
   - this is how SPy's built-in `print` is implemented internally
+
+Note on `OpSpec` — the return value of metafuncs:
+  - `OpSpec(func)`: simple form — `func` is called with the original arguments
+  - `OpSpec(func, args)`: complex form — `func` is called with pre-filled arguments
+    (some values are baked in at redshift time)
+  - `OpSpec.const(value)`: the result is a compile-time constant, no call at runtime
+  - `OpSpec.NULL`: signals that this case is not handled
 """
 
 from operator import OpSpec

--- a/examples/2_metaprogramming/metafunc_variadic.spy
+++ b/examples/2_metaprogramming/metafunc_variadic.spy
@@ -1,10 +1,14 @@
 """
 Things to notice:
-  - `*args_m` in a `@blue.metafunc` captures all arguments as a tuple of meta-args
-  - the number of arguments is known at redshift time via `len(args_m)`
-  - each call site is specialized
-  - mismatched types (e.g. `mysum(1, 'hello')`) raise TypeError at redshift time —
-    uncomment the last lines to see the errors
+  - `*args_m` captures all MetaArgs as a tuple; the number of arguments is known
+    at redshift time via `len(args_m)`, enabling dispatch on it
+  - each call site is specialized on both the number and types of arguments
+  - `T = m0.static_type` captures the static type as a blue value, which can
+    then be used as a type annotation in the inner red function
+  - for blue arguments, `m_x.blueval` gives the actual compile-time value;
+    here all arguments are red so only `static_type` is used
+  - mismatched types (e.g. `mysum(1, 'hello')`) raise `TypeError` at redshift
+    time — uncomment the last lines to see the errors
 """
 
 from operator import OpSpec

--- a/examples/2_metaprogramming/metafunc_variadic.spy
+++ b/examples/2_metaprogramming/metafunc_variadic.spy
@@ -1,14 +1,14 @@
 """
 Things to notice:
   - `*args_m` captures all MetaArgs as a tuple; the number of arguments is known
-    at redshift time via `len(args_m)`, enabling dispatch on it
-  - each call site is specialized on both the number and types of arguments
+    at redshift time via `len(args_m)`, enabling dispatch on it.
+  - Each call site is specialized on both the number and types of arguments.
   - `T = m0.static_type` captures the static type as a blue value, which can
-    then be used as a type annotation in the inner red function
-  - for blue arguments, `m_x.blueval` gives the actual compile-time value;
-    here all arguments are red so only `static_type` is used
-  - mismatched types (e.g. `mysum(1, 'hello')`) raise `TypeError` at redshift
-    time — uncomment the last lines to see the errors
+    then be used as a type annotation in the inner red function.
+  - For blue arguments, `m_x.blueval` gives the actual compile-time value;
+    here all arguments are red so only `static_type` is used.
+  - Mismatched types (e.g. `mysum(1, 'hello')`) raise `TypeError` at redshift
+    time — uncomment the last lines to see the errors.
 """
 
 from operator import OpSpec

--- a/examples/2_metaprogramming/metafunc_variadic.spy
+++ b/examples/2_metaprogramming/metafunc_variadic.spy
@@ -1,3 +1,12 @@
+"""
+Things to notice:
+  - `*args_m` in a `@blue.metafunc` captures all arguments as a tuple of meta-args
+  - the number of arguments is known at redshift time via `len(args_m)`
+  - each call site is specialized
+  - mismatched types (e.g. `mysum(1, 'hello')`) raise TypeError at redshift time —
+    uncomment the last lines to see the errors
+"""
+
 from operator import OpSpec
 
 

--- a/examples/3_low_level/mem.spy
+++ b/examples/3_low_level/mem.spy
@@ -1,12 +1,12 @@
 """
 Things to notice:
   - ptr_copy, ptr_move, ptr_setbytes, ptr_cmp are the primary mem ops; they work
-    on ptr[T] for any type T, and count is expressed in items, not bytes
-  - each op has a _slice variant that avoids the need for pointer arithmetic:
-      ptr_copy_slice(dst, dstart, dend, src, sstart, send)
-  - ptr_copy panics on overlapping regions; use ptr_move when regions may overlap
-  - bounds are checked at runtime: out-of-bounds access panics
-  - gc_alloc is used here; the GC handles memory release automatically
+    on ptr[T] for any type T, and count is expressed in items, not bytes.
+  - Each op has a _slice variant that avoids the need for pointer arithmetic:
+    `ptr_copy_slice(dst, dstart, dend, src, sstart, send)`.
+  - `ptr_copy` panics on overlapping regions; use ptr_move when regions may overlap.
+  - Bounds are checked at runtime: out-of-bounds access panics.
+  - `gc_alloc` is used here; the GC handles memory release automatically.
 
 Note: memcpy, memmove, memset, memcmp are byte-only shims (ptr[u8]/ptr[i8])
 that mirror the C standard library.

--- a/examples/3_low_level/point.spy
+++ b/examples/3_low_level/point.spy
@@ -1,14 +1,14 @@
 """
 Things to notice:
-  - the unsafe module allows C-level direct memory access to pointers and
-    unsafe arrays
-  - structs map directly to C structs
-  - structs are passed by values (i.e. copied)
-  - most users will never have to deal with this directly: using the
+  - The unsafe module allows C-level direct memory access to pointers and
+    unsafe arrays.
+  - Structs map directly to C structs.
+  - Structs are passed by values (i.e. copied).
+  - Most users will never have to deal with this directly: using the
     `unsafe` module is the equivalent of writing C extensions or using
-    Cython
+    Cython.
 
-Exercise for the reader: write a Rect struct with two points, and check what its C layout
+Exercise for the reader: write a Rect struct with two points, and check what its C layout.
 """
 
 from unsafe import gc_ptr, gc_alloc

--- a/examples/3_low_level/point.spy
+++ b/examples/3_low_level/point.spy
@@ -2,7 +2,8 @@
 Things to notice:
   - the unsafe module allows C-level direct memory access to pointers and
     unsafe arrays
-  - @struct maps directly to C structs
+  - structs map directly to C structs
+  - structs are passed by values (i.e. copied)
   - most users will never have to deal with this directly: using the
     `unsafe` module is the equivalent of writing C extensions or using
     Cython

--- a/examples/4_advanced/annotated.spy
+++ b/examples/4_advanced/annotated.spy
@@ -1,3 +1,11 @@
+"""
+Things to notice:
+  - `Annotated` is a generic blue value (not a type) that wraps a type plus metadata
+  - `_extra` is captured as a blue `interp_tuple` — a tuple known entirely at redshift time
+  - `__convert_to__` is a metafunc that fires when the value is used where a `type` is expected
+  - this pattern shows how SPy can implement PEP 593-style annotations as a library,
+    without any built-in support
+"""
 from operator import OpSpec
 from __spy__ import interp_tuple
 

--- a/examples/4_advanced/annotated.spy
+++ b/examples/4_advanced/annotated.spy
@@ -6,6 +6,7 @@ Things to notice:
   - this pattern shows how SPy can implement PEP 593-style annotations as a library,
     without any built-in support
 """
+
 from operator import OpSpec
 from __spy__ import interp_tuple
 

--- a/examples/4_advanced/annotated.spy
+++ b/examples/4_advanced/annotated.spy
@@ -1,10 +1,10 @@
 """
 Things to notice:
-  - `Annotated` is a generic blue value (not a type) that wraps a type plus metadata
-  - `_extra` is captured as a blue `interp_tuple` — a tuple known entirely at redshift time
-  - `__convert_to__` is a metafunc that fires when the value is used where a `type` is expected
-  - this pattern shows how SPy can implement PEP 593-style annotations as a library,
-    without any built-in support
+  - `Annotated` is a generic blue value (not a type) that wraps a type plus metadata.
+  - `_extra` is captured as a blue `interp_tuple` — a tuple known entirely at redshift time.
+  - `__convert_to__` is a metafunc that fires when the value is used where a `type` is expected.
+  - This pattern shows how SPy can implement PEP 593-style annotations as a library,
+    without any built-in support.
 """
 
 from operator import OpSpec

--- a/examples/4_advanced/convert.spy
+++ b/examples/4_advanced/convert.spy
@@ -1,13 +1,13 @@
 """
 Things to notice:
   - `__convert_from__` is a metafunc that SPy calls automatically as a static method
-    when a value is used where a different type is expected (implicit conversion)
-  - it receives three MetaArgs: the expected type, the actual type, and the value
-  - it returns an `OpSpec` describing the conversion function to call
+    when a value is used where a different type is expected (implicit conversion).
+  - It receives three MetaArgs: the expected type, the actual type, and the value.
+  - It returns an `OpSpec` describing the conversion function to call.
   - `OpSpec.NULL` signals that this conversion is not supported for the given
-    types; SPy will then raise a type error at redshift time
-  - this mechanism allows user-defined types to integrate with SPy's type system
-    without any built-in support
+    types; SPy will then raise a type error at redshift time.
+  - This mechanism allows user-defined types to integrate with SPy's type system
+    without any built-in support.
 """
 
 from operator import OpSpec

--- a/examples/4_advanced/convert.spy
+++ b/examples/4_advanced/convert.spy
@@ -1,5 +1,13 @@
 """
-Example which shows how to use __convert_to__ and __convert_from__
+Things to notice:
+  - `__convert_from__` is a metafunc that SPy calls automatically as a static method
+    when a value is used where a different type is expected (implicit conversion)
+  - it receives three MetaArgs: the expected type, the actual type, and the value
+  - it returns an `OpSpec` describing the conversion function to call
+  - `OpSpec.NULL` signals that this conversion is not supported for the given
+    types; SPy will then raise a type error at redshift time
+  - this mechanism allows user-defined types to integrate with SPy's type system
+    without any built-in support
 """
 
 from operator import OpSpec

--- a/examples/4_advanced/generic_types.spy
+++ b/examples/4_advanced/generic_types.spy
@@ -1,0 +1,67 @@
+"""
+Things to notice:
+  - a generic type is defined with `@struct` and parameters between []: `class Pair[T]`
+  - under the hood, `Pair` is a `@blue.generic` type factory: `Pair[i32]` and
+    `Pair[str]` are two distinct concrete types, resolved at redshift time
+  - generic methods work just like regular methods: `T` is in scope as a type
+  - generic types can be nested: `Pair[Pair[i32]]` is valid
+  - structs are passed by value (copied); for reference semantics, use a gc_ptr
+    (see myarray.spy)
+"""
+
+
+@struct
+class Pair[T]:
+    first: T
+    second: T
+
+    # Self is the name of the concrete type
+    def swap(self) -> Self:
+        return Self(self.second, self.first)
+
+    def __repr__(self) -> str:
+        return "Pair[" + repr(self.first) + ", " + repr(self.second) + "]"
+
+
+# This generic class is just syntactic sugar for
+
+
+@blue.generic
+def PairWOSyntacticSugar(T):
+    @struct
+    class Self:
+        first: T
+        second: T
+
+        # Self is the name of the concrete type
+        def swap(self) -> Self:
+            return Self(self.second, self.first)
+
+        def __repr__(self) -> str:
+            return (
+                "PairWOSyntacticSugar["
+                + repr(self.first)
+                + ", "
+                + repr(self.second)
+                + "]"
+            )
+
+    return Self
+
+
+def main() -> None:
+    p = Pair[i32](1, 2)
+    print(p)
+
+    p2 = PairWOSyntacticSugar[i32](1, 2)
+    print(p2)
+
+    q = p.swap()
+    print(q)
+
+    s = Pair[str]("hello", "world")
+    print(s)
+
+    # nested generic types
+    p_of_p = Pair[Pair[i32]](p, q)
+    print(p_of_p)

--- a/examples/4_advanced/generic_types.spy
+++ b/examples/4_advanced/generic_types.spy
@@ -1,12 +1,12 @@
 """
 Things to notice:
-  - a generic type is defined with `@struct` and parameters between []: `class Pair[T]`
-  - under the hood, `Pair` is a `@blue.generic` type factory: `Pair[i32]` and
-    `Pair[str]` are two distinct concrete types, resolved at redshift time
-  - generic methods work just like regular methods: `T` is in scope as a type
-  - generic types can be nested: `Pair[Pair[i32]]` is valid
-  - structs are passed by value (copied); for reference semantics, use a gc_ptr
-    (see myarray.spy)
+  - A generic type is defined with `@struct` and parameters between []: `class Pair[T]`.
+  - Under the hood, `Pair` is a `@blue.generic` type factory: `Pair[i32]` and
+    `Pair[str]` are two distinct concrete types, resolved at redshift time.
+  - Generic methods work just like regular methods: `T` is in scope as a type.
+  - Generic types can be nested: `Pair[Pair[i32]]` is valid.
+  - Structs are passed by value (copied); for reference semantics, use a gc_ptr
+    (see myarray.spy).
 """
 
 

--- a/examples/4_advanced/generic_types.spy
+++ b/examples/4_advanced/generic_types.spy
@@ -1,6 +1,6 @@
 """
 Things to notice:
-  - A generic type is defined with `@struct` and parameters between []: `class Pair[T]`.
+  - A generic type is defined with parameters between []: `class Pair[T]`.
   - Under the hood, `Pair` is a `@blue.generic` type factory: `Pair[i32]` and
     `Pair[str]` are two distinct concrete types, resolved at redshift time.
   - Generic methods work just like regular methods: `T` is in scope as a type.

--- a/examples/4_advanced/myarray.spy
+++ b/examples/4_advanced/myarray.spy
@@ -1,12 +1,25 @@
 """
 This is one of the most advanced examples of SPy so far.
+It implements the basics of a generic array type using the low-level primitives
+introduced in the previous examples.
 
-It implements the basics of a generic array type.
-
-Note that structs are passed by values (i.e. copied).
+Things to notice:
+  - `Array1d[DTYPE]` is a generic struct — see generic_types.spy for an introduction
+    to generic types
+  - `Array1d` is a value type (passed by copy), but it holds a `gc_ptr` to `ArrayData`
+    which lives on the heap — so copying an `Array1d` is cheap (just a pointer copy)
+  - this is the current SPy idiom for objects that behave like references: wrap the
+    mutable heap-allocated data in a struct that holds a pointer to it
+  - `__new__` and `__make__` are the low-level constructor protocol for structs
+    (see point.spy and smallpoint.spy)
+  - `ptr_setbytes` and `ptr_copy` are used for efficient bulk memory operations
 """
 
 from unsafe import gc_alloc, gc_ptr, ptr_setbytes, ptr_copy
+
+# Remember that these generic types are just @blue.generic type factories
+# parametrized with DTYPE.
+# Note that the name of the concrete type is always "Self".
 
 
 @struct
@@ -14,23 +27,6 @@ class ArrayData[DTYPE]:
     length: i32
     capacity: i32
     items: gc_ptr[DTYPE]
-
-
-"""
-This generic class is just syntactic sugar for
-
-@blue.generic
-def ArrayData(DTYPE):
-    @struct
-    class Self:
-        length: i32
-        capacity: i32
-        items: gc_ptr[DTYPE]
-
-    return Self
-
-Note that the name of the concrete type is always "Self".
-"""
 
 
 @struct

--- a/examples/4_advanced/myarray.spy
+++ b/examples/4_advanced/myarray.spy
@@ -6,7 +6,7 @@ It implements the basics of a generic array type.
 Note that structs are passed by values (i.e. copied).
 """
 
-from unsafe import gc_alloc, gc_ptr
+from unsafe import gc_alloc, gc_ptr, ptr_setbytes, ptr_copy
 
 
 @struct
@@ -46,10 +46,7 @@ class Array1d[DTYPE]:
         ll.length = length
         ll.capacity = length
         ll.items = gc_alloc[DTYPE](length)
-        i = 0
-        while i < length:
-            ll.items[i] = 0
-            i = i + 1
+        ptr_setbytes(ll.items, 0, length)
         return Self.__make__(ll)
 
     def append(self, value: DTYPE) -> None:
@@ -61,10 +58,7 @@ class Array1d[DTYPE]:
                 new_capacity = 1
             new_items = gc_alloc[DTYPE](new_capacity)
             # copy existing items
-            i = 0
-            while i < ll.length:
-                new_items[i] = ll.items[i]
-                i = i + 1
+            ptr_copy(new_items, ll.items, ll.length)
             ll.items = new_items
             ll.capacity = new_capacity
 

--- a/examples/4_advanced/myarray.spy
+++ b/examples/4_advanced/myarray.spy
@@ -5,14 +5,14 @@ introduced in the previous examples.
 
 Things to notice:
   - `Array1d[DTYPE]` is a generic struct — see generic_types.spy for an introduction
-    to generic types
+    to generic types.
   - `Array1d` is a value type (passed by copy), but it holds a `gc_ptr` to `ArrayData`
-    which lives on the heap — so copying an `Array1d` is cheap (just a pointer copy)
-  - this is the current SPy idiom for objects that behave like references: wrap the
-    mutable heap-allocated data in a struct that holds a pointer to it
+    which lives on the heap — so copying an `Array1d` is cheap (just a pointer copy).
+  - This is the current SPy idiom for objects that behave like references: wrap the
+    mutable heap-allocated data in a struct that holds a pointer to it.
   - `__new__` and `__make__` are the low-level constructor protocol for structs
-    (see point.spy and smallpoint.spy)
-  - `ptr_setbytes` and `ptr_copy` are used for efficient bulk memory operations
+    (see point.spy and smallpoint.spy).
+  - `ptr_setbytes` and `ptr_copy` are used for efficient bulk memory operations.
 """
 
 from unsafe import gc_alloc, gc_ptr, ptr_setbytes, ptr_copy

--- a/examples/4_advanced/myarray.spy
+++ b/examples/4_advanced/myarray.spy
@@ -1,9 +1,9 @@
 """
 This is one of the most advanced examples of SPy so far.
 
-It implements the basics of a generic array type
+It implements the basics of a generic array type.
 
-Note that struct are passed by values (i.e. copied).
+Note that structs are passed by values (i.e. copied).
 """
 
 from unsafe import gc_alloc, gc_ptr

--- a/examples/4_advanced/type_name_and_fqn.spy
+++ b/examples/4_advanced/type_name_and_fqn.spy
@@ -1,3 +1,13 @@
+"""
+Things to notice:
+  - SPy types carry several name attributes at different levels of qualification
+  - `__full_fqn__` includes the module path; `__fqn__` is shorter; `__qualname__`
+    and `__name__` follow Python conventions
+  - for generic types, the type argument is part of the name (e.g. `Foo[i32]`)
+  - this is useful for debugging, error messages, and metaprogramming
+"""
+
+
 @struct
 class Foo[T]:
     pass

--- a/examples/4_advanced/type_name_and_fqn.spy
+++ b/examples/4_advanced/type_name_and_fqn.spy
@@ -3,8 +3,8 @@ Things to notice:
   - SPy types carry several name attributes at different levels of qualification
   - `__full_fqn__` includes the module path; `__fqn__` and `__qualname__` are shorter;
     `__name__` follows Python conventions
-  - for generic types, the type argument is part of the name (e.g. `Foo[i32]`)
-  - this is useful for debugging, error messages, and metaprogramming
+  - For generic types, the type argument is part of the name (e.g. `Foo[i32]`).
+  - This is useful for debugging, error messages, and metaprogramming.
 """
 
 

--- a/examples/4_advanced/type_name_and_fqn.spy
+++ b/examples/4_advanced/type_name_and_fqn.spy
@@ -1,8 +1,8 @@
 """
 Things to notice:
   - SPy types carry several name attributes at different levels of qualification
-  - `__full_fqn__` includes the module path; `__fqn__` is shorter; `__qualname__`
-    and `__name__` follow Python conventions
+  - `__full_fqn__` includes the module path; `__fqn__` and `__qualname__` are shorter;
+    `__name__` follows Python conventions
   - for generic types, the type argument is part of the name (e.g. `Foo[i32]`)
   - this is useful for debugging, error messages, and metaprogramming
 """

--- a/examples/expected_output/generic_types.txt
+++ b/examples/expected_output/generic_types.txt
@@ -1,0 +1,5 @@
+Pair[1, 2]
+PairWOSyntacticSugar[1, 2]
+Pair[2, 1]
+Pair['hello', 'world']
+Pair[Pair[1, 2], Pair[2, 1]]

--- a/examples/expected_output/var_const.txt
+++ b/examples/expected_output/var_const.txt
@@ -1,0 +1,7 @@
+COLOR(LIMIT) blue
+COLOR(LIMIT2) blue
+COLOR(LIMIT3) blue
+COLOR(LIMIT4) red
+N+1: 11
+counter: 0
+counter: 5

--- a/playground/main.py
+++ b/playground/main.py
@@ -313,6 +313,7 @@ def main():
                     RunSPyButton("redshift"),
                     RunSPyButton("redshift --linearize"),
                     RunSPyButton("redshift --full-fqn"),
+                    RunSPyButton("redshift --execute"),
                     RunSPyButton("build --cdump"),
                 ).css({"display": "flex", "gap": "5px", "vertical-align": "bottom"}),
             ).css(

--- a/playground/pyscript.toml
+++ b/playground/pyscript.toml
@@ -25,6 +25,7 @@ packages = [ "micropip"]
 "./examples/3_low_level/smallpoint.spy" = "examples/3_low_level/"
 "./examples/3_low_level/mem.spy" = "examples/3_low_level/"
 
+"./examples/4_advanced/generic_types.spy" = "examples/4_advanced/"
 "./examples/4_advanced/myarray.spy" = "examples/4_advanced/"
 "./examples/4_advanced/convert.spy" = "examples/4_advanced/"
 "./examples/4_advanced/type_name_and_fqn.spy" = "examples/4_advanced/"

--- a/playground/pyscript.toml
+++ b/playground/pyscript.toml
@@ -6,11 +6,13 @@ packages = [ "micropip"]
 
 "./examples/1_high_level/hello.spy" = "examples/1_high_level/"
 "./examples/1_high_level/hello_add.spy" = "examples/1_high_level/"
-"./examples/1_high_level/fibo.spy" = "examples/1_high_level/"
+"./examples/1_high_level/var_const.spy" = "examples/1_high_level/"
 "./examples/1_high_level/factorial.spy" = "examples/1_high_level/"
+"./examples/1_high_level/fibo.spy" = "examples/1_high_level/"
+"./examples/1_high_level/exit_code.spy" = "examples/1_high_level/"
 "./examples/1_high_level/collections.spy" = "examples/1_high_level/"
 "./examples/1_high_level/str_bytes.spy" = "examples/1_high_level/"
-"./examples/1_high_level/exit_code.spy" = "examples/1_high_level/"
+"./examples/1_high_level/fileio.spy" = "examples/1_high_level/"
 
 "./examples/2_metaprogramming/bluefunc_pi.spy" = "examples/2_metaprogramming/"
 "./examples/2_metaprogramming/bluefunc_adder.spy" = "examples/2_metaprogramming/"
@@ -24,9 +26,9 @@ packages = [ "micropip"]
 "./examples/3_low_level/mem.spy" = "examples/3_low_level/"
 
 "./examples/4_advanced/myarray.spy" = "examples/4_advanced/"
-"./examples/4_advanced/annotated.spy" = "examples/4_advanced/"
 "./examples/4_advanced/convert.spy" = "examples/4_advanced/"
 "./examples/4_advanced/type_name_and_fqn.spy" = "examples/4_advanced/"
+"./examples/4_advanced/annotated.spy" = "examples/4_advanced/"
 "./examples/4_advanced/unroll_nested_loops.spy" = "examples/4_advanced/"
 
 "https://raw.githubusercontent.com/pyscript/ltk/main/ltk/jquery.py" = "ltk/jquery.py"


### PR DESCRIPTION
This PR improves the playground as a self-guided tour of SPy. I reordered examples to follow a pedagogical progression, added docstrings with "Things to notice:" to all examples, added few examples (`var_const.spy` and `generic_types.spy`), and added a `redshift --execute` button.

I used Claude to get more polished and clearer explanations.