### PR TITLE
examples/1_high_level/hello.spy as a standard file, not a symlink

### DIFF
--- a/examples/1_high_level/hello.spy
+++ b/examples/1_high_level/hello.spy
@@ -1,1 +1,9 @@
-../hello.spy
+"""
+Things to notice:
+  - Every SPy program defines `main()` as its entry point.
+    SPy libraries do not need a `main()` function.
+"""
+
+
+def main() -> None:
+    print("Hello world!")


### PR DESCRIPTION
Fixes #645 (playground build broken in the CI)

I don't really understand why the CI does not like the symlink.

```
    tar: ./examples/1_high_level/hello.spy: File removed before we read it
```

The simplest fix is to just use a real copy. I don't think it can ever become an issue for such simple and small file.