### PR TITLE
allow initialization of list[StructT]

### DIFF
--- a/spy/tests/compiler/test_list.py
+++ b/spy/tests/compiler/test_list.py
@@ -179,3 +179,18 @@ class TestList(CompilerTest):
             ("help: use an explicit type: `l: list[T] = []`", "l"),
         )
         self.compile_raises(src, "foo", errors)
+
+    def test_list_init(self):
+        src = """
+        @struct
+        class Point:
+            x: i32
+            y: i32
+
+        def foo() -> i32:
+            lst: list[Point] = [Point(10, 2)]
+            return lst[0].x + lst[0].y
+        """
+        mod = self.compile(src)
+        res = mod.foo()
+        assert res == 12

--- a/stdlib/_list.spy
+++ b/stdlib/_list.spy
@@ -300,7 +300,7 @@ def list(T):
             ll = self.__ll__
             i = 0
             while i < ll.length:
-                if ll.items[i] == value:
+                if self[i] == value:
                     return i
                 i = i + 1
             raise ValueError
@@ -310,7 +310,7 @@ def list(T):
             result = 0
             i = 0
             while i < ll.length:
-                if ll.items[i] == value:
+                if self[i] == value:
                     result = result + 1
                 i = i + 1
             return result
@@ -320,7 +320,7 @@ def list(T):
             idx = -1
             i = 0
             while i < ll.length:
-                if ll.items[i] == value:
+                if self[i] == value:
                     idx = i
                     i = ll.length
                 i = i + 1


### PR DESCRIPTION
Fixes #539 by using `list.__getitem__()` rather than accessing `list.items[]` directly when testing element equality.

(AI assisted in the diagnosis of this issue.)
