### PR TITLE
Fix path to `examples/1_high_level/hello.spy` in `README.md`

### DIFF
--- a/examples/1_high_level/hello.spy
+++ b/examples/1_high_level/hello.spy
@@ -1,9 +1,1 @@
-"""
-Things to notice:
-  - Every SPy program defines `main()` as its entry point.
-    SPy libraries do not need a `main()` function.
-"""
-
-
-def main() -> None:
-    print("Hello world!")
+../hello.spy

--- a/examples/hello.spy
+++ b/examples/hello.spy
@@ -1,0 +1,9 @@
+"""
+Things to notice:
+  - Every SPy program defines `main()` as its entry point.
+    SPy libraries do not need a `main()` function.
+"""
+
+
+def main() -> None:
+    print("Hello world!")

--- a/spy/tests/test_cli.py
+++ b/spy/tests/test_cli.py
@@ -337,8 +337,8 @@ class TestMain:
     def test_execute_pyodide(self):
         # pyodide under node cannot access /tmp/, so we cannot try to execute
         # files which we wrote to self.tmpdir. Instead, let's try to execute
-        # examples/1_high_level/hello.spy
-        hello_spy = spy.ROOT.dirpath().join("examples", "1_high_level", "hello.spy")
+        # examples/hello.spy
+        hello_spy = spy.ROOT.dirpath().join("examples", "hello.spy")
         assert hello_spy.exists()
         res, stdout = self.run_external(PYODIDE_EXE, hello_spy)
         assert stdout == "Hello world!\n"


### PR DESCRIPTION
`hello.spy` has been moved last month by commit cf0d731f60ef6e9902c8698663c8b7c8f86bddd2, but README hasn't been updated accordingly ;-)