### PR TITLE
Add proper tests for astcompile

### DIFF
--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -220,6 +220,20 @@ class SPyBackend:
     def emit_decl_GlobalFuncDef(self, decl: ast.GlobalFuncDef) -> None:
         self.emit_stmt(decl.funcdef)
 
+    def emit_decl_GlobalVarDef(self, decl: ast.GlobalVarDef) -> None:
+        vardef = decl.vardef
+        name = vardef.name.value
+        has_type = not isinstance(vardef.type, ast.Auto)
+        t = self.fmt_expr(vardef.type) if has_type else ""
+        if vardef.value is not None:
+            v = self.fmt_expr(vardef.value)
+            if has_type:
+                self.wl(f"var {name}: {t} = {v}")
+            else:
+                self.wl(f"var {name} = {v}")
+        else:
+            self.wl(f"var {name}: {t}")
+
     # statements
 
     def get_vartype_to_declare_maybe(self, varname: str) -> Optional[str]:

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -477,7 +477,7 @@ class SPyBackend:
         return name.id
 
     def fmt_expr_NameError(self, name: ast.NameError) -> str:
-        return f"raise NameError({name.id!r})"
+        return f"NameError({name.id})"
 
     def fmt_expr_NameImportRef(self, name: ast.NameImportRef) -> str:
         if self.ast_format == "full":

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -23,6 +23,7 @@ from spy.vm.object import W_Object, W_Type
 from spy.vm.vm import SPyVM
 
 FQN_FORMAT = Literal["full", "short"]
+AST_FORMAT = Literal["full", "short"]
 
 # Regex pattern for valid identifiers (alphanumeric + underscore)
 VALID_IDENTIFIER = re.compile(r"^[a-zA-Z0-9_]+$")
@@ -35,9 +36,16 @@ class SPyBackend:
     Mostly used for testing.
     """
 
-    def __init__(self, vm: SPyVM, *, fqn_format: FQN_FORMAT = "short") -> None:
+    def __init__(
+        self,
+        vm: SPyVM,
+        *,
+        fqn_format: FQN_FORMAT = "short",
+        ast_format: AST_FORMAT = "short",
+    ) -> None:
         self.vm = vm
         self.fqn_format = fqn_format
+        self.ast_format = ast_format
         self.out = TextBuilder(use_colors=False)
         self.w = self.out.w
         self.wl = self.out.wl
@@ -297,7 +305,9 @@ class SPyBackend:
         varname = assign.expr.target.value
         t = self.get_vartype_to_declare_maybe(varname)
         v = self.fmt_expr(assign.expr.value)
-        if t is not None:
+        if self.ast_format == "full":
+            self.wl(f"AssignLocal({varname} := {v})")
+        elif t is not None:
             self.wl(f"{varname}: {t} = {v}")
         else:
             self.wl(f"{varname} = {v}")
@@ -314,7 +324,10 @@ class SPyBackend:
             else assign.expr.sym.name
         )
         v = self.fmt_expr(assign.expr.value)
-        self.wl(f"{varname} = {v}")
+        if self.ast_format == "full":
+            self.wl(f"AssignCell({varname} := {v})")
+        else:
+            self.wl(f"{varname} = {v}")
 
     def emit_stmt_AugAssign(self, node: ast.AugAssign) -> None:
         varname = node.target.value
@@ -464,21 +477,36 @@ class SPyBackend:
         return name.id
 
     def fmt_expr_NameError(self, name: ast.NameError) -> str:
-        return name.id
+        return f"raise NameError({name.id!r})"
 
     def fmt_expr_NameImportRef(self, name: ast.NameImportRef) -> str:
+        if self.ast_format == "full":
+            return f"ImportRef({name.sym.name})"
         return name.sym.name
 
     def fmt_expr_NameLocalDirect(self, name: ast.NameLocalDirect) -> str:
+        if self.ast_format == "full":
+            return f"LocalDirect({name.sym.name})"
+        return name.sym.name
+
+    def fmt_expr_NameLocalCell(self, name: ast.NameLocalCell) -> str:
+        if self.ast_format == "full":
+            return f"LocalCell({name.sym.name})"
         return name.sym.name
 
     def fmt_expr_NameOuterDirect(self, name: ast.NameOuterDirect) -> str:
+        if self.ast_format == "full":
+            return f"OuterDirect({name.sym.name})"
         return name.sym.name
 
     def fmt_expr_NameOuterCell(self, name: ast.NameOuterCell) -> str:
         if name.fqn is not None:
-            return self.fmt_fqn(name.fqn)
-        return name.sym.name
+            varname = self.fmt_fqn(name.fqn)
+        else:
+            varname = name.sym.name
+        if self.ast_format == "full":
+            return f"OuterCell({varname})"
+        return varname
 
     def fmt_expr_BinOp(self, binop: ast.BinOp) -> str:
         l = self.fmt_expr(binop.left)

--- a/spy/backend/spy.py
+++ b/spy/backend/spy.py
@@ -491,7 +491,9 @@ class SPyBackend:
         return name.id
 
     def fmt_expr_NameError(self, name: ast.NameError) -> str:
-        return f"NameError({name.id})"
+        if self.ast_format == "full":
+            return f"NameError({name.id})"
+        return name.id
 
     def fmt_expr_NameImportRef(self, name: ast.NameImportRef) -> str:
         if self.ast_format == "full":

--- a/spy/cli/_format.py
+++ b/spy/cli/_format.py
@@ -3,16 +3,19 @@ from pathlib import Path
 import spy.ast
 from spy.analyze.symtable import Color
 from spy.backend.html import HTMLBackend, SpyastJs
-from spy.backend.spy import FQN_FORMAT, SPyBackend
+from spy.backend.spy import AST_FORMAT, FQN_FORMAT, SPyBackend
 from spy.highlight import highlight_src
 from spy.util import build_char_color_map
 from spy.vm.function import W_ASTFunc
 from spy.vm.vm import SPyVM
 
 
-def dump_spy_mod(vm: SPyVM, modname: str, full_fqn: bool) -> None:
+def dump_spy_mod(
+    vm: SPyVM, modname: str, full_fqn: bool, full_ast: bool = False
+) -> None:
     fqn_format: FQN_FORMAT = "full" if full_fqn else "short"
-    b = SPyBackend(vm, fqn_format=fqn_format)
+    ast_format: AST_FORMAT = "full" if full_ast else "short"
+    b = SPyBackend(vm, fqn_format=fqn_format, ast_format=ast_format)
     spy_code = b.dump_mod(modname).rstrip()
     print(highlight_src("spy", spy_code))
 

--- a/spy/cli/commands/astcompile.py
+++ b/spy/cli/commands/astcompile.py
@@ -7,7 +7,7 @@ from typer import Option
 
 from spy.analyze.importing import ImportAnalyzer
 from spy.backend.html import HTMLBackend, SpyastJs
-from spy.backend.spy import SPyBackend
+from spy.backend.spy import AST_FORMAT, SPyBackend
 from spy.cli._format import dump_spy_mod, dump_spy_mod_ast
 from spy.cli._runners import init_vm
 from spy.cli.commands.shared_args import (
@@ -28,6 +28,11 @@ class _astcompile_mixin:
             click_type=click.Choice(["ast", "spy", "html"]),
         ),
     ] = "ast"
+
+    full_ast: Annotated[
+        bool,
+        Option("--full-ast", help="Show full AST node types (e.g., LocalDirect, OuterCell)"),
+    ] = False
 
     spyast_js: Annotated[
         SpyastJs,
@@ -55,7 +60,8 @@ async def astcompile(args: ASTCompile_Args) -> None:
     if args.format == "ast":
         mod.pp()
     elif args.format == "spy":
-        b = SPyBackend(vm)
+        ast_format: AST_FORMAT = "full" if args.full_ast else "short"
+        b = SPyBackend(vm, ast_format=ast_format)
         b.modname = modname
         for decl in mod.decls:
             b.emit_decl(decl)

--- a/spy/cli/commands/astcompile.py
+++ b/spy/cli/commands/astcompile.py
@@ -31,7 +31,9 @@ class _astcompile_mixin:
 
     full_ast: Annotated[
         bool,
-        Option("--full-ast", help="Show full AST node types (e.g., LocalDirect, OuterCell)"),
+        Option(
+            "--full-ast", help="Show full AST node types (e.g., LocalDirect, OuterCell)"
+        ),
     ] = False
 
     spyast_js: Annotated[

--- a/spy/cli/commands/redshift.py
+++ b/spy/cli/commands/redshift.py
@@ -24,6 +24,11 @@ class _redshift_mixin:
         Option("--full-fqn", help="Show full FQNs in redshifted modules"),
     ] = False
 
+    full_ast: Annotated[
+        bool,
+        Option("--full-ast", help="Show full AST node types (e.g., LocalDirect, OuterCell)"),
+    ] = False
+
     linearize_: Annotated[
         bool,
         Option("--linearize", help="Apply linearize pass before dumping"),
@@ -99,7 +104,7 @@ async def redshift(args: Redshift_Args) -> None:
             if show_filename and args.format in ("spy", "ast"):
                 print(f"# {filename}")
             if args.format == "spy":
-                dump_spy_mod(vm, mod_name, args.full_fqn)
+                dump_spy_mod(vm, mod_name, args.full_fqn, args.full_ast)
             elif args.format == "ast":
                 dump_spy_mod_ast(vm, mod_name)
             elif args.format == "html":

--- a/spy/cli/commands/redshift.py
+++ b/spy/cli/commands/redshift.py
@@ -26,7 +26,9 @@ class _redshift_mixin:
 
     full_ast: Annotated[
         bool,
-        Option("--full-ast", help="Show full AST node types (e.g., LocalDirect, OuterCell)"),
+        Option(
+            "--full-ast", help="Show full AST node types (e.g., LocalDirect, OuterCell)"
+        ),
     ] = False
 
     linearize_: Annotated[

--- a/spy/tests/test_astcompile.py
+++ b/spy/tests/test_astcompile.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import pytest
 
+from spy.analyze.importing import ImportAnalyzer
 from spy.backend.spy import AST_FORMAT, FQN_FORMAT, SPyBackend
 from spy.fqn import FQN
 from spy.util import print_diff
@@ -27,6 +28,14 @@ class TestASTCompile:
         f.write(src)
         self.vm.import_("test")
 
+    def write_src(self, src: str) -> None:
+        """
+        Write source code to test.spy without importing.
+        """
+        f = self.tmpdir.join("test.spy")
+        src = textwrap.dedent(src)
+        f.write(src)
+
     def assert_dump(
         self,
         expected: str,
@@ -49,6 +58,29 @@ class TestASTCompile:
         if got != expected:
             print_diff(expected, got, "expected", "got")
             pytest.fail("assert_dump failed")
+
+    def assert_dump_decls(
+        self,
+        expected: str,
+        *,
+        ast_format: AST_FORMAT = "short",
+    ) -> None:
+        """
+        Dump all declarations using emit_decl, like the CLI does.
+        """
+        importer = ImportAnalyzer(self.vm, "test", use_spyc=False)
+        importer.astcompile_all()
+        mod = importer.getmod("test")
+        b = SPyBackend(self.vm, ast_format=ast_format)
+        b.modname = "test"
+        for decl in mod.decls:
+            b.emit_decl(decl)
+            b.out.wl()
+        got = b.out.build().strip()
+        expected = textwrap.dedent(expected).strip()
+        if got != expected:
+            print_diff(expected, got, "expected", "got")
+            pytest.fail("assert_dump_decls failed")
 
     def test_name_lowered_to_nameerror(self):
         self.compile_src("""
@@ -131,3 +163,17 @@ class TestASTCompile:
             return LocalDirect(inner)
         """
         self.assert_dump(expected, ast_format="full", funcname="outer")
+
+    def test_global_vardef(self):
+        self.write_src("""
+        var x: i32 = 42
+        def foo() -> i32:
+            return x
+        """)
+        expected = """
+        var x: i32 = 42
+
+        def foo() -> i32:
+            return x
+        """
+        self.assert_dump_decls(expected)

--- a/spy/tests/test_astcompile.py
+++ b/spy/tests/test_astcompile.py
@@ -57,7 +57,7 @@ class TestASTCompile:
         """)
         self.assert_dump("""
         def foo() -> i32:
-            return raise NameError('undefined_name')
+            return NameError(undefined_name)
         """)
 
     def test_for(self):

--- a/spy/tests/test_astcompile.py
+++ b/spy/tests/test_astcompile.py
@@ -55,10 +55,11 @@ class TestASTCompile:
         def foo() -> i32:
             return undefined_name
         """)
-        self.assert_dump("""
+        expected = """
         def foo() -> i32:
             return NameError(undefined_name)
-        """)
+        """
+        self.assert_dump(expected)
 
     def test_for(self):
         self.compile_src("""
@@ -66,14 +67,15 @@ class TestASTCompile:
             for i in lst:
                 print(i)
         """)
-        self.assert_dump("""
+        expected = """
         def foo(lst: dynamic) -> None:
             _$iter0 = lst.__fastiter__()
             while _$iter0.__continue_iteration__():
                 i = _$iter0.__item__()
                 _$iter0 = _$iter0.__next__()
                 print(i)
-        """)
+        """
+        self.assert_dump(expected)
 
     def test_local_direct(self):
         self.compile_src("""
@@ -81,21 +83,23 @@ class TestASTCompile:
             y = x
             return y
         """)
-        self.assert_dump("""
+        expected = """
         def foo(x: i32) -> i32:
             AssignLocal(y := LocalDirect(x))
             return LocalDirect(y)
-        """, ast_format="full")
+        """
+        self.assert_dump(expected, ast_format="full")
 
     def test_import_ref(self):
         self.compile_src("""
         def foo() -> None:
             print('hello')
         """)
-        self.assert_dump("""
+        expected = """
         def foo() -> None:
             ImportRef(print)('hello')
-        """, ast_format="full")
+        """
+        self.assert_dump(expected, ast_format="full")
 
     def test_outer_cell(self):
         self.compile_src("""
@@ -104,11 +108,12 @@ class TestASTCompile:
             x = 1
             return x
         """)
-        self.assert_dump("""
+        expected = """
         def foo() -> i32:
             AssignCell(x := 1)
             return OuterCell(x)
-        """, ast_format="full", funcname="foo")
+        """
+        self.assert_dump(expected, ast_format="full", funcname="foo")
 
     def test_outer_direct(self):
         self.compile_src("""
@@ -118,10 +123,11 @@ class TestASTCompile:
                 return x
             return inner
         """)
-        self.assert_dump("""
+        expected = """
         def outer() -> dynamic:
             AssignLocal(x := 1)
             def inner() -> ImportRef(i32):
                 return OuterDirect(x)
             return LocalDirect(inner)
-        """, ast_format="full", funcname="outer")
+        """
+        self.assert_dump(expected, ast_format="full", funcname="outer")

--- a/spy/tests/test_astcompile.py
+++ b/spy/tests/test_astcompile.py
@@ -91,7 +91,7 @@ class TestASTCompile:
         def foo() -> i32:
             return NameError(undefined_name)
         """
-        self.assert_dump(expected)
+        self.assert_dump(expected, ast_format="full")
 
     def test_for(self):
         self.compile_src("""

--- a/spy/tests/test_astcompile.py
+++ b/spy/tests/test_astcompile.py
@@ -1,0 +1,127 @@
+import textwrap
+from typing import Optional
+
+import pytest
+
+from spy.backend.spy import AST_FORMAT, FQN_FORMAT, SPyBackend
+from spy.fqn import FQN
+from spy.util import print_diff
+from spy.vm.function import W_ASTFunc
+from spy.vm.vm import SPyVM
+
+
+@pytest.mark.usefixtures("init")
+class TestASTCompile:
+    @pytest.fixture
+    def init(self, tmpdir):
+        self.tmpdir = tmpdir
+        self.vm = SPyVM()
+        self.vm.path.append(str(self.tmpdir))
+
+    def compile_src(self, src: str) -> None:
+        """
+        Compile source code without redshifting, to test astcompile output.
+        """
+        f = self.tmpdir.join("test.spy")
+        src = textwrap.dedent(src)
+        f.write(src)
+        self.vm.import_("test")
+
+    def assert_dump(
+        self,
+        expected: str,
+        *,
+        fqn_format: FQN_FORMAT = "short",
+        ast_format: AST_FORMAT = "short",
+        funcname: Optional[str] = None,
+    ) -> None:
+        b = SPyBackend(self.vm, fqn_format=fqn_format, ast_format=ast_format)
+        if funcname is not None:
+            fqn = FQN(f"test::{funcname}")
+            w_func = self.vm.globals_w[fqn]
+            assert isinstance(w_func, W_ASTFunc)
+            b.modname = "test"
+            b.dump_w_func(fqn, w_func)
+            got = b.out.build().strip()
+        else:
+            got = b.dump_mod("test").strip()
+        expected = textwrap.dedent(expected).strip()
+        if got != expected:
+            print_diff(expected, got, "expected", "got")
+            pytest.fail("assert_dump failed")
+
+    def test_name_lowered_to_nameerror(self):
+        self.compile_src("""
+        def foo() -> i32:
+            return undefined_name
+        """)
+        self.assert_dump("""
+        def foo() -> i32:
+            return raise NameError('undefined_name')
+        """)
+
+    def test_for(self):
+        self.compile_src("""
+        def foo(lst: dynamic) -> None:
+            for i in lst:
+                print(i)
+        """)
+        self.assert_dump("""
+        def foo(lst: dynamic) -> None:
+            _$iter0 = lst.__fastiter__()
+            while _$iter0.__continue_iteration__():
+                i = _$iter0.__item__()
+                _$iter0 = _$iter0.__next__()
+                print(i)
+        """)
+
+    def test_local_direct(self):
+        self.compile_src("""
+        def foo(x: i32) -> i32:
+            y = x
+            return y
+        """)
+        self.assert_dump("""
+        def foo(x: i32) -> i32:
+            AssignLocal(y := LocalDirect(x))
+            return LocalDirect(y)
+        """, ast_format="full")
+
+    def test_import_ref(self):
+        self.compile_src("""
+        def foo() -> None:
+            print('hello')
+        """)
+        self.assert_dump("""
+        def foo() -> None:
+            ImportRef(print)('hello')
+        """, ast_format="full")
+
+    def test_outer_cell(self):
+        self.compile_src("""
+        var x: i32 = 0
+        def foo() -> i32:
+            x = 1
+            return x
+        """)
+        self.assert_dump("""
+        def foo() -> i32:
+            AssignCell(x := 1)
+            return OuterCell(x)
+        """, ast_format="full", funcname="foo")
+
+    def test_outer_direct(self):
+        self.compile_src("""
+        def outer() -> dynamic:
+            x = 1
+            def inner() -> i32:
+                return x
+            return inner
+        """)
+        self.assert_dump("""
+        def outer() -> dynamic:
+            AssignLocal(x := 1)
+            def inner() -> ImportRef(i32):
+                return OuterDirect(x)
+            return LocalDirect(inner)
+        """, ast_format="full", funcname="outer")


### PR DESCRIPTION
This should have belonged to #649 , but too late and too bad.

The hard part is how to write readable tests, because comparing the generated AST is a pain. We ideally want to use the SPy backend to generated "astcompiled source code", but then all the nuances of NameLocalDirect, AssignLocal, etc, disappears.

The solution was to introduce a new option for the SPy backend `ast_format="full"`, which annotates some selected nodes with extra info needed for tests.
This is now exposed also from the `spy` cli.
E.g.:

```
❯ cat /tmp/x.spy
def main() -> None:
    x = 1
    print(x)
```

with the default "human-readable" format, we don't see any difference:

```
❯ spy astcompile -f spy /tmp/x.spy
def main() -> None:
    x = 1
    print(x)
```

But with `--full-ast`, we do!
```
❯ spy astcompile -f spy /tmp/x.spy --full-ast
def main() -> None:
    AssignLocal(x := 1)
    ImportRef(print)(LocalDirect(x))
```