### PR TITLE
Try to fix playground-deploy.yml

### DIFF
--- a/.github/workflows/playground-deploy.yml
+++ b/.github/workflows/playground-deploy.yml
@@ -39,6 +39,11 @@ jobs:
       - name: Setup Emscripten
         uses: mymindstorm/setup-emsdk@v14
 
+      - name: Install SPy
+        run: |
+          # to be able to call `python -m spy.build.flags`
+          pip install .
+
       - name: Build libspy
         run: make -C spy/libspy TARGET=emscripten
 


### PR DESCRIPTION
The playground build is broken till https://github.com/spylang/spy/pull/559/changes#diff-77d83b361755f3295d18cd7b6a4caebdc974ca6ac96d4e7cc9b3b8cc58a2eec9. We now need spy to build libspy... The simplest fix is to install spy before building libspy in playground-deploy.yml. Let's try.

We just need spy to execute python -m spy.build.flags.