### PR TITLE
Use type keyword when defining types

### DIFF
--- a/spy/analyze/importing.py
+++ b/spy/analyze/importing.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from spy.vm.module import W_Module
     from spy.vm.vm import SPyVM
 
-MODULE = Union[ast.Module, "W_Module", None]
+type MODULE = Union[ast.Module, "W_Module", None]
 
 # Cache version: increment this when ast.Module or SymTable structure changes
 SPYC_VERSION = 7

--- a/spy/analyze/symtable.py
+++ b/spy/analyze/symtable.py
@@ -31,10 +31,10 @@ from spy.textbuilder import ColorFormatter
 #   - if a variable is assigned multiple times, it's a "var"
 #   - if a variable is assigned inside a loop, it's a "var"
 
-Color = Literal["red", "blue"]
-VarStorage = Literal["direct", "cell", "NameError"]
-VarKind = Literal["var", "const"]
-VarKindOrigin = Literal[
+type Color = Literal["red", "blue"]
+type VarStorage = Literal["direct", "cell", "NameError"]
+type VarKind = Literal["var", "const"]
+type VarKindOrigin = Literal[
     "auto",          # "x = 0" inside a function
     "global-const",  # "x = 0" at module level
     "explicit",      # "var x = 0" or "const x = 0"
@@ -47,7 +47,7 @@ VarKindOrigin = Literal[
 
 # each ScopeKind corresponds to a different Frame for evaluation: ModFrame, ClassFrame,
 # ASTFrame
-ScopeKind = Literal["module", "class", "function"]
+type ScopeKind = Literal["module", "class", "function"]
 
 
 def maybe_blue(*colors: Color) -> Color:

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -27,9 +27,9 @@ if TYPE_CHECKING:
     from spy.vm.object import W_Object, W_Type
     from spy.vm.vm import SPyVM
 
-ClassKind = typing.Literal["class", "struct"]
-FuncKind = typing.Literal["plain", "generic", "metafunc"]
-FuncParamKind = typing.Literal["simple", "var_positional"]
+type ClassKind = typing.Literal["class", "struct"]
+type FuncKind = typing.Literal["plain", "generic", "metafunc"]
+type FuncParamKind = typing.Literal["simple", "var_positional"]
 
 # ==== Typed vs untyped ASTs ====
 #

--- a/spy/backend/html.py
+++ b/spy/backend/html.py
@@ -12,7 +12,7 @@ from spy.backend.spy import SPyBackend
 from spy.util import build_char_color_map, encode_color_map
 from spy.vm.vm import SPyVM
 
-SpyastJs = Literal["cdn", "inline"]
+type SpyastJs = Literal["cdn", "inline"]
 
 FIELDS_TO_IGNORE = frozenset(
     {

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -22,7 +22,7 @@ from spy.vm.modules.types import W_Loc as W_Loc
 from spy.vm.object import W_Object, W_Type
 from spy.vm.vm import SPyVM
 
-FQN_FORMAT = Literal["full", "short"]
+type FQN_FORMAT = Literal["full", "short"]
 
 # Regex pattern for valid identifiers (alphanumeric + underscore)
 VALID_IDENTIFIER = re.compile(r"^[a-zA-Z0-9_]+$")

--- a/spy/build/build_info.py
+++ b/spy/build/build_info.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass, field
 from typing import Callable, Literal
 
-BuildTarget = Literal["native", "wasi", "emscripten"]
-BuildType = Literal["release", "debug"]
-OutputKind = Literal["exe", "testlib", "py-cffi"]
+type BuildTarget = Literal["native", "wasi", "emscripten"]
+type BuildType = Literal["release", "debug"]
+type OutputKind = Literal["exe", "testlib", "py-cffi"]
 
 
 @dataclass
@@ -17,4 +17,4 @@ class BuildInfo:
     ldflags: list[str] = field(default_factory=list)
 
 
-BuildInfoFunc = Callable[[BuildTarget, BuildType], BuildInfo]
+type BuildInfoFunc = Callable[[BuildTarget, BuildType], BuildInfo]

--- a/spy/build/config.py
+++ b/spy/build/config.py
@@ -9,7 +9,7 @@ from spy.build.build_info import BuildTarget, BuildType, OutputKind
 from spy.build.flags import get_cc, get_cflags, get_ldflags, get_libdir
 from spy.errors import WIP
 
-GCOption = Literal["none", "bdwgc"]
+type GCOption = Literal["none", "bdwgc"]
 
 
 @dataclass

--- a/spy/cli/commands/build.py
+++ b/spy/cli/commands/build.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import (
     Annotated,
     Optional,
+    get_args,
 )
 
 import click
@@ -77,7 +78,7 @@ class _build_mixin:
             "-t",
             "--target",
             help="Compilation target",
-            click_type=click.Choice(BuildTarget.__args__),
+            click_type=click.Choice(get_args(BuildTarget.__value__)),
         ),
     ] = "native"
 
@@ -87,7 +88,7 @@ class _build_mixin:
             "-k",
             "--output-kind",
             help="Output kind",
-            click_type=click.Choice(OutputKind.__args__),
+            click_type=click.Choice(get_args(OutputKind.__value__)),
         ),
     ] = "exe"
 
@@ -97,7 +98,7 @@ class _build_mixin:
             "--gc",
             help="GC implementation: auto, none, bdwgc (default: auto, "
             "i.e. bdwgc for native, none for wasm targets)",
-            click_type=click.Choice(["auto", *GCOption.__args__]),
+            click_type=click.Choice(["auto", *get_args(GCOption.__value__)]),
         ),
     ] = "auto"
 

--- a/spy/cli/commands/shared_args.py
+++ b/spy/cli/commands/shared_args.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated, Optional, get_args
 
 import click
 from typer import Argument, BadParameter, Option
@@ -28,7 +28,7 @@ class Base_Args:
             "-E",
             "--error-mode",
             help="Handling strategy for static errors",
-            click_type=click.Choice(ErrorMode.__args__),
+            click_type=click.Choice(get_args(ErrorMode.__value__)),
         ),
     ] = "eager"
 

--- a/spy/doppler.py
+++ b/spy/doppler.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from spy.vm.object import W_Type
     from spy.vm.vm import SPyVM
 
-ErrorMode = Literal["eager", "lazy", "warn"]
+type ErrorMode = Literal["eager", "lazy", "warn"]
 
 
 def redshift(vm: "SPyVM", w_func: W_ASTFunc, error_mode: ErrorMode) -> W_ASTFunc:

--- a/spy/errfmt.py
+++ b/spy/errfmt.py
@@ -8,7 +8,7 @@ from spy.textbuilder import ColorFormatter, TextBuilder
 if TYPE_CHECKING:
     from spy.vm.exc import FrameInfo, W_Exception, W_Traceback
 
-Level = Literal["error", "note", "panic"]
+type Level = Literal["error", "note", "panic"]
 
 
 @dataclass

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -68,8 +68,8 @@ import re
 from dataclasses import dataclass, field
 from typing import Any, Optional, Sequence, Union
 
-PARTS = Sequence[Union[str, "NSPart"]]
-QUALIFIERS = Optional[Sequence[Union[str, "FQN"]]]
+type PARTS = Sequence[Union[str, "NSPart"]]
+type QUALIFIERS = Optional[Sequence[Union[str, "FQN"]]]
 
 
 def get_parts(x: PARTS) -> tuple["NSPart", ...]:

--- a/spy/llwasm/base.py
+++ b/spy/llwasm/base.py
@@ -4,7 +4,7 @@ from typing import Any, Literal, Self
 
 import py.path
 
-LLWasmType = Literal[None, "void *", "int32_t", "int16_t"]
+type LLWasmType = Literal[None, "void *", "int32_t", "int16_t"]
 
 
 class HostModule:

--- a/spy/tests/support.py
+++ b/spy/tests/support.py
@@ -1,6 +1,6 @@
 import textwrap
 from contextlib import contextmanager
-from typing import Any, Literal, Optional, no_type_check
+from typing import Any, Literal, Optional, get_args, no_type_check
 
 import py.path
 import pytest
@@ -17,8 +17,8 @@ from spy.tests.exe_wrapper import ExeWrapper
 from spy.tests.wasm_wrapper import WasmModuleWrapper
 from spy.vm.vm import SPyVM
 
-Backend = Literal["interp", "doppler", "C"]
-ALL_BACKENDS = Backend.__args__  # type: ignore
+type Backend = Literal["interp", "doppler", "C"]
+ALL_BACKENDS = get_args(Backend.__value__)
 
 
 def params_with_marks(params):
@@ -306,7 +306,7 @@ class CompilerTest:
                 fn()
 
 
-MatchAnnotation = tuple[str, str]
+type MatchAnnotation = tuple[str, str]
 
 
 @contextmanager

--- a/spy/util.py
+++ b/spy/util.py
@@ -50,6 +50,16 @@ class AnythingClass:
 ANYTHING: typing.Any = AnythingClass()
 
 
+def unwrap_type_alias(ann: Any) -> Any:
+    """
+    Resolve type aliases declared like `type X = ...` into the annotation they
+    point to.
+    """
+    while isinstance(ann, typing.TypeAliasType):
+        ann = ann.__value__
+    return ann
+
+
 @typing.no_type_check
 def magic_dispatch(self, prefix, obj, *args, **kwargs):
     """

--- a/spy/vm/bluecache.py
+++ b/spy/vm/bluecache.py
@@ -11,9 +11,9 @@ if TYPE_CHECKING:
 
 DEBUG = False
 
-ARGS_W = Sequence[W_Object]
-ARGS_KEY = tuple[W_Object, ...]
-KEY = tuple[W_Func, ARGS_KEY]
+type ARGS_W = Sequence[W_Object]
+type ARGS_KEY = tuple[W_Object, ...]
+type KEY = tuple[W_Func, ARGS_KEY]
 
 
 class BlueCache:

--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -20,6 +20,7 @@ from typing import (
 from spy.ast import Color, FuncKind
 from spy.errors import SPyError
 from spy.fqn import FQN, QUALIFIERS
+from spy.util import unwrap_type_alias
 from spy.vm.function import FuncParam, FuncParamKind, W_BuiltinFunc, W_FuncType
 from spy.vm.object import (
     W_Object,
@@ -31,7 +32,7 @@ from spy.vm.object import (
     builtin_staticmethod,
 )
 
-TYPES_DICT = dict[str, W_Type]
+type TYPES_DICT = dict[str, W_Type]
 
 
 def is_W_class(x: Any) -> bool:
@@ -39,6 +40,7 @@ def is_W_class(x: Any) -> bool:
 
 
 def get_spy_type_annotation(ann: Any) -> Optional[W_Type]:
+    ann = unwrap_type_alias(ann)
     if get_origin(ann) is Annotated:
         for x in ann.__metadata__:
             if isinstance(x, W_Type):
@@ -57,6 +59,7 @@ def to_spy_type(ann: Any, *, allow_None: bool = False) -> W_Type:
     """
     from spy.vm.b import TYPES, B
 
+    ann = unwrap_type_alias(ann)
     if allow_None and ann is None:
         return TYPES.w_NoneType
     elif is_W_class(ann):

--- a/spy/vm/debugger/spdb.py
+++ b/spy/vm/debugger/spdb.py
@@ -28,7 +28,7 @@ from spy.vm.w import W_Object
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
-FILE = Optional[IO[str]]
+type FILE = Optional[IO[str]]
 
 
 @BUILTINS.builtin_func

--- a/spy/vm/exc.py
+++ b/spy/vm/exc.py
@@ -4,7 +4,7 @@
 import traceback
 from dataclasses import dataclass
 from types import FrameType, TracebackType
-from typing import TYPE_CHECKING, Annotated, Iterable, Literal, Optional
+from typing import TYPE_CHECKING, Annotated, Iterable, Literal, Optional, get_args
 
 from spy.errfmt import Annotation, ErrorFormatter, Level
 from spy.fqn import FQN
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from spy.vm.astframe import AbstractFrame
     from spy.vm.vm import SPyVM
 
-FrameKind = Literal["astframe", "modframe", "classframe", "dopplerframe"]
+type FrameKind = Literal["astframe", "modframe", "classframe", "dopplerframe"]
 
 
 class FrameInfo:
@@ -31,7 +31,7 @@ class FrameInfo:
     @property
     def kind(self) -> FrameKind:
         k = self.spyframe.__class__.__name__.lower()
-        assert k in FrameKind.__args__  # type: ignore
+        assert k in get_args(FrameKind.__value__)
         return k  # type: ignore
 
     @property

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -39,7 +39,7 @@ class LocalVar:
     w_val: Optional[W_Object] = None
 
 
-CLOSURE = tuple[dict[str, LocalVar], ...]
+type CLOSURE = tuple[dict[str, LocalVar], ...]
 # ========= /Closures =========
 
 
@@ -83,7 +83,7 @@ class FuncParam:
 # happily creates prebuilt W_BuiltinFunc and W_Type which are shared among
 # different VMs.
 #
-_KEY = tuple[FQN, tuple[FuncParam, ...], W_Type]
+type _KEY = tuple[FQN, tuple[FuncParam, ...], W_Type]
 _CACHE: dict[_KEY, "W_FuncType"] = {}
 
 
@@ -378,7 +378,7 @@ class W_Func(W_Object):
 # versions of the function. Once a function has been lowered it becomes "invalid", and
 # we set the `w_replaced_by` field.
 
-LoweringStage = Literal["source", "redshift_in_progress", "redshift", "linearize"]
+type LoweringStage = Literal["source", "redshift_in_progress", "redshift", "linearize"]
 
 
 class W_ASTFunc(W_Func):

--- a/spy/vm/modules/__spy__/interp_list.py
+++ b/spy/vm/modules/__spy__/interp_list.py
@@ -300,8 +300,10 @@ w_metaarg_interp_list_type = _make_interp_list_type(OP.w_MetaArg)
 PREBUILT_INTERP_LIST_TYPES[B.w_str] = w_str_interp_list_type
 PREBUILT_INTERP_LIST_TYPES[OP.w_MetaArg] = w_metaarg_interp_list_type
 
-W_StrInterpList = Annotated[W_InterpList[W_Str], w_str_interp_list_type]
-W_MetaArgInterpList = Annotated[W_InterpList[W_MetaArg], w_metaarg_interp_list_type]
+type W_StrInterpList = Annotated[W_InterpList[W_Str], w_str_interp_list_type]
+type W_MetaArgInterpList = Annotated[
+    W_InterpList[W_MetaArg], w_metaarg_interp_list_type
+]
 
 
 def make_str_interp_list(items_w: list[W_Str]) -> W_StrInterpList:

--- a/spy/vm/modules/operator/attrop.py
+++ b/spy/vm/modules/operator/attrop.py
@@ -12,7 +12,7 @@ from . import OP
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
-OpKind = Literal["get", "set"]
+type OpKind = Literal["get", "set"]
 
 
 def unwrap_name_maybe(vm: "SPyVM", wam_name: W_MetaArg) -> str:

--- a/spy/vm/modules/operator/multimethod.py
+++ b/spy/vm/modules/operator/multimethod.py
@@ -27,7 +27,7 @@ from spy.vm.opspec import W_MetaArg, W_OpSpec
 if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
-KeyType = tuple[str, Optional[W_Type], Optional[W_Type]]
+type KeyType = tuple[str, Optional[W_Type], Optional[W_Type]]
 
 
 def parse_type(s: Optional[str]) -> Optional[W_Type]:

--- a/spy/vm/modules/posix.py
+++ b/spy/vm/modules/posix.py
@@ -26,7 +26,7 @@ POSIX.struct_type(
     builtin=True,
 )
 
-W_TerminalSize = Annotated[W_Struct, POSIX.w_TerminalSize]
+type W_TerminalSize = Annotated[W_Struct, POSIX.w_TerminalSize]
 
 
 @POSIX.builtin_func

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
     from spy.vm.vm import SPyVM
 
 
-MEMKIND = Literal["raw", "gc"]
+type MEMKIND = Literal["raw", "gc"]
 
 
 @UNSAFE.builtin_func(color="blue", kind="generic")

--- a/spy/vm/object.py
+++ b/spy/vm/object.py
@@ -65,6 +65,7 @@ from spy.ast import Color
 from spy.errors import WIP, SPyError
 from spy.fqn import FQN
 from spy.location import Loc
+from spy.util import unwrap_type_alias
 from spy.vm.b import B
 
 if TYPE_CHECKING:
@@ -510,6 +511,7 @@ class W_Type(W_Object):
 
         # initialize W_Member
         for field, t in self._pyclass.__annotations__.items():
+            t = unwrap_type_alias(t)
             if member := Member.from_annotation(t):
                 # if we have this declaration:
                 #    w_x: Annotated[W_I32, Member('x')]

--- a/spy/vm/primitive.py
+++ b/spy/vm/primitive.py
@@ -568,4 +568,4 @@ B.add("NotImplemented", W_NotImplementedType.__new__(W_NotImplementedType))
 
 w_DynamicType = W_Type.declare(FQN("builtins::dynamic"))
 B.add("dynamic", w_DynamicType)
-W_Dynamic = Annotated[W_Object, B.w_dynamic]
+type W_Dynamic = Annotated[W_Object, B.w_dynamic]

--- a/spy/vm/typechecker.py
+++ b/spy/vm/typechecker.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 #     binary operators)
 #
 #   - 'convert' for operator.CONVERT
-DispatchKind = Literal["single", "multi", "convert"]
+type DispatchKind = Literal["single", "multi", "convert"]
 
 
 def maybe_plural(n: int, singular: str, plural: Optional[str] = None) -> str:


### PR DESCRIPTION
This makes type introspection a bit more complicated but it has the advantage that the name of the type is preserved so in errors you'll see the type name instead of the expansion of the type. It also handles forward references automatically and has several other small ergonomics benefits.