### PR TITLE
Playground layout: file explorer instead of buttons

### DIFF
--- a/examples/1_high_level/factorial.spy
+++ b/examples/1_high_level/factorial.spy
@@ -1,7 +1,7 @@
 """
 Things to notice:
   - `i32` is a concrete 32-bit integer type (unlike Python's arbitrary-precision `int`).
-  - SPy primitive types include i8, i16, i32, u8, u16, u32, f32, f64.
+  - SPy primitive types include i8, i32, i64, u8, u32, u64, f32, f64.
   - `for` loops and `range()` work as in Python.
   - After redshift, the for loop is compiled to efficient code without runtime dispatch and boxing.
 """

--- a/examples/1_high_level/hello.spy
+++ b/examples/1_high_level/hello.spy
@@ -1,8 +1,7 @@
-"""
-## About the playground:
+"""About the playground:
 
 The playground presents example files organized in 4 categories. You can discover
-SPy by following the proposed progression from left to right.
+SPy by following the proposed progression from top to bottom.
 
 You can use the `spy` CLI in the playground by typing a command in the input bar
 and pressing Enter or the Run button, or by clicking one of the shortcut buttons

--- a/examples/1_high_level/hello.spy
+++ b/examples/1_high_level/hello.spy
@@ -1,19 +1,4 @@
-"""About the playground:
-
-The playground presents example files organized in 4 categories. You can discover
-SPy by following the proposed progression from top to bottom.
-
-You can use the `spy` CLI in the playground by typing a command in the input bar
-and pressing Enter or the Run button, or by clicking one of the shortcut buttons
-below the editor. These buttons correspond to the most useful commands for running
-and inspecting the compilation pipeline:
-
-  - `spy execute hello.spy`             run the program (interpreted)
-  - `spy colorize hello.spy`            show code with blue/red coloring
-  - `spy redshift hello.spy`            show the redshifted typed AST (as code)
-  - `spy redshift --execute hello.spy`  run the redshifted AST (interpreted)
-  - `spy build --cdump hello.spy`       emit C code
-
+"""
 Things to notice:
   - Every SPy program defines `main()` as its entry point.
     SPy libraries do not need a `main()` function.

--- a/playground/main.py
+++ b/playground/main.py
@@ -430,11 +430,18 @@ def main():
         ).css("margin", "5px"),
         editor.css("border", "1px solid gray").attr("id", "editor"),
         ltk.VBox(
-            ltk.Label("Try the SPy CLI:"),
             ltk.HBox(
+                ltk.Label("Try the SPy CLI:").css("white-space", "nowrap"),
                 term_input,
                 term_input_run_btn,
-            ).css({"width": "100%", "display": "flex", "gap": "5px"}),
+            ).css(
+                {
+                    "width": "100%",
+                    "display": "flex",
+                    "gap": "5px",
+                    "align-items": "center",
+                }
+            ),
             ltk.Div(
                 ButtonLabel("Sample Flags:"),
                 RunSPyButton("execute"),
@@ -445,12 +452,8 @@ def main():
                 RunSPyButton("redshift --full-fqn"),
                 RunSPyButton("redshift --execute"),
                 RunSPyButton("build --cdump"),
-            ).css({"display": "flex", "gap": "5px", "vertical-align": "bottom"}),
-        ).css(
-            {
-                "align-items": "flex-start",
-            }
-        ),
+            ).css({"display": "flex", "gap": "5px", "flex-wrap": "wrap"}),
+        ).css({"align-items": "flex-start"}),
         ltk.Div().attr("id", "terminal"),
     ).addClass("editor-panel")
 

--- a/playground/main.py
+++ b/playground/main.py
@@ -118,7 +118,6 @@ load_shared_code_from_url()
 
 # Currently selected file path
 current_file: str = next(iter(CATEGORIES.values()))[0]
-current_cat_idx: int = 0
 
 console.log(f"[Python] Creating editor with initial file: {current_file}")
 editor = Editor(Path(current_file).read_text())
@@ -247,83 +246,103 @@ def load_file(filepath: str) -> None:
     filename_label.text(display_filename())
 
 
-def make_category_tabs() -> ltk.Tabs:
-    """Build the two-level tab widget: outer = categories, inner = files."""
-    inner_tabs_list: list[ltk.Tabs] = []
+def make_file_explorer() -> ltk.Div:
+    """Build a file-explorer sidebar: collapsible category sections with file items."""
+    explorer = ltk.Div().addClass("file-explorer")
 
     for cat, files in CATEGORIES.items():
-        file_tabs = ltk.Tabs(*[ltk.VBox().attr("name", Path(f).name) for f in files])
+        label = category_label(cat)
 
+        # Category header (clickable to collapse/expand)
+        header = ltk.Div(ltk.Span("▾ ").addClass("caret"), ltk.Span(label))
+        header.addClass("fe-category")
+
+        # File list container
+        file_list = ltk.Div().addClass("fe-file-list")
+
+        for filepath in files:
+            fname = Path(filepath).name
+            item = ltk.Div(fname).addClass("fe-file-item")
+            if filepath == current_file:
+                item.addClass("fe-file-active")
+
+            @ltk.callback
+            def on_file_click(event, _fp=filepath, _item=item):
+                # Deactivate all items, activate clicked one
+                ltk.find(".fe-file-item").removeClass("fe-file-active")
+                _item.addClass("fe-file-active")
+                load_file(_fp)
+
+            item.on("click", on_file_click)
+            file_list.append(item)
+
+        # Toggle collapse on header click
         @ltk.callback
-        def on_file_tab(event, ui=None, _file_tabs=file_tabs, _files=files):
-            idx = _file_tabs.active()
-            console.log(f"on_file_tab: {_files[idx]}...")
-            load_file(_files[idx])
+        def on_header_click(event, _fl=file_list, _hdr=header):
+            caret = _hdr.find(".caret")
+            if _fl.is_(":visible"):
+                _fl.hide()
+                caret.text("▸ ")
+            else:
+                _fl.show()
+                caret.text("▾ ")
 
-        file_tabs.on("tabsactivate", on_file_tab)
-        file_tabs.find(".ui-tabs-panel").hide()
-        inner_tabs_list.append(file_tabs)
+        header.on("click", on_header_click)
+        explorer.append(header)
+        explorer.append(file_list)
 
-    outer_tabs = ltk.Tabs(
-        *[
-            inner_tabs.attr("name", category_label(cat))
-            for cat, inner_tabs in zip(CATEGORIES.keys(), inner_tabs_list)
-        ]
-    )
-
-    @ltk.callback
-    def on_category_tab(event, ui=None):
-        # When switching category, load the first file of the new category
-        cat_idx = outer_tabs.active()
-        global current_cat_idx
-        if cat_idx == current_cat_idx:
-            return
-        current_cat_idx = cat_idx
-        cat = list(CATEGORIES.keys())[cat_idx]
-        load_file(CATEGORIES[cat][0])
-
-    outer_tabs.on("tabsactivate", on_category_tab)
-    return outer_tabs
+    return explorer
 
 
 def main():
     console.log("[Python] main() function started - building GUI...")
 
-    category_tabs = make_category_tabs()
+    file_explorer = make_file_explorer()
+
+    editor_panel = ltk.VBox(
+        ltk.HBox(
+            filename_label,
+            RunShareButton().css("margin-left", "auto"),
+        ).css("margin", "5px"),
+        editor.css("border", "1px solid gray").attr("id", "editor"),
+        ltk.VBox(
+            ltk.Label("Try the SPy CLI:"),
+            ltk.HBox(
+                term_input,
+                term_input_run_btn,
+            ).css({"width": "100%", "display": "flex", "gap": "5px"}),
+            ltk.Div(
+                ButtonLabel("Sample Flags:"),
+                RunSPyButton("execute"),
+                RunSPyButton("parse"),
+                RunSPyButton("colorize"),
+                RunSPyButton("redshift"),
+                RunSPyButton("redshift --linearize"),
+                RunSPyButton("redshift --full-fqn"),
+                RunSPyButton("redshift --execute"),
+                RunSPyButton("build --cdump"),
+            ).css({"display": "flex", "gap": "5px", "vertical-align": "bottom"}),
+        ).css(
+            {
+                "align-items": "flex-start",
+            }
+        ),
+        ltk.Div().attr("id", "terminal"),
+    ).addClass("editor-panel")
 
     (
-        ltk.VBox(
-            category_tabs,
-            ltk.HBox(
-                filename_label,
-                RunShareButton().css("margin-left", "auto"),
-            ).css("margin", "5px"),
-            editor.css("border", "1px solid gray").attr("id", "editor"),
-            ltk.VBox(
-                ltk.Label("Try the SPy CLI:"),
-                ltk.HBox(
-                    term_input,
-                    term_input_run_btn,
-                ).css({"width": "100%", "display": "flex", "gap": "5px"}),
-                ltk.Div(
-                    ButtonLabel("Sample Flags:"),
-                    RunSPyButton("execute"),
-                    RunSPyButton("parse"),
-                    RunSPyButton("colorize"),
-                    RunSPyButton("redshift"),
-                    RunSPyButton("redshift --linearize"),
-                    RunSPyButton("redshift --full-fqn"),
-                    RunSPyButton("redshift --execute"),
-                    RunSPyButton("build --cdump"),
-                ).css({"display": "flex", "gap": "5px", "vertical-align": "bottom"}),
-            ).css(
-                {
-                    "align-items": "flex-start",
-                }
-            ),
-            ltk.Div().attr("id", "terminal"),
+        ltk.HBox(
+            file_explorer,
+            editor_panel,
         )
-        .css({"width": "95%", "max-width": "1600px", "margin": "20px auto"})
+        .css(
+            {
+                "width": "95%",
+                "max-width": "1600px",
+                "margin": "20px auto",
+                "align-items": "flex-start",
+            }
+        )
         .css("font-size", 14)
         .attr("name", "Editor")
         .appendTo(ltk.window.document.body)

--- a/playground/main.py
+++ b/playground/main.py
@@ -335,11 +335,92 @@ def make_file_explorer() -> ltk.Div:
     return explorer
 
 
+ABOUT_HTML = """
+<div class="about-body">
+  <p>
+    The playground presents example files organized in 4 categories.
+    Explore SPy by following the proposed progression from top to bottom
+    in the file explorer (or the dropdown on mobile).
+  </p>
+  <p>
+    Use the <strong>SPy CLI</strong> by typing a command in the input bar and pressing
+    <kbd>Enter</kbd> or the <strong>Run ▶</strong> button, or by clicking one of the
+    shortcut buttons. The most useful commands are:
+  </p>
+  <ul>
+    <li><code>spy execute hello.spy</code> — run the program (interpreted)</li>
+    <li><code>spy colorize hello.spy</code> — show blue/red coloring</li>
+    <li><code>spy redshift hello.spy</code> — show the redshifted typed AST</li>
+    <li><code>spy redshift --execute hello.spy</code> — run the redshifted AST</li>
+    <li><code>spy build --cdump hello.spy</code> — emit C code</li>
+  </ul>
+  <p>
+    The playground does not yet support <code>spy build</code>.
+  </p>
+</div>
+"""
+
+
+def make_about_button() -> ltk.Div:
+    """An ℹ button that opens a modal <dialog> with the about text."""
+    from js import document
+
+    # Build the <dialog> element directly
+    dialog = document.createElement("dialog")
+    dialog.className = "about-dialog"
+    dialog.innerHTML = (
+        "<h3 class='about-dialog-title'>ℹ About the SPy Playground</h3>"
+        + ABOUT_HTML
+        + "<button class='about-close-btn' autofocus>Close</button>"
+    )
+    document.body.appendChild(dialog)
+
+    # Close button inside dialog
+    close_btn = dialog.querySelector(".about-close-btn")
+
+    @ltk.callback
+    def on_close(event):
+        dialog.close()
+
+    ltk.window.jQuery(close_btn).on("click", on_close)
+
+    # Click on backdrop (the dialog element outside its content box) also closes
+    @ltk.callback
+    def on_backdrop_click(event):
+        rect = dialog.getBoundingClientRect()
+        if (
+            event.clientX < rect.left
+            or event.clientX > rect.right
+            or event.clientY < rect.top
+            or event.clientY > rect.bottom
+        ):
+            dialog.close()
+
+    ltk.window.jQuery(dialog).on("click", on_backdrop_click)
+
+    # The ℹ trigger button
+    btn = ltk.Button("ℹ \u00b7 About", lambda e: None)
+    btn.addClass("about-open-btn")
+
+    @ltk.callback
+    def on_open(event):
+        dialog.showModal()
+
+    btn.on("click", on_open)
+    return btn
+
+
 def main():
     console.log("[Python] main() function started - building GUI...")
 
     file_explorer = make_file_explorer()
     mobile_select = make_mobile_select()
+    about_btn = make_about_button()
+
+    sidebar = ltk.VBox(
+        about_btn,
+        file_explorer,
+    ).addClass("sidebar")
 
     editor_panel = ltk.VBox(
         mobile_select,
@@ -375,7 +456,7 @@ def main():
 
     (
         ltk.HBox(
-            file_explorer,
+            sidebar,
             editor_panel,
         )
         .css(

--- a/playground/main.py
+++ b/playground/main.py
@@ -246,9 +246,50 @@ def load_file(filepath: str) -> None:
     filename_label.text(display_filename())
 
 
+def make_mobile_select() -> ltk.Div:
+    """Build a <select> dropdown for mobile, grouped by category with <optgroup>."""
+    from js import document
+
+    sel = document.createElement("select")
+    sel.className = "fe-mobile-select"
+
+    # Build filepath -> index map for programmatic selection
+    all_paths: list[str] = []
+    for cat, files in CATEGORIES.items():
+        grp = document.createElement("optgroup")
+        grp.label = category_label(cat)
+        for filepath in files:
+            opt = document.createElement("option")
+            opt.value = filepath
+            opt.textContent = Path(filepath).name
+            if filepath == current_file:
+                opt.selected = True
+            grp.appendChild(opt)
+            all_paths.append(filepath)
+        sel.appendChild(grp)
+
+    @ltk.callback
+    def on_select_change(event):
+        filepath = sel.value
+        # Sync active state in sidebar too (in case both are rendered)
+        ltk.find(".fe-file-item").removeClass("fe-file-active")
+        ltk.find(f".fe-file-item:contains('{Path(filepath).name}')").addClass(
+            "fe-file-active"
+        )
+        load_file(filepath)
+
+    ltk.window.jQuery(sel).on("change", on_select_change)
+
+    wrapper = ltk.Div()
+    wrapper.addClass("fe-mobile-bar")
+    wrapper.element.append(ltk.window.jQuery(sel))
+    return wrapper
+
+
 def make_file_explorer() -> ltk.Div:
     """Build a file-explorer sidebar: collapsible category sections with file items."""
     explorer = ltk.Div().addClass("file-explorer")
+    explorer.addClass("fe-desktop-only")
 
     for cat, files in CATEGORIES.items():
         label = category_label(cat)
@@ -298,8 +339,10 @@ def main():
     console.log("[Python] main() function started - building GUI...")
 
     file_explorer = make_file_explorer()
+    mobile_select = make_mobile_select()
 
     editor_panel = ltk.VBox(
+        mobile_select,
         ltk.HBox(
             filename_label,
             RunShareButton().css("margin-left", "auto"),

--- a/playground/style.css
+++ b/playground/style.css
@@ -197,3 +197,62 @@ button.run-button:active {
     flex: 1;
     min-width: 0;
 }
+
+/* Mobile select dropdown (hidden on desktop) */
+.fe-mobile-bar {
+    display: none;
+    padding: 6px 0 8px;
+}
+
+.fe-mobile-select {
+    width: 100%;
+    font-size: 15px;
+    padding: 6px 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: white;
+}
+
+/* ===== Responsive: mobile (≤ 600px) ===== */
+@media (max-width: 600px) {
+    /* Switch to vertical stacked layout */
+    .ltk-hbox[name="Editor"] {
+        flex-direction: column !important;
+    }
+
+    /* Hide sidebar, show dropdown instead */
+    .fe-desktop-only {
+        display: none !important;
+    }
+
+    .fe-mobile-bar {
+        display: block;
+    }
+
+    /* Editor takes full width */
+    .editor-panel {
+        width: 100%;
+    }
+
+    /* Shrink editor height a bit to leave room for terminal */
+    #editor {
+        height: 280px;
+    }
+
+    /* Buttons row: allow wrapping */
+    #editor ~ div div {
+        flex-wrap: wrap;
+    }
+
+    /* Terminal: constrain height on small screens */
+    #terminal {
+        min-height: 120px;
+        resize: vertical;
+    }
+
+    /* Outer container: full width, tighter margin */
+    .ltk-hbox[name="Editor"] {
+        width: 100% !important;
+        margin: 8px auto !important;
+    }
+}

--- a/playground/style.css
+++ b/playground/style.css
@@ -119,8 +119,16 @@ button.run-button:active {
     font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
     font-size: 13px;
     min-height: 200px;
-    overflow: auto;
+    height: 200px;
+    overflow: hidden;
     resize: both;
+}
+
+#terminal py-terminal {
+    display: block;
+    height: 100%;
+    overflow-y: auto;
+    box-sizing: border-box;
 }
 
 /* Command prompt - only style the "$ spy" prompt span */

--- a/playground/style.css
+++ b/playground/style.css
@@ -327,14 +327,12 @@ button.run-button:active {
         width: 100%;
     }
 
+    /* Shrink CLI label on small screens */
+    .ltk-label { font-size: 12px; }
+
     /* Shrink editor height a bit to leave room for terminal */
     #editor {
         height: 280px;
-    }
-
-    /* Buttons row: allow wrapping */
-    #editor ~ div div {
-        flex-wrap: wrap;
     }
 
     /* Terminal: constrain height on small screens */

--- a/playground/style.css
+++ b/playground/style.css
@@ -128,3 +128,72 @@ button.run-button:active {
     font-family: monospace;
     color: #666;
 }
+
+/* ===== File Explorer Sidebar ===== */
+
+.file-explorer {
+    width: 200px;
+    min-width: 160px;
+    flex-shrink: 0;
+    background: #f0f0f0;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    margin-right: 12px;
+    padding: 6px 0;
+    font-size: 13px;
+    align-self: flex-start;
+}
+
+.fe-category {
+    padding: 6px 10px;
+    font-weight: 600;
+    color: #444;
+    cursor: pointer;
+    user-select: none;
+    background: #e4e4e4;
+    border-bottom: 1px solid #ccc;
+}
+
+.fe-category:first-child {
+    border-radius: 5px 5px 0 0;
+}
+
+.fe-category:hover {
+    background: #d8d8d8;
+}
+
+.fe-category .caret {
+    font-style: normal;
+    color: #666;
+}
+
+.fe-file-list {
+    padding: 3px 0;
+    border-bottom: 1px solid #ddd;
+}
+
+.fe-file-item {
+    padding: 5px 10px 5px 22px;
+    cursor: pointer;
+    color: #333;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.fe-file-item:hover {
+    background: #dce8f8;
+    color: #0055cc;
+}
+
+.fe-file-active {
+    background: #cce0ff;
+    color: #003a99;
+    font-weight: 500;
+}
+
+/* Editor panel takes all remaining width */
+.editor-panel {
+    flex: 1;
+    min-width: 0;
+}

--- a/playground/style.css
+++ b/playground/style.css
@@ -129,19 +129,100 @@ button.run-button:active {
     color: #666;
 }
 
+/* ===== About modal dialog ===== */
+
+.about-open-btn {
+    width: 100%;
+    background: #1a4a7a;
+    color: white;
+    border: none;
+    border-radius: 5px 5px 0 0;
+    padding: 7px 12px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    text-align: left;
+}
+
+.about-open-btn:hover {
+    background: #0055cc;
+}
+
+.about-dialog {
+    border: 1px solid #b8d0ec;
+    border-radius: 8px;
+    padding: 0;
+    max-width: 520px;
+    width: 90vw;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.25);
+}
+
+.about-dialog::backdrop {
+    background: rgba(0,0,0,0.35);
+}
+
+.about-dialog-title {
+    margin: 0;
+    padding: 14px 18px 10px;
+    font-size: 15px;
+    color: #1a4a7a;
+    border-bottom: 1px solid #d0e4f7;
+    background: #eef4fb;
+    border-radius: 8px 8px 0 0;
+}
+
+.about-body {
+    padding: 4px 18px 10px 18px;
+    line-height: 1.55;
+    font-size: 13px;
+}
+
+.about-body p { margin: 6px 0; }
+.about-body ul { margin: 4px 0 6px 0; padding-left: 1.4em; }
+.about-body li { margin: 3px 0; }
+.about-body code {
+    background: #dce8f8;
+    border-radius: 3px;
+    padding: 1px 4px;
+    font-size: 12px;
+    font-family: 'Consolas', 'Monaco', monospace;
+}
+.about-body kbd {
+    background: #e8e8e8;
+    border: 1px solid #bbb;
+    border-radius: 3px;
+    padding: 1px 5px;
+    font-size: 12px;
+    font-family: inherit;
+}
+
+.about-close-btn {
+    display: block;
+    margin: 2px 18px 14px auto;
+    background: #1a4a7a;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    padding: 6px 18px;
+    font-size: 13px;
+    cursor: pointer;
+}
+
+.about-close-btn:hover {
+    background: #0055cc;
+}
+
 /* ===== File Explorer Sidebar ===== */
 
 .file-explorer {
-    width: 200px;
-    min-width: 160px;
+    width: 100%;
     flex-shrink: 0;
     background: #f0f0f0;
     border: 1px solid #ccc;
-    border-radius: 6px;
-    margin-right: 12px;
+    border-top: none;
+    border-radius: 0 0 6px 6px;
     padding: 6px 0;
     font-size: 13px;
-    align-self: flex-start;
 }
 
 .fe-category {
@@ -152,10 +233,6 @@ button.run-button:active {
     user-select: none;
     background: #e4e4e4;
     border-bottom: 1px solid #ccc;
-}
-
-.fe-category:first-child {
-    border-radius: 5px 5px 0 0;
 }
 
 .fe-category:hover {
@@ -192,7 +269,15 @@ button.run-button:active {
     font-weight: 500;
 }
 
-/* Editor panel takes all remaining width */
+/* Sidebar = about button + file explorer */
+.sidebar {
+    width: 200px;
+    min-width: 160px;
+    flex-shrink: 0;
+    margin-right: 12px;
+    align-self: flex-start;
+    gap: 0 !important;
+}
 .editor-panel {
     flex: 1;
     min-width: 0;
@@ -220,8 +305,8 @@ button.run-button:active {
         flex-direction: column !important;
     }
 
-    /* Hide sidebar, show dropdown instead */
-    .fe-desktop-only {
+    /* Hide sidebar (button + explorer), show dropdown instead */
+    .sidebar {
         display: none !important;
     }
 


### PR DESCRIPTION
As suggested by @antocuni, the buttons at the top are removed and replaced with a UI looking like a file explorer.

It looks quite nice :slightly_smiling_face: 

Done with Claude.