### PR TITLE
Fix attribute lookup on gc_ref[T] and raw_ref[T]

### DIFF
--- a/spy/backend/c/cstructwriter.py
+++ b/spy/backend/c/cstructwriter.py
@@ -201,6 +201,4 @@ class CStructWriter:
         self.tbh_ptrs_def.wb(f"""
         #define {c_reftype}_from_addr {c_ptrtype}_from_addr
         #define {c_reftype}$deref {c_ptrtype}$deref
-        #define {c_reftype}$__eq__ {c_ptrtype}$__eq__
-        #define {c_reftype}$__ne__ {c_ptrtype}$__ne__
         """)

--- a/spy/tests/compiler/test_list.py
+++ b/spy/tests/compiler/test_list.py
@@ -179,3 +179,18 @@ class TestList(CompilerTest):
             ("help: use an explicit type: `l: list[T] = []`", "l"),
         )
         self.compile_raises(src, "foo", errors)
+
+    def test_list_of_structs_init(self):
+        src = """
+        @struct
+        class Point:
+            x: i32
+            y: i32
+
+        def foo() -> i32:
+            lst: list[Point] = [Point(10, 2)]
+            return lst[0].x + lst[0].y
+        """
+        mod = self.compile(src)
+        res = mod.foo()
+        assert res == 12

--- a/spy/tests/compiler/unsafe/test_ptr.py
+++ b/spy/tests/compiler/unsafe/test_ptr.py
@@ -319,7 +319,6 @@ class TestUnsafePtr(CompilerTest):
         assert not mod.ne(p0, p0)
         assert mod.ne(p0, p1)
 
-    @pytest.mark.skip("FIXME")
     def test_ref_eq(self, memkind):
         # ref equality delegates to itemT.__eq__, so it compares THE VALUES
         # here we check all combinations of {ref[T],T} == {ref[T],T}
@@ -381,7 +380,6 @@ class TestUnsafePtr(CompilerTest):
         assert not mod.ne_ref_T(42, 42)
         assert not mod.ne_T_ref(42, 42)
 
-    @pytest.mark.skip("FIXME")
     def test_ref_dunder_methods(self, memkind):
         k = memkind
         mod = self.compile(f"""

--- a/spy/tests/compiler/unsafe/test_ptr.py
+++ b/spy/tests/compiler/unsafe/test_ptr.py
@@ -116,9 +116,9 @@ class TestUnsafePtr(CompilerTest):
         with SPyError.raises("W_PanicError", match="ptr_store out of bounds"):
             mod.bar(-5, 300)
 
-    def test_ptr_to_struct(self, memkind):
+    def test_ptr_to_struct_getattr_setattr(self, memkind):
         k = memkind
-        mod = self.compile(f"""
+        src = f"""
         from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, {k}_ref as k_ref
 
         @struct
@@ -128,23 +128,40 @@ class TestUnsafePtr(CompilerTest):
 
         def make_point(x: i32, y: f64) -> k_ptr[Point]:
             p = k_alloc[Point](1)
-            p.x = x
+            p.x = x  # setattr via ptr[T]
             p.y = y
             return p
 
-        def with_ptr(x: i32, y: f64) -> f64:
+        def foo(x: i32, y: f64) -> f64:
             p = make_point(x, y)
-            return p.x + p.y
+            return p.x + p.y  # getattr via ptr[T]
+        """
+        mod = self.compile(src)
+        assert mod.foo(3, 4.5) == 7.5
 
-        def with_ref(x: i32, y: f64) -> f64:
-            # reading an item out of a ptr returns a ref
-            p = make_point(x, y)
-            r: k_ref[Point] = p[0]
-            return r.x + r.y
+    def test_ref_to_struct_getattr_setattr(self, memkind):
+        k = memkind
+        src = f"""
+        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, {k}_ref as k_ref
 
-        """)
-        assert mod.with_ptr(3, 4.5) == 7.5
-        assert mod.with_ref(6, 7.8) == 13.8
+        @struct
+        class Point:
+            x: i32
+            y: f64
+
+        def make_point(x: i32, y: f64) -> k_ref[Point]:
+            p = k_alloc[Point](1)
+            r: k_ref[Point] = p[0]  # get a ref out of ptr
+            r.x = x  # setattr via ref[T]
+            r.y = y
+            return r
+
+        def foo(x: i32, y: f64) -> f64:
+            r = make_point(x, y)
+            return r.x + r.y  # getattr via ref[T]
+        """
+        mod = self.compile(src)
+        assert mod.foo(3, 4.5) == 7.5
 
     def test_ptr_to_string(self, memkind):
         # XXX: support for raw_alloc[str] was added by 30ffdb9a, but doesn't make sense
@@ -184,7 +201,6 @@ class TestUnsafePtr(CompilerTest):
             p = k_alloc[Point](1)
             r = p[0]
             return dir(r)
-
         """)
         d1 = mod.dir_ptr_point()
         assert "x" in d1
@@ -282,6 +298,7 @@ class TestUnsafePtr(CompilerTest):
         assert mod.rect_ref() == 9876
 
     def test_ptr_eq(self, memkind):
+        # ptr equaliy compares THE POINTERS
         k = memkind
         mod = self.compile(f"""
         from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr
@@ -302,7 +319,10 @@ class TestUnsafePtr(CompilerTest):
         assert not mod.ne(p0, p0)
         assert mod.ne(p0, p1)
 
+    @pytest.mark.skip("FIXME")
     def test_ref_eq(self, memkind):
+        # ref equality delegates to itemT.__eq__, so it compares THE VALUES
+        # here we check all combinations of {ref[T],T} == {ref[T],T}
         k = memkind
         mod = self.compile(f"""
         from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, {k}_ref as k_ref
@@ -311,27 +331,57 @@ class TestUnsafePtr(CompilerTest):
         class MyInt:
             val: i32
 
-        def alloc() -> k_ptr[MyInt]:
-            return k_alloc[MyInt](1)
+        def get_MyInt_ref(x: i32) -> k_ref[MyInt]:
+            p = k_alloc[MyInt](1)
+            p[0] = MyInt(x)
+            return p[0]
 
-        def eq(a: k_ptr[MyInt], b: k_ptr[MyInt]) -> bool:
-            ra: k_ref[MyInt] = a[0]
-            rb: k_ref[MyInt] = b[0]
+        def eq_ref_ref(a: i32, b: i32) -> bool:
+            ra = get_MyInt_ref(a)
+            rb = get_MyInt_ref(b)
             return ra == rb
 
-        def ne(a: k_ptr[MyInt], b: k_ptr[MyInt]) -> bool:
-            ra: k_ref[MyInt] = a[0]
-            rb: k_ref[MyInt] = b[0]
-            return ra != rb
-        """)
-        p0 = mod.alloc()
-        p1 = mod.alloc()
-        assert mod.eq(p0, p0)
-        assert not mod.eq(p0, p1)
-        assert not mod.ne(p0, p0)
-        assert mod.ne(p0, p1)
+        def eq_ref_T(a: i32, b: i32) -> bool:
+            ra = get_MyInt_ref(a)
+            bb = MyInt(b)
+            return ra == bb
 
-    def test_ref_method(self, memkind):
+        def eq_T_ref(a: i32, b: i32) -> bool:
+            aa = MyInt(a)
+            rb = get_MyInt_ref(b)
+            return aa == rb
+
+        def ne_ref_ref(a: i32, b: i32) -> bool:
+            ra = get_MyInt_ref(a)
+            rb = get_MyInt_ref(b)
+            return ra != rb
+
+        def ne_ref_T(a: i32, b: i32) -> bool:
+            ra = get_MyInt_ref(a)
+            bb = MyInt(b)
+            return ra != bb
+
+        def ne_T_ref(a: i32, b: i32) -> bool:
+            aa = MyInt(a)
+            rb = get_MyInt_ref(b)
+            return aa != rb
+        """)
+        # testing ==
+        assert mod.eq_ref_ref(42, 42)
+        assert mod.eq_ref_T(42, 42)
+        assert mod.eq_T_ref(42, 42)
+        assert not mod.eq_ref_ref(42, 100)
+        assert not mod.eq_ref_T(42, 100)
+        assert not mod.eq_T_ref(42, 100)
+        # testing !=
+        assert mod.ne_ref_ref(42, 100)
+        assert mod.ne_ref_T(42, 100)
+        assert mod.ne_T_ref(42, 100)
+        assert not mod.ne_ref_ref(42, 42)
+        assert not mod.ne_ref_T(42, 42)
+        assert not mod.ne_T_ref(42, 42)
+
+    def test_ref_call_method(self, memkind):
         k = memkind
         mod = self.compile(f"""
         from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, {k}_ref as k_ref
@@ -349,15 +399,8 @@ class TestUnsafePtr(CompilerTest):
             p[0] = Point(1,2)
             r: k_ref[Point] = p[0]
             return r.foo()
-
-        def compare_eq() -> bool:
-            p: k_ptr[Point] = k_alloc[Point](1)
-            r: k_ref[Point] = p[0]
-            return r == p[0]
         """)
-
         assert mod.method_on_ref() == 3
-        assert mod.compare_eq()
 
     def test_can_allocate_ptr(self, memkind):
         k = memkind

--- a/spy/tests/compiler/unsafe/test_ptr.py
+++ b/spy/tests/compiler/unsafe/test_ptr.py
@@ -381,7 +381,8 @@ class TestUnsafePtr(CompilerTest):
         assert not mod.ne_ref_T(42, 42)
         assert not mod.ne_T_ref(42, 42)
 
-    def test_ref_call_method(self, memkind):
+    @pytest.mark.skip("FIXME")
+    def test_ref_dunder_methods(self, memkind):
         k = memkind
         mod = self.compile(f"""
         from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr, {k}_ref as k_ref
@@ -394,13 +395,32 @@ class TestUnsafePtr(CompilerTest):
             def foo(self) -> i32:
                 return self.x + self.y
 
-        def method_on_ref() -> i32:
+            def __getitem__(self, i: i32) -> Point:
+                return Point(self.x + i, self.y + i)
+
+            def __add__(self, p: Point) -> Point:
+                return Point(self.x + p.x, self.y + p.y)
+
+        def get_ref() -> k_ref[Point]:
             p: k_ptr[Point] = k_alloc[Point](1)
             p[0] = Point(1,2)
-            r: k_ref[Point] = p[0]
+            return p[0]
+
+        def call_method() -> i32:
+            r = get_ref()
             return r.foo()
+
+        def getitem() -> Point:
+            r = get_ref()
+            return r[10]
+
+        def add() -> Point:
+            r = get_ref()
+            return r + Point(10, 20)
         """)
-        assert mod.method_on_ref() == 3
+        assert mod.call_method() == 3
+        assert mod.getitem() == (11, 12)
+        assert mod.add() == (11, 22)
 
     def test_can_allocate_ptr(self, memkind):
         k = memkind

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -193,7 +193,6 @@ class W_PtrType(W_MemLocType):
         if isinstance(w_itemT, W_StructType):
             if w_itemT.is_defined():
                 w_T._populate_fields()
-                w_T.is_ready = True
             # else: not-yet-defined struct (e.g. recursive self-reference);
             # fields will be back-filled by W_StructType.define_from_classbody
         else:
@@ -207,6 +206,7 @@ class W_PtrType(W_MemLocType):
             self.dict_w[w_field.name] = W_PtrField(
                 w_field.name, w_field.w_T, w_field.offset, self.memkind
             )
+        self.is_ready = True
 
     # w_NULL: ???
     # PtrTypes have a NULL member, which you can use like that:
@@ -266,7 +266,6 @@ class W_RefType(W_MemLocType):
         if isinstance(w_itemT, W_StructType):
             if w_itemT.is_defined():
                 w_T._populate_fields()
-                w_T.is_ready = True
             # else: not-yet-defined struct; back-filled by define_from_classbody
         else:
             w_T.is_ready = True
@@ -279,6 +278,7 @@ class W_RefType(W_MemLocType):
             self.dict_w[w_field.name] = W_PtrField(
                 w_field.name, w_field.w_T, w_field.offset, self.memkind
             )
+        self.is_ready = True
 
     def as_ptrtype(self, vm: "SPyVM") -> W_PtrType:
         if self.memkind == "raw":

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -24,11 +24,11 @@ on each:
     point to
 """
 
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional, Self
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Self
 
 import fixedint
 
-from spy.errors import WIP, SPyError
+from spy.errors import SPyError
 from spy.fqn import FQN
 from spy.location import Loc
 from spy.vm.b import B
@@ -40,7 +40,7 @@ from spy.vm.member import Member
 from spy.vm.modules.types import W_Loc
 from spy.vm.opspec import W_MetaArg, W_OpSpec
 from spy.vm.primitive import W_I32, W_Bool, W_Dynamic
-from spy.vm.struct import W_StructField, W_StructType
+from spy.vm.struct import W_StructType
 from spy.vm.w import W_Func, W_Object, W_Str, W_Type
 
 from . import UNSAFE
@@ -105,6 +105,60 @@ def w_gc_ref(vm: "SPyVM", w_T: W_Type) -> W_Dynamic:
     return w_reftype
 
 
+@UNSAFE.builtin_type("PtrField")
+class W_PtrField(W_Object):
+    """
+    Descriptor for struct fields accessed through ptr[T] or ref[T].
+
+    Analogous to W_StructField, but for memory-located structs.
+    Stored in W_PtrType.dict_w / W_RefType.dict_w, one per struct field.
+    """
+
+    __spy_storage_category__ = "value"
+
+    def __init__(self, name: str, w_T: W_Type, offset: int, memkind: MEMKIND) -> None:
+        self.name = name
+        self.w_T = w_T
+        self.offset = offset
+        self.memkind = memkind
+
+    def spy_key(self, vm: "SPyVM") -> Any:
+        return ("PtrField", self.name, self.w_T.spy_key(vm), self.offset, self.memkind)
+
+    def __repr__(self) -> str:
+        n = self.name
+        t = self.w_T.fqn.debug_human_name
+        k = self.memkind
+        return f"<spy ptr field {n}: `{t}` (+{self.offset}, {k})>"
+
+    @builtin_method("__get__", color="blue", kind="metafunc")
+    @staticmethod
+    def w_GET(vm: "SPyVM", wam_self: W_MetaArg, wam_ptr: W_MetaArg) -> W_OpSpec:
+        w_field = wam_self.w_blueval
+        assert isinstance(w_field, W_PtrField)
+        w_memkind = vm.wrap(w_field.memkind)
+        wam_name = W_MetaArg.from_w_obj(vm, vm.wrap(w_field.name))
+        wam_offset = W_MetaArg.from_w_obj(vm, vm.wrap(w_field.offset))
+        # ptr_getfield[field_T, memkind](ptr, name, offset)
+        w_func = vm.fast_call(UNSAFE.w_ptr_getfield, [w_field.w_T, w_memkind])
+        assert isinstance(w_func, W_Func)
+        return W_OpSpec(w_func, [wam_ptr, wam_name, wam_offset])
+
+    @builtin_method("__set__", color="blue", kind="metafunc")
+    @staticmethod
+    def w_SET(
+        vm: "SPyVM", wam_self: W_MetaArg, wam_ptr: W_MetaArg, wam_v: W_MetaArg
+    ) -> W_OpSpec:
+        w_field = wam_self.w_blueval
+        assert isinstance(w_field, W_PtrField)
+        wam_name = W_MetaArg.from_w_obj(vm, vm.wrap(w_field.name))
+        wam_offset = W_MetaArg.from_w_obj(vm, vm.wrap(w_field.offset))
+        # ptr_setfield[field_T](ptr, name, offset, v)
+        w_func = vm.fast_call(UNSAFE.w_ptr_setfield, [w_field.w_T])
+        assert isinstance(w_func, W_Func)
+        return W_OpSpec(w_func, [wam_ptr, wam_name, wam_offset, wam_v])
+
+
 @UNSAFE.builtin_type("_memloctype")
 class W_MemLocType(W_Type):
     """
@@ -113,11 +167,14 @@ class W_MemLocType(W_Type):
 
     memkind: MEMKIND
     w_itemT: Annotated[W_Type, Member("itemtype")]
+    is_ready: bool
 
-    def spy_dir(self, vm: "SPyVM") -> set[str]:
-        names = super().spy_dir(vm)
-        names.update(self.w_itemT.spy_dir(vm))
-        return names
+    def repr_hints(self) -> list[str]:
+        hints = super().repr_hints()
+        # is_ready may not be set yet during construction
+        if not getattr(self, "is_ready", True):
+            hints.append("not ready")
+        return hints
 
 
 @UNSAFE.builtin_type("rawptrtype")
@@ -132,7 +189,24 @@ class W_PtrType(W_MemLocType):
         w_T = cls.from_pyclass(fqn, W_Ptr)
         w_T.memkind = memkind
         w_T.w_itemT = w_itemT
+        w_T.is_ready = False
+        if isinstance(w_itemT, W_StructType):
+            if w_itemT.is_defined():
+                w_T._populate_fields()
+                w_T.is_ready = True
+            # else: not-yet-defined struct (e.g. recursive self-reference);
+            # fields will be back-filled by W_StructType.define_from_classbody
+        else:
+            w_T.is_ready = True
         return w_T
+
+    def _populate_fields(self) -> None:
+        assert not self.is_ready
+        assert isinstance(self.w_itemT, W_StructType)
+        for w_field in self.w_itemT.iterfields_w():
+            self.dict_w[w_field.name] = W_PtrField(
+                w_field.name, w_field.w_T, w_field.offset, self.memkind
+            )
 
     # w_NULL: ???
     # PtrTypes have a NULL member, which you can use like that:
@@ -188,7 +262,23 @@ class W_RefType(W_MemLocType):
         w_T = cls.from_pyclass(fqn, W_Ref)
         w_T.memkind = memkind
         w_T.w_itemT = w_itemT
+        w_T.is_ready = False
+        if isinstance(w_itemT, W_StructType):
+            if w_itemT.is_defined():
+                w_T._populate_fields()
+                w_T.is_ready = True
+            # else: not-yet-defined struct; back-filled by define_from_classbody
+        else:
+            w_T.is_ready = True
         return w_T
+
+    def _populate_fields(self) -> None:
+        assert not self.is_ready
+        assert isinstance(self.w_itemT, W_StructType)
+        for w_field in self.w_itemT.iterfields_w():
+            self.dict_w[w_field.name] = W_PtrField(
+                w_field.name, w_field.w_T, w_field.offset, self.memkind
+            )
 
     def as_ptrtype(self, vm: "SPyVM") -> W_PtrType:
         if self.memkind == "raw":
@@ -243,64 +333,6 @@ class W_MemLoc(W_Object):
             # I think we can get here if we have something typed 'ptr' as
             # opposed to e.g. 'ptr[i32]'
             assert False, "FIXME: raise a nice error"
-
-    @builtin_method("__getattribute__", color="blue", kind="metafunc")
-    @staticmethod
-    def w_GETATTRIBUTE(
-        vm: "SPyVM", wam_self: W_MetaArg, wam_name: W_MetaArg
-    ) -> W_OpSpec:
-        return W_MemLoc.op_ATTR("get", vm, wam_self, wam_name, None)
-
-    @builtin_method("__setattr__", color="blue", kind="metafunc")
-    @staticmethod
-    def w_SETATTR(
-        vm: "SPyVM", wam_self: W_MetaArg, wam_name: W_MetaArg, wam_v: W_MetaArg
-    ) -> W_OpSpec:
-        return W_MemLoc.op_ATTR("set", vm, wam_self, wam_name, wam_v)
-
-    @staticmethod
-    def op_ATTR(
-        opkind: str,
-        vm: "SPyVM",
-        wam_self: W_MetaArg,
-        wam_name: W_MetaArg,
-        wam_v: Optional[W_MetaArg],
-    ) -> W_OpSpec:
-        """
-        Implement both w_GETATTRIBUTE and w_SETATTR.
-        """
-        w_T = W_MemLoc._get_memlocT(wam_self)
-        w_itemT = w_T.w_itemT
-        # attributes are supported only on ptr-to-structs
-        if not w_itemT.is_struct(vm):
-            return W_OpSpec.NULL
-
-        assert isinstance(w_itemT, W_StructType)
-        name = wam_name.blue_unwrap_str(vm)
-        if name not in w_itemT.dict_w:
-            return W_OpSpec.NULL
-
-        w_obj = w_itemT.dict_w[name]
-        if not isinstance(w_obj, W_StructField):
-            raise WIP("don't know how to read this attribute from a ptr-to-struct")
-        w_field = w_obj
-
-        offset = w_field.offset
-        wam_offset = W_MetaArg.from_w_obj(vm, vm.wrap(offset))
-
-        if opkind == "get":
-            # ptr_getfield[field_T, memkind](ptr, name, offset)
-            assert wam_v is None
-            w_memkind = vm.wrap(w_T.memkind)
-            w_func = vm.fast_call(UNSAFE.w_ptr_getfield, [w_field.w_T, w_memkind])
-            assert isinstance(w_func, W_Func)
-            return W_OpSpec(w_func, [wam_self, wam_name, wam_offset])
-        else:
-            # ptr_setfield[field_T](ptr, name, offset, v)
-            assert wam_v is not None
-            w_func = vm.fast_call(UNSAFE.w_ptr_setfield, [w_field.w_T])
-            assert isinstance(w_func, W_Func)
-            return W_OpSpec(w_func, [wam_self, wam_name, wam_offset, wam_v])
 
 
 class W_Ptr(W_MemLoc):

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -169,24 +169,14 @@ class W_MemLocType(W_Type):
     w_itemT: Annotated[W_Type, Member("itemtype")]
     is_ready: bool
 
-    def repr_hints(self) -> list[str]:
-        hints = super().repr_hints()
-        # is_ready may not be set yet during construction
-        if not getattr(self, "is_ready", True):
-            hints.append("not ready")
-        return hints
-
-
-@UNSAFE.builtin_type("rawptrtype")
-class W_PtrType(W_MemLocType):
-    """
-    A specialized ptr type.
-    raw_ptr[i32] -> W_PtrType(fqn, "raw", B.w_i32)
-    """
-
     @classmethod
     def from_itemtype(cls, fqn: FQN, memkind: MEMKIND, w_itemT: W_Type) -> Self:
-        w_T = cls.from_pyclass(fqn, W_Ptr)
+        if cls is W_PtrType:
+            w_T = cls.from_pyclass(fqn, W_Ptr)
+        elif cls is W_RefType:
+            w_T = cls.from_pyclass(fqn, W_Ref)
+        else:
+            assert False
         w_T.memkind = memkind
         w_T.w_itemT = w_itemT
         w_T.is_ready = False
@@ -207,6 +197,21 @@ class W_PtrType(W_MemLocType):
                 w_field.name, w_field.w_T, w_field.offset, self.memkind
             )
         self.is_ready = True
+
+    def repr_hints(self) -> list[str]:
+        hints = super().repr_hints()
+        # is_ready may not be set yet during construction
+        if not getattr(self, "is_ready", True):
+            hints.append("not ready")
+        return hints
+
+
+@UNSAFE.builtin_type("rawptrtype")
+class W_PtrType(W_MemLocType):
+    """
+    A specialized ptr type.
+    raw_ptr[i32] -> W_PtrType(fqn, "raw", B.w_i32)
+    """
 
     # w_NULL: ???
     # PtrTypes have a NULL member, which you can use like that:
@@ -256,29 +261,6 @@ class W_RefType(W_MemLocType):
     raw_ref[i32] -> W_RefType(fqn, "raw", B.w_i32)
     gc_ref[i32] -> W_RefType(fqn, "gc", B.w_i32)
     """
-
-    @classmethod
-    def from_itemtype(cls, fqn: FQN, memkind: MEMKIND, w_itemT: W_Type) -> Self:
-        w_T = cls.from_pyclass(fqn, W_Ref)
-        w_T.memkind = memkind
-        w_T.w_itemT = w_itemT
-        w_T.is_ready = False
-        if isinstance(w_itemT, W_StructType):
-            if w_itemT.is_defined():
-                w_T._populate_fields()
-            # else: not-yet-defined struct; back-filled by define_from_classbody
-        else:
-            w_T.is_ready = True
-        return w_T
-
-    def _populate_fields(self) -> None:
-        assert not self.is_ready
-        assert isinstance(self.w_itemT, W_StructType)
-        for w_field in self.w_itemT.iterfields_w():
-            self.dict_w[w_field.name] = W_PtrField(
-                w_field.name, w_field.w_T, w_field.offset, self.memkind
-            )
-        self.is_ready = True
 
     def as_ptrtype(self, vm: "SPyVM") -> W_PtrType:
         if self.memkind == "raw":

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -24,7 +24,7 @@ on each:
     point to
 """
 
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Self
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional, Self
 
 import fixedint
 
@@ -289,6 +289,49 @@ class W_RefType(W_MemLocType):
         assert isinstance(w_ptrtype, W_PtrType)
         return w_ptrtype
 
+    def lookup(self, vm: "SPyVM", name: str) -> Optional[W_Object]:
+        """
+        Overriding lookup is more or less equivalent to override (part of)
+        type.__getattribute__.
+
+        The idea is that at first we search in RefType[T].__dict__: this is how we find
+        e.g. __convert_to__.
+
+        If we don't find anything, then we also search T.__mro__.  This means that
+        e.g. if T implements `__getitem__`, `__eq__` or a normal method `foo`, Ref[T]
+        will also automatically implements them.
+
+        It's worth noting how conversion works. Imagine this:
+
+            @struct
+            class T:
+                def foo(self) -> None:
+                    ...
+
+            r: gc_ref[T] = ...
+            r.foo()
+
+        `r.foo()` does `gc_ref[T].lookup()`, which in turns do `T.lookup()`, finds the
+        function `T::foo` and turns the method call into this:
+
+            def `T::foo`(self: T) -> None:
+                ...
+
+            `T::foo`(r)
+
+        However, `T:foo` takes a `T`, not a `gc_ref[T]`. But `gc_ref[T]` implements a
+        `__conver_to__` towards `T`, so ultimately it becomes the following, which
+        works:
+
+            `T::foo`(r.deref())
+        """
+        # do a lookup in ref[T] first
+        w_obj = super().lookup(vm, name)
+        if w_obj is None:
+            # else, do a lookup in T
+            w_obj = self.w_itemT.lookup(vm, name)
+        return w_obj
+
 
 @UNSAFE.builtin_type("_memloc")
 class W_MemLoc(W_Object):
@@ -452,11 +495,18 @@ class W_Ptr(W_MemLoc):
 
 
 class W_Ref(W_MemLoc):
-    __spy_storage_category__ = "value"
+    """
+    A reference to a memory location.
 
-    def spy_key(self, vm: "SPyVM") -> Any:
-        t = self.w_T.spy_key(vm)
-        return ("ref", t, self.addr, self.length)
+    Under the hood, `ref[T]` is impemented like a `ptr[T]`, but functionality wise it's
+    more or less equivalent to a `T`. In C++ terms, this is more similar to a `T&` than
+    to a `T*`.
+
+    In particular, methods and __dunder__ methods are looked up also in T. See the
+    docstring of W_RefType.lookup for more details.
+    """
+
+    __spy_storage_category__ = "reference"
 
     @builtin_method("__convert_to__", color="blue", kind="metafunc")
     @staticmethod
@@ -482,22 +532,6 @@ class W_Ref(W_MemLoc):
 
         else:
             return W_OpSpec.NULL
-
-    @builtin_method("__call_method__", color="blue", kind="metafunc")
-    @staticmethod
-    def w_CALL_METHOD(
-        vm: "SPyVM", wam_T: "W_MetaArg", wam_name: "W_MetaArg", *args_wam: "W_MetaArg"
-    ) -> "W_OpSpec":
-        ref_T = wam_T.w_static_T
-        assert isinstance(ref_T, W_RefType)
-        w_T = ref_T.w_itemT
-
-        name = wam_name.blue_unwrap_str(vm)
-        w_meth = w_T.lookup(vm, name)
-        if not isinstance(w_meth, W_ASTFunc):
-            return W_OpSpec.NULL
-        else:
-            return W_OpSpec(w_meth, [wam_T, *args_wam])
 
 
 @UNSAFE.builtin_func(color="blue")

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -701,7 +701,13 @@ class W_Type(W_Object):
 
     def lookup(self, vm: "SPyVM", name: str) -> Optional[W_Object]:
         """
-        Lookup the given attribute into the applevel dict
+        Lookup the given attribute into the applevel dict.
+
+        This is more or less the equivalent of _PyType_Lookup and implements the core
+        "walk the MRO __dict__s" logic.
+
+        Overriding it is more or less equivalent to override the "core" part of
+        type.__getattribute__.  See e.g. W_RefType.lookup for an example.
         """
         for w_T in self.get_mro():
             if w_obj := w_T.dict_w.get(name):

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -569,6 +569,18 @@ class W_Type(W_Object):
         assert self._dict_w is not None
         T = Annotated[W_Object, self]
 
+        # XXX: is this logic fully correct or subtly wrong? I honestly don't know.
+        #
+        # According to this, we add an __eq__ unless it exists *in our __dict__*.
+        # But what should happen if __eq__ exists in a superclass?
+        # Currently, we just ignore it and regenerate a new __eq__, which then uses
+        # spy_key() and thus should be correct.
+        #
+        # Note also that it's hard to do the full MRO lookup here: at this point, our
+        # superclasses might not be fully defined yet because of lazy_definition=True
+        # (e.g., `object`). So if we want to do a full MRO lookup, we need to call this
+        # method later somehow.
+
         if MM.lookup("==", self, self) is None and "__eq__" not in self._dict_w:
             # no suitable __eq__ found, generate one
             @builtin_method("__eq__")  # type: ignore

--- a/spy/vm/struct.py
+++ b/spy/vm/struct.py
@@ -63,6 +63,23 @@ class W_StructType(W_Type):
             vm.add_global(w_eq.fqn, w_eq)
             vm.add_global(w_ne.fqn, w_ne)
 
+        self._backfill_ptr_fields(vm)
+
+    def _backfill_ptr_fields(self, vm: "SPyVM") -> None:
+        """
+        If ptr[T] or ref[T] were created BEFORE we were fully defined, then they
+        lack the W_PtrField members. Add them now.
+        """
+        from spy.vm.modules.unsafe.ptr import W_MemLocType
+
+        for kind in ("raw_ptr", "gc_ptr", "raw_ref", "gc_ref"):
+            fqn = FQN("unsafe").join(kind, [self.fqn])
+            w_ptrtype = vm.lookup_global_maybe(fqn)
+            if w_ptrtype is not None:
+                assert isinstance(w_ptrtype, W_MemLocType)
+                assert not w_ptrtype.is_ready
+                w_ptrtype._populate_fields()
+
     def lazy_define_from_classbody(self, body: ClassBody) -> None:
         """
         Partially define the struct type.


### PR DESCRIPTION
Before this PR, `gc_ref[T]` and `raw_ref[T]` was a very distinct type from `T`.
Now, it automatically looks up attributes and methods in T's MRO, meaning that all `__dunder__` methods and operator works out of the box. This supersed the ad-hoc `__call_method__` implementation.

This has big consequences on e.g. `__eq__`. Before this PR, `gc_ref[T] == gc_ref[T]` compared BY IDENTITY. Now it compares by calling `T.__eq__`, which is probably more intuitive and what people expects.

In C++ terms, now `ref[T]` behaves more like `T&` than `T*`.

Moreover, reading/writing struct attributes work via `W_PtrField` (which obey to the descriptor protocol) instead of `__getattribute__`/`__setattr__`.

Fixes #380 
Fixes #450 
Fixes #539 

Supersedes #395 
Supersedes #597 