### PR TITLE
546 argv passthrough

### DIFF
--- a/spy/cli/cli.py
+++ b/spy/cli/cli.py
@@ -26,9 +26,9 @@ app = SpyTyper(
 
 # This is the order commands will appear in the --help
 
-app.spy_command(execute, name="execute", default=True)
-app.spy_command(build, name="build")
-app.spy_command(redshift, name="redshift | rs")
+app.spy_command(execute, name="execute", default=True, strict_argv=True)
+app.spy_command(build, name="build", strict_argv=True)
+app.spy_command(redshift, name="redshift | rs", strict_argv=True)
 app.spy_command(colorize, name="colorize")
 app.spy_command(parse, name="parse")
 app.spy_command(pyparse, name="pyparse")

--- a/spy/cli/commands/build.py
+++ b/spy/cli/commands/build.py
@@ -182,7 +182,7 @@ async def build(args: Build_Args) -> None:
 
     if args.execute:
         with timer() if args.timeit else nullcontext():
-            subprocess.run([str(executable)])
+            subprocess.run([str(executable)] + (args.argv or []))
 
 
 def get_build_dir(args: Build_Args) -> py.path.local:

--- a/spy/cli/spy_typer.py
+++ b/spy/cli/spy_typer.py
@@ -19,8 +19,18 @@ from spy.cli.commands.shared_args import Base_Args
 from spy.vendored.dataclass_typer import dataclass_typer
 
 
-class TyperDefaultCommand(typer.core.TyperCommand):
+class TyperStrictParseCommand(typer.core.TyperCommand):
+    def make_parser(self, ctx: click.Context) -> click.OptionParser:
+        """Creates the underlying option parser for this command."""
+        ctx.allow_interspersed_args = False
+        return super().make_parser(ctx)
+
+
+class TyperDefaultCommand(TyperStrictParseCommand):
     """Type that indicates if a command is the default command."""
+
+
+class TyperStrictDefaultCommand(TyperDefaultCommand, TyperStrictParseCommand): ...
 
 
 class SpyGroupConfig(TyperGroup):
@@ -110,6 +120,10 @@ class SpyGroupConfig(TyperGroup):
                 return cmd.name
         return lookup_name
 
+    def parse_args(self, ctx, args):
+        ctx.obj = {"args": args}
+        return super().parse_args(ctx, args)
+
 
 class SpyTyper(typer.Typer):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -120,14 +134,28 @@ class SpyTyper(typer.Typer):
         super().__init__(*args, **kwargs)
 
     def _command_with_default_option(
-        self: typer.Typer, default: bool = False, *args: Any, **kwargs: Any
+        self: typer.Typer,
+        default: bool = False,
+        strict_argv=False,
+        *args: Any,
+        **kwargs: Any,
     ) -> Callable[[CommandFunctionType], CommandFunctionType]:
         """
         Allow spy_command() to take a "default" argument, which marks
         a single subcommand to be selected if none is provided
+
+        Allow spy_command() to take a "strict_argv" argument, which
+        ensures that any options or flags after the filename(s) are
+        passed to argv for execution
         """
         if default:
-            kwargs["cls"] = TyperDefaultCommand
+            if strict_argv:
+                kwargs["cls"] = TyperStrictDefaultCommand
+            else:
+                kwargs["cls"] = TyperDefaultCommand
+        else:
+            if strict_argv:
+                kwargs["cls"] = TyperStrictParseCommand
         return super().command(*args, **kwargs)  # type: ignore
 
     def spy_command(self, user_func: Any, /, *cmd_args, **cmd_kwargs) -> Callable:  # type: ignore

--- a/spy/cli/spy_typer.py
+++ b/spy/cli/spy_typer.py
@@ -43,7 +43,7 @@ class TyperStrictParseCommand(typer.core.TyperCommand):
         possible_error_args: list[str] = [
             arg
             for arg in ctx.params["argv"]
-            if any(arg.lstrip(prefix) in ctx.params for prefix in ctx._opt_prefixes)
+            if any(arg in param.opts for param in ctx.command.params)
         ]
         if possible_error_args:
             print(

--- a/spy/cli/spy_typer.py
+++ b/spy/cli/spy_typer.py
@@ -25,6 +25,19 @@ class TyperStrictParseCommand(typer.core.TyperCommand):
         ctx.allow_interspersed_args = False
         return super().make_parser(ctx)
 
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        args = super().parse_args(ctx, args)
+        possible_error_args = [
+            arg
+            for arg in ctx.params["argv"]
+            if arg.lstrip(ctx._opt_prefixes) in ctx.params
+        ]  # TODO this is not correct
+        if possible_error_args:
+            print(
+                f"{','.join(possible_error_args)} passed to 'spy {ctx.command.name} as part of argv; to pass it as a flag, it must proceeed the .spy file name"
+            )
+        return args
+
 
 class TyperDefaultCommand(TyperStrictParseCommand):
     """Type that indicates if a command is the default command."""

--- a/spy/cli/spy_typer.py
+++ b/spy/cli/spy_typer.py
@@ -21,20 +21,33 @@ from spy.vendored.dataclass_typer import dataclass_typer
 
 class TyperStrictParseCommand(typer.core.TyperCommand):
     def make_parser(self, ctx: click.Context) -> click.OptionParser:
-        """Creates the underlying option parser for this command."""
+        """
+        Turn off allow_interspersed_argsd for just this command, which
+        forces positional args and options to be separate. In particular,
+        this ensures that any values following the filename are
+        passed to argv instead of parsed as flags, even if they have the same name
+
+        spy execute a.spy --timeit --> argv[1] == "--timeit"
+        """
         ctx.allow_interspersed_args = False
         return super().make_parser(ctx)
 
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        """
+        Show a hint if any of the values in argv match any of the possible option flags
+
+        >>> spy execute a.spy --timeit
+        '--timeit' passed to 'spy execute' as part of argv; to pass it as a flag, it must proceeed the .spy file name
+        """
         args = super().parse_args(ctx, args)
-        possible_error_args = [
+        possible_error_args: list[str] = [
             arg
             for arg in ctx.params["argv"]
-            if arg.lstrip(ctx._opt_prefixes) in ctx.params
-        ]  # TODO this is not correct
+            if any(arg.lstrip(prefix) in ctx.params for prefix in ctx._opt_prefixes)
+        ]
         if possible_error_args:
             print(
-                f"{','.join(possible_error_args)} passed to 'spy {ctx.command.name} as part of argv; to pass it as a flag, it must proceeed the .spy file name"
+                f"{','.join(f"'{arg}'" for arg in possible_error_args)} passed to 'spy {ctx.command.name}' as part of argv; to pass it as a flag, it must proceeed the .spy file name"
             )
         return args
 
@@ -133,10 +146,6 @@ class SpyGroupConfig(TyperGroup):
                 return cmd.name
         return lookup_name
 
-    def parse_args(self, ctx, args):
-        ctx.obj = {"args": args}
-        return super().parse_args(ctx, args)
-
 
 class SpyTyper(typer.Typer):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -149,7 +158,7 @@ class SpyTyper(typer.Typer):
     def _command_with_default_option(
         self: typer.Typer,
         default: bool = False,
-        strict_argv=False,
+        strict_argv: bool = False,
         *args: Any,
         **kwargs: Any,
     ) -> Callable[[CommandFunctionType], CommandFunctionType]:

--- a/spy/cli/spy_typer.py
+++ b/spy/cli/spy_typer.py
@@ -32,25 +32,6 @@ class TyperStrictParseCommand(typer.core.TyperCommand):
         ctx.allow_interspersed_args = False
         return super().make_parser(ctx)
 
-    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
-        """
-        Show a hint if any of the values in argv match any of the possible option flags
-
-        >>> spy execute a.spy --timeit
-        '--timeit' passed to 'spy execute' as part of argv; to pass it as a flag, it must proceeed the .spy file name
-        """
-        args = super().parse_args(ctx, args)
-        possible_error_args: list[str] = [
-            arg
-            for arg in ctx.params["argv"]
-            if any(arg in param.opts for param in ctx.command.params)
-        ]
-        if possible_error_args:
-            print(
-                f"{','.join(f"'{arg}'" for arg in possible_error_args)} passed to 'spy {ctx.command.name}' as part of argv; to pass it as a flag, it must proceeed the .spy file name"
-            )
-        return args
-
 
 class TyperDefaultCommand(TyperStrictParseCommand):
     """Type that indicates if a command is the default command."""

--- a/spy/tests/test_cli.py
+++ b/spy/tests/test_cli.py
@@ -135,12 +135,17 @@ class TestMain:
         """
         test = self.write("test.spy", src)
         argsets = [["execute"], []]  # No subcommand is equivalent to execute command
-        for argset in argsets:
-            _, stdout = self.run(*argset, test, "1", "--timeit", "2")
 
-            # --timeit appears in argc and not as flag
-            assert "1 +\n--timeit +\n2" in stdout
-            assert "seconds" not in stdout
+        _, stdout = self.run("execute", test, "1", "--timeit", "2")
+        # --timeit appears in argc and not as flag
+        assert "1 +\n--timeit +\n2" in stdout
+        assert "seconds" not in stdout
+
+        # Default command is execute - make sure the default action also doesn't affect argv
+        _, stdout = self.run(test, "1", "--timeit", "2")
+        # --timeit appears in argc and not as flag
+        assert "1 +\n--timeit +\n2" in stdout
+        assert "seconds" not in stdout
 
     def test_timeit(self):
         _, stdout = self.run("--timeit", self.main_spy)
@@ -428,18 +433,6 @@ class TestMain:
         status, out = getstatusoutput(f"{test_exe} aaa bbb ccc")
         assert out.split() == [str(test_exe), "aaa", "bbb", "ccc"]
 
-    def test_compile_argv_strict(self):
-        src = """
-        def main(argv: list[str]) -> None:
-            for a in argv:
-                print(a)
-        """
-        f = self.write("test.spy", src)
-        res = self.runner.invoke(app, ["build", "-x", str(f), "--timeit"])
-        assert res.exit_code == 0
-        output = decolorize(res.output)
-        assert "'--timeit' passed to 'spy build" in output
-
     def test_compile_argv_unused(self):
         src = """
         def main(argv: list[str]) -> i32:
@@ -458,13 +451,9 @@ class TestMain:
                 print(a)
         """
         f = self.write("test.spy", src)
-        res = self.runner.invoke(app, ["redshift", "-x", str(f), "aaa", "bbb", "ccc"])
+        res = self.runner.invoke(
+            app, ["redshift", "-x", str(f), "aaa", "bbb", "ccc", "--timeit"]
+        )
         assert res.exit_code == 0
         output = decolorize(res.output)
-        assert output.split() == [str(f), "aaa", "bbb", "ccc"]
-
-        # Test that --timeit is passed in argv instead of as flag
-        res = self.runner.invoke(app, ["redshift", "-x", str(f), "--timeit"])
-        assert res.exit_code == 0
-        output = decolorize(res.output)
-        assert "'--timeit' passed to 'spy redshift" in output
+        assert output.split() == [str(f), "aaa", "bbb", "ccc", "--timeit"]

--- a/spy/tests/test_cli.py
+++ b/spy/tests/test_cli.py
@@ -428,6 +428,18 @@ class TestMain:
         status, out = getstatusoutput(f"{test_exe} aaa bbb ccc")
         assert out.split() == [str(test_exe), "aaa", "bbb", "ccc"]
 
+    def test_compile_argv_strict(self):
+        src = """
+        def main(argv: list[str]) -> None:
+            for a in argv:
+                print(a)
+        """
+        f = self.write("test.spy", src)
+        res = self.runner.invoke(app, ["build", "-x", str(f), "--timeit"])
+        assert res.exit_code == 0
+        output = decolorize(res.output)
+        assert "'--timeit' passed to 'spy build" in output
+
     def test_redshift_argv(self):
         src = """
         def main(argv: list[str]) -> None:
@@ -435,9 +447,13 @@ class TestMain:
                 print(a)
         """
         f = self.write("test.spy", src)
-        res = self.runner.invoke(
-            app, ["redshift", "-x", str(f), "aaa", "bbb", "ccc", "--timeit"]
-        )
+        res = self.runner.invoke(app, ["redshift", "-x", str(f), "aaa", "bbb", "ccc"])
         assert res.exit_code == 0
         output = decolorize(res.output)
-        assert output.split() == [str(f), "aaa", "bbb", "ccc", "--timeit"]
+        assert output.split() == [str(f), "aaa", "bbb", "ccc"]
+
+        # Test that --timeit is passed in argv instead of as flag
+        res = self.runner.invoke(app, ["redshift", "-x", str(f), "--timeit"])
+        assert res.exit_code == 0
+        output = decolorize(res.output)
+        assert "'--timeit' passed to 'spy redshift" in output

--- a/spy/tests/test_cli.py
+++ b/spy/tests/test_cli.py
@@ -134,7 +134,6 @@ class TestMain:
                 print(s, "+") # Separate argv so we're sure we're not just seeing the input on the command line
         """
         test = self.write("test.spy", src)
-        argsets = [["execute"], []]  # No subcommand is equivalent to execute command
 
         _, stdout = self.run("execute", test, "1", "--timeit", "2")
         # --timeit appears in argc and not as flag

--- a/spy/tests/test_cli.py
+++ b/spy/tests/test_cli.py
@@ -131,13 +131,16 @@ class TestMain:
         src = """
         def main(argv: list[str]) -> None:
             for s in argv:
-                print(s) # Separate argv so we're sure we're not just seeing the input on the command line
+                print(s, "+") # Separate argv so we're sure we're not just seeing the input on the command line
         """
-        f = self.write("test.spy", src)
+        test = self.write("test.spy", src)
         argsets = [["execute"], []]  # No subcommand is equivalent to execute command
         for argset in argsets:
-            _, stdout = self.run(*argset, self.test.spy, "--timeit")
-            assert stdout == "hello world\n"
+            _, stdout = self.run(*argset, test, "1", "--timeit", "2")
+
+            # --timeit appears in argc and not as flag
+            assert "1 +\n--timeit +\n2" in stdout
+            assert "seconds" not in stdout
 
     def test_timeit(self):
         _, stdout = self.run("--timeit", self.main_spy)
@@ -432,7 +435,9 @@ class TestMain:
                 print(a)
         """
         f = self.write("test.spy", src)
-        res = self.runner.invoke(app, ["redshift", "-x", str(f), "aaa", "bbb", "ccc"])
+        res = self.runner.invoke(
+            app, ["redshift", "-x", str(f), "aaa", "bbb", "ccc", "--timeit"]
+        )
         assert res.exit_code == 0
         output = decolorize(res.output)
-        assert output.split() == [str(f), "aaa", "bbb", "ccc"]
+        assert output.split() == [str(f), "aaa", "bbb", "ccc", "--timeit"]

--- a/spy/tests/test_cli.py
+++ b/spy/tests/test_cli.py
@@ -127,6 +127,18 @@ class TestMain:
             _, stdout = self.run(*argset, self.main_spy)
             assert stdout == "hello world\n"
 
+    def test_execute_argv(self):
+        src = """
+        def main(argv: list[str]) -> None:
+            for s in argv:
+                print(s) # Separate argv so we're sure we're not just seeing the input on the command line
+        """
+        f = self.write("test.spy", src)
+        argsets = [["execute"], []]  # No subcommand is equivalent to execute command
+        for argset in argsets:
+            _, stdout = self.run(*argset, self.test.spy, "--timeit")
+            assert stdout == "hello world\n"
+
     def test_timeit(self):
         _, stdout = self.run("--timeit", self.main_spy)
         assert "main()" in stdout
@@ -288,6 +300,30 @@ class TestMain:
         # by the test runner, check the output from timeit instead
         out, err = capfd.readouterr()
         assert "hello world" in out
+
+    def test_build_execute_argv(self, capfd):
+        src = """
+        def main(argv: list[str]) -> None:
+            for s in argv:
+                print(s, "+") # Separate argv so we're sure we're not just seeing the input on the command line
+        """
+        f = self.write("test.spy", src)
+        res, stdout = self.run(
+            "build",
+            "-x",
+            "--target", "native",
+            "--build-dir", self.tmpdir,
+            f,
+            "1",
+            "2",
+            "--timeit"
+        )  # fmt: skip
+        # hack hack hack since the stdout of the subprocess isn't captured
+        # by the test runner, check the output from timeit instead
+        out, err = capfd.readouterr()
+        # --timeit should be passed to the program as argv, not a flag for SPy
+        assert "1 +\n2 +\n--timeit" in out
+        assert "seconds" not in out
 
     @pytest.mark.skipif(PYODIDE_EXE is None, reason="./pyodide/venv not found")
     @pytest.mark.pyodide


### PR DESCRIPTION
This PR makes 3 changes to the CLI. Let me illustrate them with some sample code:

1. `spy build -x` now passes any values after the filename to the newly-built executable as agrv when it is run
1. The `execute`, `redshift`, and `build` commands treat all values after the filename as values to be passed to`argv`. (Redshift is included since it also has execution mode, but it's an easy change if we want to not include it.)
1.  For those 3 commands, if any of the values after the filename exactly match an option flag for the command, a warning is printed.

Here's how that last options appears in practice:

```py
#foo.spy
def main(argv: list[str]) -> None:
    for s in argv:
        print(s)


$ spy build -x foo.spy a b --timeit
'--timeit' passed to 'spy build' as part of argv; to pass it as a flag, it must proceeed the .spy file name
[debug] build/foo 
build/foo
a
b
--timeit
```

@seibert Does this suit your needs?

Closes #546