### PR TITLE
Make examples work when compiled

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -54,6 +54,15 @@ def _run(spy_file: Path) -> subprocess.CompletedProcess:
         check=False,
     )
 
+def _build_run(spy_file: Path) -> subprocess.CompletedProcess:
+    cmd = ["spy","build","-x", str(spy_file)]
+    print( "cmd >>>>>>>"," ".join(cmd))
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
 
 def test_all_examples_have_expected_output(request) -> None:
     """Catch the case where a new .spy file was added without a saved expected output.
@@ -76,11 +85,11 @@ def test_all_examples_have_expected_output(request) -> None:
         )
 
 
-@pytest.mark.parametrize("spy_file", _spy_files, ids=lambda f: f.stem)
-def test_example(spy_file: Path, request) -> None:
-    expected_file = EXPECTED_OUTPUT_DIR / f"{spy_file.stem}.txt"
-    result = _run(spy_file)
 
+def run_example(spy_file: Path, request,runner = _run) -> None:
+    expected_file = EXPECTED_OUTPUT_DIR / f"{spy_file.stem}.txt"
+    result = runner(spy_file)
+    print(result.returncode,expected_returncode(spy_file))
     assert result.returncode == expected_returncode(spy_file), (
         f"spy exited with code {result.returncode}\n"
         f"--- stdout ---\n{result.stdout}"
@@ -107,3 +116,12 @@ def test_example(spy_file: Path, request) -> None:
             f"Output of {spy_file.name} differs from {expected_file.relative_to(EXAMPLES_DIR)}\n\n"
             "Update the expected result with: pytest --update-examples"
         )
+
+@pytest.mark.parametrize("spy_file", _spy_files, ids=lambda f: f.stem)
+def test_example_interp(spy_file: Path, request) -> None:
+    run_example(spy_file,request)
+
+@pytest.mark.xfail
+@pytest.mark.parametrize("spy_file", _spy_files, ids=lambda f: f.stem)
+def test_example_build(spy_file: Path, request) -> None:
+    run_example(spy_file,request,_build_run)

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -55,8 +55,9 @@ def _run(spy_file: Path) -> subprocess.CompletedProcess:
     )
 
 def _build_run(spy_file: Path) -> subprocess.CompletedProcess:
-    cmd = ["spy","build","-x", str(spy_file)]
-    print( "cmd >>>>>>>"," ".join(cmd))
+    cmd = ["spy","build", str(spy_file)]
+    subprocess.run(cmd)
+    cmd = [str(spy_file.parent)+'/build/'+str(spy_file.stem)]
     return subprocess.run(
         cmd,
         capture_output=True,
@@ -121,7 +122,9 @@ def run_example(spy_file: Path, request,runner = _run) -> None:
 def test_example_interp(spy_file: Path, request) -> None:
     run_example(spy_file,request)
 
-@pytest.mark.xfail
 @pytest.mark.parametrize("spy_file", _spy_files, ids=lambda f: f.stem)
 def test_example_build(spy_file: Path, request) -> None:
+    # There are four examples which fails in the c compiling stage - so they are marked as XFAIL
+    if spy_file.stem in ['collections','annotated','unroll_nested_loops','convert']:
+        pytest.xfail()
     run_example(spy_file,request,_build_run)


### PR DESCRIPTION
Added a way to test if the examples work when compiled. Due to a problem of getting the correct return code with the "spy bull -x", the building process is separate from the test of the executable.

There are four examples that are not compilable at this point in time, and these examples are marked as XFAIL.

AI was not used in this pull request