### PR TITLE
Generic metafunc

### DIFF
--- a/spy/ast.py
+++ b/spy/ast.py
@@ -64,7 +64,7 @@ LoweringStage = typing.Literal[
 
 
 ClassKind = typing.Literal["class", "struct"]
-FuncKind = typing.Literal["plain", "generic", "metafunc"]
+FuncKind = typing.Literal["plain", "generic", "metafunc", "generic_metafunc"]
 FuncParamKind = typing.Literal["simple", "var_positional"]
 
 

--- a/spy/fqn.py
+++ b/spy/fqn.py
@@ -213,7 +213,13 @@ class FQN:
             len(self.parts) == 2
             and self.modname == "builtins"
             and self.parts[1].name
-            in ("def", "blue.def", "blue.generic.def", "blue.metafunc.def")
+            in (
+                "def",
+                "blue.def",
+                "blue.generic.def",
+                "blue.metafunc.def",
+                "blue.generic_metafunc.def",
+            )
         )
         if is_def:
             p1 = self.parts[1]
@@ -223,8 +229,11 @@ class FQN:
                 d = "@blue def"
             elif p1.name == "blue.generic.def":
                 d = "@blue.generic def"
-            else:
+            elif p1.name == "blue.metafunc.def":
                 d = "@blue.metafunc def"
+            else:
+                d = "@blue.generic_metafunc def"
+
             quals = [q._human_render() for q in p1.qualifiers]
             p = ", ".join(quals[:-1])
             r = quals[-1]

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -229,6 +229,9 @@ class Parser:
             elif d == "blue.metafunc":
                 color = "blue"
                 func_kind = "metafunc"
+            elif d == "blue.generic_metafunc":
+                color = "blue"
+                func_kind = "generic_metafunc"
             else:
                 # other decorators are stored as general decorators
                 decorators.append(self.from_py_expr(deco))

--- a/spy/tests/compiler/operator/test_itemop.py
+++ b/spy/tests/compiler/operator/test_itemop.py
@@ -128,3 +128,34 @@ class TestItemop(CompilerTest):
         assert mod.set_and_get(0, 2, 24) == 24
         assert mod.set_and_get(2, 1, 99) == 99
         assert mod.get_default(1, 2) == 0
+
+    def test_generic_metafunc_getitem(self):
+        EXT = ModuleRegistry("ext")
+
+        @EXT.builtin_func(color="blue", kind="generic_metafunc")
+        def w_make_adder(
+            vm: "SPyVM", wam_x: W_MetaArg, *rest_wam: W_MetaArg
+        ) -> W_OpSpec:
+            if rest_wam:
+                wam_y = rest_wam[0]
+            else:
+                wam_y = W_MetaArg.from_w_obj(vm, vm.wrap(100), color="blue")
+
+            @vm.register_builtin_func(EXT.fqn.join("make_adder"), "impl")
+            def w_impl(vm: "SPyVM", w_x: W_I32, w_y: W_I32) -> W_I32:
+                return vm.wrap(vm.unwrap_i32(w_x) + vm.unwrap_i32(w_y))
+
+            return W_OpSpec(w_impl, [wam_x, wam_y])
+
+        self.vm.make_module(EXT)
+        mod = self.compile("""
+        from ext import make_adder
+
+        def with_default(x: i32) -> i32:
+            return make_adder[x]
+
+        def with_explicit_y(x: i32, y: i32) -> i32:
+            return make_adder[x, y]
+        """)
+        assert mod.with_default(5) == 105
+        assert mod.with_explicit_y(5, 6) == 11

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -503,6 +503,33 @@ class TestParser:
         """
         self.assert_dump(funcdef, expected)
 
+    def test_blue_generic_metafunc_FuncDef(self):
+        mod = self.parse("""
+        @blue.generic_metafunc
+        def foo() -> i32:
+            return 42
+        """)
+        funcdef = mod.get_funcdef("foo")
+        expected = """
+        FuncDef(
+            stage='parsed',
+            color='blue',
+            kind='generic_metafunc',
+            name='foo',
+            args=[],
+            return_type=Name(id='i32'),
+            defaults=[],
+            docstring=None,
+            body=[
+                Return(
+                    value=Literal(value=42),
+                ),
+            ],
+            decorators=[],
+        )
+        """
+        self.assert_dump(funcdef, expected)
+
     def test_FuncDef_prototype_loc(self):
         # blue functions without return type, are parsed as if they had a
         # synthetic '-> dynamic' annotation. We also need to generate a

--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -121,7 +121,7 @@ def make_builtin_func(
     assert isinstance(namespace, FQN)
     fqn = namespace.join(fname, qualifiers)
 
-    if kind == "metafunc" and color != "blue":
+    if kind in ("metafunc", "generic_metafunc") and color != "blue":
         msg = f"wrong color for metafunc `{fqn.debug_human_name}`: expected `blue`, got `{color}`"
         raise SPyError("W_TypeError", msg)
 

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -113,6 +113,8 @@ class W_FuncType(W_Type):
             t = "blue.generic.def"
         elif color == "blue" and kind == "metafunc":
             t = "blue.metafunc.def"
+        elif color == "blue" and kind == "generic_metafunc":
+            t = "blue.generic_metafunc.def"
         else:
             assert False
         fqn = FQN("builtins").join(t, qualifiers)
@@ -332,7 +334,7 @@ class W_Func(W_Object):
 
         w_func = wam_func.w_blueval
         assert isinstance(w_func, W_Func)
-        assert w_func.w_functype.kind == "metafunc"
+        assert w_func.w_functype.kind in ("metafunc", "generic_metafunc")
 
         # Now we want to call the metafunc to get the opspec to return.  Note
         # that we cannot just vm.fast_call() it, because we don't know whether

--- a/spy/vm/modules/operator/callop.py
+++ b/spy/vm/modules/operator/callop.py
@@ -34,6 +34,8 @@ def w_CALL(vm: "SPyVM", wam_obj: W_MetaArg, *args_wam: W_MetaArg) -> W_OpImpl:
             w_opspec = W_Func.op_METACALL(vm, wam_obj, *args_wam)  # type: ignore
         elif w_T.kind == "generic":
             errmsg = "generic functions must be called via `[...]`"
+        elif w_T.kind == "generic_metafunc":
+            errmsg = "generic metafunctions must be called via `[...]`"
         else:
             assert False, f"unknown FuncKind: {w_T.kind}"
 

--- a/spy/vm/modules/operator/itemop.py
+++ b/spy/vm/modules/operator/itemop.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from spy.vm.function import W_FuncType
+from spy.vm.function import W_Func, W_FuncType
 from spy.vm.opimpl import W_OpImpl
 from spy.vm.opspec import W_MetaArg, W_OpSpec
 
@@ -21,6 +21,8 @@ def w_GETITEM(vm: "SPyVM", wam_obj: W_MetaArg, *args_wam: W_MetaArg) -> W_OpImpl
     if isinstance(w_T, W_FuncType) and w_T.kind == "generic":
         # special case: for generic W_Funcs, "[]" means "call"
         w_opspec = w_T.pyclass.op_CALL(vm, wam_obj, *args_wam)  # type: ignore
+    elif isinstance(w_T, W_FuncType) and w_T.kind == "generic_metafunc":
+        w_opspec = w_T.pyclass.op_METACALL(vm, wam_obj, *args_wam)  # type: ignore
     elif w_getitem := w_T.lookup_func(vm, "__getitem__"):
         w_opspec = vm.fast_metacall(w_getitem, newargs_wam)
 

--- a/spy/vm/vm.py
+++ b/spy/vm/vm.py
@@ -862,7 +862,7 @@ class SPyVM:
             w_result = self._raw_call(w_func, args_w)
             self.bluecache.record(w_func, args_w, w_result)
             if (
-                w_func.w_functype.kind == "generic"
+                w_func.w_functype.kind in ("generic", "generic_metafunc")
                 and isinstance(w_result, (W_Type, W_Func))
                 and w_result.w_origin is None
             ):


### PR DESCRIPTION
A metafunc that has to be called with [].

Potentially useful for `gc_ptr[T, N]` / `gc_ptr[T]`.

@antocuni do you think it makes sense to add this?