### PR TITLE
Add initial implementation for str.strip()

### DIFF
--- a/spy/tests/compiler/test_str.py
+++ b/spy/tests/compiler/test_str.py
@@ -462,6 +462,30 @@ class TestStr(CompilerTest):
         assert mod.upper("ABC123") == "ABC123"
         assert mod.upper("") == ""
 
+    def test_strip(self):
+        src = """
+        def strip(s: str) -> str:
+            return s.strip()
+
+        def strip_chars(s: str, chars: str) -> str:
+            return s.strip(chars)
+        """
+        mod = self.compile(src)
+        # no-args
+        assert mod.strip("  hello  ") == "hello"
+        assert mod.strip("hello") == "hello"
+        assert mod.strip("   ") == ""
+        assert mod.strip("") == ""
+        assert mod.strip("\t\n hello \t\n") == "hello"
+        assert mod.strip(" \t\r\n") == ""
+        # with chars
+        assert mod.strip_chars("xxhelloxx", "x") == "hello"
+        assert mod.strip_chars("abchelloabc", "abc") == "hello"
+        assert mod.strip_chars("xyxhelloxyx", "xy") == "hello"
+        assert mod.strip_chars("hello", "") == "hello"
+        assert mod.strip_chars("hello", "xyz") == "hello"
+        assert mod.strip_chars("aaaa", "a") == ""
+
     def test_str_replace(self):
         mod = self.compile("""
         def foo(s: str, old: str, new: str) -> str:

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -50,6 +50,7 @@ class W_Str(W_Object):
         "__contains__": FQN("_str::methods::__contains__"),
         "split": FQN("_str::methods::split"),
         "isspace": FQN("_str::methods::isspace"),
+        "strip": FQN("_str::methods::strip"),
         "find": FQN("_str::methods::find"),
         "count": FQN("_str::methods::count"),
         "__repr__": FQN("_str::methods::__repr__"),

--- a/stdlib/_str.spy
+++ b/stdlib/_str.spy
@@ -418,6 +418,15 @@ class methods:
         return True
 
     @blue.metafunc
+    def strip(m_self, *args_m):
+        nargs = len(args_m)
+        if nargs == 0:
+            return OpSpec(_strip_whitespace)
+        elif nargs == 1:
+            return OpSpec(_strip_chars)
+        return OpSpec.NULL
+
+    @blue.metafunc
     def find(m_self, *args_m):
         # str.find(sub[, start[, end]]) -> i32
         nargs = len(args_m)
@@ -541,6 +550,62 @@ def _count_2(self: str, sub: str, start: i32) -> i32:
 
 def _count_3(self: str, sub: str, start: i32, end: i32) -> i32:
     return _str_count(self, sub, start, end)
+
+
+def _strip_whitespace(self: str) -> str:
+    ll = StrObject.from_str(self)
+    length = ll.length
+    start = 0
+    end = length
+    while start < end and _ll_isspace(ll.utf8[start]):
+        start = start + 1
+    while end > start and _ll_isspace(ll.utf8[end - 1]):
+        end = end - 1
+    new_len = end - start
+    if new_len == length:
+        return self
+    out = StrObject.alloc(new_len)
+    out.hash = 0
+    if new_len > 0:
+        ptr_copy_slice(out.utf8, 0, new_len, ll.utf8, start, end)
+    return StrObject.to_str(out)
+
+
+def _strip_chars(self: str, chars: str) -> str:
+    ll = StrObject.from_str(self)
+    llchars = StrObject.from_str(chars)
+    length = ll.length
+    chars_len = llchars.length
+    if chars_len == 0:
+        return self
+    start = 0
+    end = length
+    while start < end:
+        found = False
+        for i in range(chars_len):
+            if ll.utf8[start] == llchars.utf8[i]:
+                found = True
+                break
+        if not found:
+            break
+        start = start + 1
+    while end > start:
+        found = False
+        for j in range(chars_len):
+            if ll.utf8[end - 1] == llchars.utf8[j]:
+                found = True
+                break
+        if not found:
+            break
+        end = end - 1
+    new_len = end - start
+    if new_len == length:
+        return self
+    out = StrObject.alloc(new_len)
+    out.hash = 0
+    if new_len > 0:
+        ptr_copy_slice(out.utf8, 0, new_len, ll.utf8, start, end)
+    return StrObject.to_str(out)
 
 
 def _split_sep(self: str, sep: str) -> list[str]:


### PR DESCRIPTION
As titled, 

This PR aims to add initial support for `str.split()`.