### PR TITLE
Implement keyword arguments for spy functions

### DIFF
--- a/examples/1_high_level/kwargs.spy
+++ b/examples/1_high_level/kwargs.spy
@@ -1,0 +1,12 @@
+"""
+Things to notice:
+  - keyword args can be passed in any order
+  - after redshift, keyword args are reordered
+"""
+
+def compute(x: i32, y:i32, z: i32) -> i32:
+    return 100 * x + 10 * y + z
+
+def main() -> None:
+    print("Hello from SPy 🥸")
+    print(compute(1, z=5, y=3))

--- a/examples/expected_output/kwargs.txt
+++ b/examples/expected_output/kwargs.txt
@@ -1,0 +1,2 @@
+Hello from SPy 🥸
+135

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -411,6 +411,7 @@ class Call(Expr):
     precedence = 16
     func: Expr
     args: list[Expr]
+    kwargs: list[tuple["StrLiteral", Expr]] = field(default_factory=list)
 
 
 @astnode
@@ -427,6 +428,7 @@ class CallMethod(Expr):
     target: Expr
     method: StrLiteral
     args: list[Expr]
+    kwargs: list[tuple["StrLiteral", Expr]] = field(default_factory=list)
 
 
 @astnode

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -413,6 +413,11 @@ class Call(Expr):
     args: list[Expr]
     kwargs: list[tuple["StrLiteral", Expr]] = field(default_factory=list)
 
+    def all_arg_exprs(self) -> "Iterator[Expr]":
+        yield from self.args
+        for _, expr in self.kwargs:
+            yield expr
+
 
 @astnode
 class Slice(Expr):
@@ -429,6 +434,11 @@ class CallMethod(Expr):
     method: StrLiteral
     args: list[Expr]
     kwargs: list[tuple["StrLiteral", Expr]] = field(default_factory=list)
+
+    def all_arg_exprs(self) -> "Iterator[Expr]":
+        yield from self.args
+        for _, expr in self.kwargs:
+            yield expr
 
 
 @astnode

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -413,11 +413,6 @@ class Call(Expr):
     args: list[Expr]
     kwargs: list[tuple["StrLiteral", Expr]] = field(default_factory=list)
 
-    def all_arg_exprs(self) -> "Iterator[Expr]":
-        yield from self.args
-        for _, expr in self.kwargs:
-            yield expr
-
 
 @astnode
 class Slice(Expr):
@@ -434,11 +429,6 @@ class CallMethod(Expr):
     method: StrLiteral
     args: list[Expr]
     kwargs: list[tuple["StrLiteral", Expr]] = field(default_factory=list)
-
-    def all_arg_exprs(self) -> "Iterator[Expr]":
-        yield from self.args
-        for _, expr in self.kwargs:
-            yield expr
 
 
 @astnode

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -701,7 +701,9 @@ class DopplerFrame(ASTFrame):
     def shift_expr_Call(self, call: ast.Call, wam: W_MetaArg) -> ast.Expr:
         w_opimpl = self.opimpl[call]
         newfunc = self.shifted_expr[call.func]
+        # source-order flat expansion: positional args then kwargs values
         newargs = [self.shifted_expr[arg] for arg in call.args]
+        newargs += [self.shifted_expr[expr] for _, expr in call.kwargs]
 
         if self.special_calls.get(call) in ("getattr", "hasattr", "setattr"):
             # see also the corresponding code in ASTFrame.eval_expr_Call.
@@ -713,7 +715,9 @@ class DopplerFrame(ASTFrame):
         w_opimpl = self.opimpl[op]
         v_obj = self.shifted_expr[op.target]
         v_meth = self.shifted_expr[op.method]
+        # source-order flat expansion: positional args then kwargs values
         newargs_v = [self.shifted_expr[arg] for arg in op.args]
+        newargs_v += [self.shifted_expr[expr] for _, expr in op.kwargs]
         return self.shift_opimpl(op, w_opimpl, [v_obj, v_meth] + newargs_v)
 
     def eval_expr_BlockExpr(self, block: ast.BlockExpr) -> W_MetaArg:

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -876,8 +876,17 @@ class Parser:
     ) -> spy.ast.Call | spy.ast.CallMethod | spy.ast.BlockExpr | spy.ast.Literal:
         if isinstance(py_node.func, py_ast.Name) and py_node.func.id == "__block__":
             return self._parse_block_expr(py_node)
+        kwargs: list[tuple[spy.ast.StrLiteral, spy.ast.Expr]] = []
         if py_node.keywords:
-            self.unsupported(py_node.keywords[0], "keyword arguments")
+            for py_kw in py_node.keywords:
+                if py_kw.arg is None:
+                    self.unsupported(py_kw, "** var-keyword arguments")
+                kwargs.append(
+                    (
+                        spy.ast.StrLiteral(py_kw.loc, py_kw.arg),
+                        self.from_py_expr(py_kw.value),
+                    )
+                )
 
         # explicitly-prefixed integer literal, e.g. i32(42) or i64(-1)
         if (
@@ -893,10 +902,14 @@ class Parser:
         args = [self.from_py_expr(py_arg) for py_arg in py_node.args]
         if isinstance(func, spy.ast.GetAttr):
             return spy.ast.CallMethod(
-                loc=py_node.loc, target=func.value, method=func.attr, args=args
+                loc=py_node.loc,
+                target=func.value,
+                method=func.attr,
+                args=args,
+                kwargs=kwargs,
             )
         else:
-            return spy.ast.Call(loc=py_node.loc, func=func, args=args)
+            return spy.ast.Call(loc=py_node.loc, func=func, args=args, kwargs=kwargs)
 
     def _parse_block_expr(self, py_node: py_ast.Call) -> spy.ast.BlockExpr:
         if (

--- a/spy/tests/compiler/operator/test_callop.py
+++ b/spy/tests/compiler/operator/test_callop.py
@@ -197,7 +197,7 @@ class TestCallOp(CompilerTest):
         x = mod.foo(5, 7)
         assert x == 12
 
-    def test_call_instance_kwargs_not_supported(self):
+    def test_dunder_call_keyword_args_unsupported(self):
         # ========== EXT module for this test ==========
         EXT = ModuleRegistry("ext")
 

--- a/spy/tests/compiler/operator/test_callop.py
+++ b/spy/tests/compiler/operator/test_callop.py
@@ -197,6 +197,40 @@ class TestCallOp(CompilerTest):
         x = mod.foo(5, 7)
         assert x == 12
 
+    def test_call_instance_kwargs_not_supported(self):
+        # ========== EXT module for this test ==========
+        EXT = ModuleRegistry("ext")
+
+        @EXT.builtin_type("Adder")
+        class W_Adder(W_Object):
+            def __init__(self, x: int) -> None:
+                self.x = x
+
+            @builtin_method("__new__")
+            @staticmethod
+            def w_new(vm: "SPyVM", w_x: W_I32) -> "W_Adder":
+                return W_Adder(vm.unwrap_i32(w_x))
+
+            @builtin_method("__call__")
+            @staticmethod
+            def w_call(vm: "SPyVM", w_obj: "W_Adder", w_y: W_I32) -> W_I32:
+                y = vm.unwrap_i32(w_y)
+                return vm.wrap(w_obj.x + y)
+
+        # ========== /EXT module for this test =========
+        self.vm.make_module(EXT)
+        src = """
+        from ext import Adder
+
+        def foo() -> i32:
+            obj = Adder(5)
+            return obj(y=7)
+        """
+        errors = expect_errors(
+            "keyword arguments not supported for this function",
+        )
+        self.compile_raises(src, "foo", errors)
+
     def test_call_method(self):
         # ========== EXT module for this test ==========
         EXT = ModuleRegistry("ext")

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -456,6 +456,27 @@ class TestBasic(CompilerTest):
         """)
         assert mod.bar(3) == 1.5
 
+    def test_function_call_keywords(self):
+        mod = self.compile("""
+        def foo(small: i32, big: i32) -> i32:
+            return big - small
+
+        def bar(big: i32) -> i32:
+            return foo(big=big, small=7)
+        """)
+        assert mod.bar(10) == 3
+        assert mod.bar(15) == 8
+
+    def test_function_call_pos_with_keywords(self):
+        mod = self.compile("""
+        def foo(a: i32, b: i32, c: i32) -> i32:
+            return a - b // c
+
+        def bar(a: i32, b: i32, c: i32) -> i32:
+            return foo(a, c=c, b=b)
+        """)
+        assert mod.bar(1, 10, 5) == -1
+
     def test_conversions(self):
         mod = self.compile("""
         def a(x: i32) -> f64:
@@ -531,9 +552,8 @@ class TestBasic(CompilerTest):
             return inc()
         """
         errors = expect_errors(
-            "this function takes 1 argument but 0 arguments were supplied",
-            ("1 argument missing", "inc"),
-            ("function defined here", "def inc(x: i32) -> i32"),
+            "inc() missing required argument `x`",
+            ("missing required argument", "x: i32"),
         )
         self.compile_raises(src, "foo", errors)
 
@@ -1533,9 +1553,8 @@ class TestBasic(CompilerTest):
             return add()
         """
         errors = expect_errors(
-            "this function takes from 1 to 2 arguments but 0 arguments were supplied",
-            ("1 argument missing", "add"),
-            ("function defined here", "def add(x: int, y: int = 1) -> int"),
+            "add() missing required argument `x`",
+            ("missing required argument", "x: int"),
         )
         self.compile_raises(src, "foo", errors)
 

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -477,7 +477,7 @@ class TestBasic(CompilerTest):
         """)
         assert mod.bar(1, 10, 5) == -1
 
-    def test_function_call_kwargs_not_supported_for_builtins(self):
+    def test_builtin_keyword_args_unsupported(self):
         src = """
         from operator import i32_add
 
@@ -489,7 +489,7 @@ class TestBasic(CompilerTest):
         )
         self.compile_raises(src, "foo", errors)
 
-    def test_function_call_kwargs_not_supported_for_metafuncs(self):
+    def test_metafunc_keyword_args_unsupported(self):
         src = """
         def foo() -> i32:
             return hash(x=1)
@@ -499,7 +499,7 @@ class TestBasic(CompilerTest):
         )
         self.compile_raises(src, "foo", errors)
 
-    def test_function_call_kwargs_not_supported_for_dynamic(self):
+    def test_dynamic_keyword_args_unsupported(self):
         src = """
         def bar(f: dynamic) -> i32:
             return f(x=1, y=2)

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -477,6 +477,30 @@ class TestBasic(CompilerTest):
         """)
         assert mod.bar(1, 10, 5) == -1
 
+    def test_function_call_kwargs_not_supported_for_builtins(self):
+        src = """
+        from operator import i32_add
+
+        def foo() -> i32:
+            return i32_add(x=1, y=2)
+        """
+        errors = expect_errors(
+            "keyword arguments not supported for this function",
+            ("`operator::i32_add` does not support keyword arguments", "i32_add"),
+        )
+        self.compile_raises(src, "foo", errors)
+
+    def test_function_call_kwargs_not_supported_for_metafuncs(self):
+        src = """
+        def foo() -> i32:
+            return hash(x=1)
+        """
+        errors = expect_errors(
+            "keyword arguments not supported for this function",
+            ("keyword arguments not supported", "hash"),
+        )
+        self.compile_raises(src, "foo", errors)
+
     def test_conversions(self):
         mod = self.compile("""
         def a(x: i32) -> f64:

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -499,6 +499,19 @@ class TestBasic(CompilerTest):
         )
         self.compile_raises(src, "foo", errors)
 
+    def test_function_call_kwargs_not_supported_for_dynamic(self):
+        src = """
+        def bar(f: dynamic) -> i32:
+            return f(x=1, y=2)
+
+        def foo() -> i32:
+            return bar(1)
+        """
+        errors = expect_errors(
+            "keyword arguments not supported for this function",
+        )
+        self.compile_raises(src, "foo", errors)
+
     def test_conversions(self):
         mod = self.compile("""
         def a(x: i32) -> f64:

--- a/spy/tests/compiler/test_basic.py
+++ b/spy/tests/compiler/test_basic.py
@@ -486,7 +486,6 @@ class TestBasic(CompilerTest):
         """
         errors = expect_errors(
             "keyword arguments not supported for this function",
-            ("`operator::i32_add` does not support keyword arguments", "i32_add"),
         )
         self.compile_raises(src, "foo", errors)
 
@@ -497,7 +496,6 @@ class TestBasic(CompilerTest):
         """
         errors = expect_errors(
             "keyword arguments not supported for this function",
-            ("keyword arguments not supported", "hash"),
         )
         self.compile_raises(src, "foo", errors)
 

--- a/spy/tests/compiler/test_struct.py
+++ b/spy/tests/compiler/test_struct.py
@@ -246,6 +246,23 @@ class TestStructOnStack(CompilerTest):
         assert mod.movex0(3, 7) == (4, 7)
         assert mod.movexy(3, 7) == (4, 8)
 
+    def test_method_keyword_args(self):
+        src = """
+        @struct
+        class Point:
+            x: i32
+            y: i32
+
+            def move(self, dx: i32, dy: i32) -> Point:
+                return Point(self.x + dx, self.y + dy)
+
+        def foo(x: i32, y: i32, dx: i32, dy: i32) -> Point:
+            p = Point(x, y)
+            return p.move(dy=dy, dx=dx)
+        """
+        mod = self.compile(src)
+        assert mod.foo(3, 7, 1, 2) == (4, 9)
+
     def test_default_eq(self):
         src = """
         @struct

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -913,6 +913,7 @@ class TestParser:
                         args=[
                             Name(id='x'),
                         ],
+                        kwargs=[],
                     ),
                 ),
             ],

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -239,6 +239,7 @@ class TestParser:
                     args=[
                         Name(id='arg'),
                     ],
+                    kwargs=[],
                 ),
             ],
         )
@@ -1030,20 +1031,43 @@ class TestParser:
                     Literal(value=2),
                     Literal(value=3),
                 ],
+                kwargs=[],
             ),
         )
         """
         self.assert_dump(stmt, expected)
 
-    def test_Call_errors(self):
-        src = """
+    def test_Call_kwargs(self):
+        mod = self.parse("""
         def foo() -> i32:
             return Bar(1, 2, x=3)
+        """)
+        stmt = mod.get_funcdef("foo").body[0]
+        expected = """
+        Return(
+            value=Call(
+                func=Name(id='Bar'),
+                args=[
+                    Literal(value=1),
+                    Literal(value=2),
+                ],
+                kwargs=[
+                    (StrLiteral(w_T=None, value='x'), Literal(w_T=None, value=3)),
+                ],
+            ),
+        )
+        """
+        self.assert_dump(stmt, expected)
+
+    def test_Call_double_star_kwargs_unsupported(self):
+        src = """
+        def foo() -> i32:
+            return bar(1, **kwargs)
         """
         self.expect_errors(
             src,
-            "not implemented yet: keyword arguments",
-            ("this is not supported", "x=3"),
+            "not implemented yet: ** var-keyword arguments",
+            ("this is not supported", "**kwargs"),
         )
 
     def test_CallMethod(self):
@@ -1061,6 +1085,7 @@ class TestParser:
                     Literal(value=1),
                     Literal(value=2),
                 ],
+                kwargs=[],
             ),
         )
         """
@@ -1183,6 +1208,7 @@ class TestParser:
                 args=[
                     Literal(value=10),
                 ],
+                kwargs=[],
             ),
             body=[
                 Pass(),
@@ -1276,6 +1302,7 @@ class TestParser:
                 args=[
                     StrLiteral(value='error message'),
                 ],
+                kwargs=[],
             ),
         )
         """
@@ -1769,6 +1796,7 @@ class TestParser:
                 args=[
                     Literal(value=10),
                 ],
+                kwargs=[],
             ),
             body=[
                 If(
@@ -1804,6 +1832,7 @@ class TestParser:
                 args=[
                     Literal(value=10),
                 ],
+                kwargs=[],
             ),
             body=[
                 If(

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -13,7 +13,15 @@ from spy.util import magic_dispatch
 from spy.vm.b import B
 from spy.vm.cell import W_Cell
 from spy.vm.exc import W_TypeError
-from spy.vm.function import CLOSURE, FuncParam, LocalVar, W_ASTFunc, W_Func, W_FuncType
+from spy.vm.function import (
+    CLOSURE,
+    FuncParam,
+    LocalVar,
+    W_ASTFunc,
+    W_Func,
+    W_FuncArgs,
+    W_FuncType,
+)
 from spy.vm.modules.__spy__ import SPY
 from spy.vm.modules.__spy__.interp_tuple import W_InterpTuple
 from spy.vm.modules.operator import OP, OP_from_token, OP_unary_from_token
@@ -1201,7 +1209,15 @@ class AbstractFrame:
     def eval_expr_Call(self, call: ast.Call) -> W_MetaArg:
         wam_func = self.eval_expr(call.func)
         args_wam = [self.eval_expr(arg) for arg in call.args]
-        w_opimpl = self.vm.call_OP(call.loc, OP.w_CALL, [wam_func] + args_wam)
+        kwargs_wam = [(name.value, self.eval_expr(expr)) for name, expr in call.kwargs]
+        w_funcargs = W_FuncArgs(args_wam, kwargs_wam)
+        wam_funcargs = W_MetaArg(
+            self.vm, "blue", self.vm.dynamic_type(w_funcargs), w_funcargs, call.loc
+        )
+        # in_args_wam: source-order flat expansion, used as eval_opimpl args
+        in_args_wam = [wam_func] + w_funcargs.to_list()
+
+        w_opimpl = self.vm.call_OP(call.loc, OP.w_CALL, [wam_func, wam_funcargs])
 
         # special case getattr, hasattr and setattr: if we arrive at this point it means that the
         # call typed correctly (right number, type and color of arguments). The returned
@@ -1226,21 +1242,23 @@ class AbstractFrame:
             return self.eval_opimpl(call, w_opimpl, args_wam)
 
         else:
-            # normal case
-            return self.eval_opimpl(call, w_opimpl, [wam_func] + args_wam)
+            # normal case — pass source-order flat expansion so ArgSpec.Arg(i) indices match
+            return self.eval_opimpl(call, w_opimpl, in_args_wam)
 
     def eval_expr_CallMethod(self, op: ast.CallMethod) -> W_Object:
         wam_obj = self.eval_expr(op.target)
         wam_meth = self.eval_expr(op.method)
         args_wam = [self.eval_expr(arg) for arg in op.args]
+        kwargs_wam = [(name.value, self.eval_expr(expr)) for name, expr in op.kwargs]
+        w_funcargs = W_FuncArgs(args_wam, kwargs_wam)
+        wam_funcargs = W_MetaArg(
+            self.vm, "blue", self.vm.dynamic_type(w_funcargs), w_funcargs, op.loc
+        )
+        in_args_wam = [wam_obj, wam_meth] + w_funcargs.to_list()
         w_opimpl = self.vm.call_OP(
-            op.loc, OP.w_CALL_METHOD, [wam_obj, wam_meth] + args_wam
+            op.loc, OP.w_CALL_METHOD, [wam_obj, wam_meth, wam_funcargs]
         )
-        return self.eval_opimpl(
-            op,
-            w_opimpl,
-            [wam_obj, wam_meth] + args_wam,
-        )
+        return self.eval_opimpl(op, w_opimpl, in_args_wam)
 
     def eval_expr_GetItem(self, op: ast.GetItem) -> W_MetaArg:
         wam_obj = self.eval_expr(op.value)
@@ -1292,7 +1310,11 @@ class AbstractFrame:
         w_T = self.vm.getitem_w(w_ListType, w_itemtype, loc=lst.loc)  # list[i32]
         wam_T = W_MetaArg.from_w_obj(self.vm, w_T)
 
-        w_opimpl = self.vm.call_OP(lst.loc, OP.w_CALL, [wam_T])
+        w_opimpl = self.vm.call_OP(
+            lst.loc,
+            OP.w_CALL,
+            [wam_T, W_FuncArgs.from_positional(self.vm, [], lst.loc)],
+        )
         wam_list = self.eval_opimpl(lst, w_opimpl, [wam_T])
 
         # 3. push items into the list
@@ -1303,7 +1325,12 @@ class AbstractFrame:
 
         for item, wam_item in zip(lst.items, items_wam):
             w_opimpl = self.vm.call_OP(
-                lst.loc, OP.w_CALL, [wam_push, wam_list, wam_item]
+                lst.loc,
+                OP.w_CALL,
+                [
+                    wam_push,
+                    W_FuncArgs.from_positional(self.vm, [wam_list, wam_item], lst.loc),
+                ],
             )
             wam_list = self.eval_opimpl(item, w_opimpl, [wam_push, wam_list, wam_item])
 
@@ -1315,7 +1342,11 @@ class AbstractFrame:
 
         wam_T = W_MetaArg.from_w_obj(self.vm, w_SliceType)
         args = [self.eval_expr(arg) for arg in (op.start, op.stop, op.step)]
-        w_opimpl = self.vm.call_OP(op.loc, OP.w_CALL, [wam_T] + args)
+        w_opimpl = self.vm.call_OP(
+            op.loc,
+            OP.w_CALL,
+            [wam_T, W_FuncArgs.from_positional(self.vm, args, op.loc)],
+        )
         wam_slice = self.eval_opimpl(op, w_opimpl, [wam_T] + args)
         return wam_slice
 
@@ -1332,7 +1363,11 @@ class AbstractFrame:
         wam_T = W_MetaArg.from_w_obj(self.vm, w_T)
 
         # 3. instantiate it
-        w_opimpl = self.vm.call_OP(tup.loc, OP.w_CALL, [wam_T] + items_wam)
+        w_opimpl = self.vm.call_OP(
+            tup.loc,
+            OP.w_CALL,
+            [wam_T, W_FuncArgs.from_positional(self.vm, items_wam, tup.loc)],
+        )
         wam_tuple = self.eval_opimpl(tup, w_opimpl, [wam_T] + items_wam)
         return wam_tuple
 
@@ -1385,7 +1420,11 @@ class AbstractFrame:
         w_T = self.vm.getitem_w(w_DictType, w_keytype, w_valuetype)  # dict[K, V]
         wam_T = W_MetaArg.from_w_obj(self.vm, w_T)
 
-        w_opimpl = self.vm.call_OP(dict.loc, OP.w_CALL, [wam_T])
+        w_opimpl = self.vm.call_OP(
+            dict.loc,
+            OP.w_CALL,
+            [wam_T, W_FuncArgs.from_positional(self.vm, [], dict.loc)],
+        )
         wam_dict = self.eval_opimpl(dict, w_opimpl, [wam_T])
 
         # 3. push items into the dict
@@ -1396,7 +1435,14 @@ class AbstractFrame:
 
         for pair, (wam_key, wam_val) in zip(dict.items, key_value_pair):
             w_opimpl = self.vm.call_OP(
-                dict.loc, OP.w_CALL, [wam_push, wam_dict, wam_key, wam_val]
+                dict.loc,
+                OP.w_CALL,
+                [
+                    wam_push,
+                    W_FuncArgs.from_positional(
+                        self.vm, [wam_dict, wam_key, wam_val], dict.loc
+                    ),
+                ],
             )
             wam_dict = self.eval_opimpl(
                 pair, w_opimpl, [wam_push, wam_dict, wam_key, wam_val]

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -1211,12 +1211,7 @@ class AbstractFrame:
         args_wam = [self.eval_expr(arg) for arg in call.args]
         kwargs_wam = [(name.value, self.eval_expr(expr)) for name, expr in call.kwargs]
         w_funcargs = W_FuncArgs(args_wam, kwargs_wam)
-        wam_funcargs = W_MetaArg(
-            self.vm, "blue", self.vm.dynamic_type(w_funcargs), w_funcargs, call.loc
-        )
-        # in_args_wam: source-order flat expansion, used as eval_opimpl args
-        in_args_wam = [wam_func] + w_funcargs.to_list()
-
+        wam_funcargs = W_MetaArg.from_w_obj(self.vm, w_funcargs, loc=call.loc)
         w_opimpl = self.vm.call_OP(call.loc, OP.w_CALL, [wam_func, wam_funcargs])
 
         # special case getattr, hasattr and setattr: if we arrive at this point it means that the
@@ -1242,8 +1237,8 @@ class AbstractFrame:
             return self.eval_opimpl(call, w_opimpl, args_wam)
 
         else:
-            # normal case — pass source-order flat expansion so ArgSpec.Arg(i) indices match
-            return self.eval_opimpl(call, w_opimpl, in_args_wam)
+            # source-order flat expansion so ArgSpec.Arg(i) indices match
+            return self.eval_opimpl(call, w_opimpl, [wam_func] + w_funcargs.to_list())
 
     def eval_expr_CallMethod(self, op: ast.CallMethod) -> W_Object:
         wam_obj = self.eval_expr(op.target)
@@ -1251,14 +1246,13 @@ class AbstractFrame:
         args_wam = [self.eval_expr(arg) for arg in op.args]
         kwargs_wam = [(name.value, self.eval_expr(expr)) for name, expr in op.kwargs]
         w_funcargs = W_FuncArgs(args_wam, kwargs_wam)
-        wam_funcargs = W_MetaArg(
-            self.vm, "blue", self.vm.dynamic_type(w_funcargs), w_funcargs, op.loc
-        )
-        in_args_wam = [wam_obj, wam_meth] + w_funcargs.to_list()
+        wam_funcargs = W_MetaArg.from_w_obj(self.vm, w_funcargs, loc=op.loc)
         w_opimpl = self.vm.call_OP(
             op.loc, OP.w_CALL_METHOD, [wam_obj, wam_meth, wam_funcargs]
         )
-        return self.eval_opimpl(op, w_opimpl, in_args_wam)
+        return self.eval_opimpl(
+            op, w_opimpl, [wam_obj, wam_meth] + w_funcargs.to_list()
+        )
 
     def eval_expr_GetItem(self, op: ast.GetItem) -> W_MetaArg:
         wam_obj = self.eval_expr(op.value)
@@ -1310,11 +1304,10 @@ class AbstractFrame:
         w_T = self.vm.getitem_w(w_ListType, w_itemtype, loc=lst.loc)  # list[i32]
         wam_T = W_MetaArg.from_w_obj(self.vm, w_T)
 
-        w_opimpl = self.vm.call_OP(
-            lst.loc,
-            OP.w_CALL,
-            [wam_T, W_FuncArgs.from_positional(self.vm, [], lst.loc)],
+        wam_funcargs = W_MetaArg.from_w_obj(
+            self.vm, W_FuncArgs.from_args(), loc=lst.loc
         )
+        w_opimpl = self.vm.call_OP(lst.loc, OP.w_CALL, [wam_T, wam_funcargs])
         wam_list = self.eval_opimpl(lst, w_opimpl, [wam_T])
 
         # 3. push items into the list
@@ -1324,14 +1317,10 @@ class AbstractFrame:
         wam_push = W_MetaArg.from_w_obj(self.vm, w_push)
 
         for item, wam_item in zip(lst.items, items_wam):
-            w_opimpl = self.vm.call_OP(
-                lst.loc,
-                OP.w_CALL,
-                [
-                    wam_push,
-                    W_FuncArgs.from_positional(self.vm, [wam_list, wam_item], lst.loc),
-                ],
+            wam_funcargs = W_MetaArg.from_w_obj(
+                self.vm, W_FuncArgs.from_args(wam_list, wam_item), loc=lst.loc
             )
+            w_opimpl = self.vm.call_OP(lst.loc, OP.w_CALL, [wam_push, wam_funcargs])
             wam_list = self.eval_opimpl(item, w_opimpl, [wam_push, wam_list, wam_item])
 
         return wam_list
@@ -1342,11 +1331,10 @@ class AbstractFrame:
 
         wam_T = W_MetaArg.from_w_obj(self.vm, w_SliceType)
         args = [self.eval_expr(arg) for arg in (op.start, op.stop, op.step)]
-        w_opimpl = self.vm.call_OP(
-            op.loc,
-            OP.w_CALL,
-            [wam_T, W_FuncArgs.from_positional(self.vm, args, op.loc)],
+        wam_funcargs = W_MetaArg.from_w_obj(
+            self.vm, W_FuncArgs.from_args(*args), loc=op.loc
         )
+        w_opimpl = self.vm.call_OP(op.loc, OP.w_CALL, [wam_T, wam_funcargs])
         wam_slice = self.eval_opimpl(op, w_opimpl, [wam_T] + args)
         return wam_slice
 
@@ -1363,11 +1351,10 @@ class AbstractFrame:
         wam_T = W_MetaArg.from_w_obj(self.vm, w_T)
 
         # 3. instantiate it
-        w_opimpl = self.vm.call_OP(
-            tup.loc,
-            OP.w_CALL,
-            [wam_T, W_FuncArgs.from_positional(self.vm, items_wam, tup.loc)],
+        wam_funcargs = W_MetaArg.from_w_obj(
+            self.vm, W_FuncArgs.from_args(*items_wam), loc=tup.loc
         )
+        w_opimpl = self.vm.call_OP(tup.loc, OP.w_CALL, [wam_T, wam_funcargs])
         wam_tuple = self.eval_opimpl(tup, w_opimpl, [wam_T] + items_wam)
         return wam_tuple
 
@@ -1420,11 +1407,10 @@ class AbstractFrame:
         w_T = self.vm.getitem_w(w_DictType, w_keytype, w_valuetype)  # dict[K, V]
         wam_T = W_MetaArg.from_w_obj(self.vm, w_T)
 
-        w_opimpl = self.vm.call_OP(
-            dict.loc,
-            OP.w_CALL,
-            [wam_T, W_FuncArgs.from_positional(self.vm, [], dict.loc)],
+        wam_funcargs = W_MetaArg.from_w_obj(
+            self.vm, W_FuncArgs.from_args(), loc=dict.loc
         )
+        w_opimpl = self.vm.call_OP(dict.loc, OP.w_CALL, [wam_T, wam_funcargs])
         wam_dict = self.eval_opimpl(dict, w_opimpl, [wam_T])
 
         # 3. push items into the dict
@@ -1434,16 +1420,10 @@ class AbstractFrame:
         wam_push = W_MetaArg.from_w_obj(self.vm, w_push)
 
         for pair, (wam_key, wam_val) in zip(dict.items, key_value_pair):
-            w_opimpl = self.vm.call_OP(
-                dict.loc,
-                OP.w_CALL,
-                [
-                    wam_push,
-                    W_FuncArgs.from_positional(
-                        self.vm, [wam_dict, wam_key, wam_val], dict.loc
-                    ),
-                ],
+            wam_funcargs = W_MetaArg.from_w_obj(
+                self.vm, W_FuncArgs.from_args(wam_dict, wam_key, wam_val), loc=dict.loc
             )
+            w_opimpl = self.vm.call_OP(dict.loc, OP.w_CALL, [wam_push, wam_funcargs])
             wam_dict = self.eval_opimpl(
                 pair, w_opimpl, [wam_push, wam_dict, wam_key, wam_val]
             )

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -322,15 +322,23 @@ class W_Func(W_Object):
         if isinstance(w_func, W_ASTFunc):
             args_wam = w_func._bind_args(vm, w_funcargs)
         else:
+            if w_funcargs.kwargs_wam:
+                err = SPyError(
+                    "W_TypeError", "keyword arguments not supported for this function"
+                )
+                err.add("error", "keyword arguments not supported", wam_func.loc)
+                raise err
             args_wam = w_funcargs.to_list()
         return W_OpSpec(w_func, args_wam, is_direct_call=True)
 
     @staticmethod
     def op_METACALL(
-        vm: "SPyVM", wam_func: "W_MetaArg", *args_wam: "W_MetaArg"
+        vm: "SPyVM", wam_func: "W_MetaArg", wam_funcargs: "W_MetaArg"
     ) -> "W_OpSpec":
         """
-        Call this function and use the return value as the OpSpec
+        Call this function and use the return value as the OpSpec.
+        Mirrors op_CALL: W_ASTFunc metafuncs support kwargs via _bind_args;
+        W_BuiltinFunc metafuncs do not.
         """
         from spy.vm.opspec import W_MetaArg, W_OpSpec
         from spy.vm.typechecker import typecheck_opspec
@@ -339,11 +347,25 @@ class W_Func(W_Object):
         assert isinstance(w_func, W_Func)
         assert w_func.w_functype.kind == "metafunc"
 
+        w_funcargs = wam_funcargs.w_blueval
+        assert isinstance(w_funcargs, W_FuncArgs)
+
+        if w_funcargs.kwargs_wam:
+            err = SPyError(
+                "W_TypeError", "keyword arguments not supported for this function"
+            )
+            err.add("error", "keyword arguments not supported", wam_func.loc)
+            raise err
+
         # Now we want to call the metafunc to get the opspec to return.  Note
         # that we cannot just vm.fast_call() it, because we don't know whether
         # the metafunc has the right signature. Instead, we do a full
         # OpSpec/typecheck/OpImpl dance, to raise proper TypeErrors if needed.
         # This is a bit of code duplication with callop.w_CALL, but too bad.
+        #
+        # Metafuncs receive their arguments as MetaArg-typed values, so each
+        # call-site wam is wrapped inside another W_MetaArg of type operator::MetaArg.
+        args_wam = w_funcargs.to_list()
         meta_args_wam = [W_MetaArg.from_w_obj(vm, wam) for wam in args_wam]
         w_meta_opspec = W_OpSpec(w_func, meta_args_wam)
         w_meta_opimpl = typecheck_opspec(
@@ -367,11 +389,11 @@ class W_Func(W_Object):
             raise err
 
         # if we return a simple opspec, it will be called with arguments
-        # [wam_func, *args_wam]. But what we want is to call it with just
-        # *args_wam. This is the equivalent of passing "list(args_wam)" in
+        # [wam_func, *meta_args_wam]. But what we want is to call it with just
+        # *meta_args_wam. This is the equivalent of passing "list(args_wam)" in
         # op_CALL.
         if w_opspec.is_simple():
-            w_opspec._args_wam = list(args_wam)
+            w_opspec._args_wam = args_wam
 
         return w_opspec
 
@@ -519,6 +541,17 @@ class W_ASTFunc(W_Func):
         got_posargs_wam = list(w_funcargs.args_wam)
         got_kwargs_wam: dict[str, W_MetaArg] = dict(w_funcargs.kwargs_wam)
 
+        # check for positional args that are also provided as kwargs
+        for i, func_arg in enumerate(self.funcdef.args[: len(got_posargs_wam)]):
+            if func_arg.name in got_kwargs_wam:
+                func_name = self.funcdef.name
+                err = SPyError(
+                    "W_TypeError",
+                    f"{func_name}() got multiple values for argument `{func_arg.name}`",
+                )
+                err.add("error", "multiple values for argument", func_arg.loc)
+                raise err
+
         defaults_wam: dict[str, W_MetaArg] = {}
         n_default_w = len(self.defaults_w)
         if n_default_w > 0:
@@ -531,9 +564,8 @@ class W_ASTFunc(W_Func):
                 wam = W_MetaArg.from_w_obj(vm, w_default, loc=loc)
                 defaults_wam[param_name] = wam
 
-        n_pos_params = len(got_posargs_wam)
         args_wam = got_posargs_wam.copy()
-        remaining_args = self.funcdef.args[n_pos_params:]
+        remaining_args = self.funcdef.args[len(got_posargs_wam) :]
 
         for func_arg in remaining_args:
             param_name = func_arg.name

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -337,8 +337,7 @@ class W_Func(W_Object):
     ) -> "W_OpSpec":
         """
         Call this function and use the return value as the OpSpec.
-        Mirrors op_CALL: W_ASTFunc metafuncs support kwargs via _bind_args;
-        W_BuiltinFunc metafuncs do not.
+        Keyword arguments are not supported for metafuncs.
         """
         from spy.vm.opspec import W_MetaArg, W_OpSpec
         from spy.vm.typechecker import typecheck_opspec
@@ -418,11 +417,9 @@ class W_FuncArgs(W_Object):
 
     @classmethod
     def from_args(cls, *args_wam: "W_MetaArg") -> "W_FuncArgs":
-        """Create a positional-only W_FuncArgs from individual args."""
         return cls(list(args_wam), [])
 
     def to_list(self) -> list["W_MetaArg"]:
-        """Return a flat list in source order: positional args then kwargs values."""
         return self.args_wam + [wam for _, wam in self.kwargs_wam]
 
     def spy_key(self, vm: "SPyVM") -> Any:

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -322,6 +322,17 @@ class W_Func(W_Object):
         if isinstance(w_func, W_ASTFunc):
             args_wam = w_func._bind_args(vm, w_funcargs)
         else:
+            if w_funcargs.kwargs_wam:
+                func_name = w_func.fqn.human_name(vm)
+                err = SPyError(
+                    "W_TypeError", "keyword arguments not supported for this function"
+                )
+                err.add(
+                    "error",
+                    f"`{func_name}` does not support keyword arguments",
+                    wam_func.loc,
+                )
+                raise err
             args_wam = w_funcargs.to_list()
         return W_OpSpec(w_func, args_wam, is_direct_call=True)
 
@@ -395,17 +406,9 @@ class W_FuncArgs(W_Object):
         self.kwargs_wam = kwargs_wam
 
     @classmethod
-    def from_positional(
-        cls, vm: "SPyVM", args_wam: list["W_MetaArg"], loc: "Loc"
-    ) -> "W_MetaArg":
-        """
-        Wrap a positional-only args list into a blue W_MetaArg holding a W_FuncArgs.
-        Convenience for internal call sites that don't use kwargs.
-        """
-        from spy.vm.opspec import W_MetaArg as _W_MetaArg
-
-        w_fa = cls(args_wam, [])
-        return _W_MetaArg(vm, "blue", W_FuncArgs._w, w_fa, loc)
+    def from_args(cls, *args_wam: "W_MetaArg") -> "W_FuncArgs":
+        """Create a positional-only W_FuncArgs from individual args."""
+        return cls(list(args_wam), [])
 
     def to_list(self) -> list["W_MetaArg"]:
         """Return a flat list in source order: positional args then kwargs values."""

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -305,7 +305,7 @@ class W_Func(W_Object):
     # is 'plain' or 'generic'.
     @staticmethod
     def op_CALL(
-        vm: "SPyVM", wam_func: "W_MetaArg", *got_args_wam: "W_MetaArg"
+        vm: "SPyVM", wam_func: "W_MetaArg", wam_funcargs: "W_MetaArg"
     ) -> "W_OpSpec":
         """
         Return an OpSpec which directly calls this function.
@@ -316,9 +316,13 @@ class W_Func(W_Object):
         assert isinstance(w_func, W_Func)
         assert w_func.w_functype.kind != "metafunc"
 
-        args_wam = list(got_args_wam)
+        w_funcargs = wam_funcargs.w_blueval
+        assert isinstance(w_funcargs, W_FuncArgs)
+
         if isinstance(w_func, W_ASTFunc):
-            args_wam = w_func._fill_defaults_maybe(vm, args_wam)
+            args_wam = w_func._bind_args(vm, w_funcargs)
+        else:
+            args_wam = w_funcargs.to_list()
         return W_OpSpec(w_func, args_wam, is_direct_call=True)
 
     @staticmethod
@@ -370,6 +374,52 @@ class W_Func(W_Object):
             w_opspec._args_wam = list(args_wam)
 
         return w_opspec
+
+
+class W_FuncArgs(W_Object):
+    """
+    Encapsulates the payload of a function call: positional args and keyword
+    args in source order. Passed as a single W_MetaArg through the call_OP
+    machinery. Unpacked by w_CALL / _bind_args before typechecking.
+    """
+
+    args_wam: list["W_MetaArg"]
+    kwargs_wam: list[tuple[str, "W_MetaArg"]]  # source order
+
+    def __init__(
+        self,
+        args_wam: list["W_MetaArg"],
+        kwargs_wam: list[tuple[str, "W_MetaArg"]],
+    ) -> None:
+        self.args_wam = args_wam
+        self.kwargs_wam = kwargs_wam
+
+    @classmethod
+    def from_positional(
+        cls, vm: "SPyVM", args_wam: list["W_MetaArg"], loc: "Loc"
+    ) -> "W_MetaArg":
+        """
+        Wrap a positional-only args list into a blue W_MetaArg holding a W_FuncArgs.
+        Convenience for internal call sites that don't use kwargs.
+        """
+        from spy.vm.opspec import W_MetaArg as _W_MetaArg
+
+        w_fa = cls(args_wam, [])
+        return _W_MetaArg(vm, "blue", W_FuncArgs._w, w_fa, loc)
+
+    def to_list(self) -> list["W_MetaArg"]:
+        """Return a flat list in source order: positional args then kwargs values."""
+        return self.args_wam + [wam for _, wam in self.kwargs_wam]
+
+    def spy_key(self, vm: "SPyVM") -> Any:
+        args_keys = tuple(wam.spy_key(vm) for wam in self.args_wam)
+        kwargs_keys = tuple((name, wam.spy_key(vm)) for name, wam in self.kwargs_wam)
+        return ("W_FuncArgs", args_keys, kwargs_keys)
+
+
+# W_FuncArgs is internal and never visible at the SPy level, but needs a
+# registered type so vm.dynamic_type() works when wrapping it in a W_MetaArg.
+W_FuncArgs._w = W_Type.declare(FQN("builtins::funcargs"))
 
 
 # =========== W_ASTFunc and compilation stages ========
@@ -467,33 +517,57 @@ class W_ASTFunc(W_Func):
         frame = ASTFrame(vm, self, args_w)
         return frame.run(args_w)
 
-    def _fill_defaults_maybe(
-        self, vm: "SPyVM", got_args_wam: list["W_MetaArg"]
-    ) -> list["W_MetaArg"]:
+    def _bind_args(self, vm: "SPyVM", w_funcargs: "W_FuncArgs") -> list["W_MetaArg"]:
         """
-        If got_args_wam is not long enough and we have default values, add them.
+        Resolve W_FuncArgs into a fully positional list of W_MetaArg in param
+        order, matching keyword args to params by name and filling defaults.
         """
         from spy.vm.opspec import W_MetaArg
 
-        if not self.defaults_w:
-            return got_args_wam
+        got_posargs_wam = list(w_funcargs.args_wam)
+        got_kwargs_wam: dict[str, W_MetaArg] = dict(w_funcargs.kwargs_wam)
 
-        n_params = len(self.w_functype.params)
-        n_got = len(got_args_wam)
-        n_defaults = len(self.defaults_w)
-        n_missing = n_params - n_got
+        defaults_wam: dict[str, W_MetaArg] = {}
+        n_default_w = len(self.defaults_w)
+        if n_default_w > 0:
+            param_names = [arg.name for arg in self.funcdef.args]
+            params_with_defaults = param_names[-n_default_w:]
+            default_locs = [d.loc for d in self.funcdef.defaults]
+            for w_default, loc, param_name in zip(
+                self.defaults_w, default_locs, params_with_defaults
+            ):
+                wam = W_MetaArg.from_w_obj(vm, w_default, loc=loc)
+                defaults_wam[param_name] = wam
 
-        if n_missing <= 0 or n_missing > n_defaults:
-            return got_args_wam
+        n_pos_params = len(got_posargs_wam)
+        args_wam = got_posargs_wam.copy()
+        remaining_args = self.funcdef.args[n_pos_params:]
 
-        # defaults align to the end of the param list
-        args_wam = list(got_args_wam)
-        start = n_defaults - n_missing
-        defaults_w = self.defaults_w[start:]
-        default_locs = [d.loc for d in self.funcdef.defaults[start:]]
-        for w_default, loc in zip(defaults_w, default_locs):
-            wam = W_MetaArg.from_w_obj(vm, w_default, loc=loc)
-            args_wam.append(wam)
+        for func_arg in remaining_args:
+            param_name = func_arg.name
+            if param_name in got_kwargs_wam:
+                args_wam.append(got_kwargs_wam.pop(param_name))
+            elif param_name in defaults_wam:
+                args_wam.append(defaults_wam.pop(param_name))
+            else:
+                func_name = self.funcdef.name
+                err = SPyError(
+                    "W_TypeError",
+                    f"{func_name}() missing required argument `{param_name}`",
+                )
+                err.add("error", "missing required argument", func_arg.loc)
+                raise err
+
+        if got_kwargs_wam:
+            unused = ", ".join(f"`{k}`" for k in got_kwargs_wam)
+            err = SPyError("W_TypeError", f"unexpected keyword arguments: {unused}")
+            err.add(
+                "error",
+                "unexpected keyword arguments",
+                next(iter(got_kwargs_wam.values())).loc,
+            )
+            raise err
+
         return args_wam
 
 

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -322,17 +322,6 @@ class W_Func(W_Object):
         if isinstance(w_func, W_ASTFunc):
             args_wam = w_func._bind_args(vm, w_funcargs)
         else:
-            if w_funcargs.kwargs_wam:
-                func_name = w_func.fqn.human_name(vm)
-                err = SPyError(
-                    "W_TypeError", "keyword arguments not supported for this function"
-                )
-                err.add(
-                    "error",
-                    f"`{func_name}` does not support keyword arguments",
-                    wam_func.loc,
-                )
-                raise err
             args_wam = w_funcargs.to_list()
         return W_OpSpec(w_func, args_wam, is_direct_call=True)
 

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from spy.vm.b import B
-from spy.vm.function import W_ASTFunc, W_Func, W_FuncArgs, W_FuncType
+from spy.vm.function import W_Func, W_FuncArgs, W_FuncType
 from spy.vm.modules.operator.attrop import unwrap_name_maybe
 from spy.vm.opimpl import W_OpImpl
 from spy.vm.opspec import W_MetaArg, W_OpSpec
@@ -30,17 +30,10 @@ def w_CALL(vm: "SPyVM", wam_obj: W_MetaArg, wam_funcargs: W_MetaArg) -> W_OpImpl
         # message in case we try to call a plain function with [].
         assert w_T.pyclass is W_Func
         if w_T.kind == "plain":
-            w_func = wam_obj.w_blueval
-            if w_funcargs.kwargs_wam and not isinstance(w_func, W_ASTFunc):
-                errmsg = "keyword arguments not supported for this function"
-            else:
-                w_opspec = W_Func.op_CALL(vm, wam_obj, wam_funcargs)
+            w_opspec = W_Func.op_CALL(vm, wam_obj, wam_funcargs)
         elif w_T.kind == "metafunc":
             assert w_T.pyclass is W_Func
-            if w_funcargs.kwargs_wam:
-                errmsg = "keyword arguments not supported for this function"
-            else:
-                w_opspec = W_Func.op_METACALL(vm, wam_obj, *w_funcargs.to_list())  # type: ignore
+            w_opspec = W_Func.op_METACALL(vm, wam_obj, wam_funcargs)
         elif w_T.kind == "generic":
             errmsg = "generic functions must be called via `[...]`"
         else:
@@ -76,7 +69,10 @@ def w_CALL_METHOD(
 
     # if the type provides __call_method__, use it
     if w_call_method := w_T.lookup_func(vm, "__call_method__"):
-        w_opspec = vm.fast_metacall(w_call_method, newargs_wam)
+        if w_funcargs.kwargs_wam:
+            errmsg = "keyword arguments not supported for this function"
+        else:
+            w_opspec = vm.fast_metacall(w_call_method, newargs_wam)
     else:
         w_opspec = default_callmethod(vm, wam_obj, wam_meth, w_funcargs, meth)
 
@@ -117,7 +113,7 @@ def default_callmethod(
         if kind == "plain":
             return W_Func.op_CALL(vm, wam_func, wam_new_funcargs)
         elif kind == "metafunc":
-            return W_Func.op_METACALL(vm, wam_func, *new_funcargs.to_list())  # type: ignore
+            return W_Func.op_METACALL(vm, wam_func, wam_new_funcargs)
         else:
             return W_OpSpec.NULL
 

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -68,6 +68,7 @@ def w_CALL_METHOD(
     w_opspec = W_OpSpec.NULL
     w_T = wam_obj.w_static_T
     meth = unwrap_name_maybe(vm, wam_meth)
+    errmsg = f"method `{{0}}::{meth}` does not exist"
 
     w_funcargs = wam_funcargs.w_blueval
     assert isinstance(w_funcargs, W_FuncArgs)
@@ -87,7 +88,7 @@ def w_CALL_METHOD(
         w_opspec,
         newargs_wam,
         dispatch="single",
-        errmsg=f"method `{{0}}::{meth}` does not exist",
+        errmsg=errmsg,
     )
 
 

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -1,8 +1,7 @@
 from typing import TYPE_CHECKING
 
-from spy.errors import SPyError
 from spy.vm.b import B
-from spy.vm.function import W_Func, W_FuncArgs, W_FuncType
+from spy.vm.function import W_ASTFunc, W_Func, W_FuncArgs, W_FuncType
 from spy.vm.modules.operator.attrop import unwrap_name_maybe
 from spy.vm.opimpl import W_OpImpl
 from spy.vm.opspec import W_MetaArg, W_OpSpec
@@ -22,8 +21,7 @@ def w_CALL(vm: "SPyVM", wam_obj: W_MetaArg, wam_funcargs: W_MetaArg) -> W_OpImpl
 
     w_funcargs = wam_funcargs.w_blueval
     assert isinstance(w_funcargs, W_FuncArgs)
-    # in_args_wam is the source-order flat expansion used for ArgSpec.Arg(i) indices
-    in_args_wam = [wam_obj] + w_funcargs.to_list()
+    newargs_wam = [wam_obj] + w_funcargs.to_list()
     errmsg = "cannot call objects of type `{0}`"
 
     if isinstance(w_T, W_FuncType):
@@ -32,16 +30,17 @@ def w_CALL(vm: "SPyVM", wam_obj: W_MetaArg, wam_funcargs: W_MetaArg) -> W_OpImpl
         # message in case we try to call a plain function with [].
         assert w_T.pyclass is W_Func
         if w_T.kind == "plain":
-            w_opspec = W_Func.op_CALL(vm, wam_obj, wam_funcargs)
+            w_func = wam_obj.w_blueval
+            if w_funcargs.kwargs_wam and not isinstance(w_func, W_ASTFunc):
+                errmsg = "keyword arguments not supported for this function"
+            else:
+                w_opspec = W_Func.op_CALL(vm, wam_obj, wam_funcargs)
         elif w_T.kind == "metafunc":
             assert w_T.pyclass is W_Func
             if w_funcargs.kwargs_wam:
-                err = SPyError(
-                    "W_TypeError", "keyword arguments not supported for this function"
-                )
-                err.add("error", "keyword arguments not supported", wam_obj.loc)
-                raise err
-            w_opspec = W_Func.op_METACALL(vm, wam_obj, *w_funcargs.to_list())  # type: ignore
+                errmsg = "keyword arguments not supported for this function"
+            else:
+                w_opspec = W_Func.op_METACALL(vm, wam_obj, *w_funcargs.to_list())  # type: ignore
         elif w_T.kind == "generic":
             errmsg = "generic functions must be called via `[...]`"
         else:
@@ -50,12 +49,12 @@ def w_CALL(vm: "SPyVM", wam_obj: W_MetaArg, wam_funcargs: W_MetaArg) -> W_OpImpl
     elif w_T is B.w_dynamic:
         w_opspec = W_OpSpec(OP.w_dynamic_call)
     elif w_call := w_T.lookup_func(vm, "__call__"):
-        w_opspec = vm.fast_metacall(w_call, in_args_wam)
+        w_opspec = vm.fast_metacall(w_call, newargs_wam)
 
     return typecheck_opspec(
         vm,
         w_opspec,
-        in_args_wam,
+        newargs_wam,
         dispatch="single",
         errmsg=errmsg,
     )
@@ -73,18 +72,18 @@ def w_CALL_METHOD(
 
     w_funcargs = wam_funcargs.w_blueval
     assert isinstance(w_funcargs, W_FuncArgs)
-    in_args_wam = [wam_obj, wam_meth] + w_funcargs.to_list()
+    newargs_wam = [wam_obj, wam_meth] + w_funcargs.to_list()
 
     # if the type provides __call_method__, use it
     if w_call_method := w_T.lookup_func(vm, "__call_method__"):
-        w_opspec = vm.fast_metacall(w_call_method, in_args_wam)
+        w_opspec = vm.fast_metacall(w_call_method, newargs_wam)
     else:
         w_opspec = default_callmethod(vm, wam_obj, wam_meth, w_funcargs, meth)
 
     return typecheck_opspec(
         vm,
         w_opspec,
-        in_args_wam,
+        newargs_wam,
         dispatch="single",
         errmsg=f"method `{{0}}::{meth}` does not exist",
     )

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from spy.errors import SPyError
 from spy.vm.b import B
 from spy.vm.function import W_Func, W_FuncArgs, W_FuncType
 from spy.vm.modules.operator.attrop import unwrap_name_maybe
@@ -34,6 +35,12 @@ def w_CALL(vm: "SPyVM", wam_obj: W_MetaArg, wam_funcargs: W_MetaArg) -> W_OpImpl
             w_opspec = W_Func.op_CALL(vm, wam_obj, wam_funcargs)
         elif w_T.kind == "metafunc":
             assert w_T.pyclass is W_Func
+            if w_funcargs.kwargs_wam:
+                err = SPyError(
+                    "W_TypeError", "keyword arguments not supported for this function"
+                )
+                err.add("error", "keyword arguments not supported", wam_obj.loc)
+                raise err
             w_opspec = W_Func.op_METACALL(vm, wam_obj, *w_funcargs.to_list())  # type: ignore
         elif w_T.kind == "generic":
             errmsg = "generic functions must be called via `[...]`"
@@ -105,13 +112,7 @@ def default_callmethod(
             [wam_obj] + w_funcargs.args_wam,
             w_funcargs.kwargs_wam,
         )
-        wam_new_funcargs = W_MetaArg(
-            vm,
-            "blue",
-            vm.dynamic_type(new_funcargs),
-            new_funcargs,
-            wam_obj.loc,
-        )
+        wam_new_funcargs = W_MetaArg.from_w_obj(vm, new_funcargs, loc=wam_obj.loc)
 
         kind = w_func.w_functype.kind
         if kind == "plain":

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -40,9 +40,15 @@ def w_CALL(vm: "SPyVM", wam_obj: W_MetaArg, wam_funcargs: W_MetaArg) -> W_OpImpl
             assert False, f"unknown FuncKind: {w_T.kind}"
 
     elif w_T is B.w_dynamic:
-        w_opspec = W_OpSpec(OP.w_dynamic_call)
+        if w_funcargs.kwargs_wam:
+            errmsg = "keyword arguments not supported for this function"
+        else:
+            w_opspec = W_OpSpec(OP.w_dynamic_call)
     elif w_call := w_T.lookup_func(vm, "__call__"):
-        w_opspec = vm.fast_metacall(w_call, newargs_wam)
+        if w_funcargs.kwargs_wam:
+            errmsg = "keyword arguments not supported for this function"
+        else:
+            w_opspec = vm.fast_metacall(w_call, newargs_wam)
 
     return typecheck_opspec(
         vm,

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from spy.vm.b import B
-from spy.vm.function import W_Func, W_FuncType
+from spy.vm.function import W_Func, W_FuncArgs, W_FuncType
 from spy.vm.modules.operator.attrop import unwrap_name_maybe
 from spy.vm.opimpl import W_OpImpl
 from spy.vm.opspec import W_MetaArg, W_OpSpec
@@ -13,13 +13,16 @@ if TYPE_CHECKING:
 
 
 @OP.builtin_func(color="blue")
-def w_CALL(vm: "SPyVM", wam_obj: W_MetaArg, *args_wam: W_MetaArg) -> W_OpImpl:
+def w_CALL(vm: "SPyVM", wam_obj: W_MetaArg, wam_funcargs: W_MetaArg) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
 
     w_opspec = W_OpSpec.NULL
     w_T = wam_obj.w_static_T
 
-    newargs_wam = [wam_obj] + list(args_wam)
+    w_funcargs = wam_funcargs.w_blueval
+    assert isinstance(w_funcargs, W_FuncArgs)
+    # in_args_wam is the source-order flat expansion used for ArgSpec.Arg(i) indices
+    in_args_wam = [wam_obj] + w_funcargs.to_list()
     errmsg = "cannot call objects of type `{0}`"
 
     if isinstance(w_T, W_FuncType):
@@ -28,10 +31,10 @@ def w_CALL(vm: "SPyVM", wam_obj: W_MetaArg, *args_wam: W_MetaArg) -> W_OpImpl:
         # message in case we try to call a plain function with [].
         assert w_T.pyclass is W_Func
         if w_T.kind == "plain":
-            w_opspec = W_Func.op_CALL(vm, wam_obj, *args_wam)  # type: ignore
+            w_opspec = W_Func.op_CALL(vm, wam_obj, wam_funcargs)
         elif w_T.kind == "metafunc":
             assert w_T.pyclass is W_Func
-            w_opspec = W_Func.op_METACALL(vm, wam_obj, *args_wam)  # type: ignore
+            w_opspec = W_Func.op_METACALL(vm, wam_obj, *w_funcargs.to_list())  # type: ignore
         elif w_T.kind == "generic":
             errmsg = "generic functions must be called via `[...]`"
         else:
@@ -40,12 +43,12 @@ def w_CALL(vm: "SPyVM", wam_obj: W_MetaArg, *args_wam: W_MetaArg) -> W_OpImpl:
     elif w_T is B.w_dynamic:
         w_opspec = W_OpSpec(OP.w_dynamic_call)
     elif w_call := w_T.lookup_func(vm, "__call__"):
-        w_opspec = vm.fast_metacall(w_call, newargs_wam)
+        w_opspec = vm.fast_metacall(w_call, in_args_wam)
 
     return typecheck_opspec(
         vm,
         w_opspec,
-        newargs_wam,
+        in_args_wam,
         dispatch="single",
         errmsg=errmsg,
     )
@@ -53,7 +56,7 @@ def w_CALL(vm: "SPyVM", wam_obj: W_MetaArg, *args_wam: W_MetaArg) -> W_OpImpl:
 
 @OP.builtin_func(color="blue")
 def w_CALL_METHOD(
-    vm: "SPyVM", wam_obj: W_MetaArg, wam_meth: W_MetaArg, *args_wam: W_MetaArg
+    vm: "SPyVM", wam_obj: W_MetaArg, wam_meth: W_MetaArg, wam_funcargs: W_MetaArg
 ) -> W_OpImpl:
     from spy.vm.typechecker import typecheck_opspec
 
@@ -61,17 +64,20 @@ def w_CALL_METHOD(
     w_T = wam_obj.w_static_T
     meth = unwrap_name_maybe(vm, wam_meth)
 
+    w_funcargs = wam_funcargs.w_blueval
+    assert isinstance(w_funcargs, W_FuncArgs)
+    in_args_wam = [wam_obj, wam_meth] + w_funcargs.to_list()
+
     # if the type provides __call_method__, use it
     if w_call_method := w_T.lookup_func(vm, "__call_method__"):
-        newargs_wam = [wam_obj, wam_meth] + list(args_wam)
-        w_opspec = vm.fast_metacall(w_call_method, newargs_wam)
+        w_opspec = vm.fast_metacall(w_call_method, in_args_wam)
     else:
-        w_opspec = default_callmethod(vm, wam_obj, wam_meth, args_wam, meth)
+        w_opspec = default_callmethod(vm, wam_obj, wam_meth, w_funcargs, meth)
 
     return typecheck_opspec(
         vm,
         w_opspec,
-        [wam_obj, wam_meth] + list(args_wam),
+        in_args_wam,
         dispatch="single",
         errmsg=f"method `{{0}}::{meth}` does not exist",
     )
@@ -81,7 +87,7 @@ def default_callmethod(
     vm: "SPyVM",
     wam_obj: W_MetaArg,
     wam_meth: W_MetaArg,
-    args_wam: tuple[W_MetaArg, ...],
+    w_funcargs: W_FuncArgs,
     meth: str,
 ) -> W_OpSpec:
     """
@@ -94,13 +100,24 @@ def default_callmethod(
         # non-methods in the type dict
         assert isinstance(w_func, W_Func)
         wam_func = W_MetaArg.from_w_obj(vm, w_func, color="blue")
-        new_args_wam = (wam_obj,) + args_wam
+        # prepend self to args
+        new_funcargs = W_FuncArgs(
+            [wam_obj] + w_funcargs.args_wam,
+            w_funcargs.kwargs_wam,
+        )
+        wam_new_funcargs = W_MetaArg(
+            vm,
+            "blue",
+            vm.dynamic_type(new_funcargs),
+            new_funcargs,
+            wam_obj.loc,
+        )
 
         kind = w_func.w_functype.kind
         if kind == "plain":
-            return W_Func.op_CALL(vm, wam_func, *new_args_wam)  # type: ignore
+            return W_Func.op_CALL(vm, wam_func, wam_new_funcargs)
         elif kind == "metafunc":
-            return W_Func.op_METACALL(vm, wam_func, *new_args_wam)  # type: ignore
+            return W_Func.op_METACALL(vm, wam_func, *new_funcargs.to_list())  # type: ignore
         else:
             return W_OpSpec.NULL
 

--- a/spy/vm/modules/operator/itemop.py
+++ b/spy/vm/modules/operator/itemop.py
@@ -20,7 +20,9 @@ def w_GETITEM(vm: "SPyVM", wam_obj: W_MetaArg, *args_wam: W_MetaArg) -> W_OpImpl
     newargs_wam = [wam_obj] + list(args_wam)
     if isinstance(w_T, W_FuncType) and w_T.kind == "generic":
         # special case: for generic W_Funcs, "[]" means "call"
-        wam_funcargs = W_FuncArgs.from_positional(vm, list(args_wam), wam_obj.loc)
+        wam_funcargs = W_MetaArg.from_w_obj(
+            vm, W_FuncArgs.from_args(*args_wam), loc=wam_obj.loc
+        )
         w_opspec = w_T.pyclass.op_CALL(vm, wam_obj, wam_funcargs)  # type: ignore
     elif w_getitem := w_T.lookup_func(vm, "__getitem__"):
         w_opspec = vm.fast_metacall(w_getitem, newargs_wam)

--- a/spy/vm/modules/operator/itemop.py
+++ b/spy/vm/modules/operator/itemop.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from spy.vm.function import W_FuncType
+from spy.vm.function import W_FuncArgs, W_FuncType
 from spy.vm.opimpl import W_OpImpl
 from spy.vm.opspec import W_MetaArg, W_OpSpec
 
@@ -20,7 +20,8 @@ def w_GETITEM(vm: "SPyVM", wam_obj: W_MetaArg, *args_wam: W_MetaArg) -> W_OpImpl
     newargs_wam = [wam_obj] + list(args_wam)
     if isinstance(w_T, W_FuncType) and w_T.kind == "generic":
         # special case: for generic W_Funcs, "[]" means "call"
-        w_opspec = w_T.pyclass.op_CALL(vm, wam_obj, *args_wam)  # type: ignore
+        wam_funcargs = W_FuncArgs.from_positional(vm, list(args_wam), wam_obj.loc)
+        w_opspec = w_T.pyclass.op_CALL(vm, wam_obj, wam_funcargs)  # type: ignore
     elif w_getitem := w_T.lookup_func(vm, "__getitem__"):
         w_opspec = vm.fast_metacall(w_getitem, newargs_wam)
 

--- a/spy/vm/modules/operator/opimpl_dynamic.py
+++ b/spy/vm/modules/operator/opimpl_dynamic.py
@@ -145,7 +145,9 @@ def w_dynamic_call(vm: "SPyVM", w_obj: W_Dynamic, *args_w: W_Dynamic) -> W_Dynam
     all_args_w = [w_obj] + list(args_w)
     all_args_wam = [W_MetaArg.from_w_obj(vm, w_x) for w_x in all_args_w]
     wam_func = all_args_wam[0]
-    wam_funcargs = W_FuncArgs.from_positional(vm, all_args_wam[1:], Loc.here())
+    wam_funcargs = W_MetaArg.from_w_obj(
+        vm, W_FuncArgs.from_args(*all_args_wam[1:]), loc=Loc.here()
+    )
     w_opimpl = vm.call_OP(None, OP.w_CALL, [wam_func, wam_funcargs])
     return w_opimpl._execute(vm, all_args_w)  # XXX
 

--- a/spy/vm/modules/operator/opimpl_dynamic.py
+++ b/spy/vm/modules/operator/opimpl_dynamic.py
@@ -139,9 +139,14 @@ def w_dynamic_hasattr(vm: "SPyVM", w_obj: W_Dynamic, w_name: W_Str) -> W_Dynamic
 
 @OP.builtin_func
 def w_dynamic_call(vm: "SPyVM", w_obj: W_Dynamic, *args_w: W_Dynamic) -> W_Dynamic:
+    from spy.location import Loc
+    from spy.vm.function import W_FuncArgs
+
     all_args_w = [w_obj] + list(args_w)
-    all_args_wam = [W_MetaArg.from_w_obj(vm, w_x) for i, w_x in enumerate(all_args_w)]
-    w_opimpl = vm.call_OP(None, OP.w_CALL, all_args_wam)
+    all_args_wam = [W_MetaArg.from_w_obj(vm, w_x) for w_x in all_args_w]
+    wam_func = all_args_wam[0]
+    wam_funcargs = W_FuncArgs.from_positional(vm, all_args_wam[1:], Loc.here())
+    w_opimpl = vm.call_OP(None, OP.w_CALL, [wam_func, wam_funcargs])
     return w_opimpl._execute(vm, all_args_w)  # XXX
 
 

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -1073,7 +1073,9 @@ class SPyVM:
         "func(*args) (metacall)"
         from spy.vm.function import W_FuncArgs
 
-        wam_funcargs = W_FuncArgs.from_positional(self, args_wam, loc)
+        wam_funcargs = W_MetaArg.from_w_obj(
+            self, W_FuncArgs.from_args(*args_wam), loc=loc
+        )
         return self.call_OP(loc, OPERATOR.w_CALL, [wam_func, wam_funcargs])
 
     def call_wam(

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -1071,7 +1071,10 @@ class SPyVM:
         self, wam_func: W_MetaArg, args_wam: list[W_MetaArg], *, loc: Loc
     ) -> W_OpImpl:
         "func(*args) (metacall)"
-        return self.call_OP(loc, OPERATOR.w_CALL, [wam_func] + args_wam)
+        from spy.vm.function import W_FuncArgs
+
+        wam_funcargs = W_FuncArgs.from_positional(self, args_wam, loc)
+        return self.call_OP(loc, OPERATOR.w_CALL, [wam_func, wam_funcargs])
 
     def call_wam(
         self, wam_func: W_MetaArg, args_wam: list[W_MetaArg], *, loc: Loc


### PR DESCRIPTION
Adds support for keyword arguments in SPy function calls.

* only spy functions and methods support kwargs
* metafuncs, builtin funcs, dynamic calls and `__call__` dont support keyword args and compilation fails
* `**kwargs` not supported

## Demo

```python
> cat examples/1_high_level/kwargs.spy   
"""
Things to notice:
  - keyword args can be passed in any order
  - after redshift, keyword args are reordered
"""

def compute(x: i32, y:i32, z: i32) -> i32:
    return 100 * x + 10 * y + z

def main() -> None:
    print("Hello from SPy 🥸")
    print(compute(1, z=5, y=3))

> spy examples/1_high_level/kwargs.spy   
Hello from SPy 🥸
135

> spy % spy rs examples/1_high_level/kwargs.spy
def compute(x: i32, y: i32, z: i32) -> i32:
    return 100 * x + 10 * y + z

def main() -> None:
    `_print::println[str]`('Hello from SPy 🥸')
    `_print::println[i32]`(`kwargs::compute`(1, 3, 5))
```

## High level changes for `op_CALL`

1. The parser now accepts keyword arguments, and the `Call` nodes now hold a new `kwargs` field. `**kwargs` is rejected by the parser.
2. The `op_CALL` op now accepts exactly two parameters `[wam_func, wam_funcargs]` where funcargs is a new `W_FuncArgs` object that contains all positional and keyword arguments. Source order for keyword arguments is preserved. Previously it accepted variadic args `[wam_func, wam_arg1, wam_arg2, ...]`. This required many call sites to change even when they only use positional args (eg when `op_GETITEM` calls into `op_CALL`). 
3. `ASTFrame.eval_expr_Call` now evaluates the values in the `Call.kwargs` field and builds a new `FuncArgs` to pass into `vm.call_op(op_CALL, ...)`.
4. A new `W_ASTFunc._bind_args(funcargs)` method replaces `_fill_defaults_maybe` since default handling and keyword mapping needs to happen at the same time. It returns an ordered list of inner args, reordering keyword args and injecting defaults. 
5. The redshift pass flattens kwargs to positional in parameter order, so the C backend needs no changes.

A side effect of the new binding method `_bind_args` is that missing args even when positional have a different error:
```
TypeError: f() missing required argument `a`
  | /Users/shalabh/src-local/spy/examples/1_high_level/x.spy:2
  | def f(a: i32) -> i32:
  |       |____| missing required argument
```

This change in error required patching some more tests.

## `op_CALLMETHOD` and `op_METACALL`

`op_CALLMETHOD` also follows the same design and implements keyword args for spy methods.
`op_METACALL` signature now changed to accept funcargs, but it rejects compilation if any kwargs are present.

## Future

* keyword args for metacalls and builtin functions - seem possible, needs extra work
* `__call_method__` and `__call__` - maybe we can change this to accept funcargs directly, allowing richer custom dispatch.