### PR TITLE
Optional arg for generic function at interp level

### DIFF
--- a/spy/ast.py
+++ b/spy/ast.py
@@ -65,7 +65,7 @@ LoweringStage = typing.Literal[
 
 ClassKind = typing.Literal["class", "struct"]
 FuncKind = typing.Literal["plain", "generic", "metafunc"]
-FuncParamKind = typing.Literal["simple", "var_positional"]
+FuncParamKind = typing.Literal["simple", "var_positional", "optional"]
 
 
 @extend(py_ast.AST)

--- a/spy/tests/compiler/operator/test_itemop.py
+++ b/spy/tests/compiler/operator/test_itemop.py
@@ -4,7 +4,7 @@ from spy.vm.opspec import W_MetaArg, W_OpSpec
 from spy.vm.primitive import W_I32
 from spy.vm.registry import ModuleRegistry
 from spy.vm.vm import SPyVM
-from spy.vm.w import W_Object
+from spy.vm.w import W_Object, W_Type
 
 
 class W_MyClass(W_Object):
@@ -128,3 +128,27 @@ class TestItemop(CompilerTest):
         assert mod.set_and_get(0, 2, 24) == 24
         assert mod.set_and_get(2, 1, 99) == 99
         assert mod.get_default(1, 2) == 0
+
+    def test_generic_builtin_func_with_optional_arg(self):
+        EXT = ModuleRegistry("ext")
+
+        @EXT.builtin_func(color="blue", kind="generic")
+        def w_scaled(vm: "SPyVM", w_T: W_Type, w_N: W_I32 | None = None) -> W_I32:
+            if w_N is None:
+                n = 100
+            else:
+                n = vm.unwrap_i32(w_N)
+            return vm.wrap(n)
+
+        self.vm.make_module(EXT)
+        mod = self.compile("""
+        from ext import scaled
+
+        def with_default() -> i32:
+            return scaled[i32]
+
+        def with_explicit_n() -> i32:
+            return scaled[i32, 42]
+        """)
+        assert mod.with_default() == 100
+        assert mod.with_explicit_n() == 42

--- a/spy/vm/builtin.py
+++ b/spy/vm/builtin.py
@@ -71,7 +71,10 @@ def to_spy_FuncParam(p: Any, extra_types: TYPES_DICT) -> FuncParam:
     w_T = to_spy_type(annotation)
     kind: FuncParamKind
     if p.kind == p.POSITIONAL_OR_KEYWORD:
-        kind = "simple"
+        if p.default is not inspect.Parameter.empty:
+            kind = "optional"
+        else:
+            kind = "simple"
     elif p.kind == p.VAR_POSITIONAL:
         kind = "var_positional"
     else:

--- a/spy/vm/function.py
+++ b/spy/vm/function.py
@@ -174,18 +174,14 @@ class W_FuncType(W_Type):
     def arity(self) -> int:
         """
         Return the *minimum* number of arguments expected by the function.
-        In case of varargs, it's the number of non-varargs parameters.
         """
-        if self.has_varargs:
-            return len(self.params) - 1
-        else:
-            return len(self.params)
+        return sum(1 for p in self.params if p.kind == "simple")
 
     def is_argcount_ok(self, n: int) -> bool:
         if self.has_varargs:
             return n >= self.arity
         else:
-            return n == self.arity
+            return self.arity <= n <= len(self.params)
 
     def all_params(self) -> Iterator[FuncParam]:
         """


### PR DESCRIPTION
I think this is needed for `gc_ptr[T, N]`.