### PR TITLE
For Emscripten and WASI build both libspytest.a and libspy.a

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,10 @@ ways:
     statically linked to any spy executable
 
   - `make -C spy/libspy` creates a `libspy.a` for each supported target, which
-    currently are `native`, `emscripten` and `wasi`
+    currently are `native`, `emscripten` and `wasi`. For `emscripten` and `wasi`
+    it also creates a `libspytest.a`, which is the flavor used by testlibs.
+    `libspytest.a` expects the WebAssembly host to provide debug helpers as WASM
+    imports whereas `libspy.a` implements them in `debug.c`.
 
   - `spy/libspy/__init__.py` contains some support code to be able to load the
     WASM version of libspy in the interpreter.

--- a/README.md
+++ b/README.md
@@ -258,9 +258,9 @@ ways:
 
   - `make -C spy/libspy` creates a `libspy.a` for each supported target, which
     currently are `native`, `emscripten` and `wasi`. For `emscripten` and `wasi`
-    it also creates a `libspytest.a`, which is the flavor used by testlibs.
-    `libspytest.a` expects the WebAssembly host to provide debug helpers as WASM
-    imports whereas `libspy.a` implements them in `debug.c`.
+    it also creates a second `libspy.a` used by llwasm which expects the
+    WebAssembly host to provide debug helpers as WASM imports. The normal
+    `libspy.a` implements them in `debug.c`.
 
   - `spy/libspy/__init__.py` contains some support code to be able to load the
     WASM version of libspy in the interpreter.

--- a/spy/build/config.py
+++ b/spy/build/config.py
@@ -6,7 +6,7 @@ from typing import Literal, Optional
 
 import spy.libspy
 from spy.build.build_info import BuildTarget, BuildType, OutputKind
-from spy.build.flags import get_cc, get_cflags, get_ldflags, get_libdir
+from spy.build.flags import get_cc, get_cflags, get_ldflags, get_libdir, get_libname
 from spy.errors import WIP
 
 GCOption = Literal["none", "bdwgc"]
@@ -59,7 +59,7 @@ class CompilerConfig:
 
         self.CC = get_cc(flags_target)
         self.cflags += get_cflags(
-            flags_target, config.build_type, config.warning_as_error
+            flags_target, config.build_type, config.kind, config.warning_as_error
         )
         self.cflags += EXTRA_CFLAGS
 
@@ -67,16 +67,19 @@ class CompilerConfig:
         self.ldflags += get_ldflags(flags_target, config.build_type)
 
         libdir = get_libdir(flags_target, config.build_type)
+        libname = get_libname(config.kind)
         if config.target == "wasi" and config.kind == "testlib":
             # WASM testlibs are used by tests: in this case we want to make sure to
-            # include the whole libspy.a, so that helper functions such as spy_str_alloc
-            # are always available.
+            # include the whole libspytest.a, so that helper functions such as
+            # spy_str_alloc are always available.
             #
             # If you don't pass --whole-archive, the linker will silently discard all
             # the .o files which are not used (so e.g. if you never call any str_*
             # function, str.o is discarded and spy_str_alloc is not present at all).
             libspy_a = str(
-                spy.libspy.BUILD.join(flags_target, config.build_type, "libspy.a")
+                spy.libspy.BUILD.join(
+                    flags_target, config.build_type, f"lib{libname}.a"
+                )
             )
             self.ldflags += [
                 "-Wl,--whole-archive",
@@ -86,7 +89,7 @@ class CompilerConfig:
         else:
             self.ldflags += [
                 "-L", libdir,
-                "-lspy",
+                f"-l{libname}",
             ]  # fmt: skip
 
         # target specific flags

--- a/spy/build/config.py
+++ b/spy/build/config.py
@@ -4,9 +4,11 @@ import sys
 from dataclasses import dataclass
 from typing import Literal, Optional
 
+import py.path
+
 import spy.libspy
 from spy.build.build_info import BuildTarget, BuildType, OutputKind
-from spy.build.flags import get_cc, get_cflags, get_ldflags, get_libdir, get_libname
+from spy.build.flags import get_cc, get_cflags, get_ldflags, get_libdir
 from spy.errors import WIP
 
 GCOption = Literal["none", "bdwgc"]
@@ -66,21 +68,16 @@ class CompilerConfig:
         self.ldflags += LDFLAGS
         self.ldflags += get_ldflags(flags_target, config.build_type)
 
-        libdir = get_libdir(flags_target, config.build_type)
-        libname = get_libname(config.kind)
+        libdir = get_libdir(flags_target, config.build_type, config.kind)
         if config.target == "wasi" and config.kind == "testlib":
             # WASM testlibs are used by tests: in this case we want to make sure to
-            # include the whole libspytest.a, so that helper functions such as
-            # spy_str_alloc are always available.
+            # include the whole libspy.a, so that helper functions such as spy_str_alloc
+            # are always available.
             #
             # If you don't pass --whole-archive, the linker will silently discard all
             # the .o files which are not used (so e.g. if you never call any str_*
             # function, str.o is discarded and spy_str_alloc is not present at all).
-            libspy_a = str(
-                spy.libspy.BUILD.join(
-                    flags_target, config.build_type, f"lib{libname}.a"
-                )
-            )
+            libspy_a = str(py.path.local(libdir).join("libspy.a"))
             self.ldflags += [
                 "-Wl,--whole-archive",
                 libspy_a,
@@ -89,7 +86,7 @@ class CompilerConfig:
         else:
             self.ldflags += [
                 "-L", libdir,
-                f"-l{libname}",
+                "-lspy",
             ]  # fmt: skip
 
         # target specific flags

--- a/spy/build/flags.py
+++ b/spy/build/flags.py
@@ -148,26 +148,32 @@ def get_cflags(
     )
 
 
-def get_libname(output_kind: OutputKind) -> str:
-    """
-    Name of the libspy flavor to link against, libspy or libspytest
-    """
-    _check_output_kind(output_kind)
-    if output_kind == "testlib":
-        return "spytest"
-    return "spy"
-
-
 def get_ldflags(target: str, build_type: BuildType) -> list[str]:
     _check_target(target)
     _check_build_type(build_type)
     return _TARGET_LDFLAGS[target] + _BUILD_TYPE_LDFLAGS[build_type]
 
 
-def get_libdir(target: str, build_type: BuildType) -> str:
-    _check_target(target)
+def get_build_dirname(build_type: BuildType, output_kind: OutputKind = "exe") -> str:
+    """
+    Name of the libspy build dir for the given flavor, e.g. 'debug' or
+    'debug-testlib'.
+
+    testlibs need their own libspy.a, which expects the host to provide the
+    debug helpers instead of implementing them in debug.c.
+    """
     _check_build_type(build_type)
-    return str(_BUILD.join(target, build_type))
+    _check_output_kind(output_kind)
+    if output_kind == "testlib":
+        return f"{build_type}-testlib"
+    return build_type
+
+
+def get_libdir(
+    target: str, build_type: BuildType, output_kind: OutputKind = "exe"
+) -> str:
+    _check_target(target)
+    return str(_BUILD.join(target, get_build_dirname(build_type, output_kind)))
 
 
 def get_cc(target: str) -> str:
@@ -256,7 +262,7 @@ def main(argv: Optional[list[str]] = None) -> None:
         if not args.target:
             print("error: --libdir requires --target", file=sys.stderr)
             sys.exit(1)
-        parts.append(f"-L{get_libdir(args.target, args.build_type)}")
+        parts.append(f"-L{get_libdir(args.target, args.build_type, args.output_kind)}")
 
     if args.cc:
         if not args.target:

--- a/spy/build/flags.py
+++ b/spy/build/flags.py
@@ -16,7 +16,7 @@ from os import getenv
 from typing import Optional
 
 import spy
-from spy.build.build_info import BuildType
+from spy.build.build_info import BuildType, OutputKind
 
 _LIBSPY = spy.ROOT.join("libspy")
 _INCLUDE = _LIBSPY.join("include")
@@ -71,6 +71,12 @@ _TARGET_LDFLAGS: dict[str, list[str]] = {
     ],
 }
 
+_OUTPUT_KIND_CFLAGS: dict[str, list[str]] = {
+    "exe": ["-DSPY_OUTPUT_KIND_EXE"],
+    "testlib": ["-DSPY_OUTPUT_KIND_TESTLIB"],
+    "py-cffi": ["-DSPY_OUTPUT_KIND_PY_CFFI"],
+}
+
 _WARNING_CFLAGS: list[str] = ["-Werror=implicit-function-declaration"]
 _WARNING_AS_ERROR_CFLAGS: list[str] = ["-Werror", "-Wno-unreachable-code"]
 
@@ -111,11 +117,22 @@ def _check_build_type(build_type: str) -> None:
         )
 
 
+def _check_output_kind(output_kind: str) -> None:
+    if output_kind not in _OUTPUT_KIND_CFLAGS:
+        raise ValueError(
+            f"Unknown output_kind: {output_kind!r}. Valid: {list(_OUTPUT_KIND_CFLAGS)}"
+        )
+
+
 def get_cflags(
-    target: str, build_type: BuildType, warning_as_error: bool = False
+    target: str,
+    build_type: BuildType,
+    output_kind: OutputKind = "exe",
+    warning_as_error: bool = False,
 ) -> list[str]:
     _check_target(target)
     _check_build_type(build_type)
+    _check_output_kind(output_kind)
     if warning_as_error or getenv("SPY_WERROR") in ("true", "1"):
         warning_flags = _WARNING_AS_ERROR_CFLAGS
     else:
@@ -125,9 +142,20 @@ def get_cflags(
         _BASE_CFLAGS
         + _TARGET_CFLAGS[target]
         + _BUILD_TYPE_CFLAGS[build_type]
+        + _OUTPUT_KIND_CFLAGS[output_kind]
         + warning_flags
         + include
     )
+
+
+def get_libname(output_kind: OutputKind) -> str:
+    """
+    Name of the libspy flavor to link against, libspy or libspytest
+    """
+    _check_output_kind(output_kind)
+    if output_kind == "testlib":
+        return "spytest"
+    return "spy"
 
 
 def get_ldflags(target: str, build_type: BuildType) -> list[str]:
@@ -168,6 +196,12 @@ def main(argv: Optional[list[str]] = None) -> None:
         help="Build type (default: debug)",
     )
     parser.add_argument(
+        "--output-kind",
+        choices=list(_OUTPUT_KIND_CFLAGS),
+        default="exe",
+        help="Output kind (default: exe)",
+    )
+    parser.add_argument(
         "--warning-as-error",
         action="store_true",
         help="Treat warnings as errors (overrides SPY_WERROR env var)",
@@ -205,7 +239,12 @@ def main(argv: Optional[list[str]] = None) -> None:
         if not args.target:
             print("error: --cflags requires --target", file=sys.stderr)
             sys.exit(1)
-        parts += get_cflags(args.target, args.build_type, args.warning_as_error)
+        parts += get_cflags(
+            args.target,
+            args.build_type,
+            args.output_kind,
+            args.warning_as_error,
+        )
 
     if args.ldflags:
         if not args.target:

--- a/spy/libspy/Makefile
+++ b/spy/libspy/Makefile
@@ -14,16 +14,27 @@ SRCS = src/str.c src/bytes.c src/builtins.c src/debug.c src/unsafe.c src/operato
 
 # Add BUILD_TYPE with a default value
 BUILD_TYPE ?= release
+OUTPUT_KIND ?= exe
 
-# Modify BUILD_DIR to include build type
-BUILD_DIR := build/$(TARGET)/$(BUILD_TYPE)
+ifeq ($(filter $(BUILD_TYPE),debug release),)
+  $(error Invalid BUILD_TYPE: '$(BUILD_TYPE)'. Valid: debug, release)
+endif
+
+ifeq ($(filter $(OUTPUT_KIND),exe testlib),)
+  $(error Invalid OUTPUT_KIND: '$(OUTPUT_KIND)'. Valid: exe, testlib)
+endif
+
+ifeq ($(OUTPUT_KIND), testlib)
+  BUILD_DIR := build/$(TARGET)/$(BUILD_TYPE)-testlib
+else
+  BUILD_DIR := build/$(TARGET)/$(BUILD_TYPE)
+endif
 
 # don't bother invoking spy.build.flags if we don't have a TARGET
 ifneq ($(TARGET),)
 	CC             := $(shell python -m spy.build.flags --cc     --target=$(TARGET))
 	AR             := $(shell python -m spy.build.flags --ar     --target=$(TARGET))
-	CFLAGS         := $(shell python -m spy.build.flags --cflags --target=$(TARGET) --build-type=$(BUILD_TYPE) --output-kind=exe)
-	CFLAGS_TESTLIB := $(shell python -m spy.build.flags --cflags --target=$(TARGET) --build-type=$(BUILD_TYPE) --output-kind=testlib)
+	CFLAGS         := $(shell python -m spy.build.flags --cflags --target=$(TARGET) --build-type=$(BUILD_TYPE) --output-kind=$(OUTPUT_KIND))
 endif
 
 # ------- no target specified -------
@@ -36,7 +47,11 @@ else ifeq ($(TARGET), wasi)
 		--no-entry \
 		--import-memory
 
-	.DEFAULT_GOAL := wasi_all
+	ifeq ($(OUTPUT_KIND), testlib)
+		.DEFAULT_GOAL := wasi_all_testlib
+	else
+		.DEFAULT_GOAL := wasi_all
+	endif
 
 # -------- emscripten target --------
 else ifeq ($(TARGET), emscripten)
@@ -74,48 +89,45 @@ else
 	.DEFAULT_GOAL := usage
 endif
 
-OBJS         := $(patsubst %.c,$(BUILD_DIR)/exe/%.o,$(SRCS))
-TESTLIB_OBJS := $(patsubst %.c,$(BUILD_DIR)/testlib/%.o,$(SRCS))
+OBJS         := $(patsubst %.c,$(BUILD_DIR)/%.o,$(SRCS))
 
 # Build all targets in release/debug mode
 all:
-	make TARGET=wasi BUILD_TYPE=release
-	make TARGET=wasi BUILD_TYPE=debug
-	make TARGET=native BUILD_TYPE=release
-	make TARGET=native BUILD_TYPE=debug
-	make TARGET=native-static BUILD_TYPE=release
-	make TARGET=native-static BUILD_TYPE=debug
-	make TARGET=emscripten BUILD_TYPE=release
-	make TARGET=emscripten BUILD_TYPE=debug
+	make TARGET=native        BUILD_TYPE=release OUTPUT_KIND=exe
+	make TARGET=native        BUILD_TYPE=debug   OUTPUT_KIND=exe
+	make TARGET=native-static BUILD_TYPE=release OUTPUT_KIND=exe
+	make TARGET=native-static BUILD_TYPE=debug   OUTPUT_KIND=exe
+
+	make TARGET=wasi          BUILD_TYPE=release OUTPUT_KIND=exe
+	make TARGET=wasi          BUILD_TYPE=debug   OUTPUT_KIND=exe
+	make TARGET=wasi          BUILD_TYPE=debug   OUTPUT_KIND=testlib
+
+	make TARGET=emscripten    BUILD_TYPE=release OUTPUT_KIND=exe
+	make TARGET=emscripten    BUILD_TYPE=debug   OUTPUT_KIND=exe
+	make TARGET=emscripten    BUILD_TYPE=debug   OUTPUT_KIND=testlib
 
 # wasi-specific rules
-wasi_all: build/wasi/$(BUILD_TYPE)/libspy.a build/wasi/$(BUILD_TYPE)/libspy.wasm
+wasi_all_testlib: $(BUILD_DIR)/libspy.wasm
+wasi_all: $(BUILD_DIR)/libspy.a
 
-# link libspytest.a because libspy.wasm is loaded by the SPy VM, which provides
-# the debug helpers as WASM imports
-build/wasi/$(BUILD_TYPE)/libspy.wasm: build/$(TARGET)/$(BUILD_TYPE)/libspytest.a
+# libspy.wasm is loaded by the SPy VM, which provides the debug helpers as WASM
+# imports: this is why we build it out of the testlib flavor
+$(BUILD_DIR)/libspy.wasm: $(BUILD_DIR)/libspy.a
 	$(CC) \
         --target=wasm32-wasi-musl \
         -mexec-model=reactor \
         -Wl,--whole-archive \
-        build/$(TARGET)/$(BUILD_TYPE)/libspytest.a \
+        $(BUILD_DIR)/libspy.a \
         -o $@
 
 # emscripten-specific rules
-emscripten_all: build/emscripten/$(BUILD_TYPE)/libspy.mjs build/emscripten/$(BUILD_TYPE)/libspytest.mjs
+emscripten_all: $(BUILD_DIR)/libspy.mjs
 
-build/emscripten/$(BUILD_TYPE)/libspy.mjs: build/$(TARGET)/$(BUILD_TYPE)/libspy.a
+$(BUILD_DIR)/libspy.mjs: $(BUILD_DIR)/libspy.a
 	$(CC) \
 		$(LDFLAGS) \
         -Wl,--whole-archive \
-		build/$(TARGET)/$(BUILD_TYPE)/libspy.a \
-		-o $@
-
-build/emscripten/$(BUILD_TYPE)/libspytest.mjs: build/$(TARGET)/$(BUILD_TYPE)/libspytest.a
-	$(CC) \
-		$(LDFLAGS) \
-        -Wl,--whole-archive \
-		build/$(TARGET)/$(BUILD_TYPE)/libspytest.a \
+		$(BUILD_DIR)/libspy.a \
 		-o $@
 
 
@@ -127,24 +139,18 @@ native_all: $(BUILD_DIR)/libspy.a
 
 native_static_all: $(BUILD_DIR)/libspy.a
 
-build/$(TARGET)/$(BUILD_TYPE)/libspy.a: $(OBJS)
+$(BUILD_DIR)/libspy.a: $(OBJS)
 	$(AR) rcs $@ $(OBJS)
 
-build/$(TARGET)/$(BUILD_TYPE)/libspytest.a: $(TESTLIB_OBJS)
-	$(AR) rcs $@ $(TESTLIB_OBJS)
-
-$(BUILD_DIR)/exe/%.o: %.c | $(BUILD_DIR)
+$(BUILD_DIR)/%.o: %.c | $(BUILD_DIR)
 	mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -MMD -MF $@.d -c $< -o $@
 
-$(BUILD_DIR)/testlib/%.o: %.c | $(BUILD_DIR)
-	mkdir -p $(dir $@)
-	$(CC) $(CFLAGS_TESTLIB) -MMD -MF $@.d -c $< -o $@
 
 # without this, editing a header does not trigger a recompilation, and we can
 # end up with .a files whose objects were compiled with different versions of
 # debug.h
--include $(OBJS:.o=.o.d) $(TESTLIB_OBJS:.o=.o.d)
+-include $(OBJS:.o=.o.d)
 
 skip_native_static:
 	@echo "Skipping native-static build - not supported on macOS"

--- a/spy/libspy/Makefile
+++ b/spy/libspy/Makefile
@@ -20,9 +20,10 @@ BUILD_DIR := build/$(TARGET)/$(BUILD_TYPE)
 
 # don't bother invoking spy.build.flags if we don't have a TARGET
 ifneq ($(TARGET),)
-	CC     := $(shell python -m spy.build.flags --cc     --target=$(TARGET))
-	AR     := $(shell python -m spy.build.flags --ar     --target=$(TARGET))
-	CFLAGS := $(shell python -m spy.build.flags --cflags --target=$(TARGET) --build-type=$(BUILD_TYPE))
+	CC             := $(shell python -m spy.build.flags --cc     --target=$(TARGET))
+	AR             := $(shell python -m spy.build.flags --ar     --target=$(TARGET))
+	CFLAGS         := $(shell python -m spy.build.flags --cflags --target=$(TARGET) --build-type=$(BUILD_TYPE) --output-kind=exe)
+	CFLAGS_TESTLIB := $(shell python -m spy.build.flags --cflags --target=$(TARGET) --build-type=$(BUILD_TYPE) --output-kind=testlib)
 endif
 
 # ------- no target specified -------
@@ -35,7 +36,7 @@ else ifeq ($(TARGET), wasi)
 		--no-entry \
 		--import-memory
 
-	.DEFAULT_GOAL := build/wasi/$(BUILD_TYPE)/libspy.wasm
+	.DEFAULT_GOAL := wasi_all
 
 # -------- emscripten target --------
 else ifeq ($(TARGET), emscripten)
@@ -52,12 +53,12 @@ else ifeq ($(TARGET), emscripten)
     $(warning Skipping emscripten target - emcc compiler not found in PATH)
     .DEFAULT_GOAL := skip_emscripten
   else
-    .DEFAULT_GOAL := build/emscripten/$(BUILD_TYPE)/libspy.mjs
+    .DEFAULT_GOAL := emscripten_all
   endif
 
 # ---------- native target ----------
 else ifeq ($(TARGET), native)
-	.DEFAULT_GOAL := build/native/$(BUILD_TYPE)/libspy.a
+	.DEFAULT_GOAL := native_all
 
 # ------- native-static target ------
 else ifeq ($(TARGET), native-static)
@@ -65,7 +66,7 @@ else ifeq ($(TARGET), native-static)
     $(warning Skipping native-static target - not supported on macOS)
     .DEFAULT_GOAL := skip_native_static
   else
-	.DEFAULT_GOAL := build/native-static/$(BUILD_TYPE)/libspy.a
+    .DEFAULT_GOAL := native_static_all
   endif
 
 # ---------- invalid target ---------
@@ -73,7 +74,8 @@ else
 	.DEFAULT_GOAL := usage
 endif
 
-OBJS := $(patsubst %.c,$(BUILD_DIR)/%.o,$(SRCS))
+OBJS         := $(patsubst %.c,$(BUILD_DIR)/exe/%.o,$(SRCS))
+TESTLIB_OBJS := $(patsubst %.c,$(BUILD_DIR)/testlib/%.o,$(SRCS))
 
 # Build all targets in release/debug mode
 all:
@@ -87,15 +89,21 @@ all:
 	make TARGET=emscripten BUILD_TYPE=debug
 
 # wasi-specific rules
-build/wasi/$(BUILD_TYPE)/libspy.wasm: build/$(TARGET)/$(BUILD_TYPE)/libspy.a
+wasi_all: build/wasi/$(BUILD_TYPE)/libspy.a build/wasi/$(BUILD_TYPE)/libspy.wasm
+
+# link libspytest.a because libspy.wasm is loaded by the SPy VM, which provides
+# the debug helpers as WASM imports
+build/wasi/$(BUILD_TYPE)/libspy.wasm: build/$(TARGET)/$(BUILD_TYPE)/libspytest.a
 	$(CC) \
         --target=wasm32-wasi-musl \
         -mexec-model=reactor \
         -Wl,--whole-archive \
-        build/$(TARGET)/$(BUILD_TYPE)/libspy.a \
+        build/$(TARGET)/$(BUILD_TYPE)/libspytest.a \
         -o $@
 
 # emscripten-specific rules
+emscripten_all: build/emscripten/$(BUILD_TYPE)/libspy.mjs build/emscripten/$(BUILD_TYPE)/libspytest.mjs
+
 build/emscripten/$(BUILD_TYPE)/libspy.mjs: build/$(TARGET)/$(BUILD_TYPE)/libspy.a
 	$(CC) \
 		$(LDFLAGS) \
@@ -103,17 +111,40 @@ build/emscripten/$(BUILD_TYPE)/libspy.mjs: build/$(TARGET)/$(BUILD_TYPE)/libspy.
 		build/$(TARGET)/$(BUILD_TYPE)/libspy.a \
 		-o $@
 
+build/emscripten/$(BUILD_TYPE)/libspytest.mjs: build/$(TARGET)/$(BUILD_TYPE)/libspytest.a
+	$(CC) \
+		$(LDFLAGS) \
+        -Wl,--whole-archive \
+		build/$(TARGET)/$(BUILD_TYPE)/libspytest.a \
+		-o $@
+
 
 $(BUILD_DIR):
 	mkdir -p $@
 
 # generic rules
+native_all: $(BUILD_DIR)/libspy.a
+
+native_static_all: $(BUILD_DIR)/libspy.a
+
 build/$(TARGET)/$(BUILD_TYPE)/libspy.a: $(OBJS)
 	$(AR) rcs $@ $(OBJS)
 
-$(BUILD_DIR)/%.o: %.c | $(BUILD_DIR)
+build/$(TARGET)/$(BUILD_TYPE)/libspytest.a: $(TESTLIB_OBJS)
+	$(AR) rcs $@ $(TESTLIB_OBJS)
+
+$(BUILD_DIR)/exe/%.o: %.c | $(BUILD_DIR)
 	mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -MMD -MF $@.d -c $< -o $@
+
+$(BUILD_DIR)/testlib/%.o: %.c | $(BUILD_DIR)
+	mkdir -p $(dir $@)
+	$(CC) $(CFLAGS_TESTLIB) -MMD -MF $@.d -c $< -o $@
+
+# without this, editing a header does not trigger a recompilation, and we can
+# end up with .a files whose objects were compiled with different versions of
+# debug.h
+-include $(OBJS:.o=.o.d) $(TESTLIB_OBJS:.o=.o.d)
 
 skip_native_static:
 	@echo "Skipping native-static build - not supported on macOS"

--- a/spy/libspy/__init__.py
+++ b/spy/libspy/__init__.py
@@ -17,7 +17,7 @@ DEPS = spy.ROOT.join("libspy", "deps")
 
 
 if IS_NODE:
-    LIBSPY_WASM = BUILD.join("emscripten", "debug", "libspy.mjs")
+    LIBSPY_WASM = BUILD.join("emscripten", "debug", "libspytest.mjs")
     LLMOD = None
 elif IS_BROWSER or IS_DOCS_BUILD:
     LIBSPY_WASM = None  # type: ignore    # needs to be set by the embedder
@@ -43,8 +43,9 @@ def get_LLMOD(
     Return a LLWasmModule for libspy, optionally bundled with extra .a archives.
 
     When extra_archives is empty, returns the prebuilt LLMOD (no build step).
-    When extra_archives is non-empty, links libspy.a + each extra archive into
-    a single bundle (cached by content hash) and returns a LLWasmModule for it.
+    When extra_archives is non-empty, links libspytest.a + each extra archive
+    into a single bundle (cached by content hash) and returns a LLWasmModule
+    for it.
     """
     if not extra_archives:
         assert LLMOD is not None
@@ -58,7 +59,9 @@ def get_LLMOD(
                 f"Did you forget to build the spyvm extension module?",
             )
 
-    libspy_a = BUILD.join("wasi", "debug", "libspy.a")
+    # the bundle is loaded by the VM, which provides the debug helpers as WASM
+    # imports: this is why we use libspytest.a and not libspy.a
+    libspy_a = BUILD.join("wasi", "debug", "libspytest.a")
     all_archives = [libspy_a] + list(extra_archives)
     bundle_path = get_or_build_bundle(all_archives, force_rebuild=force_rebuild)
     return LLWasmModule(str(bundle_path))

--- a/spy/libspy/__init__.py
+++ b/spy/libspy/__init__.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 import py.path
 
 import spy
+from spy.build.flags import get_libdir
 from spy.build.wasm_bundle import get_or_build_bundle
 from spy.errors import SPyError
 from spy.llwasm import HostModule, LLWasmInstance, LLWasmModule, WasmTrap
@@ -15,9 +16,14 @@ INCLUDE = spy.ROOT.join("libspy", "include")
 BUILD = spy.ROOT.join("libspy", "build")
 DEPS = spy.ROOT.join("libspy", "deps")
 
+# the VM provides the debug helpers as WASM imports, so it always wants the
+# testlib flavor of libspy (e.g. build/wasi/debug-testlib)
+WASI_TESTLIB = py.path.local(get_libdir("wasi", "debug", "testlib"))
+EMSCRIPTEN_TESTLIB = py.path.local(get_libdir("emscripten", "debug", "testlib"))
+
 
 if IS_NODE:
-    LIBSPY_WASM = BUILD.join("emscripten", "debug", "libspytest.mjs")
+    LIBSPY_WASM = EMSCRIPTEN_TESTLIB.join("libspy.mjs")
     LLMOD = None
 elif IS_BROWSER or IS_DOCS_BUILD:
     LIBSPY_WASM = None  # type: ignore    # needs to be set by the embedder
@@ -25,7 +31,7 @@ elif IS_BROWSER or IS_DOCS_BUILD:
 else:
     assert not IS_PYODIDE
     # "normal" python, we can preload LLMOD
-    LIBSPY_WASM = BUILD.join("wasi", "debug", "libspy.wasm")
+    LIBSPY_WASM = WASI_TESTLIB.join("libspy.wasm")
     LLMOD = LLWasmModule(LIBSPY_WASM)  # type: ignore
 
 # XXX ^^^^
@@ -43,9 +49,8 @@ def get_LLMOD(
     Return a LLWasmModule for libspy, optionally bundled with extra .a archives.
 
     When extra_archives is empty, returns the prebuilt LLMOD (no build step).
-    When extra_archives is non-empty, links libspytest.a + each extra archive
-    into a single bundle (cached by content hash) and returns a LLWasmModule
-    for it.
+    When extra_archives is non-empty, links libspy.a + each extra archive into
+    a single bundle (cached by content hash) and returns a LLWasmModule for it.
     """
     if not extra_archives:
         assert LLMOD is not None
@@ -59,9 +64,7 @@ def get_LLMOD(
                 f"Did you forget to build the spyvm extension module?",
             )
 
-    # the bundle is loaded by the VM, which provides the debug helpers as WASM
-    # imports: this is why we use libspytest.a and not libspy.a
-    libspy_a = BUILD.join("wasi", "debug", "libspytest.a")
+    libspy_a = WASI_TESTLIB.join("libspy.a")
     all_archives = [libspy_a] + list(extra_archives)
     bundle_path = get_or_build_bundle(all_archives, force_rebuild=force_rebuild)
     return LLWasmModule(str(bundle_path))

--- a/spy/libspy/include/spy.h
+++ b/spy/libspy/include/spy.h
@@ -31,6 +31,13 @@
 #  error "You must define either SPY_GC_NONE or SPY_GC_BDWGC"
 #endif
 
+// the SPY_OUTPUT_KIND_* macros mirror the OutputKind literals defined in
+// spy/build/build_info.py
+#if (defined(SPY_OUTPUT_KIND_EXE) + defined(SPY_OUTPUT_KIND_TESTLIB) +                 \
+     defined(SPY_OUTPUT_KIND_PY_CFFI)) != 1
+#  error "You must define one and exactly one of the SPY_OUTPUT_KIND_* macros"
+#endif
+
 #if defined(SPY_TARGET_NATIVE)
 #  define WASM_EXPORT(name) name
 
@@ -61,7 +68,6 @@
 // the linker happy because it sees the symbol as defined. We mark it as a stub
 // so that llwasm's adjustImports callback will write over it with a method
 // defined in a host module. If it's ever called at runtime, we panic.
-//
 
 #  include "emscripten.h"
 

--- a/spy/libspy/include/spy/debug.h
+++ b/spy/libspy/include/spy/debug.h
@@ -4,27 +4,21 @@
 #include "spy.h"
 
 /* Debug utilities:
-  - In emscripten and native mode, these are implemented in debug.c
-  - In WASI mode, they must be provided by the host.
-
-TODO: ideally, we want TWO different WASI modes:
-  - for tests, we want the imports
-  - for standalone executables, we want debug.c
+  - for testlib, they must be provided by the host: this is what we want for
+    tests, where the host records the panic and turns it into a SPyError.
+  - in all the other cases, they are implemented in debug.c.
 */
-#ifdef SPY_TARGET_WASI
-#  define IMP WASM_IMPORT
-#else
-#  define IMP(name) name
+#ifdef SPY_OUTPUT_KIND_TESTLIB
+#  define SPY_DEBUG_FROM_HOST
 #endif
 
-void IMP(spy_debug_log)(const char *s);
-void IMP(spy_debug_log_i32)(const char *s, int32_t n);
+#ifdef SPY_DEBUG_FROM_HOST
 
-#ifdef SPY_TARGET_WASI
-
-// for WASI/reactor targets, we expect the host to provide
-// spy_debug_set_panic_message
-void IMP(spy_debug_set_panic_message)(
+// the host provides these as WASM imports. On emscripten the linker also wants
+// a JS definition for them: see the EMSCRIPTEN_IMPORT stubs in debug.c
+void WASM_IMPORT(spy_debug_log)(const char *s);
+void WASM_IMPORT(spy_debug_log_i32)(const char *s, int32_t n);
+void WASM_IMPORT(spy_debug_set_panic_message)(
     const char *etype,
     const char *message,
     const char *fname,
@@ -45,7 +39,10 @@ static void inline spy_panic(
 
 #else
 
-// for other targets, we define spy_panic in debug.c
+void spy_debug_log(const char *s);
+void spy_debug_log_i32(const char *s, int32_t n);
+
+// in all the other cases, we define spy_panic in debug.c
 NORETURN
 void
 spy_panic(const char *etype, const char *message, const char *fname, int32_t lineno);

--- a/spy/libspy/src/debug.c
+++ b/spy/libspy/src/debug.c
@@ -3,7 +3,17 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#if !defined(SPY_TARGET_WASI)
+#if defined(SPY_DEBUG_FROM_HOST)
+
+EMSCRIPTEN_IMPORT(void, spy_debug_log, (const char *s));
+EMSCRIPTEN_IMPORT(void, spy_debug_log_i32, (const char *s, int32_t n));
+EMSCRIPTEN_IMPORT(
+    void,
+    spy_debug_set_panic_message,
+    (const char *etype, const char *message, const char *fname, int32_t lineno)
+);
+
+#else // defined(SPY_DEBUG_FROM_HOST)
 
 void
 spy_debug_log(const char *s) {
@@ -84,7 +94,7 @@ spy_panic(const char *etype, const char *message, const char *fname, int32_t lin
     abort();
 }
 
-#endif /* !defined(SPY_TARGET_WASI) */
+#endif /* !defined(SPY_DEBUG_FROM_HOST) */
 
 #if defined(SPY_TARGET_EMSCRIPTEN)
 #  include "emscripten.h"

--- a/spy/tests/test_llwasm.py
+++ b/spy/tests/test_llwasm.py
@@ -217,7 +217,7 @@ class TestLLWasm(CTest):
         a_file = self.tmpdir.join(f"{name}.a")
         c_file.write(src)
 
-        cflags = get_cflags(self.target, build_type)
+        cflags = get_cflags(self.target, build_type, self.kind)
         cc = ["python", "-m", "ziglang", "cc"]
         robust_run(
             [


### PR DESCRIPTION
libspy.a defines the debug helpers in debug.c whereas libspytest.a imports them from wasm imports. libspytest.a is designed for using with llwasm, maybe we should have a different name that reflects this more accurately.