### PR TITLE
playground: build and use the debug version of libspy locally

### DIFF
--- a/playground/Makefile
+++ b/playground/Makefile
@@ -3,7 +3,7 @@
 # Paths relative to playground directory
 ROOT_DIR := ..
 LIBSPY_DIR := $(ROOT_DIR)/spy/libspy
-BUILD_DIR := $(LIBSPY_DIR)/build/emscripten/release
+BUILD_DIR := $(LIBSPY_DIR)/build/emscripten/debug
 DIST_DIR := $(ROOT_DIR)/dist
 
 # Use $PYTHON from environment if set, otherwise default to just 'python'
@@ -25,7 +25,7 @@ WHEEL_NAME := spylang-$(VERSION)-py3-none-any.whl
 # This mirrors the steps from .github/workflows/playground.yml
 local:
 	@echo "Building libspy for emscripten..."
-	$(MAKE) -C $(LIBSPY_DIR) TARGET=emscripten
+	$(MAKE) -C $(LIBSPY_DIR) TARGET=emscripten BUILD_TYPE=debug
 
 	@echo "Building Python wheel..."
 	$(PYTHON) -m build --wheel --outdir $(DIST_DIR) $(ROOT_DIR)


### PR DESCRIPTION
@paugier I noticed that the playground was _bulding_ `emscripten/release` but then using `emscripten/debug` (which could be stale). The following is explanation/fix written by claude.

Please review and feel free to merge if it's fine.

---

The `make local` target in `playground/Makefile` built the **release**
version of libspy (since `BUILD_TYPE` defaulted to `release` in
`spy/libspy/Makefile`) but then copied the artifacts from the **debug**
directory. So the build and the copy disagreed, and `make local` ended up
shipping whatever stale/missing debug files happened to be on disk.

This makes both sides consistent on the debug build:
- pass `BUILD_TYPE=debug` when invoking the libspy Makefile
- point `BUILD_DIR` at the `debug` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)