### PR TITLE
Add unicode_codepoint iterator

### DIFF
--- a/spy/tests/compiler/test_str.py
+++ b/spy/tests/compiler/test_str.py
@@ -1,6 +1,8 @@
 import re
 from textwrap import dedent
 
+import pytest
+
 from spy.errors import SPyError
 from spy.tests.support import CompilerTest, only_interp, skip_backends
 
@@ -669,3 +671,61 @@ class TestStr(CompilerTest):
         assert mod.foo("aaab", "aaab") == True
         assert mod.foo("aaaa", "aaaa") == True
         assert mod.foo("aaab", "aaaab") == False
+
+
+class TestUnicodeCodePoints(CompilerTest):
+    @pytest.fixture
+    def get_codepoint(self):
+        src = """
+        from _str import unicode_codepoints, StrObject
+        def get_codepoint(s: str, i: int) -> int:
+            it = unicode_codepoints(StrObject.from_str(s))
+            j = 0
+            for codepoint in it:
+                if j == i:
+                    return codepoint
+                j += 1
+            return -1
+        """
+        mod = self.compile(src)
+        return mod.get_codepoint
+
+    def test_simple(self, get_codepoint):
+        input = "he"
+        assert get_codepoint(input, 0) == 104
+        assert get_codepoint(input, 1) == 101
+        assert get_codepoint(input, 2) == -1
+
+    def test_unicode(self, get_codepoint):
+        input = "hé桁🨀"
+        # h (1 utf byte)
+        assert get_codepoint(input, 0) == 104
+        # é (2 utf bytes)
+        assert get_codepoint(input, 1) == 233
+        # 桁 (3 utf bytes)
+        assert get_codepoint(input, 2) == 26689
+        # 🨀 (4 utf bytes)
+        assert get_codepoint(input, 3) == 129536
+        # end of string
+        assert get_codepoint(input, 4) == -1
+
+    def test_highest_unicode_char(self, get_codepoint):
+        input = "\U0010ffff"
+        assert get_codepoint(input, 0) == 0x10FFFF
+        assert get_codepoint(input, 1) == -1
+
+    def test_invalid_utf8(self):
+        src = """
+        from _str import unicode_codepoints, StrObject
+        from _bytes import BytesObject
+        def run_unicode_codepoints(bs: bytes) -> int:
+            bytes_object = BytesObject.from_bytes(bs)
+            s = StrObject.alloc(len(bs))
+            s.utf8 = bytes_object.data
+            for _ in unicode_codepoints(s):
+                pass
+        """
+        mod = self.compile(src)
+        input = b"\xff"
+        with pytest.raises(SPyError, match="invalid first utf-8 byte: 255"):
+            mod.run_unicode_codepoints(input)

--- a/spy/tests/compiler/test_str.py
+++ b/spy/tests/compiler/test_str.py
@@ -672,10 +672,7 @@ class TestStr(CompilerTest):
         assert mod.foo("aaaa", "aaaa") == True
         assert mod.foo("aaab", "aaaab") == False
 
-
-class TestUnicodeCodePoints(CompilerTest):
-    @pytest.fixture
-    def get_codepoint(self):
+    def test_unicode_codepoints(self):
         src = """
         from _str import unicode_codepoints, StrObject
         def get_codepoint(s: str, i: int) -> int:
@@ -688,31 +685,22 @@ class TestUnicodeCodePoints(CompilerTest):
             return -1
         """
         mod = self.compile(src)
-        return mod.get_codepoint
 
-    def test_simple(self, get_codepoint):
-        input = "he"
-        assert get_codepoint(input, 0) == 104
-        assert get_codepoint(input, 1) == 101
-        assert get_codepoint(input, 2) == -1
-
-    def test_unicode(self, get_codepoint):
         input = "hé桁🨀"
         # h (1 utf byte)
-        assert get_codepoint(input, 0) == 104
+        assert mod.get_codepoint(input, 0) == ord("h")
         # é (2 utf bytes)
-        assert get_codepoint(input, 1) == 233
+        assert mod.get_codepoint(input, 1) == ord("é")
         # 桁 (3 utf bytes)
-        assert get_codepoint(input, 2) == 26689
+        assert mod.get_codepoint(input, 2) == ord("桁")
         # 🨀 (4 utf bytes)
-        assert get_codepoint(input, 3) == 129536
+        assert mod.get_codepoint(input, 3) == ord("🨀")
         # end of string
-        assert get_codepoint(input, 4) == -1
+        assert mod.get_codepoint(input, 4) == -1
 
-    def test_highest_unicode_char(self, get_codepoint):
         input = "\U0010ffff"
-        assert get_codepoint(input, 0) == 0x10FFFF
-        assert get_codepoint(input, 1) == -1
+        assert mod.get_codepoint(input, 0) == 0x10FFFF
+        assert mod.get_codepoint(input, 1) == -1
 
     def test_invalid_utf8(self):
         src = """

--- a/stdlib/_str.spy
+++ b/stdlib/_str.spy
@@ -656,3 +656,62 @@ def _split_whitespace(self:str) -> list[str]:
         result.append(StrObject.to_str(llnew))
 
     return result
+        
+
+@struct
+class unicode_codepoints:
+    """Iterates over the unicode codepoints in a string."""
+    str: gc_ptr[StrObject]
+  
+    def __fastiter__(self) -> unicode_codepoints_iterator:
+        return unicode_codepoints_iterator(self.str, 0)
+
+@struct
+class unicode_codepoints_iterator:
+    str_ptr: gc_ptr[StrObject]
+    i: int
+   
+    def __next__(self) -> unicode_codepoints_iterator:
+        return unicode_codepoints_iterator(self.str_ptr, self.i + self.__item_len())
+    
+    def __item__(self) -> i32:
+        current_byte = self.str_ptr.utf8[self.i]
+        codepoint: i32 = current_byte & __first_byte_mask(current_byte)
+
+        for j in range(self.__item_len() - 1):
+            current_byte = self.str_ptr.utf8[self.i + j + 1] & u8(0b0011_1111)
+            codepoint = i32(current_byte) | (codepoint << 6)
+        
+        return codepoint
+    
+    # the opposite of StopIteration :)
+    def __continue_iteration__(self) -> bool:
+        return self.i < self.str_ptr.length
+
+    def __item_len(self) -> int:
+        current_byte: u8 = self.str_ptr.utf8[self.i]
+        if (current_byte & u8(0b1000_0000)) == u8(0):
+            return 1
+        elif (current_byte & u8(0b1110_0000)) == u8(0b1100_0000):
+            return 2
+        elif (current_byte & u8(0b1111_0000)) == u8(0b1110_0000):
+            return 3
+        elif (current_byte & u8(0b1111_1000)) == u8(0b1111_0000):
+            return 4
+        assert False, "invalid first utf-8 byte: " + str(current_byte)
+
+def __first_byte_mask(byte: u8) -> u8:
+    """returns the bitmaks for the first byte"""
+    if (byte & u8(0b1000_0000)) == u8(0):
+        # for 1-byte sequence
+        return u8(0b0111_1111)
+    elif (byte & u8(0b1110_0000)) == u8(0b1100_0000):
+        # for 2-byte sequence
+        return u8(0b0001_1111)
+    elif (byte & u8(0b1111_0000)) == u8(0b1110_0000):
+        # for 3-byte sequence
+        return u8(0b0000_1111)
+    elif (byte & u8(0b1111_1000)) == u8(0b1111_0000):
+        # for 4-byte sequence
+        return u8(0b0000_0111)
+    assert False, "invalid first utf-8 byte: " + str(byte)


### PR DESCRIPTION
This PR adds a the `unicode_codepoint` iterator in the `_str` module, allowing to iterate over the individual codepoints of a utf-8 string.