### PR TITLE
implement sizeof for u64 and i64

### DIFF
--- a/spy/tests/compiler/unsafe/test_sizeof.py
+++ b/spy/tests/compiler/unsafe/test_sizeof.py
@@ -9,4 +9,6 @@ def test_sizeof_primitives():
     assert sizeof(B.w_i32) == 4
     assert sizeof(B.w_u32) == 4
     assert sizeof(B.w_f32) == 4
+    assert sizeof(B.w_i64) == 8
+    assert sizeof(B.w_u64) == 8
     assert sizeof(B.w_f64) == 8

--- a/spy/vm/modules/unsafe/misc.py
+++ b/spy/vm/modules/unsafe/misc.py
@@ -12,7 +12,7 @@ def sizeof(w_T: W_Type) -> int:
         return 1
     elif w_T in (B.w_i32, B.w_u32, B.w_f32):
         return 4
-    elif w_T is B.w_f64:
+    elif w_T in (B.w_i64, B.w_u64, B.w_f64):
         return 8
     elif isinstance(w_T, W_StructType):
         return w_T.size


### PR DESCRIPTION
Following on from #579, this PR adds `sizeof()` for u64 and i64.