### PR TITLE
typed var declaration in loops is not allowed in interpreted mode

### DIFF
--- a/spy/tests/compiler/test_str.py
+++ b/spy/tests/compiler/test_str.py
@@ -349,6 +349,7 @@ class TestStr(CompilerTest):
             "it's",
             "\x00",
             "\x1f",
+            "\x1f\x1f",
             "café",
             "line1\nline2\ttabbed",
         ]

--- a/stdlib/_str.spy
+++ b/stdlib/_str.spy
@@ -264,8 +264,8 @@ class methods:
                 j = j + 1
                 out.utf8[j] = ord(b"x")
                 j = j + 1
-                hi: i32 = i32(c2) >> 4
-                lo: i32 = i32(c2) & 15
+                hi = i32(c2) >> 4
+                lo = i32(c2) & 15
                 if hi < 10:
                     out.utf8[j] = u8(hi) + ord(b"0")
                 else:


### PR DESCRIPTION
Original code was working by chance because the \xHH escape was exercised only once in the tests.
Removing the type makes it ok.