### PR TITLE
Add initial implementation of input() keyword support

### DIFF
--- a/docs/src/reference/python_builtins.md
+++ b/docs/src/reference/python_builtins.md
@@ -55,6 +55,10 @@ The following built-in functions work similarly to their equivalents in CPython;
 
 :   The `int` type is currently an alias to `i32`. In the future, `int` will alias preferred individual types for specific platforms, but currently it is always `i32`.
 
+### __input__(prompt: str = "") { data-toc-label='input()' }
+
+:   Writes `prompt` to standard out (and flushes it), then reads a line from standard input. The trailing newline is stripped from the result. Raises `EOFError` if standard input is exhausted before any character is read.
+
 ### __len__(object) { data-toc-label='len()' }
 
 :   Return the length (the number of items) in a container
@@ -152,9 +156,3 @@ The internals of SPy are significantly different from CPython; as such, the road
 Many of these types are not implemented yet; others are in active development.
 
 :   ascii(), bool(), bytearray(), bytes(), chr(), complex(), format(), frozenset(), memoryview(), ord() set()
-
-### I/O
-
-The I/O story is currently a high priority and is in active development.
-
-:   input(), open()

--- a/examples/1_high_level/input_print.spy
+++ b/examples/1_high_level/input_print.spy
@@ -1,0 +1,5 @@
+
+
+def main() -> None:
+    name = input("Enter your name: ")
+    print(name)

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -10,7 +10,15 @@ from spy.util import print_diff
 EXAMPLES_DIR = Path(__file__).parent
 EXPECTED_OUTPUT_DIR = EXAMPLES_DIR / "expected_output"
 
-_spy_files = sorted(EXAMPLES_DIR.glob("[0-9]*/**/*.spy"))
+# Examples which read from stdin cannot be run non-interactively by the test
+# harness, so they are excluded from the parametrized tests.
+INTERACTIVE_EXAMPLES = {"input_print.spy"}
+
+_spy_files = sorted(
+    f
+    for f in EXAMPLES_DIR.glob("[0-9]*/**/*.spy")
+    if f.name not in INTERACTIVE_EXAMPLES
+)
 
 
 def expected_returncode(path: Path) -> int:

--- a/spy/analyze/symtable.py
+++ b/spy/analyze/symtable.py
@@ -193,6 +193,7 @@ class SymTable:
         add_sym("abs", ImportRef("_builtins", "abs"))
         add_sym("min", ImportRef("_builtins", "min"))
         add_sym("max", ImportRef("_builtins", "max"))
+        add_sym("input", ImportRef("_input", "input"))
         add_sym("range", ImportRef("_range", "range"))
         add_sym("list", ImportRef("_list", "list"))
         add_sym("tuple", ImportRef("_tuple", "tuple"))

--- a/spy/libspy/__init__.py
+++ b/spy/libspy/__init__.py
@@ -150,10 +150,11 @@ class LLSPyInstance(LLWasmInstance):
         hostmods: list[HostModule] = [],
         *,
         instance: Any = None,
+        stdin_file: Optional[str] = None,
     ) -> None:
         self.libspy = LibSPyHost()
         hostmods = [self.libspy] + hostmods
-        super().__init__(llmod, hostmods, instance=instance)
+        super().__init__(llmod, hostmods, instance=instance, stdin_file=stdin_file)
         layout = self.call("_spy_StrObject_layout")
         self.str_layout = StrLayout(*layout)
         blayout = self.call("_spy_BytesObject_layout")

--- a/spy/libspy/include/spy/posix.h
+++ b/spy/libspy/include/spy/posix.h
@@ -8,6 +8,9 @@
 #endif
 #include <unistd.h>
 
+FILE *WASM_EXPORT(spy_posix$_get_stdin)(void);
+FILE *WASM_EXPORT(spy_posix$_get_stdout)(void);
+FILE *WASM_EXPORT(spy_posix$_get_stderr)(void);
 FILE *WASM_EXPORT(spy_posix$_fopen)(spy_StrObject *filename, spy_StrObject *mode);
 spy_StrObject *WASM_EXPORT(spy_posix$_fread)(FILE *f, int32_t size);
 spy_StrObject *WASM_EXPORT(spy_posix$__freadall_chunked)(FILE *f);

--- a/spy/libspy/src/posix.c
+++ b/spy/libspy/src/posix.c
@@ -36,6 +36,21 @@ spy_posix$_parse_mode(spy_StrObject *mode, char *out) {
 }
 
 FILE *
+spy_posix$_get_stdin(void) {
+    return stdin;
+}
+
+FILE *
+spy_posix$_get_stdout(void) {
+    return stdout;
+}
+
+FILE *
+spy_posix$_get_stderr(void) {
+    return stderr;
+}
+
+FILE *
 spy_posix$_fopen(spy_StrObject *filename, spy_StrObject *mode) {
     char cmode[3];
     if (!spy_posix$_parse_mode(mode, cmode)) {

--- a/spy/llwasm/base.py
+++ b/spy/llwasm/base.py
@@ -1,6 +1,6 @@
 import struct
 import weakref
-from typing import Any, Literal, Self
+from typing import Any, Literal, Optional, Self
 
 import py.path
 
@@ -46,7 +46,13 @@ class LLWasmInstanceBase:
         raise NotImplementedError
 
     @classmethod
-    def from_file(cls, f: py.path.local, hostmods: list[HostModule] = []) -> Self:
+    def from_file(
+        cls,
+        f: py.path.local,
+        hostmods: list[HostModule] = [],
+        *,
+        stdin_file: Optional[str] = None,
+    ) -> Self:
         raise NotImplementedError
 
     def call(self, name: str, *args: Any) -> Any:

--- a/spy/llwasm/emscripten.py
+++ b/spy/llwasm/emscripten.py
@@ -57,7 +57,10 @@ class LLWasmInstance(LLWasmInstanceBase):
         hostmods: list[HostModule] = [],
         *,
         instance: Optional[JsProxy] = None,
+        stdin_file: Optional[str] = None,
     ) -> None:
+        if stdin_file is not None:
+            raise NotImplementedError("stdin_file is not supported on emscripten")
         self.llmod = llmod
 
         if instance is None:
@@ -100,9 +103,15 @@ class LLWasmInstance(LLWasmInstanceBase):
         return llmod.instance_factory(adjustWasmImports=adjust_imports)
 
     @classmethod
-    def from_file(cls, f: py.path.local, hostmods: list[HostModule] = []) -> Self:
+    def from_file(
+        cls,
+        f: py.path.local,
+        hostmods: list[HostModule] = [],
+        *,
+        stdin_file: Optional[str] = None,
+    ) -> Self:
         llmod = LLWasmModule(str(f))
-        return cls(llmod, hostmods)
+        return cls(llmod, hostmods, stdin_file=stdin_file)
 
     def get_export(self, name: str) -> Any:
         return getattr(self.instance, "_" + name)

--- a/spy/llwasm/wasmtime.py
+++ b/spy/llwasm/wasmtime.py
@@ -108,12 +108,15 @@ def get_linker(
     return linker
 
 
-def get_wasi_config() -> wt.WasiConfig:
+def get_wasi_config(stdin_file: Optional[str] = None) -> wt.WasiConfig:
     wasi_config = wt.WasiConfig()
     # eventually, we want to support argv, with either:
     #    wasi_config.argv = [...]
     #    wasi_config.inherit_argv()
-    wasi_config.inherit_stdin()
+    if stdin_file is not None:
+        wasi_config.stdin_file = stdin_file
+    else:
+        wasi_config.inherit_stdin()
     wasi_config.inherit_stdout()
     wasi_config.inherit_stderr()
     wasi_config.preopen_dir("/", "/")
@@ -132,11 +135,15 @@ class LLWasmInstance(LLWasmInstanceBase):
         hostmods: list[HostModule] = [],
         *,
         instance: Optional[wt.Instance] = None,
+        stdin_file: Optional[str] = None,
     ) -> None:
         self.llmod = llmod
         self.store = wt.Store(get_engine())
         linker = get_linker(
-            self.store, self.llmod, wasi_config=get_wasi_config(), hostmods=hostmods
+            self.store,
+            self.llmod,
+            wasi_config=get_wasi_config(stdin_file),
+            hostmods=hostmods,
         )
         if instance is None:
             self.instance = linker.instantiate(self.store, self.llmod.mod)
@@ -162,9 +169,15 @@ class LLWasmInstance(LLWasmInstanceBase):
         return cls(llmod, hostmods)
 
     @classmethod
-    def from_file(cls, f: py.path.local, hostmods: list[HostModule] = []) -> Self:
+    def from_file(
+        cls,
+        f: py.path.local,
+        hostmods: list[HostModule] = [],
+        *,
+        stdin_file: Optional[str] = None,
+    ) -> Self:
         llmod = LLWasmModule(str(f))
-        return cls(llmod, hostmods)
+        return cls(llmod, hostmods, stdin_file=stdin_file)
 
     def get_export(self, name: str) -> Any:
         exports = self.instance.exports(self.store)

--- a/spy/tests/stdlib/test__file.py
+++ b/spy/tests/stdlib/test__file.py
@@ -242,3 +242,51 @@ class TestFile(CompilerTest):
 
         with SPyError.raises("W_ValueError", match="I/O operation on closed file"):
             mod.do_writelines_closed(str(f))
+
+    def test_get_stdout(self, capfd):
+        src = """
+        from _file import get_stdout
+
+        def foo() -> str:
+            out = get_stdout()
+            out.write('hello stdout')
+            out.flush()
+            return str(out)
+        """
+        mod = self.compile(src)
+        assert mod.foo() == "<spy open file '<stdout>', mode 'w'>"
+        out, err = capfd.readouterr()
+        assert out == "hello stdout"
+
+    def test_get_stderr(self, capfd):
+        src = """
+        from _file import get_stderr
+
+        def foo() -> str:
+            err = get_stderr()
+            err.write('hello stderr')
+            err.flush()
+            return str(err)
+        """
+        mod = self.compile(src)
+        assert mod.foo() == "<spy open file '<stderr>', mode 'w'>"
+        out, err = capfd.readouterr()
+        assert err == "hello stderr"
+
+    def test_get_stdin(self):
+        self.set_wasi_stdin("hello\nworld\n")
+        src = """
+        from _file import get_stdin
+
+        def foo() -> tuple[str, str, str]:
+            f = get_stdin()
+            a = f.readline()
+            b = f.readline()
+            return a, b, str(f)
+        """
+        mod = self.compile(src)
+        assert mod.foo() == (
+            "hello\n",
+            "world\n",
+            "<spy open file '<stdin>', mode 'r'>",
+        )

--- a/spy/tests/stdlib/test__input.py
+++ b/spy/tests/stdlib/test__input.py
@@ -1,0 +1,107 @@
+import subprocess
+
+from spy.errors import SPyError
+from spy.tests.support import (
+    CompilerTest,
+    expect_errors,
+    only_native,
+)
+
+
+class TestInput(CompilerTest):
+    def test_input_prompt(self, capfd):
+        self.set_wasi_stdin("Alice\n")
+        src = """
+        def foo(prompt: str) -> str:
+            return input(prompt)
+        """
+        mod = self.compile(src)
+        assert mod.foo("Enter your name: ") == "Alice"
+        out, err = capfd.readouterr()
+        assert out == "Enter your name: "
+
+    def test_input_no_prompt(self):
+        self.set_wasi_stdin("Alice\n")
+        src = """
+        def foo() -> str:
+            return input()
+        """
+        mod = self.compile(src)
+        assert mod.foo() == "Alice"
+
+    def test_input_strips_newline(self):
+        # input() strips the trailing newline, like CPython
+        self.set_wasi_stdin("Alice\n")
+        src = """
+        def foo() -> str:
+            return input("> ")
+        """
+        mod = self.compile(src)
+        assert mod.foo() == "Alice"
+
+    def test_input_strips_crlf(self):
+        # input() also strips a trailing \r, to handle CRLF line endings
+        self.set_wasi_stdin("Alice\r\n")
+        src = """
+        def foo() -> str:
+            return input()
+        """
+        mod = self.compile(src)
+        assert mod.foo() == "Alice"
+
+    def test_input_multiple_lines(self):
+        self.set_wasi_stdin("first\nsecond\n")
+        src = """
+        def foo() -> str:
+            a = input()
+            b = input()
+            return a + "|" + b
+        """
+        mod = self.compile(src)
+        assert mod.foo() == "first|second"
+
+    def test_input_eof(self):
+        # at EOF, input() raises EOFError, like CPython
+        self.set_wasi_stdin("")
+        src = """
+        def foo() -> str:
+            return input()
+        """
+        mod = self.compile(src)
+        with SPyError.raises("W_EOFError", match="EOF when reading a line"):
+            mod.foo()
+
+    def test_input_wrong_type(self):
+        src = """
+        def foo() -> str:
+            return input(42)
+        """
+        errors = expect_errors(
+            "mismatched types",
+            ("expected `str`, got `i32`", "42"),
+        )
+        self.compile_raises(src, "foo", errors)
+
+    def test_input_too_many_args(self):
+        src = """
+        def foo() -> str:
+            return input("a", "b")
+        """
+        errors = expect_errors(
+            "this function takes from 0 to 1 arguments but 2 arguments were supplied",
+            ("1 extra argument", '"b"'),
+        )
+        self.compile_raises(src, "foo", errors)
+
+
+@only_native
+class TestInputNative(CompilerTest):
+    def test_input_native(self):
+        src = """
+        def main() -> None:
+            name = input("Enter your name: ")
+            print(name)
+        """
+        exe = self.compile(src)
+        out = subprocess.check_output([str(exe.f)], input=b"Alice\n")
+        assert out == b"Enter your name: Alice\n"

--- a/spy/tests/support.py
+++ b/spy/tests/support.py
@@ -122,6 +122,8 @@ class CompilerTest:
     vm: SPyVM
 
     OPT_LEVEL: Optional[int] = None
+    # if set, WASI instances created by the test read stdin from this file
+    wasi_stdin_file: Optional[str] = None
 
     @pytest.fixture(params=params_with_marks(ALL_BACKENDS))  # type: ignore
     def compiler_backend(self, request):
@@ -155,6 +157,26 @@ class CompilerTest:
         srcfile = self.tmpdir.join(filename)
         srcfile.write(src)
         return srcfile
+
+    def set_wasi_stdin(self, data: str) -> None:
+        """
+        Arrange for WASI stdin to read `data`. Must be called before compile().
+
+        For the interp/doppler backends this recreates self.vm with a WASI
+        config which reads stdin from a file; for the C backend the file is
+        used when the WasmModuleWrapper is created by compile().
+        """
+        from spy import libspy
+        from spy.libspy import LLSPyInstance
+
+        stdin_f = self.tmpdir.join("wasi_stdin.txt")
+        stdin_f.write(data)
+        self.wasi_stdin_file = str(stdin_f)
+        if self.backend != "C":
+            # recreate the VM so that its ll instance picks up the new stdin
+            ll = LLSPyInstance(libspy.get_LLMOD(), stdin_file=self.wasi_stdin_file)
+            self.vm = SPyVM(ll=ll)
+            self.vm.path.append(str(self.tmpdir))
 
     @property
     def error_reporting(self) -> str:
@@ -262,6 +284,10 @@ class CompilerTest:
         backend.cwrite()
         backend.write_build_script()
         outfile = backend.build()  # e.g. 'test.wasm' or 'test.mjs'
+        if WrapperClass is WasmModuleWrapper:
+            return WasmModuleWrapper(
+                self.vm, modname, outfile, stdin_file=self.wasi_stdin_file
+            )
         return WrapperClass(self.vm, modname, outfile)
 
     def dump_module(self, modname: str) -> None:

--- a/spy/tests/wasm_wrapper.py
+++ b/spy/tests/wasm_wrapper.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Optional
 
 import fixedint
 import py.path
@@ -31,11 +31,18 @@ class WasmModuleWrapper:
     modname: str
     ll: LLSPyInstance
 
-    def __init__(self, vm: SPyVM, modname: str, f: py.path.local) -> None:
+    def __init__(
+        self,
+        vm: SPyVM,
+        modname: str,
+        f: py.path.local,
+        *,
+        stdin_file: Optional[str] = None,
+    ) -> None:
         self.vm = vm
         self.modname = modname
         self.w_mod = vm.modules_w[modname]
-        self.ll = LLSPyInstance.from_file(f)
+        self.ll = LLSPyInstance.from_file(f, stdin_file=stdin_file)
 
     def __repr__(self) -> str:
         return f"<WasmModuleWrapper '{self.ll.llmod}'>"

--- a/spy/vm/exc.py
+++ b/spy/vm/exc.py
@@ -331,6 +331,11 @@ class W_OSError(W_Exception):
     pass
 
 
+@BUILTINS.builtin_type("EOFError")
+class W_EOFError(W_Exception):
+    pass
+
+
 @BUILTINS.builtin_type("NotImplementedError")
 class W_NotImplementedError(W_Exception):
     pass

--- a/spy/vm/modules/posix.py
+++ b/spy/vm/modules/posix.py
@@ -79,6 +79,24 @@ POSIX.add("_FILE_NULL", W__FILE(0))
 
 
 @POSIX.builtin_func
+def w__get_stdin(vm: "SPyVM") -> W__FILE:
+    h = vm.ll.call("spy_posix$_get_stdin")
+    return W__FILE(h)
+
+
+@POSIX.builtin_func
+def w__get_stdout(vm: "SPyVM") -> W__FILE:
+    h = vm.ll.call("spy_posix$_get_stdout")
+    return W__FILE(h)
+
+
+@POSIX.builtin_func
+def w__get_stderr(vm: "SPyVM") -> W__FILE:
+    h = vm.ll.call("spy_posix$_get_stderr")
+    return W__FILE(h)
+
+
+@POSIX.builtin_func
 def w__fopen(vm: "SPyVM", w_filename: W_Str, w_mode: W_Str) -> W__FILE:
     h = vm.ll.call("spy_posix$_fopen", w_filename.ptr, w_mode.ptr)
     return W__FILE(h)

--- a/stdlib/_file.spy
+++ b/stdlib/_file.spy
@@ -1,6 +1,7 @@
 from posix import (
-    _FILE, _FILE_NULL, _fopen, _fread, _freadall, _freadline,
-    _fwrite, _ftell, _fseek, _fflush, _fileno, _isatty, _fclose, SEEK_SET,
+    _FILE, _FILE_NULL, _get_stdin, _get_stdout, _get_stderr, _fopen, _fread,
+    _freadall, _freadline, _fwrite, _ftell, _fseek, _fflush, _fileno, _isatty,
+    _fclose, SEEK_SET,
 )
 from unsafe import gc_ptr, gc_alloc
 
@@ -126,3 +127,24 @@ class file_iterator:
 
 def open(filename: str, mode: str = "r") -> file:
     return file(filename, mode)
+
+
+def _wrap_fp(fp: _FILE, filename: str, mode: str) -> file:
+    # wrap an existing FILE* (e.g. stdin) into a `file` object
+    data = gc_alloc[_FileData](1)
+    data.fp = fp
+    data.filename = filename
+    data.mode = mode
+    return file.__make__(data)
+
+
+def get_stdin() -> file:
+    return _wrap_fp(_get_stdin(), "<stdin>", "r")
+
+
+def get_stdout() -> file:
+    return _wrap_fp(_get_stdout(), "<stdout>", "w")
+
+
+def get_stderr() -> file:
+    return _wrap_fp(_get_stderr(), "<stderr>", "w")

--- a/stdlib/_input.spy
+++ b/stdlib/_input.spy
@@ -1,0 +1,22 @@
+from _file import get_stdin, get_stdout
+
+
+def input(prompt: str = "") -> str:
+    """
+    Write `prompt` to standard out (and flush it), then read a line from
+    standard input. The trailing newline is stripped from the result.
+    Raise EOFError if standard input is exhausted before any character is read.
+    """
+    stdout = get_stdout()
+    stdout.write(prompt)
+    stdout.flush()
+    line = get_stdin().readline()
+    if line == "":
+        # this happens only at EOF
+        raise EOFError("EOF when reading a line")
+    # strip the trailing newline (and \r, to handle CRLF line endings)
+    if line[-1] == "\n":
+        line = line[0 : len(line) - 1]
+    if len(line) > 0 and line[-1] == "\r":
+        line = line[0 : len(line) - 1]
+    return line


### PR DESCRIPTION
As titled, 

This PR aims to add support for the `input()` keyword allowing user input from terminal. 