### PR TITLE
Make the alloc macros C++ safe with explicit casts in initializer list

### DIFF
--- a/spy/libspy/include/spy/unsafe.h
+++ b/spy/libspy/include/spy/unsafe.h
@@ -55,7 +55,7 @@ spy_gc_alloc_bdwgc(size_t size) {
         return (PTR){p};                                                               \
     }                                                                                  \
     static inline PTR PTR##$alloc(size_t n) {                                          \
-        return (PTR){spy_##MEMKIND##_alloc(sizeof(T) * n)};                            \
+        return (PTR){(T*)spy_##MEMKIND##_alloc(sizeof(T) * n)};                        \
     }                                                                                  \
     static inline T PTR##$deref(PTR p) {                                               \
         return *(p.p);                                                                 \
@@ -84,7 +84,7 @@ spy_gc_alloc_bdwgc(size_t size) {
         return (PTR){p, 1};                                                            \
     }                                                                                  \
     static inline PTR PTR##$alloc(size_t n) {                                          \
-        return (PTR){spy_##MEMKIND##_alloc(sizeof(T) * n), n};                         \
+        return (PTR){(T*)spy_##MEMKIND##_alloc(sizeof(T) * n), (ptrdiff_t) n};         \
     }                                                                                  \
     static inline T PTR##$deref(PTR p) {                                               \
         return *(p.p);                                                                 \


### PR DESCRIPTION
(This problem was discovered and diagnosed with AI, but the solution here is my own.)

While trying to write a SPy extension that needs some C++ code, I found that the `spy.h` header is not valid C++11 (or later) because the there is some implicit casting in struct initializers.  These are fixed with a couple explicit casts, as seen in the diff.

In order to test if the header is valid C++, I've been using the following minimal test:
```
// test_spy_h.cpp
#define SPY_TARGET_NATIVE
#define SPY_RELEASE
// comment above and uncomment below to test the CHECKED version of the macros
//#define SPY_DEBUG
#include "spy.h"
int main() { return 0; }
```
Then run:
```
c++  -Ispy/libspy/include test_spy_h.cpp
```

Without this patch, you'll get something like:
```
❯ c++ -std=c++17 -Ispy/libspy/include test_spy_h.cpp
In file included from test_spy_h.cpp:3:
In file included from spy/libspy/include/spy.h:41:
In file included from spy/libspy/include/spy/__spy__.h:4:
In file included from spy/libspy/include/spy/str.h:6:
spy/libspy/include/spy/unsafe.h:138:1: error: cannot initialize a member subobject of type
      'uint8_t *' (aka 'unsigned char *') with an rvalue of type 'void *'
  138 | SPY_PTR_FUNCTIONS(gc, spy_unsafe$gc_ptr__builtins$u8, uint8_t)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
spy/libspy/include/spy/unsafe.h:50:29: note: expanded from macro 'SPY_PTR_FUNCTIONS'
   50 | #  define SPY_PTR_FUNCTIONS _SPY_PTR_FUNCTIONS_UNCHECKED
      |                             ^
spy/libspy/include/spy/unsafe.h:58:22: note: expanded from macro '_SPY_PTR_FUNCTIONS_UNCHECKED'
   58 |         return (PTR){spy_##MEMKIND##_alloc(sizeof(T) * n)};                            \
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<scratch space>:96:1: note: expanded from here
   96 | spy_gc_alloc
      | ^
In file included from test_spy_h.cpp:3:
In file included from spy/libspy/include/spy.h:41:
In file included from spy/libspy/include/spy/__spy__.h:4:
spy/libspy/include/spy/str.h:46:1: error: cannot initialize a member subobject of type
      'spy_StrObject *' with an rvalue of type 'void *'
   46 | SPY_PTR_FUNCTIONS(gc, spy_unsafe$gc_ptr___str$StrObject, spy_StrObject)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
spy/libspy/include/spy/unsafe.h:50:29: note: expanded from macro 'SPY_PTR_FUNCTIONS'
   50 | #  define SPY_PTR_FUNCTIONS _SPY_PTR_FUNCTIONS_UNCHECKED
      |                             ^
spy/libspy/include/spy/unsafe.h:58:22: note: expanded from macro '_SPY_PTR_FUNCTIONS_UNCHECKED'
   58 |         return (PTR){spy_##MEMKIND##_alloc(sizeof(T) * n)};                            \
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<scratch space>:118:1: note: expanded from here
  118 | spy_gc_alloc
      | ^
In file included from test_spy_h.cpp:3:
In file included from spy/libspy/include/spy.h:42:
In file included from spy/libspy/include/spy/builtins.h:5:
spy/libspy/include/spy/bytes.h:52:1: error: cannot initialize a member subobject of type
      'spy_BytesObject *' with an rvalue of type 'void *'
   52 | SPY_PTR_FUNCTIONS(gc, spy_unsafe$gc_ptr___bytes$BytesObject, spy_BytesObject)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
spy/libspy/include/spy/unsafe.h:50:29: note: expanded from macro 'SPY_PTR_FUNCTIONS'
   50 | #  define SPY_PTR_FUNCTIONS _SPY_PTR_FUNCTIONS_UNCHECKED
      |                             ^
spy/libspy/include/spy/unsafe.h:58:22: note: expanded from macro '_SPY_PTR_FUNCTIONS_UNCHECKED'
   58 |         return (PTR){spy_##MEMKIND##_alloc(sizeof(T) * n)};                            \
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<scratch space>:141:1: note: expanded from here
  141 | spy_gc_alloc
      | ^
3 errors generated.
```