### PR TITLE
Topologically sort type entries so all types come before their usage

### DIFF
--- a/spy/backend/c/cbackend.py
+++ b/spy/backend/c/cbackend.py
@@ -9,6 +9,7 @@ from spy.build.build_info import BuildInfo
 from spy.build.cffi import cffi_build
 from spy.build.config import BuildConfig
 from spy.build.ninja import NinjaWriter
+from spy.fqn import FQN
 from spy.highlight import highlight_src
 from spy.vm.cell import W_Cell
 from spy.vm.function import W_ASTFunc
@@ -164,6 +165,10 @@ class CBackend:
             else:
                 self.c_modules[modname].content.append((fqn, w_obj))
 
+        self.c_structdefs["globals"].content = _topo_sort_struct_content(
+            self.c_structdefs["globals"].content
+        )
+
     def cwrite(self) -> None:
         """
         Convert all non-builtins modules into .c files
@@ -261,3 +266,46 @@ class CBackend:
         wasm_exports.extend(libspy_exports)
 
         return wasm_exports
+
+
+def _topo_sort_struct_content(
+    content: list[tuple[FQN, W_Type]],
+) -> list[tuple[FQN, W_Type]]:
+    """
+    Re-order all type entries so that each type is emitted after the types it
+    depends on.
+
+    Ordering constraints:
+    - W_StructType X depends on any type Y used as a by-value field of X,
+      since C requires field types to be fully defined.
+    - W_PtrType/W_RefType depends on its w_itemT, since emit_PtrType writes
+      an inline struct body in the forward declaration using the item type's
+      typedef name.
+    """
+    all_types: dict[FQN, W_Type] = {fqn: w_t for fqn, w_t in content}
+
+    visited: set[FQN] = set()
+    ordered: list[tuple[FQN, W_Type]] = []
+
+    # depth-first traversal of nested types
+    def visit(fqn: FQN) -> None:
+        if fqn in visited:
+            return
+        visited.add(fqn)
+        w_t = all_types[fqn]
+        if isinstance(w_t, W_StructType):
+            if w_t.is_defined():
+                for field in w_t.iterfields_w():
+                    dep_fqn = field.w_T.fqn
+                    if dep_fqn in all_types:
+                        visit(dep_fqn)
+        elif isinstance(w_t, W_MemLocType):
+            dep_fqn = w_t.w_itemT.fqn
+            if dep_fqn in all_types:
+                visit(dep_fqn)
+        ordered.append((fqn, w_t))
+
+    for fqn in all_types:
+        visit(fqn)
+
+    return ordered

--- a/spy/backend/c/cbackend.py
+++ b/spy/backend/c/cbackend.py
@@ -1,3 +1,4 @@
+from graphlib import TopologicalSorter
 from typing import Optional
 
 import py.path
@@ -116,19 +117,9 @@ class CBackend:
             )
             self.c_modules[modname] = c_mod
 
-        # for now we create a global with all types CStructDefs. Eventually we
-        # want to split them into multiple independent ones
-        #
-        # NOTE: currently structdefs work because of a very specific property.
-        # The point is that when we have nested structs, C requires that
-        # structs are defined be in topological order: i.e. the "inner" func
-        # first, the "outer" func next.
-        #
-        # As long as we have a single "spy_structdefs.h" file, we are
-        # guaranteed to have the structs in the right order: this happens
-        # because similarly to C you must define structs before being able to
-        # use them as fields for another struct, which means that the various
-        # W_Struct objects are put in vm.globals_w in the right order.
+        # We need to emit .h files with the struct defs.  For now we create a single
+        # "structdefs.h" file with ALL the structs, topologically sorted to ensure that
+        # is struct B has a field (by value) of type struct A, we emit A before B.
         #
         # See test_importing::test_circular_type_ref for an example of that.
         #
@@ -142,11 +133,9 @@ class CBackend:
         #      modname, but keep in mind that in case of circular deps it will
         #      be impossible to guarantee the correspondance fqn.modname <=>
         #      modname.h)
-        self.c_structdefs["globals"] = CStructDefs(
-            hfile=bdir.join("src", "spy_structdefs.h"), content=[]
-        )
+        structdefs: list[tuple[FQN, W_Type]] = []
 
-        # Put each FQN into the corresponding CModule or CStructDefs
+        # Put each FQN into the corresponding CModule or structdefs
         for fqn, w_obj in self.vm.globals_w.items():
             # ignore W_Modules
             if fqn.is_module():
@@ -161,12 +150,14 @@ class CBackend:
                 continue
 
             if isinstance(w_obj, W_Type):
-                self.c_structdefs["globals"].content.append((fqn, w_obj))
+                structdefs.append((fqn, w_obj))
             else:
                 self.c_modules[modname].content.append((fqn, w_obj))
 
-        self.c_structdefs["globals"].content = _topo_sort_struct_content(
-            self.c_structdefs["globals"].content
+        structdefs = self.topo_sort_structdefs(structdefs)
+        self.c_structdefs["globals"] = CStructDefs(
+            hfile=bdir.join("src", "spy_structdefs.h"),
+            content=structdefs,
         )
 
     def cwrite(self) -> None:
@@ -267,45 +258,37 @@ class CBackend:
 
         return wasm_exports
 
+    def get_type_deps(self, fqn: FQN) -> list[FQN]:
+        """
+        Return the FQNs of the types which `fqn` depends on, i.e. which need
+        to be fully defined before `fqn` itself can be defined in C.
 
-def _topo_sort_struct_content(
-    content: list[tuple[FQN, W_Type]],
-) -> list[tuple[FQN, W_Type]]:
-    """
-    Re-order all type entries so that each type is emitted after the types it
-    depends on.
+        A struct depends on the struct types of its by-value fields. Pointer
+        and ref fields are NOT dependencies: a forward declaration of the
+        pointee is enough, which is what makes mutually recursive types via
+        pointers work.
+        """
+        w_type = self.vm.lookup_global(fqn)
+        if not isinstance(w_type, W_StructType) or not w_type.is_defined():
+            return []
+        deps: list[FQN] = []
+        seen: set[FQN] = set()
+        for field in w_type.iterfields_w():
+            w_fieldT = field.w_T
+            if not isinstance(w_fieldT, W_StructType):
+                continue
+            dep_fqn = w_fieldT.fqn
+            if dep_fqn != fqn and dep_fqn not in seen:
+                seen.add(dep_fqn)
+                deps.append(dep_fqn)
+        return deps
 
-    Ordering constraints:
-    - W_StructType X depends on any type Y used as a by-value field of X,
-      since C requires field types to be fully defined.
-    - W_PtrType/W_RefType depends on its w_itemT, since emit_PtrType writes
-      an inline struct body in the forward declaration using the item type's
-      typedef name.
-    """
-    all_types: dict[FQN, W_Type] = {fqn: w_t for fqn, w_t in content}
-
-    visited: set[FQN] = set()
-    ordered: list[tuple[FQN, W_Type]] = []
-
-    # depth-first traversal of nested types
-    def visit(fqn: FQN) -> None:
-        if fqn in visited:
-            return
-        visited.add(fqn)
-        w_t = all_types[fqn]
-        if isinstance(w_t, W_StructType):
-            if w_t.is_defined():
-                for field in w_t.iterfields_w():
-                    dep_fqn = field.w_T.fqn
-                    if dep_fqn in all_types:
-                        visit(dep_fqn)
-        elif isinstance(w_t, W_MemLocType):
-            dep_fqn = w_t.w_itemT.fqn
-            if dep_fqn in all_types:
-                visit(dep_fqn)
-        ordered.append((fqn, w_t))
-
-    for fqn in all_types:
-        visit(fqn)
-
-    return ordered
+    def topo_sort_structdefs(
+        self, content: list[tuple[FQN, W_Type]]
+    ) -> list[tuple[FQN, W_Type]]:
+        all_types: dict[FQN, W_Type] = dict(content)
+        ts: TopologicalSorter[FQN] = TopologicalSorter()
+        for fqn in all_types:
+            deps = [d for d in self.get_type_deps(fqn) if d in all_types]
+            ts.add(fqn, *deps)
+        return [(fqn, all_types[fqn]) for fqn in ts.static_order()]

--- a/spy/backend/c/cbackend.py
+++ b/spy/backend/c/cbackend.py
@@ -269,6 +269,11 @@ class CBackend:
         pointers work.
         """
         w_type = self.vm.lookup_global(fqn)
+        if isinstance(w_type, W_MemLocType):
+            # A ptr/ref type emits `typedef struct PTR { T *p; ...} PTR;` into
+            # the forward-decl section: it needs T's own typedef to appear
+            # first.
+            return [w_type.w_itemT.fqn]
         if not isinstance(w_type, W_StructType) or not w_type.is_defined():
             return []
         deps: list[FQN] = []

--- a/spy/tests/compiler/test_importing.py
+++ b/spy/tests/compiler/test_importing.py
@@ -178,6 +178,7 @@ class TestImporting(CompilerTest):
         assert mods == ["a1", "a2", "aaa", "b1", "b2", "bbb", "main"]
 
     def test_circular_type_refs(self):
+        # See CBackend.split_fqns()
         src = """
         @blue.generic
         def Vec2(T):
@@ -200,6 +201,30 @@ class TestImporting(CompilerTest):
         """
         mod = self.compile(src)
         assert mod.foo() == (1, 1)
+
+    def test_structdefs_toposort(self):
+        # this is technically not about importing, but it's related to
+        # test_circular_type_refs, so we keep it next to it. Ensure that we emit structs
+        # in topological order.  See CBackend.split_fqns()
+        src = """
+        @blue.generic
+        def Vec2(T):
+            @struct
+            class Inner:
+                a: T
+                b: T
+            return Inner
+
+        @struct
+        class Outer:
+            v: Vec2[i32]
+
+        def foo() -> i32:
+            o = Outer.__make__(Vec2[i32].__make__(1, 2))
+            return o.v.a + o.v.b
+        """
+        mod = self.compile(src)
+        assert mod.foo() == 3
 
     def test_multi_step_import(self):
         self.write_file("a.spy", "X = 42")

--- a/spy/tests/compiler/test_list.py
+++ b/spy/tests/compiler/test_list.py
@@ -194,3 +194,19 @@ class TestList(CompilerTest):
         mod = self.compile(src)
         res = mod.foo()
         assert res == 12
+
+    def test_struct_with_list_field(self):
+        # NOTE: what this is actually testing is that in the C backend we do a
+        # topological sort of structdefs, i.e. that we emit list[i32] before Item. See
+        # also test_importing.test_structdefs_toposort and CBackend.split_fqns()
+        src = """
+        @struct
+        class Item:
+            values: list[i32]
+
+        def foo() -> i32:
+            item = Item.__make__([1, 2, 3])
+            return item.values[1]
+        """
+        mod = self.compile(src)
+        assert mod.foo() == 2

--- a/spy/tests/compiler/test_struct.py
+++ b/spy/tests/compiler/test_struct.py
@@ -183,19 +183,6 @@ class TestStructOnStack(CompilerTest):
         mod = self.compile(src)
         assert mod.foo() == ((1, 2), (3, 4))
 
-    def test_struct_with_list_field(self):
-        src = """
-        @struct
-        class Item:
-            values: list[i32]
-
-        def foo() -> i32:
-            item = Item.__make__([1, 2, 3])
-            return item.values[1]
-        """
-        mod = self.compile(src)
-        assert mod.foo() == 2
-
     def test_method(self):
         src = """
         from math import sqrt

--- a/spy/tests/compiler/test_struct.py
+++ b/spy/tests/compiler/test_struct.py
@@ -183,6 +183,19 @@ class TestStructOnStack(CompilerTest):
         mod = self.compile(src)
         assert mod.foo() == ((1, 2), (3, 4))
 
+    def test_struct_with_list_field(self):
+        src = """
+        @struct
+        class Item:
+            values: list[i32]
+
+        def foo() -> i32:
+            item = Item.__make__([1, 2, 3])
+            return item.values[1]
+        """
+        mod = self.compile(src)
+        assert mod.foo() == 2
+
     def test_method(self):
         src = """
         from math import sqrt

--- a/spy/tests/test_backend_c.py
+++ b/spy/tests/test_backend_c.py
@@ -22,20 +22,20 @@ class TestCBackend:
     @pytest.fixture
     def vm(self, tmpdir):
         self.tmpdir = tmpdir
-        self.vm = SPyVM()
-        self.vm.path.append(str(tmpdir))
-        yield
-        self.vm = None  # type: ignore
+        vm = SPyVM()
+        vm.path.append(str(tmpdir))
+        return vm
 
-    def compile_until_CBackend(self, src: str, modname: str = "test") -> CBackend:
+    def compile_until_CBackend(self, vm: SPyVM, src: str) -> CBackend:
         # XXX: there is a lot of code duplication with other similar tests
+        modname = "test"
         srcfile = self.tmpdir.join(f"{modname}.spy")
         srcfile.write(textwrap.dedent(src))
-        self.vm.import_(modname)
-        self.vm.redshift(error_mode="eager")
+        vm.import_(modname)
+        vm.redshift(error_mode="eager")
         builddir = self.tmpdir.join("build").ensure(dir=True)
         config = BuildConfig(target="wasi", kind="lib", build_type="debug", opt_level=0)
-        backend = CBackend(self.vm, modname, config, builddir, dump_c=False)
+        backend = CBackend(vm, modname, config, builddir, dump_c=False)
         return backend
 
     def test_make_table(self):
@@ -127,7 +127,7 @@ class TestCBackend:
             b: Point
             color: gc_ptr[Color]
         """
-        backend = self.compile_until_CBackend(src)
+        backend = self.compile_until_CBackend(vm, src)
 
         def deps(fqn_str: str) -> list[str]:
             return [str(d) for d in backend.get_type_deps(FQN(fqn_str))]
@@ -161,7 +161,7 @@ class TestCBackend:
             o = Outer.__make__(Vec2[i32].__make__(1, 2))
             return o.v.a + o.v.b
         """
-        backend = self.compile_until_CBackend(src)
+        backend = self.compile_until_CBackend(vm, src)
         backend.split_fqns()
         order = [str(fqn) for fqn, _ in backend.c_structdefs["globals"].content]
         i_inner = order.index("test::Vec2[i32]::Inner")

--- a/spy/tests/test_backend_c.py
+++ b/spy/tests/test_backend_c.py
@@ -5,11 +5,39 @@ This is just a small part of the tests: the majority of the functionality is
 tested by tests/compiler/*.py.
 """
 
+import textwrap
+
+import py.path
+import pytest
+
 from spy.backend.c.c_ast import BinOp, Literal, UnaryOp, make_table
+from spy.backend.c.cbackend import CBackend
 from spy.backend.c.context import C_Ident
+from spy.build.config import BuildConfig
+from spy.fqn import FQN
+from spy.vm.vm import SPyVM
 
 
-class TestExpr:
+class TestCBackend:
+    @pytest.fixture
+    def vm(self, tmpdir):
+        self.tmpdir = tmpdir
+        self.vm = SPyVM()
+        self.vm.path.append(str(tmpdir))
+        yield
+        self.vm = None  # type: ignore
+
+    def compile_until_CBackend(self, src: str, modname: str = "test") -> CBackend:
+        # XXX: there is a lot of code duplication with other similar tests
+        srcfile = self.tmpdir.join(f"{modname}.spy")
+        srcfile.write(textwrap.dedent(src))
+        self.vm.import_(modname)
+        self.vm.redshift(error_mode="eager")
+        builddir = self.tmpdir.join("build").ensure(dir=True)
+        config = BuildConfig(target="wasi", kind="lib", build_type="debug", opt_level=0)
+        backend = CBackend(self.vm, modname, config, builddir, dump_c=False)
+        return backend
+
     def test_make_table(self):
         table = make_table("""
         12: * /
@@ -76,7 +104,66 @@ class TestExpr:
         assert cstr(b"ball\n\nball") == r'"ball\x0a\x0a""ball"'
         assert cstr(b"\x00\x01\x02") == r'"\x00\x01\x02"'
 
+    def test_C_Ident(self):
+        assert str(C_Ident("hello")) == "hello"
+        assert str(C_Ident("default")) == "default$"
 
-def test_C_Ident():
-    assert str(C_Ident("hello")) == "hello"
-    assert str(C_Ident("default")) == "default$"
+    def test_struct_deps(self, vm):
+        src = """
+        from unsafe import gc_ptr
+
+        @struct
+        class Color:
+            name: str
+
+        @struct
+        class Point:
+            x: i32
+            y: i32
+
+        @struct
+        class Rect:
+            a: Point
+            b: Point
+            color: gc_ptr[Color]
+        """
+        backend = self.compile_until_CBackend(src)
+
+        def deps(fqn_str: str) -> list[str]:
+            return [str(d) for d in backend.get_type_deps(FQN(fqn_str))]
+
+        # A struct containing only primitive/pointer fields has no by-value
+        # type deps. Pointers do NOT count as dependencies, since we already
+        # emit a forward declaration for the pointee type.
+        assert deps("test::Color") == []
+        assert deps("test::Point") == []
+        assert deps("test::Rect") == ["test::Point"]
+
+    def test_topo_sort(self, vm):
+        # `Inner` is created lazily by Vec2[i32], so it ends up in
+        # vm.globals_w AFTER `Outer` even though `Outer` has it as a
+        # by-value field. Without the topo sort, the C backend would emit
+        # Outer before Inner and produce broken code.
+        src = """
+        @blue.generic
+        def Vec2(T):
+            @struct
+            class Inner:
+                a: T
+                b: T
+            return Inner
+
+        @struct
+        class Outer:
+            v: Vec2[i32]
+
+        def foo() -> i32:
+            o = Outer.__make__(Vec2[i32].__make__(1, 2))
+            return o.v.a + o.v.b
+        """
+        backend = self.compile_until_CBackend(src)
+        backend.split_fqns()
+        order = [str(fqn) for fqn, _ in backend.c_structdefs["globals"].content]
+        i_inner = order.index("test::Vec2[i32]::Inner")
+        i_outer = order.index("test::Outer")
+        assert i_inner < i_outer


### PR DESCRIPTION
Do a topo sort of types before emitting them so types are defined before they are used in nested structures.

This solves a problem I discovered while trying to create a struct that contained a field which was a list of integers.

(This PR was created with AI assistance.)