### PR TITLE
Merge Assign and UnpackAssign ast classes.

### DIFF
--- a/spy/analyze/importing.py
+++ b/spy/analyze/importing.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 MODULE = Union[ast.Module, "W_Module", None]
 
 # Cache version: increment this when ast.Module or SymTable structure changes
-SPYC_VERSION = 6
+SPYC_VERSION = 7
 
 
 @dataclass

--- a/spy/analyze/scope.py
+++ b/spy/analyze/scope.py
@@ -378,17 +378,13 @@ class ScopeAnalyzer:
         self.pop_scope()
 
     def declare_Assign(self, assign: ast.Assign) -> None:
-        self._declare_target_maybe(assign.target, assign.value)
+        for target in assign.target.flatten():
+            self._declare_target_maybe(target, assign.value)
         self.declare(assign.value)
 
     def declare_AugAssign(self, augassign: ast.AugAssign) -> None:
         self._promote_const_to_var_maybe(augassign.target)
         self.declare(augassign.value)
-
-    def declare_UnpackAssign(self, unpack: ast.UnpackAssign) -> None:
-        for target in unpack.targets:
-            self._declare_target_maybe(target, unpack.value)
-        self.declare(unpack.value)
 
     def declare_AssignExpr(self, assignexpr: ast.AssignExpr) -> None:
         self._declare_target_maybe(assignexpr.target, assignexpr.value)
@@ -556,7 +552,11 @@ class ScopeAnalyzer:
         self.capture_maybe(name.id)
 
     def flatten_Assign(self, assign: ast.Assign) -> None:
-        self.capture_maybe(assign.target.value)
+        if isinstance(assign.target, ast.UnpackTarget):
+            self.mod_scope.implicit_imports.add("_tuple")
+        for target in assign.target.flatten():
+            assert isinstance(target, ast.StrLiteral)
+            self.capture_maybe(target.value)
         self.flatten(assign.value)
 
     def flatten_AssignExpr(self, assignexpr: ast.AssignExpr) -> None:
@@ -585,12 +585,6 @@ class ScopeAnalyzer:
         self.mod_scope.implicit_imports.add("_slice")
         for item in (slc.start, slc.stop, slc.step):
             self.flatten(item)
-
-    def flatten_UnpackAssign(self, unpack: ast.UnpackAssign) -> None:
-        self.mod_scope.implicit_imports.add("_tuple")
-        for target in unpack.targets:
-            self.flatten(target)
-        self.flatten(unpack.value)
 
     def flatten_Dict(self, dict: ast.Dict) -> None:
         self.mod_scope.implicit_imports.add("_dict")

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -5,12 +5,14 @@
 import ast as py_ast
 import dataclasses
 import typing
+from abc import abstractmethod
 from dataclasses import dataclass, field
 from typing import (
     TYPE_CHECKING,
     Any,
     Iterator,
     Optional,
+    Sequence,
     Type,
     dataclass_transform,
     no_type_check,
@@ -704,14 +706,31 @@ class StmtExpr(Stmt):
 
 
 @astnode
-class Assign(Stmt):
-    target: StrLiteral
-    value: Expr
+class AssignTarget(Node):
+    @abstractmethod
+    def flatten(self) -> Iterator[StrLiteral]: ...
 
 
 @astnode
-class UnpackAssign(Stmt):
-    targets: list[StrLiteral]
+class SingleTarget(AssignTarget):
+    name: StrLiteral
+
+    def flatten(self) -> Iterator[StrLiteral]:
+        yield self.name
+
+
+@astnode
+class UnpackTarget(AssignTarget):
+    targets: Sequence[AssignTarget]
+
+    def flatten(self) -> Iterator[StrLiteral]:
+        for target in self.targets:
+            yield from target.flatten()
+
+
+@astnode
+class Assign(Stmt):
+    target: AssignTarget
     value: Expr
 
 

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -176,9 +176,6 @@ class CFuncWriter:
             else:
                 self.tbc.wl(f"{target} = {v};")
 
-    def emit_stmt_Assign(self, assign: ast.Assign) -> None:
-        assert False, "ast.Assign nodes should not survive redshifting"
-
     def emit_stmt_AssignLocal(self, assign: ast.AssignLocal) -> None:
         target = assign.target.value
         v = self.fmt_expr(assign.value)
@@ -194,11 +191,16 @@ class CFuncWriter:
         c_varname = C_Ident(target)
         self.tbc.wl(f"{c_varname} = {v};")
 
-    def emit_stmt_UnpackAssign(self, unpack: ast.UnpackAssign) -> None:
-        if isinstance(unpack.value, ast.Tuple):
+    def emit_stmt_Assign(self, assign: ast.Assign) -> None:
+        unpack = assign.target
+        assert isinstance(unpack, ast.UnpackTarget), (
+            "simple ast.Assign nodes should not survive redshifting"
+        )
+        if isinstance(assign.value, ast.Tuple):
             # Blue tuple literal: directly assign each item to its target
-            for target, item in zip(unpack.targets, unpack.value.items):
-                c_target = C_Ident(target.value)
+            for target, item in zip(unpack.targets, assign.value.items):
+                assert isinstance(target, ast.SingleTarget)
+                c_target = C_Ident(target.name.value)
                 v = self.fmt_expr(item)
                 self.tbc.wl(f"{c_target} = {v};")
         else:
@@ -209,14 +211,15 @@ class CFuncWriter:
             #     a = tmp._item0;
             #     b = tmp._item1;
             # }
-            assert unpack.value.w_T is not None
-            c_tuple_type = self.ctx.w2c(unpack.value.w_T)
-            v = self.fmt_expr(unpack.value)
+            assert assign.value.w_T is not None
+            c_tuple_type = self.ctx.w2c(assign.value.w_T)
+            v = self.fmt_expr(assign.value)
             self.tbc.wl("{")
             with self.tbc.indent():
                 self.tbc.wl(f"{c_tuple_type} tmp = {v};")
                 for i, target in enumerate(unpack.targets):
-                    c_target = C_Ident(target.value)
+                    assert isinstance(target, ast.SingleTarget)
+                    c_target = C_Ident(target.name.value)
                     self.tbc.wl(f"{c_target} = tmp._item{i};")
             self.tbc.wl("}")
 

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -270,13 +270,24 @@ class SPyBackend:
         self.wl(f"return {v}")
 
     def emit_stmt_Assign(self, assign: ast.Assign) -> None:
-        varname = assign.target.value
-        t = self.get_vartype_to_declare_maybe(varname)
-        v = self.fmt_expr(assign.value)
-        if t is not None:
-            self.wl(f"{varname}: {t} = {v}")
+        if isinstance(assign.target, ast.SingleTarget):
+            varname = assign.target.name.value
+            t = self.get_vartype_to_declare_maybe(varname)
+            v = self.fmt_expr(assign.value)
+            if t is not None:
+                self.wl(f"{varname}: {t} = {v}")
+            else:
+                self.wl(f"{varname} = {v}")
         else:
-            self.wl(f"{varname} = {v}")
+            unpack = assign.target
+            assert isinstance(unpack, ast.UnpackTarget)
+            names = []
+            for tt in unpack.targets:
+                assert isinstance(tt, ast.SingleTarget)
+                names.append(tt.name.value)
+            targets = ", ".join(names)
+            v = self.fmt_expr(assign.value)
+            self.wl(f"{targets} = {v}")
 
     def emit_stmt_AssignLocal(self, assign: ast.AssignLocal) -> None:
         varname = assign.target.value
@@ -297,11 +308,6 @@ class SPyBackend:
         op = node.op
         v = self.fmt_expr(node.value)
         self.wl(f"{varname} {op}= {v}")
-
-    def emit_stmt_UnpackAssign(self, unpack: ast.UnpackAssign) -> None:
-        targets = ", ".join([t.value for t in unpack.targets])
-        v = self.fmt_expr(unpack.value)
-        self.wl(f"{targets} = {v}")
 
     def emit_stmt_SetAttr(self, node: ast.SetAttr) -> None:
         t = self.fmt_expr(node.target)

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -249,23 +249,34 @@ class DopplerFrame(ASTFrame):
 
     def shift_stmt_Assign(self, assign: ast.Assign) -> list[ast.Stmt]:
         self.exec_stmt_Assign(assign)
-        varname = assign.target.value
-        sym = self.symtable.lookup(varname)
-        if sym.is_local and self.locals[varname].color == "blue":
-            self.record_node_color(assign, "blue")
-            # redshift away assignments to blue locals, but preserve
-            # any side effects from BlockExpr bodies
-            shifted_value = self.shifted_expr[assign.value]
-            if isinstance(shifted_value, ast.BlockExpr):
-                return shifted_value.body
-            return []
+        if isinstance(assign.target, ast.SingleTarget):
+            varname = assign.target.name.value
+            sym = self.symtable.lookup(varname)
+            if sym.is_local and self.locals[varname].color == "blue":
+                self.record_node_color(assign, "blue")
+                # redshift away assignments to blue locals, but preserve
+                # any side effects from BlockExpr bodies
+                shifted_value = self.shifted_expr[assign.value]
+                if isinstance(shifted_value, ast.BlockExpr):
+                    return shifted_value.body
+                return []
+            else:
+                if sym.is_local:
+                    self.record_node_color(assign, self.locals[varname].color)
+                specialized = self.specialized_assigns[assign]
+                newname = assign.target.name.as_typed_node()
+                newvalue = self.shifted_expr[assign.value]
+                return [specialized.replace(target=newname, value=newvalue)]
         else:
-            if sym.is_local:
-                self.record_node_color(assign, self.locals[varname].color)
-            specialized = self.specialized_assigns[assign]
-            newtarget = assign.target.as_typed_node()
+            unpack = assign.target
+            assert isinstance(unpack, ast.UnpackTarget)
+            newtargets = []
+            for target in unpack.targets:
+                assert isinstance(target, ast.SingleTarget)
+                newtargets.append(target.replace(name=target.name.as_typed_node()))
+            unpack = unpack.replace(targets=newtargets)
             newvalue = self.shifted_expr[assign.value]
-            return [specialized.replace(target=newtarget, value=newvalue)]
+            return [assign.replace(target=unpack, value=newvalue)]
 
     def shift_stmt_AssignLocal(self, assign: ast.AssignLocal) -> list[ast.Stmt]:
         # specialized stmts such as AssignLocal and AssignCell are present
@@ -280,12 +291,6 @@ class DopplerFrame(ASTFrame):
     def shift_stmt_AugAssign(self, node: ast.AugAssign) -> list[ast.Stmt]:
         assign = self._desugar_AugAssign(node)
         return self.shift_stmt_Assign(assign)
-
-    def shift_stmt_UnpackAssign(self, unpack: ast.UnpackAssign) -> list[ast.Stmt]:
-        newtargets = [target.as_typed_node() for target in unpack.targets]
-        self.exec_stmt_UnpackAssign(unpack)
-        newvalue = self.shifted_expr[unpack.value]
-        return [unpack.replace(targets=newtargets, value=newvalue)]
 
     def shift_stmt_SetAttr(self, node: ast.SetAttr) -> list[ast.Stmt]:
         self.exec_stmt(node)

--- a/spy/linearize.py
+++ b/spy/linearize.py
@@ -215,7 +215,7 @@ class Linearizer:
         new_value = self.rewrite_expr(assign.value, to_spill)
         return [assign.replace(value=new_value)]
 
-    def rewrite_stmt_UnpackAssign(self, assign: ast.UnpackAssign) -> list[ast.Stmt]:
+    def rewrite_stmt_Assign(self, assign: ast.Assign) -> list[ast.Stmt]:
         to_spill = self.mark_to_spill([assign.value])
         new_value = self.rewrite_expr(assign.value, to_spill)
         return [assign.replace(value=new_value)]

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -510,11 +510,12 @@ class Parser:
         assert isinstance(assign, spy.ast.Assign)
         assert len(py_node.targets) == 1
         assert isinstance(py_node.targets[0], py_ast.Name)
+        assert isinstance(assign.target, spy.ast.SingleTarget)
         varkind, _ = parse_var_name(py_node.targets[0].id)
         vardef = spy.ast.VarDef(
             loc=py_node.loc,
             kind=varkind,
-            name=assign.target,
+            name=assign.target.name,
             type=spy.ast.Auto(loc=py_node.loc),
             value=assign.value,
         )
@@ -568,7 +569,9 @@ class Parser:
                 # "x = 0" is an Assign
                 return spy.ast.Assign(
                     loc=py_node.loc,
-                    target=spy.ast.StrLiteral(py_target.loc, real_name),
+                    target=spy.ast.SingleTarget(
+                        py_target.loc, spy.ast.StrLiteral(py_target.loc, real_name)
+                    ),
                     value=self.from_py_expr(py_node.value),
                 )
         elif isinstance(py_target, py_ast.Attribute):
@@ -596,9 +599,16 @@ class Parser:
             targets = []
             for item in py_target.elts:
                 assert isinstance(item, py_ast.Name)
-                targets.append(spy.ast.StrLiteral(item.loc, item.id))
-            return spy.ast.UnpackAssign(
-                loc=py_node.loc, targets=targets, value=self.from_py_expr(py_node.value)
+                targets.append(
+                    spy.ast.SingleTarget(
+                        item.loc, spy.ast.StrLiteral(item.loc, item.id)
+                    )
+                )
+            newtarget = spy.ast.UnpackTarget(loc=py_target.loc, targets=targets)
+            return spy.ast.Assign(
+                loc=py_node.loc,
+                target=newtarget,
+                value=self.from_py_expr(py_node.value),
             )
         else:
             self.unsupported(py_target, "assign to complex expressions")

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -737,7 +737,9 @@ class TestParser:
         stmt = mod.get_funcdef("foo").body[0]
         expected = f"""
             Assign(
-                target=StrLiteral(value='dict_test'),
+                target=SingleTarget(
+                    name=StrLiteral(value='dict_test'),
+                ),
                 value=Dict(
                     items=[
                         KeyValuePair(
@@ -1017,7 +1019,9 @@ class TestParser:
         stmt = mod.get_funcdef("foo").body[0]
         expected = """
         Assign(
-            target=StrLiteral(value='x'),
+            target=SingleTarget(
+                name=StrLiteral(value='x'),
+            ),
             value=Literal(value=42),
         )
         """
@@ -1052,12 +1056,20 @@ class TestParser:
         """)
         stmt = mod.get_funcdef("foo").body[0]
         expected = """
-        UnpackAssign(
-            targets=[
-                StrLiteral(value='a'),
-                StrLiteral(value='b'),
-                StrLiteral(value='c'),
-            ],
+        Assign(
+            target=UnpackTarget(
+                targets=[
+                    SingleTarget(
+                        name=StrLiteral(value='a'),
+                    ),
+                    SingleTarget(
+                        name=StrLiteral(value='b'),
+                    ),
+                    SingleTarget(
+                        name=StrLiteral(value='c'),
+                    ),
+                ],
+            ),
             value=Name(id='x'),
         )
         """
@@ -1433,11 +1445,12 @@ class TestParser:
         assert isclass(nodes[4], "If")
         assert isclass(nodes[5], "Literal") and nodes[5].value is True
         assert isclass(nodes[6], "Assign")
-        assert isclass(nodes[7], "StrLiteral") and nodes[7].value == "x"
-        assert isclass(nodes[8], "BinOp")
-        assert isclass(nodes[9], "Name") and nodes[9].id == "y"
-        assert isclass(nodes[10], "Literal") and nodes[10].value == 1
-        assert len(nodes) == 11
+        assert isclass(nodes[7], "SingleTarget")
+        assert isclass(nodes[8], "StrLiteral") and nodes[8].value == "x"
+        assert isclass(nodes[9], "BinOp")
+        assert isclass(nodes[10], "Name") and nodes[10].id == "y"
+        assert isclass(nodes[11], "Literal") and nodes[11].value == 1
+        assert len(nodes) == 12
         #
         nodes2 = list(mod.walk(ast.Stmt))
         expected2 = [node for node in nodes if isinstance(node, ast.Stmt)]
@@ -1460,15 +1473,15 @@ class TestParser:
         assert isclass(nodes[0], "Literal") and nodes[0].value is None
         assert isclass(nodes[1], "Literal") and nodes[1].value is True
         assert isclass(nodes[2], "StrLiteral") and nodes[2].value == "x"
-        assert isclass(nodes[3], "Name") and nodes[3].id == "y"
-        assert isclass(nodes[4], "Literal") and nodes[4].value == 1
-        assert isclass(nodes[5], "BinOp")
-        assert isclass(nodes[6], "Assign")
-        assert isclass(nodes[7], "If")
-        assert isclass(nodes[8], "FuncDef")
-        assert isclass(nodes[9], "GlobalFuncDef")
-        assert isclass(nodes[10], "Module")
-        assert len(nodes) == 11
+        assert isclass(nodes[4], "Name") and nodes[4].id == "y"
+        assert isclass(nodes[5], "Literal") and nodes[5].value == 1
+        assert isclass(nodes[6], "BinOp")
+        assert isclass(nodes[7], "Assign")
+        assert isclass(nodes[8], "If")
+        assert isclass(nodes[9], "FuncDef")
+        assert isclass(nodes[10], "GlobalFuncDef")
+        assert isclass(nodes[11], "Module")
+        assert len(nodes) == 12
         #
         nodes2 = list(mod.walk_postorder(ast.Stmt))
         expected2 = [node for node in nodes if isinstance(node, ast.Stmt)]
@@ -1683,7 +1696,9 @@ class TestParser:
                     value=Literal(value=42),
                 ),
                 Assign(
-                    target=StrLiteral(value='y'),
+                    target=SingleTarget(
+                        name=StrLiteral(value='y'),
+                    ),
                     value=Literal(value=1),
                 ),
             ],
@@ -1907,7 +1922,9 @@ class TestParser:
             BlockExpr(
                 body=[
                     Assign(
-                        target=StrLiteral(value='x'),
+                        target=SingleTarget(
+                            name=StrLiteral(value='x'),
+                        ),
                         value=Literal(value=1),
                     ),
                 ],

--- a/spy/tests/test_scope.py
+++ b/spy/tests/test_scope.py
@@ -103,6 +103,30 @@ class TestScopeAnalyzer:
             "i32": MatchSymbol("i32", "const", "explicit", level=1),
         }
 
+    def test_capture_global(self):
+        scopes = self.analyze("""
+        var a: i32 = 0
+        def foo() -> None:
+            a = 1
+            b = 2
+        def bar() -> None:
+            a, b = 3, 4
+        """)
+        foo_def = self.mod.get_funcdef("foo")
+        foo_scope = scopes.by_funcdef(foo_def)
+        assert foo_scope._symbols == {
+            "a": MatchSymbol("a", "var", "explicit", storage="cell", level=1),
+            "b": MatchSymbol("b", "const", "auto"),
+            "@return": MatchSymbol("@return", "var", "auto"),
+        }
+        bar_def = self.mod.get_funcdef("bar")
+        bar_scope = scopes.by_funcdef(bar_def)
+        assert bar_scope._symbols == {
+            "a": MatchSymbol("a", "var", "explicit", storage="cell", level=1),
+            "b": MatchSymbol("b", "const", "auto"),
+            "@return": MatchSymbol("@return", "var", "auto"),
+        }
+
     def test_funcargs_and_locals(self):
         scopes = self.analyze("""
         def foo(a: i32) -> i32:

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -552,12 +552,15 @@ class AbstractFrame:
             self.store_local(varname, wam.w_val)
 
     def exec_stmt_Assign(self, assign: ast.Assign) -> None:
-        # see the commnet in __init__ about specialized_assigns
-        specialized = self.specialized_assigns.get(assign)
-        if specialized is None:
-            specialized = self._specialize_Assign(assign)
-            self.specialized_assigns[assign] = specialized
-        self.exec_stmt(specialized)
+        if isinstance(assign.target, ast.SingleTarget):
+            # see the comment in __init__ about specialized_assigns
+            specialized = self.specialized_assigns.get(assign)
+            if specialized is None:
+                specialized = self._specialize_Assign(assign)
+                self.specialized_assigns[assign] = specialized
+            self.exec_stmt(specialized)
+        else:
+            self.exec_stmt_Assign_unpack(assign)
 
     def _specialize_assign_common(
         self, loc: Loc, target: ast.StrLiteral, value: ast.Expr, expr: bool
@@ -608,8 +611,9 @@ class AbstractFrame:
             assert False
 
     def _specialize_Assign(self, assign: ast.Assign) -> ast.Stmt:
+        assert isinstance(assign.target, ast.SingleTarget)
         res = self._specialize_assign_common(
-            loc=assign.loc, target=assign.target, value=assign.value, expr=False
+            loc=assign.loc, target=assign.target.name, value=assign.value, expr=False
         )
         assert isinstance(res, (ast.AssignLocal, ast.AssignCell))
         return res
@@ -657,8 +661,9 @@ class AbstractFrame:
             w_cell.set(wam.w_val)
         return wam
 
-    def exec_stmt_UnpackAssign(self, unpack: ast.UnpackAssign) -> None:
-        wam_tup = self.eval_expr(unpack.value)
+    def exec_stmt_Assign_unpack(self, assign: ast.Assign) -> None:
+        assert isinstance(assign.target, ast.UnpackTarget)
+        wam_tup = self.eval_expr(assign.value)
         w_T = wam_tup.w_static_T
 
         is_interp_tuple = w_T is SPY.w_interp_tuple
@@ -669,7 +674,7 @@ class AbstractFrame:
                 "W_TypeError",
                 f"`{t}` does not support unpacking",
             )
-            err.add("error", f"this is `{t}`", unpack.value.loc)
+            err.add("error", f"this is `{t}`", assign.value.loc)
             raise err
 
         # check that the tuple has the right length
@@ -682,13 +687,14 @@ class AbstractFrame:
             assert isinstance(w_T, W_StructType)
             got = len(list(w_T.iterfields_w()))
 
-        exp = len(unpack.targets)
+        targets = assign.target.targets
+        exp = len(targets)
         if exp != got:
             # we cannot use ValueError because we want an exception type which
             # inherits from StaticError.
             targets_loc = Loc.combine(
-                start=unpack.targets[0].loc,
-                end=unpack.targets[-1].loc,
+                start=targets[0].loc,
+                end=targets[-1].loc,
             )
             err = SPyError(
                 "W_TypeError",
@@ -697,23 +703,23 @@ class AbstractFrame:
             exp_values = maybe_plural(exp, "value")
             got_values = maybe_plural(got, "value")
             err.add("error", f"expected {exp} {exp_values}", targets_loc)
-            err.add("error", f"got {got} {got_values}", unpack.value.loc)
+            err.add("error", f"got {got} {got_values}", assign.value.loc)
             raise err
 
-        for i, target in enumerate(unpack.targets):
+        for i, target in enumerate(targets):
             # fabricate an expr to get an individual item of the tuple
             expr = ast.GetItem(
-                loc=unpack.value.loc,
-                value=unpack.value,
-                args=[ast.Literal(loc=unpack.value.loc, value=i)],
+                loc=assign.value.loc,
+                value=assign.value,
+                args=[ast.Literal(loc=assign.value.loc, value=i)],
             )
             # fabricate an ast.Assign
             # XXX: ideally we should cache the specialization instead of
             # rebuilding it at every exec
-            assign = self._specialize_Assign(
-                ast.Assign(loc=unpack.loc, target=target, value=expr)
+            assign_item = self._specialize_Assign(
+                ast.Assign(loc=assign.loc, target=target, value=expr)
             )
-            self.exec_stmt(assign)
+            self.exec_stmt(assign_item)
 
     def exec_stmt_AugAssign(self, node: ast.AugAssign) -> None:
         # XXX: eventually we want to support things like __IADD__ etc, but for
@@ -725,7 +731,7 @@ class AbstractFrame:
         # transform "x += 1" into "x = x + 1"
         return ast.Assign(
             loc=node.loc,
-            target=node.target,
+            target=ast.SingleTarget(node.loc, node.target),
             value=ast.BinOp(
                 loc=node.loc,
                 op=node.op,
@@ -810,7 +816,9 @@ class AbstractFrame:
         # way, 'continue' works out of the box.
         iter_name = f"_$iter{for_node.seq}"
         iter_sym = self.symtable.lookup(iter_name)
-        iter_target = ast.StrLiteral(for_node.loc, iter_name)
+        iter_target = ast.SingleTarget(
+            for_node.loc, ast.StrLiteral(for_node.loc, iter_name)
+        )
 
         # it = X.__fastiter__()
         init_iter = ast.Assign(
@@ -826,7 +834,7 @@ class AbstractFrame:
         # i = it.__item__()
         assign_item = ast.Assign(
             loc=for_node.loc,
-            target=for_node.target,
+            target=ast.SingleTarget(for_node.loc, for_node.target),
             value=ast.CallMethod(
                 loc=for_node.loc,
                 target=ast.NameLocalDirect(for_node.loc, iter_sym),


### PR DESCRIPTION
Simple and unpacking assignments are now distinguished by the type of their target.

Fixes buggy scope analysis when assigning to `a, b` when `a` exists in an outer scope.

For context, this was discussed with @antocuni during the EuroPython sprint as a prerequisite to #455. The next step would be to desugar complex assignments into a sequence of simple ones, but this refactoring appears to be already useful on its own.