### PR TITLE
Rename lib OutputKind to testlib

### DIFF
--- a/spy/backend/c/cbackend.py
+++ b/spy/backend/c/cbackend.py
@@ -206,7 +206,7 @@ class CBackend:
     def write_build_script(self) -> None:
         assert self.cfiles != [], "call .cwrite() first"
         wasm_exports = []
-        if self.config.target == "wasi" and self.config.kind == "lib":
+        if self.config.target == "wasi" and self.config.kind == "testlib":
             wasm_exports = self.get_wasm_exports()
 
         extra = self.get_merged_build_info()

--- a/spy/build/build_info.py
+++ b/spy/build/build_info.py
@@ -3,6 +3,7 @@ from typing import Callable, Literal
 
 BuildTarget = Literal["native", "wasi", "emscripten"]
 BuildType = Literal["release", "debug"]
+OutputKind = Literal["exe", "testlib", "py-cffi"]
 
 
 @dataclass

--- a/spy/build/config.py
+++ b/spy/build/config.py
@@ -5,10 +5,10 @@ from dataclasses import dataclass
 from typing import Literal, Optional
 
 import spy.libspy
-from spy.build.build_info import BuildTarget, BuildType
+from spy.build.build_info import BuildTarget, BuildType, OutputKind
 from spy.build.flags import get_cc, get_cflags, get_ldflags, get_libdir
+from spy.errors import WIP
 
-OutputKind = Literal["exe", "lib", "py-cffi"]
 GCOption = Literal["none", "bdwgc"]
 
 
@@ -21,6 +21,12 @@ class BuildConfig:
     warning_as_error: bool = False
     gc: GCOption = "none"
     static: bool = False
+
+    def __post_init__(self) -> None:
+        if self.kind == "testlib" and self.target not in ("wasi", "emscripten"):
+            raise WIP(
+                "--output-kind=testlib works only for wasi and emscripten targets"
+            )
 
 
 # ======= CFLAGS and LDFLAGS logic =======
@@ -61,8 +67,8 @@ class CompilerConfig:
         self.ldflags += get_ldflags(flags_target, config.build_type)
 
         libdir = get_libdir(flags_target, config.build_type)
-        if config.target == "wasi" and config.kind == "lib":
-            # WASM libs are mostly used by tests: in this case we want to make sure to
+        if config.target == "wasi" and config.kind == "testlib":
+            # WASM testlibs are used by tests: in this case we want to make sure to
             # include the whole libspy.a, so that helper functions such as spy_str_alloc
             # are always available.
             #
@@ -89,7 +95,7 @@ class CompilerConfig:
 
         elif config.target == "wasi":
             self.ext = ".wasm"
-            if config.kind == "lib":
+            if config.kind == "testlib":
                 self.ldflags += ["-mexec-model=reactor"]
 
         elif config.target == "emscripten":

--- a/spy/build/flags.py
+++ b/spy/build/flags.py
@@ -7,6 +7,7 @@ Usage:
     python -m spy.build.flags --ldflags --target=wasi --build-type=release
     python -m spy.build.flags --libdir --target=wasi --build-type=debug
     python -m spy.build.flags --cc --target=wasi
+    python -m spy.build.flags --cflags --target=wasi --output-kind=testlib
 """
 
 import argparse
@@ -15,12 +16,12 @@ from os import getenv
 from typing import Optional
 
 import spy
+from spy.build.build_info import BuildType
 
 _LIBSPY = spy.ROOT.join("libspy")
 _INCLUDE = _LIBSPY.join("include")
 _BUILD = _LIBSPY.join("build")
 
-BuildType = str  # "release" | "debug"
 
 # Base CFLAGS shared by all targets (mirrors spy/libspy/Makefile)
 _BASE_CFLAGS: list[str] = [

--- a/spy/build/ninja.py
+++ b/spy/build/ninja.py
@@ -38,10 +38,10 @@ class NinjaWriter:
 
     def __init__(self, config: BuildConfig, build_dir: py.path.local) -> None:
         # for now, we support only some combinations of target/kind
-        if config.kind == "lib":
+        if config.kind == "testlib":
             if config.target not in ("wasi", "emscripten"):
                 raise WIP(
-                    "--output-kind=lib works only for wasi and emscripten targets"
+                    "--output-kind=testlib works only for wasi and emscripten targets"
                 )
         self.config = config
         self.build_dir = build_dir
@@ -60,7 +60,7 @@ class NinjaWriter:
     ) -> None:
         comp = CompilerConfig(self.config)
         self.out = basename + comp.ext
-        if self.config.kind == "lib":
+        if self.config.kind == "testlib":
             comp.ldflags += [f"-Wl,--export={name}" for name in wasm_exports]
         for d in extra_include_dirs:
             comp.cflags += ["-I", d]

--- a/spy/tests/support.py
+++ b/spy/tests/support.py
@@ -226,7 +226,7 @@ class CompilerTest:
         if self.backend == "C":
             config = BuildConfig(
                 target="wasi",
-                kind="lib",
+                kind="testlib",
                 build_type="debug",
                 opt_level=self.OPT_LEVEL,
             )
@@ -370,7 +370,7 @@ class CTest:
         self.tmpdir = tmpdir
         # NOTE: target is overwritten by TestLLWasm.init_llwasm
         self.target = "wasi"
-        self.kind = "lib"
+        self.kind = "testlib"
         self.build_dir = self.tmpdir.join("build").ensure(dir=True)
 
     def write(self, src: str) -> py.path.local:

--- a/spy/tests/test_backend_c.py
+++ b/spy/tests/test_backend_c.py
@@ -34,7 +34,9 @@ class TestCBackend:
         vm.import_(modname)
         vm.redshift(error_mode="eager")
         builddir = self.tmpdir.join("build").ensure(dir=True)
-        config = BuildConfig(target="wasi", kind="lib", build_type="debug", opt_level=0)
+        config = BuildConfig(
+            target="wasi", kind="testlib", build_type="debug", opt_level=0
+        )
         backend = CBackend(vm, modname, config, builddir, dump_c=False)
         return backend
 


### PR DESCRIPTION
Since it's only used for tests. I also moved the definition of the OutputKind type into build_info.py to go next to BuildType and BuildTarget.