### PR TITLE
Implement function keyword args

### DIFF
--- a/examples/1_high_level/hello_sub.spy
+++ b/examples/1_high_level/hello_sub.spy
@@ -1,0 +1,13 @@
+"""
+Things to notice:
+  - keyword args can be passed in any order
+  - after redshift, keyword args are reordered
+"""
+
+
+def sub(x: i32, y:i32, z: i32) -> i32:
+    return x - (y - z)
+
+def main() -> None:
+    print("Hello from SPy 🥸")
+    print(sub(100, z=10, y=20))

--- a/examples/1_high_level/kwargs.spy
+++ b/examples/1_high_level/kwargs.spy
@@ -4,10 +4,9 @@ Things to notice:
   - after redshift, keyword args are reordered
 """
 
-
-def sub(x: i32, y:i32, z: i32) -> i32:
-    return x - (y - z)
+def compute(x: i32, y:i32, z: i32) -> i32:
+    return 100 * x + 10 * y + z
 
 def main() -> None:
     print("Hello from SPy 🥸")
-    print(sub(100, z=10, y=20))
+    print(compute(1, z=5, y=3))

--- a/examples/1_high_level/x.spy
+++ b/examples/1_high_level/x.spy
@@ -1,0 +1,6 @@
+
+def f(a: i32) -> i32:
+    return a * 2
+
+def main() -> None:
+    f()

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -411,6 +411,7 @@ class Call(Expr):
     precedence = 16
     func: Expr
     args: list[Expr]
+    kwargs: list[tuple[StrLiteral, Expr]] = field(default_factory=list)
 
 
 @astnode
@@ -427,6 +428,7 @@ class CallMethod(Expr):
     target: Expr
     method: StrLiteral
     args: list[Expr]
+    kwargs: list[tuple[StrLiteral, Expr]] = field(default_factory=list)
 
 
 @astnode

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -674,6 +674,7 @@ class DopplerFrame(ASTFrame):
         v_obj = self.shifted_expr[op.target]
         v_meth = self.shifted_expr[op.method]
         newargs_v = [self.shifted_expr[arg] for arg in op.args]
+        newargs_v += [self.shifted_expr[arg] for _, arg in op.kwargs]
         return self.shift_opimpl(op, w_opimpl, [v_obj, v_meth] + newargs_v)
 
     def eval_expr_BlockExpr(self, block: ast.BlockExpr) -> W_MetaArg:

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -661,6 +661,7 @@ class DopplerFrame(ASTFrame):
         w_opimpl = self.opimpl[call]
         newfunc = self.shifted_expr[call.func]
         newargs = [self.shifted_expr[arg] for arg in call.args]
+        newargs += [self.shifted_expr[arg] for _, arg in call.kwargs]
 
         if self.special_calls.get(call) in ("getattr", "hasattr", "setattr"):
             # see also the corresponding code in ASTFrame.eval_expr_Call.

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -836,16 +836,29 @@ class Parser:
     ) -> spy.ast.Call | spy.ast.CallMethod | spy.ast.BlockExpr:
         if isinstance(py_node.func, py_ast.Name) and py_node.func.id == "__block__":
             return self._parse_block_expr(py_node)
+        kwargs: list[tuple[spy.ast.StrLiteral, spy.ast.Expr]] = []
         if py_node.keywords:
-            self.unsupported(py_node.keywords[0], "keyword arguments")
+            for py_kw in py_node.keywords:
+                if py_kw.arg == None:
+                    self.unsupported(py_kw, "** var-keyword arguments")
+                kwargs.append(
+                    (
+                        spy.ast.StrLiteral(py_kw.loc, py_kw.arg),
+                        self.from_py_expr(py_kw.value),
+                    )
+                )
         func = self.from_py_expr(py_node.func)
         args = [self.from_py_expr(py_arg) for py_arg in py_node.args]
         if isinstance(func, spy.ast.GetAttr):
             return spy.ast.CallMethod(
-                loc=py_node.loc, target=func.value, method=func.attr, args=args
+                loc=py_node.loc,
+                target=func.value,
+                method=func.attr,
+                args=args,
+                kwargs=kwargs,
             )
         else:
-            return spy.ast.Call(loc=py_node.loc, func=func, args=args)
+            return spy.ast.Call(loc=py_node.loc, func=func, args=args, kwargs=kwargs)
 
     def _parse_block_expr(self, py_node: py_ast.Call) -> spy.ast.BlockExpr:
         if (

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -456,6 +456,27 @@ class TestBasic(CompilerTest):
         """)
         assert mod.bar(3) == 1.5
 
+    def test_function_call_keywords(self):
+        mod = self.compile("""
+        def foo(small: i32, big: i32) -> i32:
+            return big - small
+
+        def bar(big: i32) -> i32:
+            return foo(big=big, small=7)
+        """)
+        assert mod.bar(10) == 3
+        assert mod.bar(15) == 8
+
+    def test_function_call_pos_with_keywords(self):
+        mod = self.compile("""
+        def foo(a: i32, b: i32, c: i32) -> i32:
+            return a - b // c
+
+        def bar(a: i32, b: i32, c: i32) -> i32:
+            return foo(a, c=c, b=b)
+        """)
+        assert mod.bar(1, 10, 5) == -1
+
     def test_conversions(self):
         mod = self.compile("""
         def a(x: i32) -> f64:
@@ -531,9 +552,8 @@ class TestBasic(CompilerTest):
             return inc()
         """
         errors = expect_errors(
-            "this function takes 1 argument but 0 arguments were supplied",
-            ("1 argument missing", "inc"),
-            ("function defined here", "def inc(x: i32) -> i32"),
+            "inc() missing required argument `x`",
+            ("missing required argument", "x: i32"),
         )
         self.compile_raises(src, "foo", errors)
 
@@ -1533,9 +1553,8 @@ class TestBasic(CompilerTest):
             return add()
         """
         errors = expect_errors(
-            "this function takes from 1 to 2 arguments but 0 arguments were supplied",
-            ("1 argument missing", "add"),
-            ("function defined here", "def add(x: int, y: int = 1) -> int"),
+            "add() missing required argument `x`",
+            ("missing required argument", "x: int"),
         )
         self.compile_raises(src, "foo", errors)
 

--- a/spy/tests/compiler/test_struct.py
+++ b/spy/tests/compiler/test_struct.py
@@ -246,6 +246,23 @@ class TestStructOnStack(CompilerTest):
         assert mod.movex0(3, 7) == (4, 7)
         assert mod.movexy(3, 7) == (4, 8)
 
+    def test_method_keyword_args(self):
+        src = """
+        @struct
+        class Point:
+            x: i32
+            y: i32
+
+            def move(self, dx: i32, dy: i32) -> Point:
+                return Point(self.x + dx, self.y + dy)
+
+        def foo(x: i32, y: i32, dx: i32, dy: i32) -> Point:
+            p = Point(x, y)
+            return p.move(dy=dy, dx=dx)
+        """
+        mod = self.compile(src)
+        assert mod.foo(3, 7, 1, 2) == (4, 9)
+
     def test_default_eq(self):
         src = """
         @struct

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -239,6 +239,7 @@ class TestParser:
                     args=[
                         Name(id='arg'),
                     ],
+                    kwargs=[],
                 ),
             ],
         )
@@ -975,20 +976,43 @@ class TestParser:
                     Literal(value=2),
                     Literal(value=3),
                 ],
+                kwargs=[],
             ),
         )
         """
         self.assert_dump(stmt, expected)
 
-    def test_Call_errors(self):
-        src = """
+    def test_Call_kwargs(self):
+        mod = self.parse("""
         def foo() -> i32:
             return Bar(1, 2, x=3)
+        """)
+        stmt = mod.get_funcdef("foo").body[0]
+        expected = """
+        Return(
+            value=Call(
+                func=Name(id='Bar'),
+                args=[
+                    Literal(value=1),
+                    Literal(value=2),
+                ],
+                kwargs=[
+                    (StrLiteral(w_T=None, value='x'), Literal(w_T=None, value=3)),
+                ],
+            ),
+        )
+        """
+        self.assert_dump(stmt, expected)
+
+    def test_Call_double_star_kwargs_unsupported(self):
+        src = """
+        def foo() -> i32:
+            return bar(1, **kwargs)
         """
         self.expect_errors(
             src,
-            "not implemented yet: keyword arguments",
-            ("this is not supported", "x=3"),
+            "not implemented yet: ** var-keyword arguments",
+            ("this is not supported", "**kwargs"),
         )
 
     def test_CallMethod(self):
@@ -1006,6 +1030,7 @@ class TestParser:
                     Literal(value=1),
                     Literal(value=2),
                 ],
+                kwargs=[],
             ),
         )
         """
@@ -1128,6 +1153,7 @@ class TestParser:
                 args=[
                     Literal(value=10),
                 ],
+                kwargs=[],
             ),
             body=[
                 Pass(),
@@ -1221,6 +1247,7 @@ class TestParser:
                 args=[
                     StrLiteral(value='error message'),
                 ],
+                kwargs=[],
             ),
         )
         """
@@ -1714,6 +1741,7 @@ class TestParser:
                 args=[
                     Literal(value=10),
                 ],
+                kwargs=[],
             ),
             body=[
                 If(
@@ -1749,6 +1777,7 @@ class TestParser:
                 args=[
                     Literal(value=10),
                 ],
+                kwargs=[],
             ),
             body=[
                 If(

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -1171,6 +1171,11 @@ class AbstractFrame:
     def eval_expr_Call(self, call: ast.Call) -> W_MetaArg:
         wam_func = self.eval_expr(call.func)
         args_wam = [self.eval_expr(arg) for arg in call.args]
+        for kwarg_name, kw_arg in call.kwargs:
+            wam_value = self.eval_expr(kw_arg)
+            wam_value.kwarg_name = kwarg_name.value
+            args_wam.append(wam_value)
+
         w_opimpl = self.vm.call_OP(call.loc, OP.w_CALL, [wam_func] + args_wam)
 
         # special case getattr, hasattr and setattr: if we arrive at this point it means that the

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -1208,6 +1208,10 @@ class AbstractFrame:
         wam_obj = self.eval_expr(op.target)
         wam_meth = self.eval_expr(op.method)
         args_wam = [self.eval_expr(arg) for arg in op.args]
+        for kwarg_name, kw_arg in op.kwargs:
+            wam_value = self.eval_expr(kw_arg)
+            wam_value.kwarg_name = kwarg_name.value
+            args_wam.append(wam_value)
         w_opimpl = self.vm.call_OP(
             op.loc, OP.w_CALL_METHOD, [wam_obj, wam_meth] + args_wam
         )

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -318,7 +318,8 @@ class W_Func(W_Object):
 
         args_wam = list(got_args_wam)
         if isinstance(w_func, W_ASTFunc):
-            args_wam = w_func._fill_defaults_maybe(vm, args_wam)
+            args_wam = w_func._bind_args(vm, args_wam)
+
         return W_OpSpec(w_func, args_wam, is_direct_call=True)
 
     @staticmethod
@@ -467,33 +468,66 @@ class W_ASTFunc(W_Func):
         frame = ASTFrame(vm, self, args_w)
         return frame.run(args_w)
 
-    def _fill_defaults_maybe(
+    def _bind_args(
         self, vm: "SPyVM", got_args_wam: list["W_MetaArg"]
     ) -> list["W_MetaArg"]:
         """
-        If got_args_wam is not long enough and we have default values, add them.
+        Reorder keyword arguments (unpack W_KeywordArg) and supply default values
         """
         from spy.vm.opspec import W_MetaArg
 
-        if not self.defaults_w:
-            return got_args_wam
+        got_posargs_wam: list[W_MetaArg] = []
+        got_kwargs_wam: dict[str, W_MetaArg] = {}
+        for arg in got_args_wam:
+            if arg.kwarg_name is None:
+                got_posargs_wam.append(arg)
+            else:
+                got_kwargs_wam[arg.kwarg_name] = arg
 
-        n_params = len(self.w_functype.params)
-        n_got = len(got_args_wam)
-        n_defaults = len(self.defaults_w)
-        n_missing = n_params - n_got
+        defaults_wam = {}
+        n_default_w = len(self.defaults_w)
+        if n_default_w > 0:
+            param_names = [arg.name for arg in self.funcdef.args]
+            params_with_defaults = param_names[-n_default_w:]
+            default_locs = [d.loc for d in self.funcdef.defaults]
+            for w_default, loc, param_name in zip(
+                self.defaults_w, default_locs, params_with_defaults
+            ):
+                wam = W_MetaArg.from_w_obj(vm, w_default, loc=loc)
+                defaults_wam[param_name] = wam
 
-        if n_missing <= 0 or n_missing > n_defaults:
-            return got_args_wam
+        # positional args match first
+        n_pos_params = len(got_posargs_wam)
+        args_wam = got_posargs_wam.copy()
+        remaining_args = self.funcdef.args[n_pos_params:]
 
-        # defaults align to the end of the param list
-        args_wam = list(got_args_wam)
-        start = n_defaults - n_missing
-        defaults_w = self.defaults_w[start:]
-        default_locs = [d.loc for d in self.funcdef.defaults[start:]]
-        for w_default, loc in zip(defaults_w, default_locs):
-            wam = W_MetaArg.from_w_obj(vm, w_default, loc=loc)
-            args_wam.append(wam)
+        # match remaining args to keywords or defaults
+        for func_arg in remaining_args:
+            param_name = func_arg.name
+            if param_name in got_kwargs_wam:
+                args_wam.append(got_kwargs_wam.pop(param_name))
+            elif param_name in defaults_wam:
+                args_wam.append(defaults_wam.pop(param_name))
+            else:
+                func_name = self.funcdef.name
+                err = SPyError(
+                    "W_TypeError",
+                    f"{func_name}() missing required argument `{param_name}`",
+                )
+                err.add("error", "missing required argument", func_arg.loc)
+                raise err
+
+        # unused keywords
+        if got_kwargs_wam:
+            unused = ", ".join(f"`{k}`" for k in got_kwargs_wam)
+            err = SPyError("W_TypeError", f"unexpected keyword arguments: {unused}")
+            err.add(
+                "error",
+                "unexpected keyword arguments",
+                next(iter(got_kwargs_wam.values())).loc,
+            )
+            raise err
+
         return args_wam
 
 

--- a/spy/vm/opspec.py
+++ b/spy/vm/opspec.py
@@ -95,6 +95,7 @@ class W_MetaArg(W_Object):
     loc: Loc
     _w_val: Optional[W_Object]
     sym: Optional[Symbol]
+    kwarg_name: Optional[str]
 
     # see DEBUG_METAARG
     debug_counter: ClassVar[int] = 0
@@ -121,6 +122,7 @@ class W_MetaArg(W_Object):
         self._w_val = w_val
         self.loc = loc
         self.sym = sym
+        self.kwarg_name = None
         if DEBUG_METAARG:
             self.debug_id = W_MetaArg.debug_counter
             W_MetaArg.debug_counter += 1


### PR DESCRIPTION
Adds support for keyword arguments in SPy function calls.

* only spy funtions supported (no builtin functions)
* `**kwargs` not supported
* methods WIP

Demo:

```python
> cat examples/1_high_level/kwargs.spy   
"""
Things to notice:
  - keyword args can be passed in any order
  - after redshift, keyword args are reordered
"""

def compute(x: i32, y:i32, z: i32) -> i32:
    return 100 * x + 10 * y + z

def main() -> None:
    print("Hello from SPy 🥸")
    print(compute(1, z=5, y=3))

> spy examples/1_high_level/kwargs.spy   
Hello from SPy 🥸
135

> spy % spy rs examples/1_high_level/kwargs.spy
def compute(x: i32, y: i32, z: i32) -> i32:
    return 100 * x + 10 * y + z

def main() -> None:
    `_print::println[str]`('Hello from SPy 🥸')
    `_print::println[i32]`(`kwargs::compute`(1, 3, 5))
```

High level changes, described bottom up:

1. The function for default value resolution replaced with a new `W_ASTFunc._bind_args` that handles both default args and keyword args reordering. This needs to identify keyword args, so the metaarg now carries an optional `kwarg_name` field.
2. `ASTFrame.eval_expr_Call` now evaluates kwarg expressions on the `Call` node and tags their metaarg the keyword name.
3.  Parser now accepts keyword args and records them as a new `kwargs` field on the `Call` node Expr]]`. It still rejects `**kwargs` with a clear error. 

A side effect of the new binding method `_bind_args` is that missing args even when positional have a clear error:
```
Traceback (most recent call last):
  * x::main at /Users/shalabh/src-local/spy/examples/1_high_level/x.spy:6
  |     f()
  |     |_|

TypeError: f() missing required argument `a`
  | /Users/shalabh/src-local/spy/examples/1_high_level/x.spy:2
  | def f(a: i32) -> i32:
  |       |____| missing required argument

  | /Users/shalabh/src-local/spy/examples/1_high_level/x.spy:6
  |     f()
  |     |_| operator::CALL called here
```

This change in error required patching a whole bunch of tests.
