### PR TITLE
Handle signed zero and non-finite f32 constants

### DIFF
--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -1,3 +1,4 @@
+import math
 from types import NoneType
 from typing import TYPE_CHECKING
 
@@ -288,9 +289,17 @@ class CFuncWriter:
         elif w_T is B.w_f64:
             return C.Literal(str(vm.unwrap_f64(w_val)))
         elif w_T is B.w_f32:
+            value = vm.unwrap_f32(w_val)
+            # Python's "inf" and "nan" spellings are not C literals. Use the
+            # C99 macros so folded non-finite values remain valid float constants.
+            if math.isnan(value):
+                return C.Literal("NAN")
+            if math.isinf(value):
+                sign = "-" if value < 0 else ""
+                return C.Literal(f"{sign}INFINITY")
             # the 'f' suffix makes it a float literal, avoiding double->float
             # narrowing warnings
-            return C.Literal(f"{vm.unwrap_f32(w_val)}f")
+            return C.Literal(f"{value}f")
         elif w_T is B.w_complex128:
             val = vm.unwrap_complex128(w_val)
             return C.Literal(

--- a/spy/tests/compiler/test_float.py
+++ b/spy/tests/compiler/test_float.py
@@ -28,6 +28,14 @@ class TestFloat(CompilerTest):
         assert mod.b() == 2.5
         assert mod.c() == 3.5
 
+    def test_f32_inf_const(self):
+        mod = self.compile("""
+        def positive_inf() -> f32:
+            largest = f32(3.4028234663852886e38)
+            return largest + largest
+        """)
+        assert mod.positive_inf() == float("inf")
+
     def test_BinOp(self, float_type):
         mod = self.compile(f"""
         T = {float_type}

--- a/spy/tests/compiler/unsafe/test_div.py
+++ b/spy/tests/compiler/unsafe/test_div.py
@@ -147,10 +147,15 @@ class TestUnsafeFloatDiv(CompilerTest):
         from unsafe import ieee754_div
         T = {float_type}
         def div(x: T, y: T) -> T: return ieee754_div(x, y)
+
+        def div_by_negative_zero(x: T) -> T:
+            negative_zero: T = -0.0
+            return ieee754_div(x, negative_zero)
         """)
         assert mod.div(1.5, 0.0) == float("inf")
         assert mod.div(-1.5, 0.0) == float("-inf")
         assert isnan(mod.div(0.0, 0.0))
+        assert mod.div_by_negative_zero(1.5) == float("-inf")
 
     def test_spy_zero_division_unchecked(self, float_type):
         mod = self.compile(f"""

--- a/spy/vm/modules/unsafe/div.py
+++ b/spy/vm/modules/unsafe/div.py
@@ -1,3 +1,4 @@
+import math
 from ctypes import c_float as float32
 from typing import TYPE_CHECKING, Annotated, Any, Protocol
 
@@ -168,12 +169,13 @@ def w_f64_ieee754_div(vm: "SPyVM", w_a: W_F64, w_b: W_F64) -> W_F64:
     b = w_b.value
 
     if b == 0:
-        if a > 0:
-            result = float("inf")
-        elif a < 0:
-            result = float("-inf")
-        else:
+        # Python raises instead of producing an IEEE-754 result, so combine both
+        # operand signs explicitly; comparing with zero alone loses the sign of -0.0.
+        if a == 0:
             result = float("nan")
+        else:
+            sign = math.copysign(1.0, a) * math.copysign(1.0, b)
+            result = math.copysign(float("inf"), sign)
 
         return vm.wrap(result)
 


### PR DESCRIPTION
The interpreter's IEEE-754 division fallback selected infinity from the numerator sign alone, so division by negative zero returned the wrong sign. Combine both operand signs with copysign while retaining NaN for zero divided by zero.

Redshift can fold `f32` overflow into infinity. The C writer previously appended an `f` suffix to Python's spelling and emitted invalid identifiers such as `inff` and `nanf`; emit the C99 `INFINITY` and `NAN` macros instead.

The signed-zero regression constructs -0.0 inside SPy, so it tests signed-zero behavior independently of Python-to-SPy argument conversion. The constant-emission regression overflows the largest finite `f32` deliberately, ensuring the C writer receives a folded non-finite constant instead of a runtime division call.

It was possible thanks to the help of gpt-5.6-sol.