### PR TITLE
fix playground: export individual uint32_t fields for str/bytes layout

### DIFF
--- a/spy/libspy/__init__.py
+++ b/spy/libspy/__init__.py
@@ -116,7 +116,7 @@ class LibSPyHost(HostModule):
 
 @dataclass
 class StrLayout:
-    # See also the struct _spy_StrObject_layout in str.h
+    # See also spy_StrObject in str.h
     size: int
     length_offset: int
     hash_offset: int
@@ -125,7 +125,7 @@ class StrLayout:
 
 @dataclass
 class BytesLayout:
-    # See also the struct _spy_BytesObject_layout in bytes.h
+    # See also spy_BytesObject in bytes.h
     size: int
     length_offset: int
     hash_offset: int
@@ -148,10 +148,18 @@ class LLSPyInstance(LLWasmInstance):
         self.libspy = LibSPyHost()
         hostmods = [self.libspy] + hostmods
         super().__init__(llmod, hostmods, instance=instance)
-        layout = self.call("_spy_StrObject_layout")
-        self.str_layout = StrLayout(*layout)
-        blayout = self.call("_spy_BytesObject_layout")
-        self.bytes_layout = BytesLayout(*blayout)
+        self.str_layout = StrLayout(
+            size=self.call("_spy_StrObject_size"),
+            length_offset=self.call("_spy_StrObject_length_offset"),
+            hash_offset=self.call("_spy_StrObject_hash_offset"),
+            utf8_offset=self.call("_spy_StrObject_utf8_offset"),
+        )
+        self.bytes_layout = BytesLayout(
+            size=self.call("_spy_BytesObject_size"),
+            length_offset=self.call("_spy_BytesObject_length_offset"),
+            hash_offset=self.call("_spy_BytesObject_hash_offset"),
+            data_offset=self.call("_spy_BytesObject_data_offset"),
+        )
 
     def read_bytes(self, ptr: int) -> tuple[int, int, bytes]:
         """

--- a/spy/libspy/include/spy/bytes.h
+++ b/spy/libspy/include/spy/bytes.h
@@ -67,14 +67,13 @@ spy_unsafe$_BytesObject_to_bytes$impl(spy_gc_ptr_BytesObject p) {
 }
 
 // Layout info exported for bytes.py.
-typedef struct {
-    size_t size;
-    size_t length_offset;
-    size_t hash_offset;
-    size_t data_offset;
-} _spy_BytesObject_Layout;
-
-_spy_BytesObject_Layout WASM_EXPORT(_spy_BytesObject_layout)(void);
+// NOTE: we export individual uint32_t fields instead of a struct, because
+// struct-returning functions use the sret ABI in Emscripten/WASM and return
+// None/undefined to Python callers instead of an iterable.
+uint32_t WASM_EXPORT(_spy_BytesObject_size)(void);
+uint32_t WASM_EXPORT(_spy_BytesObject_length_offset)(void);
+uint32_t WASM_EXPORT(_spy_BytesObject_hash_offset)(void);
+uint32_t WASM_EXPORT(_spy_BytesObject_data_offset)(void);
 
 spy_BytesObject *WASM_EXPORT(spy_bytes_alloc)(size_t length);
 

--- a/spy/libspy/include/spy/str.h
+++ b/spy/libspy/include/spy/str.h
@@ -79,14 +79,13 @@ spy_unsafe$_StrObject_to_str$impl(spy_gc_ptr_StrObject p) {
 #endif
 
 // Layout info exported for str.py.
-typedef struct {
-    size_t size;
-    size_t length_offset;
-    size_t hash_offset;
-    size_t utf8_offset;
-} _spy_StrObject_Layout;
-
-_spy_StrObject_Layout WASM_EXPORT(_spy_StrObject_layout)(void);
+// NOTE: we export individual uint32_t fields instead of a struct, because
+// struct-returning functions use the sret ABI in Emscripten/WASM and return
+// None/undefined to Python callers instead of an iterable.
+uint32_t WASM_EXPORT(_spy_StrObject_size)(void);
+uint32_t WASM_EXPORT(_spy_StrObject_length_offset)(void);
+uint32_t WASM_EXPORT(_spy_StrObject_hash_offset)(void);
+uint32_t WASM_EXPORT(_spy_StrObject_utf8_offset)(void);
 
 spy_StrObject *WASM_EXPORT(spy_str_alloc)(size_t length);
 

--- a/spy/libspy/src/bytes.c
+++ b/spy/libspy/src/bytes.c
@@ -2,15 +2,17 @@
 #include <stddef.h>
 #include <stdint.h>
 
-_spy_BytesObject_Layout
-_spy_BytesObject_layout(void) {
-    return (_spy_BytesObject_Layout){
-        .size = sizeof(spy_BytesObject),
-        .length_offset = offsetof(spy_BytesObject, length),
-        .hash_offset = offsetof(spy_BytesObject, hash),
-        .data_offset = offsetof(spy_BytesObject, data),
-    };
-}
+uint32_t
+_spy_BytesObject_size(void) { return (uint32_t)sizeof(spy_BytesObject); }
+
+uint32_t
+_spy_BytesObject_length_offset(void) { return (uint32_t)offsetof(spy_BytesObject, length); }
+
+uint32_t
+_spy_BytesObject_hash_offset(void) { return (uint32_t)offsetof(spy_BytesObject, hash); }
+
+uint32_t
+_spy_BytesObject_data_offset(void) { return (uint32_t)offsetof(spy_BytesObject, data); }
 
 spy_BytesObject *
 spy_bytes_alloc(size_t length) {

--- a/spy/libspy/src/str.c
+++ b/spy/libspy/src/str.c
@@ -5,15 +5,17 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-_spy_StrObject_Layout
-_spy_StrObject_layout(void) {
-    return (_spy_StrObject_Layout){
-        .size = sizeof(spy_StrObject),
-        .length_offset = offsetof(spy_StrObject, length),
-        .hash_offset = offsetof(spy_StrObject, hash),
-        .utf8_offset = offsetof(spy_StrObject, utf8),
-    };
-}
+uint32_t
+_spy_StrObject_size(void) { return (uint32_t)sizeof(spy_StrObject); }
+
+uint32_t
+_spy_StrObject_length_offset(void) { return (uint32_t)offsetof(spy_StrObject, length); }
+
+uint32_t
+_spy_StrObject_hash_offset(void) { return (uint32_t)offsetof(spy_StrObject, hash); }
+
+uint32_t
+_spy_StrObject_utf8_offset(void) { return (uint32_t)offsetof(spy_StrObject, utf8); }
 
 spy_StrObject *
 spy_str_alloc(size_t length) {


### PR DESCRIPTION
Fixes #578

The issue was understood by Claude, who also proposed the fix.

4 calls instead of one but at least it works also for Emscripten and therefore it fixes the playground!

---

**Description by Claude**

### Root cause

`_spy_StrObject_layout()` and `_spy_BytesObject_layout()` are C functions that return a struct by value (4 × size_t fields = 16 bytes on wasm32).

In WebAssembly, structs larger than a primitive scalar can't be returned directly. Emscripten uses the sret (struct return) ABI: the caller allocates space and passes a hidden pointer as the first argument; the function writes the struct there and returns void. From the Python/Pyodide side, the function returns None/undefined — so `StrLayout(*layout)` blows up with `TypeError: argument after * must be an iterable, not NoneType`.

This was never a problem on the wasmtime backend because wasmtime handles multi-value returns differently (it unpacks struct returns into a tuple).

### Fix

Replaced the two struct-returning functions with individual uint32_t-returning accessor functions — one per field — in both the C headers and implementations:

```
_spy_StrObject_size/length_offset/hash_offset/utf8_offset(void) → uint32_t
_spy_BytesObject_size/length_offset/hash_offset/data_offset(void) → uint32_t
```

`uint32_t` is a scalar type and crosses the WASM/Emscripten boundary correctly in both backends. The Python side now calls each function individually to build the StrLayout/BytesLayout dataclasses.

The `_spy_StrObject_Layout` typedef can be removed from the headers entirely since nothing references it anymore (done).