### PR TITLE
Eagerly evaluate blue type conversions in doppler

### DIFF
--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -93,6 +93,20 @@ def make_const(vm: "SPyVM", loc: Loc, w_val: W_Object) -> ast.Expr:
     return res
 
 
+def unmake_const_maybe(vm: "SPyVM", expr: ast.Expr) -> Optional[W_Object]:
+    """
+    The inverse of make_const: if `expr` is a constant AST node, return its
+    W_Object value. Otherwise return None.
+    """
+    if isinstance(expr, ast.Const):
+        return expr.w_val
+    elif isinstance(expr, ast.StrLiteral):
+        return vm.wrap(expr.value)
+    elif isinstance(expr, ast.FQNConst):
+        return vm.lookup_global(expr.fqn)
+    return None
+
+
 class DopplerFrame(ASTFrame):
     """
     Perform redshift on a W_ASTFunc
@@ -394,17 +408,27 @@ class DopplerFrame(ASTFrame):
         new_expr = self.shift_expr(expr, wam)
         assert new_expr.w_T is not None, "shift_expr should return a typed ast.Expr"
 
+        # do we need a type conversion because we are assigning to a local var?
         w_typeconv_opimpl = self.typecheck_maybe(wam, varname)
         if w_typeconv_opimpl:
             assert varname is not None
             lv = self.locals[varname]
-            expT = make_const(self.vm, lv.decl_loc, lv.w_T)
-            gotT = make_const(self.vm, wam.loc, wam.w_static_T)
-            new_expr = self.shift_opimpl(
-                expr,
-                w_typeconv_opimpl,
-                [expT, gotT, new_expr],
-            )
+            if wam.color == "blue" and w_typeconv_opimpl.is_pure():
+                # apply it eagerly: see the case "local var conv" in
+                # test_doppler::test_eager_type_conversion
+                w_res = w_typeconv_opimpl._execute(
+                    self.vm, [lv.w_T, wam.w_static_T, wam.w_val]
+                )
+                new_expr = make_const(self.vm, expr.loc, w_res)
+            else:
+                # add a residual call to the convert function
+                expT = make_const(self.vm, lv.decl_loc, lv.w_T)
+                gotT = make_const(self.vm, wam.loc, wam.w_static_T)
+                new_expr = self.shift_opimpl(
+                    expr,
+                    w_typeconv_opimpl,
+                    [expT, gotT, new_expr],
+                )
 
         self.shifted_expr[expr] = new_expr
         # record the color of the ORIGINAL expression
@@ -501,7 +525,22 @@ class DopplerFrame(ASTFrame):
                 expT = getarg(spec.expT)
                 gotT = getarg(spec.gotT)
                 arg = getarg(spec.arg)
-                return self.shift_opimpl(arg, spec.w_conv_opimpl, [expT, gotT, arg])
+
+                # try to evaluate the conversion eagerly, if the opimpl is pure and the
+                # the arg is known. See the case "func arg conv" in
+                # test_doppler::test_eager_type_conversion
+                is_pure = spec.w_conv_opimpl.is_pure()
+                if is_pure and (w_arg := unmake_const_maybe(self.vm, arg)) is not None:
+                    w_expT = unmake_const_maybe(self.vm, expT)
+                    w_gotT = unmake_const_maybe(self.vm, gotT)
+                    assert w_expT is not None and w_gotT is not None
+                    w_res = spec.w_conv_opimpl._execute(
+                        self.vm, [w_expT, w_gotT, w_arg]
+                    )
+                    return make_const(self.vm, arg.loc, w_res)
+                else:
+                    # no eager evaluation: insert a residual call to the conversion func
+                    return self.shift_opimpl(arg, spec.w_conv_opimpl, [expT, gotT, arg])
             else:
                 assert False
 

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -417,10 +417,9 @@ class DopplerFrame(ASTFrame):
             if wam.color == "blue" and w_typeconv_opimpl.is_pure():
                 # apply it eagerly: see the case "local var conv" in
                 # test_doppler::test_eager_type_conversion
-                w_res = w_typeconv_opimpl._execute(
-                    self.vm, [lv.w_T, wam.w_static_T, wam.w_val]
-                )
-                new_expr = make_const(self.vm, expr.loc, w_res)
+                wam = self.vm.eval_opimpl(w_typeconv_opimpl, [wam], loc=expr.loc)
+                assert wam.color == "blue"
+                new_expr = make_const(self.vm, expr.loc, wam.w_val)
             else:
                 # add a residual call to the convert function
                 expT = make_const(self.vm, lv.decl_loc, lv.w_T)

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -47,6 +47,7 @@ def make_const(vm: "SPyVM", loc: Loc, w_val: W_Object) -> ast.Expr:
         B.w_i8,
         B.w_u8,
         B.w_u32,
+        B.w_f32,
         B.w_f64,
         B.w_complex128,
         B.w_bool,

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -247,8 +247,8 @@ class TestBasic(CompilerTest):
         # a runtime error. The compilation always succeed.
         mod = self.compile("""
         def foo() -> str:
-            x: i32 = 1
-            y: object = x
+            var x: i32 = 1
+            var y: object = x
             return y
         """)
         msg = "Invalid cast. Expected `str`, got `i32`"

--- a/spy/tests/compiler/test_float.py
+++ b/spy/tests/compiler/test_float.py
@@ -141,3 +141,14 @@ class TestFloat(CompilerTest):
         assert mod.f32_to_f64(42.0) == 42.0
         assert mod.f64_to_i32(42.0) == 42
         assert mod.f32_to_i32(42.0) == 42
+
+    @pytest.mark.skip("FIXME")
+    def test_prebuilt_const(self):
+        src = """
+        def foo() -> f64:
+            x: f32 = 1.25
+            y: f64 = 2.5
+            return x + y
+        """
+        mod = self.compile(src)
+        assert mod.foo() == 3.75

--- a/spy/tests/compiler/test_float.py
+++ b/spy/tests/compiler/test_float.py
@@ -142,7 +142,6 @@ class TestFloat(CompilerTest):
         assert mod.f64_to_i32(42.0) == 42
         assert mod.f32_to_i32(42.0) == 42
 
-    @pytest.mark.skip("FIXME")
     def test_prebuilt_const(self):
         src = """
         def foo() -> f64:

--- a/spy/tests/conftest.py
+++ b/spy/tests/conftest.py
@@ -11,6 +11,9 @@ from pytest_pyodide import get_global_config
 from spy.util import cleanup_spyc_files
 
 # pytest --hypothesis-profile=...
+# "default" is loaded automatically; keep the example count low so the normal
+# test run stays fast. Use --hypothesis-profile=stress for thorough fuzzing.
+hypothesis.settings.register_profile("default", max_examples=5)
 hypothesis.settings.register_profile("dev", max_examples=1, database=None)
 hypothesis.settings.register_profile("stress", max_examples=500)
 

--- a/spy/tests/test_doppler.py
+++ b/spy/tests/test_doppler.py
@@ -6,6 +6,7 @@ import pytest
 from spy import ast
 from spy.analyze.symtable import Color
 from spy.backend.spy import FQN_FORMAT, SPyBackend
+from spy.errors import SPyError
 from spy.fqn import FQN
 from spy.util import print_diff
 from spy.vm.function import W_ASTFunc
@@ -27,9 +28,9 @@ class TestDoppler:
         f.write(src)
         self.vm.import_("test")
 
-    def redshift(self, src: str) -> None:
+    def redshift(self, src: str, *, error_mode="eager") -> None:
         self.import_src(src)
-        self.vm.redshift(error_mode="eager")
+        self.vm.redshift(error_mode=error_mode)
 
     def assert_dump(
         self,
@@ -286,37 +287,15 @@ class TestDoppler:
 `list[i32]::new`(), 1), 12)
         """)
 
-    def test_type_conversion(self):
+    def test_pure_blue_call_folded(self):
         src = """
-        def foo(x: f64) -> None:
-            pass
-
-        def convert_in_call() -> None:
-            foo(42)
-
-        def convert_in_locals(x: i32) -> bool:
-            flag: bool = x
-            return x
-
-        def convert_in_conditions(x: i32) -> None:
-            if x:
-                pass
+        def foo() -> f64:
+            return 1 + 2.5
         """
         self.redshift(src)
         self.assert_dump("""
-        def foo(x: f64) -> None:
-            pass
-
-        def convert_in_call() -> None:
-            `test::foo`(`operator::i32_to_f64`(42))
-
-        def convert_in_locals(x: i32) -> bool:
-            flag: bool = `operator::i32_to_bool`(x)
-            return `operator::i32_to_bool`(x)
-
-        def convert_in_conditions(x: i32) -> None:
-            if `operator::i32_to_bool`(x):
-                pass
+        def foo() -> f64:
+            return 3.5
         """)
 
     def test_blue_namespace(self):
@@ -540,3 +519,77 @@ class TestDoppler:
         """,
             funcname="foo",
         )
+
+    def test_residual_type_conversion(self):
+        src = """
+        def bar(x: f64) -> None:
+            pass
+
+        def foo(x: i32) -> f64:
+            bar(x)           # func arg conv
+            flag: bool = x   # local var conv
+            if x:            # 'if conditional' conv
+                pass
+            return x         # return value conv
+        """
+        self.redshift(src)
+        self.assert_dump("""
+        def bar(x: f64) -> None:
+            pass
+
+        def foo(x: i32) -> f64:
+            `test::bar`(`operator::i32_to_f64`(x))
+            flag: bool = `operator::i32_to_bool`(x)
+            if `operator::i32_to_bool`(x):
+                pass
+            return `operator::i32_to_f64`(x)
+       """)
+
+    def test_eager_type_conversion(self):
+        src = """
+        def bar(x: f64) -> None:
+            pass
+
+        def foo() -> f64:
+            x = 42
+            bar(x)               # func arg conv
+            var flag: bool = x   # local var conv
+            if x:                # 'if conditional' conv
+                pass
+            return x             # return value conv
+        """
+        self.redshift(src)
+        self.assert_dump("""
+        def bar(x: f64) -> None:
+            pass
+
+        def foo() -> f64:
+            `test::bar`(42.0)
+            flag: bool = True
+            if True:
+                pass
+            return 42.0
+        """)
+
+    def test_eager_conversion_becomes_static_error(self):
+        src = """
+        def foo() -> str:
+            x: object = 1
+            return x
+        """
+        with SPyError.raises(
+            "W_TypeError", match="Invalid cast. Expected `str`, got `i32`"
+        ):
+            self.redshift(src)
+
+    def test_eager_conversion_become_lazy_error(self):
+        src = """
+        def foo() -> str:
+            x: object = 1
+            return x
+        """
+        self.redshift(src, error_mode="lazy")
+        self.assert_dump("""
+        def foo() -> str:
+            raise TypeError('Invalid cast. Expected `str`, got `i32`') # /.../test.spy:4
+        """)

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -165,9 +165,11 @@ class AbstractFrame:
 
     def store_local(self, name: str, w_value: W_Object) -> None:
         lv = self.locals[name]
-        # XXX: this sanity check fails in some tests. Uncomment it and fix the tests!
-        ## if not isinstance(w_value, W_Cell):
-        ##     assert self.vm.isinstance(w_value, lv.w_T)  # sanity check
+        # sanity check
+        if isinstance(w_value, W_Cell):
+            assert self.vm.isinstance(w_value.get(), lv.w_T)
+        else:
+            assert self.vm.isinstance(w_value, lv.w_T)
         lv.w_val = w_value
 
     def load_local(self, name: str) -> W_Object:

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -154,6 +154,7 @@ class AbstractFrame:
                 color = "blue"
             else:
                 color = "red"
+
         self.locals[name] = LocalVar(
             varname=name, decl_loc=loc, color=color, w_T=w_type, w_val=None
         )
@@ -163,7 +164,11 @@ class AbstractFrame:
             self.declare_local(name, "red", B.w_bool, Loc.fake())
 
     def store_local(self, name: str, w_value: W_Object) -> None:
-        self.locals[name].w_val = w_value
+        lv = self.locals[name]
+        # XXX: this sanity check fails in some tests. Uncomment it and fix the tests!
+        ## if not isinstance(w_value, W_Cell):
+        ##     assert self.vm.isinstance(w_value, lv.w_T)  # sanity check
+        lv.w_val = w_value
 
     def load_local(self, name: str) -> W_Object:
         localvar = self.locals.get(name)

--- a/spy/vm/opspec.py
+++ b/spy/vm/opspec.py
@@ -121,6 +121,10 @@ class W_MetaArg(W_Object):
         self._w_val = w_val
         self.loc = loc
         self.sym = sym
+        # XXX: this sanity check fails in some tests. Uncomment it and fix the tests!
+        ## if w_val is not None:
+        ##     # sanity check
+        ##     assert vm.isinstance(w_val, w_static_T)
         if DEBUG_METAARG:
             self.debug_id = W_MetaArg.debug_counter
             W_MetaArg.debug_counter += 1


### PR DESCRIPTION
Consider this case:
```python
def bar(x: f64) -> None:
    pass

def main() -> None:
    bar(42)
    var y: f64 = 43
```

On `main`, it redshifts to:
```python
def bar(x: f64) -> None:
    pass

def main() -> None:
    `x::bar`(`operator::i32_to_f64`(42))
    y: f64 = `operator::i32_to_f64`(43)
```

This PR makes doppler to evaluate the conversions eagerly, if the conv functions is pure and the argument is blue.
Now it redshifts to:
```python
def bar(x: f64) -> None:
    pass

def main() -> None:
    `x::bar`(42.0)
    y: f64 = 43.0
```

Fixes #561.