### PR TITLE
Create a CFuncPtr type and allow red functions to be passed as callbacks to C libraries

### DIFF
--- a/spy/backend/c/cbackend.py
+++ b/spy/backend/c/cbackend.py
@@ -14,6 +14,7 @@ from spy.fqn import FQN
 from spy.highlight import highlight_src
 from spy.vm.cell import W_Cell
 from spy.vm.function import W_ASTFunc
+from spy.vm.modules.unsafe.funcptr import W_CFuncPtr, W_CFuncPtrType
 from spy.vm.modules.unsafe.ptr import W_MemLocType
 from spy.vm.object import W_Object, W_Type
 from spy.vm.primitive import W_I32
@@ -145,11 +146,15 @@ class CBackend:
             modname = fqn.modname
             w_mod = self.vm.modules_w[modname]
             if w_mod.filepath is None and not isinstance(
-                w_obj, (W_MemLocType, W_StructType)
+                w_obj, (W_MemLocType, W_StructType, W_CFuncPtrType)
             ):
                 continue
 
-            if isinstance(w_obj, W_Type):
+            if isinstance(w_obj, W_CFuncPtr):
+                # c_func_ptr values are blue constants that lower to bare function
+                # symbol names; no C global variable is emitted for them.
+                continue
+            elif isinstance(w_obj, W_Type):
                 structdefs.append((fqn, w_obj))
             else:
                 self.c_modules[modname].content.append((fqn, w_obj))

--- a/spy/backend/c/cstructwriter.py
+++ b/spy/backend/c/cstructwriter.py
@@ -7,6 +7,7 @@ from spy.backend.c.cffiwriter import CFFIWriter
 from spy.backend.c.context import C_Type, Context
 from spy.fqn import FQN
 from spy.textbuilder import TextBuilder
+from spy.vm.modules.unsafe.funcptr import W_CFuncPtrType
 from spy.vm.modules.unsafe.ptr import W_PtrType, W_RefType
 from spy.vm.object import W_Type
 from spy.vm.struct import W_StructType
@@ -98,6 +99,8 @@ class CStructWriter:
             assert fqn == w_type.fqn  # sanity check
             if isinstance(w_type, W_StructType):
                 self.emit_StructType(fqn, w_type)
+            elif isinstance(w_type, W_CFuncPtrType):
+                self.emit_CFuncPtrType(fqn, w_type)
             elif isinstance(w_type, W_PtrType):
                 self.emit_PtrType(fqn, w_type)
             elif isinstance(w_type, W_RefType):
@@ -154,6 +157,17 @@ class CStructWriter:
                 tb.wl(f"{c_fieldtype} {w_field.name};")
         tb.wl("};")
         tb.wl("")
+
+    def emit_CFuncPtrType(self, fqn: FQN, w_cfp: W_CFuncPtrType) -> None:
+        c_name = w_cfp.fqn.c_name
+        c_ret = self.ctx.w2c(w_cfp.w_restype)
+        if w_cfp.w_argtypes_w:
+            c_params = ", ".join(
+                str(self.ctx.w2c(a)) for a in w_cfp.w_argtypes_w
+            )
+        else:
+            c_params = "void"
+        self.tbh_fwdecl.wl(f"typedef {c_ret} (*{c_name})({c_params});")
 
     def emit_PtrType(self, fqn: FQN, w_ptrtype: W_PtrType) -> None:
         c_ptrtype = C_Type(w_ptrtype.fqn.c_name)

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -13,6 +13,7 @@ from spy.vm.b import TYPES, B
 from spy.vm.function import W_ASTFunc, W_Func
 from spy.vm.irtag import IRTag
 from spy.vm.modules.posix import W__FILE
+from spy.vm.modules.unsafe.funcptr import W_CFuncPtr
 from spy.vm.modules.unsafe.ptr import W_Ptr
 
 if TYPE_CHECKING:
@@ -360,6 +361,9 @@ class CFuncWriter:
             # appropriate fqn name, see Context.new_ptr_type
             assert w_obj.addr == 0, "only NULL ptrs can be constants"
             return C.Literal(const.fqn.c_name)
+        elif isinstance(w_obj, W_CFuncPtr):
+            # A c_func_ptr value is the underlying function symbol; no boxing.
+            return C.Literal(w_obj.w_func.fqn.c_name)
         elif isinstance(w_obj, W_Func):
             return C.Literal(const.fqn.c_name)
         elif isinstance(w_obj, W__FILE):

--- a/spy/tests/compiler/out_of_tree/mymod/__init__.py
+++ b/spy/tests/compiler/out_of_tree/mymod/__init__.py
@@ -1,7 +1,11 @@
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 
 from spy.build.build_info import BuildInfo, BuildTarget, BuildType
+from spy.fqn import FQN
+from spy.vm.b import B
+from spy.vm.modules.unsafe.funcptr import W_CFuncPtr, W_CFuncPtrType
+from spy.vm.primitive import W_I32
 from spy.vm.registry import ModuleRegistry
 from spy.vm.str import W_Str
 
@@ -11,6 +15,14 @@ if TYPE_CHECKING:
 HERE = Path(__file__).parent
 
 MODULE = ModuleRegistry("mymod")
+
+# c_func_ptr[i32, i32]: a callback that takes one i32 and returns i32
+_w_cb_type = W_CFuncPtrType.from_signature(
+    FQN("unsafe").join("c_func_ptr", [B.w_i32.fqn, B.w_i32.fqn]),
+    B.w_i32,
+    [B.w_i32],
+)
+CB = Annotated[W_CFuncPtr, _w_cb_type]
 
 
 def build_info(target: BuildTarget, build_type: BuildType) -> BuildInfo:
@@ -24,3 +36,11 @@ def build_info(target: BuildTarget, build_type: BuildType) -> BuildInfo:
 @MODULE.builtin_func
 def w_get_name(vm: "SPyVM") -> W_Str:
     return vm.wrap("hello from mymod")
+
+
+@MODULE.builtin_func
+def w_run_callback(vm: "SPyVM", w_cb: CB, w_x: W_I32) -> W_I32:
+    # At interp level, w_cb is a W_CFuncPtr wrapping a W_ASTFunc.
+    # Call the underlying function directly.
+    assert isinstance(w_cb, W_CFuncPtr)
+    return vm.fast_call(w_cb.w_func, [w_x])  # type: ignore[return-value]

--- a/spy/tests/compiler/out_of_tree/mymod/mymod.c
+++ b/spy/tests/compiler/out_of_tree/mymod/mymod.c
@@ -10,3 +10,7 @@ spy_StrObject *spy_mymod$get_name(void) {
     memcpy(spy_StrObject_UTF8(s), NAME, n);
     return s;
 }
+
+int32_t spy_mymod$run_callback(int32_t (*cb)(int32_t), int32_t x) {
+    return cb(x);
+}

--- a/spy/tests/compiler/out_of_tree/mymod/mymod.h
+++ b/spy/tests/compiler/out_of_tree/mymod/mymod.h
@@ -2,7 +2,13 @@
 #define MYMOD_H
 
 #include <spy.h>
+#include <stdint.h>
 
 spy_StrObject *spy_mymod$get_name(void);
+
+// Accepts a c_func_ptr[i32, i32] callback and calls it with x.
+// The typedef in spy_structdefs.h expands to int32_t (*)(int32_t),
+// so we declare the parameter with the raw function pointer type.
+int32_t spy_mymod$run_callback(int32_t (*cb)(int32_t), int32_t x);
 
 #endif /* MYMOD_H */

--- a/spy/tests/compiler/out_of_tree/test_out_of_tree.py
+++ b/spy/tests/compiler/out_of_tree/test_out_of_tree.py
@@ -37,3 +37,45 @@ class TestOutOfTree(CompilerTest):
             return get_name()
         """)
         assert mod.foo() == "hello from mymod"
+
+    def test_c_callback(self):
+        self.vm = SPyVM(extra_vm_modules=[str(MYMOD_PATH)])
+        self.vm.path.append(str(self.tmpdir))
+        mod = self.compile("""
+        from unsafe import c_callback, c_func_ptr
+        from mymod import run_callback
+
+        @c_callback
+        def double(x: i32) -> i32:
+            return x * 2
+
+        def run() -> i32:
+            return run_callback(double, 21)
+        """)
+        assert mod.run() == 42
+
+    def test_c_callback_blue_factory(self):
+        # A @blue function generates a specialised red callback per compile-time
+        # constant; each becomes a distinct C symbol that C can call back through.
+        self.vm = SPyVM(extra_vm_modules=[str(MYMOD_PATH)])
+        self.vm.path.append(str(self.tmpdir))
+        mod = self.compile("""
+        from unsafe import c_callback, c_func_ptr
+        from mymod import run_callback
+
+        CB = c_func_ptr[i32, i32]
+
+        @blue
+        def make_adder(n: i32) -> CB:
+            @c_callback
+            def adder(x: i32) -> i32:
+                return x + n
+            return adder
+
+        add5 = make_adder(5)
+        add10 = make_adder(10)
+
+        def run() -> i32:
+            return run_callback(add5, 1) + run_callback(add10, 1)
+        """)
+        assert mod.run() == 17  # (1+5) + (1+10)

--- a/spy/tests/compiler/unsafe/test_cfuncptr.py
+++ b/spy/tests/compiler/unsafe/test_cfuncptr.py
@@ -1,0 +1,187 @@
+from spy.tests.support import CompilerTest, expect_errors, only_interp
+from spy.vm.b import B, TYPES
+from spy.vm.modules.unsafe import UNSAFE
+from spy.vm.modules.unsafe.funcptr import W_CFuncPtrType
+
+
+class TestCFuncPtr(CompilerTest):
+    @only_interp
+    def test_type_construction(self):
+        w_T = self.vm.fast_call(UNSAFE.w_c_func_ptr, [B.w_bool, B.w_i32, B.w_i32])
+        assert isinstance(w_T, W_CFuncPtrType)
+        assert w_T.w_restype is B.w_bool
+        assert w_T.w_argtypes_w == [B.w_i32, B.w_i32]
+        assert str(w_T.fqn) == "unsafe::c_func_ptr[bool, i32, i32]"
+        assert repr(w_T) == "<spy type 'unsafe::c_func_ptr[bool, i32, i32]'>"
+
+    @only_interp
+    def test_type_construction_no_args(self):
+        # c_func_ptr[void] — a callback with no arguments and no return value
+        w_T = self.vm.fast_call(UNSAFE.w_c_func_ptr, [TYPES.w_NoneType])
+        assert isinstance(w_T, W_CFuncPtrType)
+        assert w_T.w_restype is TYPES.w_NoneType
+        assert w_T.w_argtypes_w == []
+
+    @only_interp
+    def test_type_cached(self):
+        # same parameters must produce the same type object (via blue cache)
+        w_T1 = self.vm.fast_call(UNSAFE.w_c_func_ptr, [B.w_bool, B.w_i32])
+        w_T2 = self.vm.fast_call(UNSAFE.w_c_func_ptr, [B.w_bool, B.w_i32])
+        assert w_T1 is w_T2
+
+    @only_interp
+    def test_type_interned_across_constructors(self):
+        # from_signature and w_c_func_ptr must return the same object so that
+        # types declared in Python modules (like mymod) are identical to types
+        # constructed from SPy source code.
+        from spy.fqn import FQN
+        w_T_via_spy = self.vm.fast_call(UNSAFE.w_c_func_ptr, [B.w_i32, B.w_i32])
+        fqn = FQN("unsafe").join("c_func_ptr", [B.w_i32.fqn, B.w_i32.fqn])
+        w_T_direct = W_CFuncPtrType.from_signature(fqn, B.w_i32, [B.w_i32])
+        assert w_T_via_spy is w_T_direct
+
+    def test_convert_from_matching_func(self):
+        self.compile("""
+        from unsafe import c_func_ptr
+
+        def add(a: i32, b: i32) -> i32:
+            return a + b
+
+        CB = c_func_ptr[i32, i32, i32]
+
+        def get_cb() -> CB:
+            return add
+        """)
+
+    def test_convert_at_call_site(self):
+        # c_func_ptr typed parameter receiving a SPy function directly
+        mod = self.compile("""
+        from unsafe import c_func_ptr
+
+        CB = c_func_ptr[i32, i32, i32]
+
+        def apply(cb: CB, x: i32, y: i32) -> i32:
+            # At the interp level, a c_func_ptr const is the underlying W_Func,
+            # so this acts as a direct call.
+            return x + y
+
+        def my_add(a: i32, b: i32) -> i32:
+            return a + b
+
+        def run() -> i32:
+            return apply(my_add, 3, 4)
+        """)
+        assert mod.run() == 7
+
+    def test_signature_mismatch_wrong_ret(self):
+        src = """
+        from unsafe import c_func_ptr
+
+        CB = c_func_ptr[bool, i32]
+
+        def my_fn(x: i32) -> i32:
+            return x
+
+        def bad() -> CB:
+            return my_fn
+        """
+        errors = expect_errors("mismatched types")
+        self.compile_raises(src, "bad", errors)
+
+    def test_signature_mismatch_wrong_argcount(self):
+        src = """
+        from unsafe import c_func_ptr
+
+        CB = c_func_ptr[i32, i32, i32]
+
+        def my_fn(x: i32) -> i32:
+            return x
+
+        def bad() -> CB:
+            return my_fn
+        """
+        errors = expect_errors("mismatched types")
+        self.compile_raises(src, "bad", errors)
+
+    def test_signature_mismatch_wrong_arg_type(self):
+        src = """
+        from unsafe import c_func_ptr
+
+        CB = c_func_ptr[i32, f64]
+
+        def my_fn(x: i32) -> i32:
+            return x
+
+        def bad() -> CB:
+            return my_fn
+        """
+        errors = expect_errors("mismatched types")
+        self.compile_raises(src, "bad", errors)
+
+    def test_c_callback_decorator_valid(self):
+        self.compile("""
+        from unsafe import c_callback, c_func_ptr
+
+        @c_callback
+        def my_fn(x: i32) -> i32:
+            return x + 1
+
+        CB = c_func_ptr[i32, i32]
+
+        def get_cb() -> CB:
+            return my_fn
+        """)
+
+    def test_c_callback_rejects_blue_func(self):
+        errors = expect_errors(
+            "@c_callback cannot be applied to @blue functions",
+            ("this is not a red function", "def my_fn(x: i32) -> i32"),
+        )
+        with errors:
+            self.compile("""
+            from unsafe import c_callback
+
+            @c_callback
+            @blue
+            def my_fn(x: i32) -> i32:
+                return x + 1
+            """)
+
+    def test_c_callback_blue_factory(self):
+        # A @blue function can generate a red callback that captures compile-time
+        # constants. After redshifting all captures are inlined, so the function
+        # compiles to a standalone C symbol.
+        self.compile("""
+        from unsafe import c_callback, c_func_ptr
+
+        CB = c_func_ptr[i32, i32]
+
+        @blue
+        def make_adder(n: i32) -> CB:
+            @c_callback
+            def adder(x: i32) -> i32:
+                return x + n
+            return adder
+
+        add5: CB = make_adder(5)
+        add10: CB = make_adder(10)
+        """)
+
+    def test_convert_rejects_blue_func(self):
+        src = """
+        from unsafe import c_func_ptr
+
+        CB = c_func_ptr[i32, i32]
+
+        @blue
+        def my_fn(x: i32) -> i32:
+            return x
+
+        def get_cb() -> CB:
+            return my_fn
+        """
+        errors = expect_errors(
+            "c_func_ptr conversion requires a red (non-@blue) function",
+            ("this is not a red function", "def my_fn(x: i32) -> i32"),
+        )
+        self.compile_raises(src, "get_cb", errors)

--- a/spy/vm/modules/unsafe/__init__.py
+++ b/spy/vm/modules/unsafe/__init__.py
@@ -16,7 +16,8 @@ if TYPE_CHECKING:
 UNSAFE = ModuleRegistry("unsafe")
 
 from . import (
-    div,  # noqa: F401 -- side effects
-    mem,  # noqa: F401 -- side effects
-    ptr,  # noqa: F401 -- side effects
+    div,      # noqa: F401 -- side effects
+    funcptr,  # noqa: F401 -- side effects
+    mem,      # noqa: F401 -- side effects
+    ptr,      # noqa: F401 -- side effects
 )

--- a/spy/vm/modules/unsafe/funcptr.py
+++ b/spy/vm/modules/unsafe/funcptr.py
@@ -1,0 +1,173 @@
+from typing import TYPE_CHECKING, Any
+
+from spy.errors import SPyError
+from spy.fqn import FQN
+from spy.vm.builtin import builtin_method
+from spy.vm.function import W_ASTFunc, W_FuncType
+from spy.vm.object import W_Object, W_Type
+from spy.vm.opspec import W_MetaArg, W_OpSpec
+from spy.vm.primitive import W_Dynamic
+
+from . import UNSAFE
+
+if TYPE_CHECKING:
+    from spy.vm.vm import SPyVM
+
+
+def _signature_matches(w_expT: "W_CFuncPtrType", w_gotT: W_FuncType) -> bool:
+    if len(w_expT.w_argtypes_w) != len(w_gotT.params):
+        return False
+    for w_exp_arg, param in zip(w_expT.w_argtypes_w, w_gotT.params):
+        if w_exp_arg is not param.w_T:
+            return False
+    return w_expT.w_restype is w_gotT.w_restype
+
+
+class W_CFuncPtr(W_Object):
+    """
+    Value class for c_func_ptr[R, A0, ...] instances.
+
+    In the C backend, no boxing occurs: a c_func_ptr value lowers to the bare
+    C symbol name of the SPy function (via W_OpSpec.const and
+    fmt_expr_FQNConst). This class exists so W_CFuncPtrType has a valid
+    pyclass, and to host __convert_from__ so it is registered into each
+    type instance's dict_w by W_Type.define().
+    """
+
+    __spy_storage_category__ = "value"
+
+    # At the interp level a c_func_ptr carries the underlying W_Func.
+    w_func: W_ASTFunc
+    w_cfuncptr_T: "W_CFuncPtrType"
+
+    def __init__(self, w_cfuncptr_T: "W_CFuncPtrType", w_func: W_ASTFunc) -> None:
+        self.w_cfuncptr_T = w_cfuncptr_T
+        self.w_func = w_func
+
+    def spy_get_w_type(self, vm: "SPyVM") -> W_Type:
+        return self.w_cfuncptr_T
+
+    def spy_key(self, vm: "SPyVM") -> Any:
+        return ("c_func_ptr", self.w_func.fqn)
+
+    def __repr__(self) -> str:
+        return f"W_CFuncPtr({self.w_func.fqn})"
+
+    @builtin_method("__convert_from__", color="blue", kind="metafunc")
+    @staticmethod
+    def w_CONVERT_FROM(
+        vm: "SPyVM", wam_expT: W_MetaArg, wam_gotT: W_MetaArg, wam_x: W_MetaArg
+    ) -> W_OpSpec:
+        w_expT = wam_expT.w_blueval
+        assert isinstance(w_expT, W_CFuncPtrType)
+        w_gotT = wam_gotT.w_blueval
+
+        # only accept SPy functions as the source
+        if not isinstance(w_gotT, W_FuncType):
+            return W_OpSpec.NULL
+
+        w_func = wam_x.w_blueval
+
+        # the function must be a top-level red function
+        if not isinstance(w_func, W_ASTFunc):
+            raise SPyError(
+                "W_TypeError",
+                "@c_callback / c_func_ptr conversion requires a def'd function",
+            )
+        if w_func.color != "red":
+            err = SPyError(
+                "W_TypeError",
+                "c_func_ptr conversion requires a red (non-@blue) function",
+            )
+            err.add("error", "this is not a red function", w_func.def_loc)
+            raise err
+
+        # signature must match structurally
+        if not _signature_matches(w_expT, w_gotT):
+            return W_OpSpec.NULL
+
+        # Wrap in W_CFuncPtr so the interp-level return type matches.
+        # In the C backend, fmt_expr_FQNConst for W_CFuncPtr emits the bare
+        # symbol name — a function pointer value requires no boxing.
+        return W_OpSpec.const(W_CFuncPtr(w_expT, w_func))
+
+
+@UNSAFE.builtin_type("_c_func_ptr_type")
+class W_CFuncPtrType(W_Type):
+    """
+    The metatype for c_func_ptr[R, A0, ...].
+
+    Each distinct (R, A...) combination produces one W_CFuncPtrType instance,
+    interned by FQN in _CACHE so that the same signature always yields the
+    same Python object regardless of where or when it is constructed.
+    At the C level, the type lowers to a typedef of the form:
+
+        typedef R (*name)(A...);
+
+    emitted into spy_structdefs.h by cstructwriter.
+    """
+
+    _CACHE: "dict[FQN, W_CFuncPtrType]" = {}
+
+    w_restype: W_Type
+    w_argtypes_w: list[W_Type]
+
+    @classmethod
+    def from_signature(
+        cls, fqn: FQN, w_restype: W_Type, w_argtypes_w: list[W_Type]
+    ) -> "W_CFuncPtrType":
+        if fqn in cls._CACHE:
+            return cls._CACHE[fqn]
+        # from_pyclass(fqn, W_CFuncPtr) calls define(W_CFuncPtr), which scans
+        # W_CFuncPtr.__dict__ and registers all @builtin_method entries
+        # (including __convert_from__) into this type instance's dict_w.
+        w_T = cls.from_pyclass(fqn, W_CFuncPtr)
+        w_T.w_restype = w_restype
+        w_T.w_argtypes_w = w_argtypes_w
+        cls._CACHE[fqn] = w_T
+        return w_T
+
+
+@UNSAFE.builtin_func(color="blue", kind="generic")
+def w_c_func_ptr(vm: "SPyVM", w_R: W_Type, *w_argtypes: W_Type) -> W_Dynamic:
+    """
+    c_func_ptr[R, A0, A1, ...] — a C function-pointer type.
+
+    The first subscript argument is the return type; the remaining arguments
+    are the parameter types, e.g.:
+        c_func_ptr[bool, i32, i32]   # bool (*)(int32_t, int32_t)
+        c_func_ptr[void]             # void (*)(void)
+    """
+    for i, w_a in enumerate(w_argtypes):
+        if not isinstance(w_a, W_Type):
+            raise SPyError(
+                "W_TypeError",
+                f"c_func_ptr argument type at position {i} must be a type, "
+                f"got {w_a!r}",
+            )
+    w_argtypes_w = list(w_argtypes)
+    fqn = FQN("unsafe").join("c_func_ptr", [w_R.fqn] + [w.fqn for w in w_argtypes_w])
+    return W_CFuncPtrType.from_signature(fqn, w_R, w_argtypes_w)
+
+
+@UNSAFE.builtin_func(color="blue")
+def w_c_callback(vm: "SPyVM", w_func: W_Object) -> W_Object:
+    """
+    @c_callback — a no-op decorator that documents intent and validates that
+    a function is suitable as a C callback: must be a red def'd function.
+
+    The actual type conversion is performed by __convert_from__ above.
+    """
+    if not isinstance(w_func, W_ASTFunc):
+        raise SPyError(
+            "W_TypeError",
+            "@c_callback can only be applied to def'd functions",
+        )
+    if w_func.color != "red":
+        err = SPyError(
+            "W_TypeError",
+            "@c_callback cannot be applied to @blue functions",
+        )
+        err.add("error", "this is not a red function", w_func.def_loc)
+        raise err
+    return w_func

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -47,6 +47,7 @@ from spy.vm.modules.rawbuffer import RAW_BUFFER
 from spy.vm.modules.time import TIME
 from spy.vm.modules.types import TYPES, W_Loc
 from spy.vm.modules.unsafe import UNSAFE
+from spy.vm.modules.unsafe.funcptr import W_CFuncPtr
 from spy.vm.object import W_Object, W_Type
 from spy.vm.opimpl import W_OpImpl
 from spy.vm.opspec import W_MetaArg, W_OpSpec
@@ -490,6 +491,13 @@ class SPyVM:
             return fqn
 
         # no FQN yet, we need to assign it one.
+        if isinstance(w_val, W_CFuncPtr):
+            # A c_func_ptr wrapper: give it a unique FQN derived from the
+            # underlying function's key, then register it so future lookups work.
+            fqn = w_val.w_func.fqn.join("@cfuncptr", [])
+            self.add_global(fqn, w_val)
+            return fqn
+
         if isinstance(w_val, W_ASTFunc):
             # this is a W_ASTFunc which is NOT in the globals. The only
             # possibility is that it's a function which has already been


### PR DESCRIPTION
I am using the newly added external module support to wrap a C library that takes callbacks via function arguments.  I'd like to pass a red function from SPy to this module.

_Note: This is a design proposal PR to suggest a possible approach that we can discuss.  The implementation was constructed and refined with AI assistance.  Feel free to close this PR or use it as source material for a different implementation._

Overall approach:
* adds a `unsafe.c_func_ptr`: used to construct a type signature for a C function. 
   Example: `CB = c_func_ptr[i32, i32]      # type: int32_t (*)(int32_t)`
* adds a `@unsafe.c_callback` decorator which can be placed on red functions.  Initially I thought this would need to do something functional, but now it is just documentation / validation (it raises an error if you decorate a function that can't be used as a callback).  I'm open to either remove it, or have it do something.
* `W_CFuncPtrType` - the parametric function pointer type.  We cache instances of these so identical C signatures get the same type everywhere and we don't have to check structural identity.
* `W_CFuncPtr` - the value wrapper of a `W_ASTFunc` that knows how to convert from a red function and rejects blue functions.
* The C backend emits the C symbol name for the function directly when it needs to be passed as an argument.

Note that this PR _does not_ allow calling the CFuncPtr from SPy code.  It only allows passing it to C code where it can be called back.  Because of this, the PR augments the `out_of_tree` test to actually show that the callback is functional, rather than create another module to test the callback.  An example of a C callback factory function from that test looks like:

``` python
from unsafe import c_callback, c_func_ptr
from mymod import run_callback

CB = c_func_ptr[i32, i32]

@blue
def make_adder(n: i32) -> CB:
    @c_callback
    def adder(x: i32) -> i32:
        return x + n
    return adder

add5 = make_adder(5)
add10 = make_adder(10)

def run() -> i32:
    return run_callback(add5, 1) + run_callback(add10, 1)
```

Open issues:
* Should `@c_callback` be required to pass a red function as a CFuncPtr?  Right now the code accepts any red function and checks the type signature matches.
* The more logical syntax for making a CFuncPtr type is `CB = c_func_ptr[i32, (i32,)]` where the first parameter is the return type, and the second parameter is a tuple of argument types.  This ran into implementation trouble because there isn't a way to mark a tuple literal as blue.  Either the tuple constructor needs to be pure, or we need to handle tuple literals in a special way.
