### PR TITLE
[docs] Move `STATIC_TYPE()` from __spy__ module to builtin function

### DIFF
--- a/docs/src/reference/spy_builtin_functions.md
+++ b/docs/src/reference/spy_builtin_functions.md
@@ -5,7 +5,7 @@ title: Builtin Functions
 }
 </style>
 
-SPy adds several new builtins to the global namespace. Currently, all of them happen to be decorators for classes or callables.
+SPy adds several new builtins to the global namespace.
 
 /// warning
 The contents of the `__spy__` module and SPy's builtins form the API surface of a language that's rapidly evolving. All of the constructs, names, functions, or decorators here are likely to change!
@@ -15,6 +15,10 @@ The contents of the `__spy__` module and SPy's builtins form the API surface of 
 For a deeper explanation of the current state of SPy's coloring nomenclature, see [this post by Antonio Cuni](https://antocuni.eu/2026/03/25/inside-spy-part-2-language-semantics/#blue-functions).
 ///
 
+## Functions
+
+### __STATIC_TYPE__(object) { #markdown data-toc-label='STATIC_TYPE()' }
+:   Returns the type of the expression determined in a static context. Useful in tests, and is used in some of SPy's internal machinery.
 
 ## Class and Callable Decorators
 

--- a/docs/src/reference/spy_module.md
+++ b/docs/src/reference/spy_module.md
@@ -19,9 +19,6 @@ The contents of the `__spy__` module and SPy's builtins form the API surface of 
 
 : May be useful during metaprograming ensure that blue objects which are equal do not get optimized into the same object at redshift time. See, for example, the [implementation of `exal_expr_List`](https://github.com/spylang/spy/blob/main/spy/vm/astframe.py#L1161).
 
-### __STATIC_TYPE__(object) { #markdown data-toc-label='STATIC_TYPE()' }
-:   Returns the type of the expression determined in a static context. Useful in tests, and is used in some of SPy's internal machinery.
-
 ### __is_compiled__() -> bool { #markdown data-toc-label='is_compiled()' }
 :   Returns `False` when run in the interpreter, with or without redshifting. Returns `True` in compiled C code. Useful for testing and benchmarks, where it may be useful to adjust parameters depending on whether the code is compiled or not.
 


### PR DESCRIPTION
I previously had listed `STATIC_TYPE` in the documention for the `__spy__` module. This is wrong - it is included as a builtin.