### PR TITLE
Implement str.count()

### DIFF
--- a/spy/tests/compiler/test_str.py
+++ b/spy/tests/compiler/test_str.py
@@ -173,6 +173,43 @@ class TestStr(CompilerTest):
         assert mod.find("aXbXcXqzx", "qzx") == 6
         assert mod.find("qaqbqcqzx", "qzx") == 6
 
+    def test_count(self):
+        mod = self.compile("""
+            def count(s: str, sub: str) -> i32:
+                return s.count(sub)
+
+            def count_start(s: str, sub: str, start: i32) -> i32:
+                return s.count(sub, start)
+
+            def count_range(s: str, sub: str, start: i32, end: i32) -> i32:
+                return s.count(sub, start, end)
+        """)
+
+        # basic
+        assert mod.count("hello world", "o") == 2
+        assert mod.count("hello world", "l") == 3
+        assert mod.count("abcabc", "bc") == 2
+        assert mod.count("hello", "xyz") == 0
+
+        # non-overlapping
+        assert mod.count("aaaa", "aa") == 2
+        assert mod.count("aaaaa", "aa") == 2
+
+        # empty needle counts the gaps between characters
+        assert mod.count("abc", "") == 4
+        assert mod.count("", "") == 1
+        assert mod.count("", "a") == 0
+        assert mod.count_start("abc", "", 1) == 3
+        assert mod.count_range("abcabc", "", 0, 4) == 5
+        assert mod.count_range("abc", "", 2, 1) == 0
+
+        # with start
+        assert mod.count_start("abcabc", "bc", 2) == 1
+
+        # with start and end
+        assert mod.count_range("abcabc", "bc", 0, 4) == 1
+        assert mod.count_range("aaaa", "a", 1, 3) == 2
+
     def test_isspace(self):
         mod = self.compile("""
             def iss(s: str) -> bool:

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -51,6 +51,7 @@ class W_Str(W_Object):
         "split": FQN("_str::methods::split"),
         "isspace": FQN("_str::methods::isspace"),
         "find": FQN("_str::methods::find"),
+        "count": FQN("_str::methods::count"),
         "__repr__": FQN("_str::methods::__repr__"),
         "__len__": FQN("_str::methods::__len__"),
         "__getitem__": FQN("_str::methods::__getitem__"),

--- a/stdlib/_str.spy
+++ b/stdlib/_str.spy
@@ -408,6 +408,18 @@ class methods:
             return OpSpec(_find_3)
         return OpSpec.NULL
 
+    @blue.metafunc
+    def count(m_self, *args_m):
+        # str.count(sub[, start[, end]]) -> i32
+        nargs = len(args_m)
+        if nargs == 1:
+            return OpSpec(_count_1)
+        elif nargs == 2:
+            return OpSpec(_count_2)
+        elif nargs == 3:
+            return OpSpec(_count_3)
+        return OpSpec.NULL
+
 def _ll_isspace(ch: u8) -> bool:
     """
     A version of str.isspace that operates on single character indices (u8's)
@@ -477,6 +489,37 @@ def _find_2(self: str, sub: str, start: i32) -> i32:
 
 def _find_3(self: str, sub: str, start: i32, end: i32) -> i32:
     return _str_find(self, sub, start, end)
+
+
+def _str_count(self: str, sub: str, start: i32, end: i32) -> i32:
+    # number of non-overlapping occurrences of sub. Repeatedly find()s forward,
+    # stepping past each match (by 1 for the empty sub, which matches everywhere).
+    #
+    # Possible optimization: the empty sub always yields (normalized end - start
+    # + 1), so it could be computed from len() without scanning. That would also
+    # be codepoint-correct for free once len() is unicode-aware. Left as a scan
+    # for now since the closed form needs its own start/end normalization.
+    step = len(sub)
+    if step == 0:
+        step = 1
+    count: i32 = 0
+    idx = _str_find(self, sub, start, end)
+    while idx != -1:
+        count = count + 1
+        idx = _str_find(self, sub, idx + step, end)
+    return count
+
+
+def _count_1(self: str, sub: str) -> i32:
+    return _str_count(self, sub, 0, len(self))
+
+
+def _count_2(self: str, sub: str, start: i32) -> i32:
+    return _str_count(self, sub, start, len(self))
+
+
+def _count_3(self: str, sub: str, start: i32, end: i32) -> i32:
+    return _str_count(self, sub, start, end)
 
 
 def _split_sep(self: str, sep: str) -> list[str]:


### PR DESCRIPTION
Algo is super simple - just uses `find()` underneath. So if `find()` handles code points correctly this will too.

Discovered an interesting case in Python's behavior: apparently you can count the empty string between characters and at the ends:
```python
>>> 'hello'.count('')
6
```

The implementation copies the behavior but has no optimization for this case. Note we can't used len as-is because `start` and `end` may be provided. Byte based indexing will eventually need to be replaced with optimized code point based indexing I think.