### PR TITLE
Fix spy backend u8

### DIFF
--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -364,8 +364,14 @@ class SPyBackend:
             return repr(int(vm.unwrap_i32(w_val)))
         elif w_T is B.w_f64:
             return repr(float(vm.unwrap_f64(w_val)))
+        elif w_T is B.w_f32:
+            return f"f32({float(vm.unwrap_f32(w_val))})"
         elif w_T is B.w_complex128:
             return repr(vm.unwrap_complex128(w_val))
+        elif w_T in (B.w_i8, B.w_u8, B.w_u32, B.w_i64, B.w_u64):
+            val = vm.unwrap(w_val)
+            prefix = self.IPREFIX[type(val)]
+            return f"{prefix}({int(val)})"
         elif w_T is TYPES.w_NoneType:
             assert w_val is B.w_None
             return "None"

--- a/spy/tests/test_backend_spy.py
+++ b/spy/tests/test_backend_spy.py
@@ -442,3 +442,29 @@ class TestSPyBackend(CompilerTest):
         def foo() -> i32:
             return __block__(x: i32 = 1; x)
         """)
+
+    def test_typed_consts(self):
+        self.backend = "doppler"
+        src = """
+        def foo() -> None:
+            var a = i8(1)
+            var b = u8(1)
+            var c = i32(1)
+            var d = u32(1)
+            var e = i64(1)
+            var f = u64(1)
+            var g = f32(1.0)
+            var h = f64(1.0)
+        """
+        self.compile(src)
+        self.assert_dump("""
+        def foo() -> None:
+            a: i8 = i8(1)
+            b: u8 = u8(1)
+            c: i32 = 1
+            d: u32 = u32(1)
+            e: i64 = i64(1)
+            f: u64 = u64(1)
+            g: f32 = f32(1.0)
+            h: f64 = 1.0
+        """)


### PR DESCRIPTION
The bug can for example be reproduced with:

```
from unsafe import gc_alloc, gc_ptr, ptr_setbytes

def main() -> None:
    buf = gc_alloc[i32](4)
    ptr_setbytes(buf, 0, 4)
    total = buf[0] + buf[1] + buf[2] + buf[3]
    assert total == 0
```

The traceback ends with:

```
  File "/home/pierre/dev/spy/spy/backend/spy.py", line 177, in fmt_expr
    return magic_dispatch(self, "fmt_expr", expr)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pierre/dev/spy/spy/util.py", line 76, in magic_dispatch
    return meth(obj, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pierre/dev/spy/spy/backend/spy.py", line 379, in fmt_expr_Const
    raise NotImplementedError(f"WIP: {w_T}")
NotImplementedError: WIP: <spy type 'u8'>
```

I'm not sure of the correct way to test this.

The fix should also work for other integer types, but it is not tested.