### PR TITLE
playground: use debug build of libspy

### DIFF
--- a/playground/Makefile
+++ b/playground/Makefile
@@ -3,7 +3,7 @@
 # Paths relative to playground directory
 ROOT_DIR := ..
 LIBSPY_DIR := $(ROOT_DIR)/spy/libspy
-BUILD_DIR := $(LIBSPY_DIR)/build/emscripten/release
+BUILD_DIR := $(LIBSPY_DIR)/build/emscripten/debug
 DIST_DIR := $(ROOT_DIR)/dist
 
 # Use $PYTHON from environment if set, otherwise default to just 'python'


### PR DESCRIPTION
Workaround #564 and #578 (no -flto in debug build)

The playground has to use the debug build of libspy. The interpreter is only tested with the debug build. This is what works!

#564 is the manifestation of a bug related to using the interpreter with the release mode, for which pointers have no length.

