### PR TITLE
Add value-based repr for bool

### DIFF
--- a/spy/libspy/include/spy/str.h
+++ b/spy/libspy/include/spy/str.h
@@ -145,6 +145,7 @@ spy_StrObject *spy_builtins$bool$__str__(bool x);
 #define spy_builtins$u64$__repr__ spy_builtins$u64$__str__
 #define spy_builtins$f64$__repr__ spy_builtins$f64$__str__
 #define spy_builtins$f32$__repr__ spy_builtins$f32$__str__
+#define spy_builtins$bool$__repr__ spy_builtins$bool$__str__
 
 // str -> numeric conversion operators
 int32_t spy_operator$str_to_i32(spy_StrObject *s);

--- a/spy/tests/compiler/test_str.py
+++ b/spy/tests/compiler/test_str.py
@@ -324,6 +324,9 @@ class TestStr(CompilerTest):
 
         def repr_f32(x: f32) -> str:
             return repr(x)
+
+        def repr_bool(x: bool) -> str:
+            return repr(x)
         """)
         assert mod.repr_i32(-10) == "-10"
         assert mod.repr_i32(123) == "123"
@@ -333,6 +336,8 @@ class TestStr(CompilerTest):
         assert mod.repr_f64(3.14) == "3.14"
         assert mod.repr_f64(3.14) == mod.str_f64(3.14)
         assert mod.repr_f32(3.14) == "3.14"
+        assert mod.repr_bool(True) == "True"
+        assert mod.repr_bool(False) == "False"
 
     def test_repr_blue(self):
         src = """

--- a/spy/vm/primitive.py
+++ b/spy/vm/primitive.py
@@ -538,6 +538,12 @@ class W_Bool(W_Object):
         b = vm.unwrap(w_self)
         return vm.wrap(str(b))
 
+    @builtin_method("__repr__", is_pure=True)
+    @staticmethod
+    def w_repr(vm: "SPyVM", w_self: "W_Bool") -> "W_Str":
+        b = vm.unwrap(w_self)
+        return vm.wrap(str(b))
+
 
 B.add("True", W_Bool._make_singleton(True))
 B.add("False", W_Bool._make_singleton(False))


### PR DESCRIPTION
Boolean values previously had inconsistent `repr` behavior:

- the interpreter inherited `object`’s identity-based representation;
- C builds generated a call to a missing generic `repr` symbol.

Define `bool.__repr__` to share `bool.__str__` formatting, giving `True` and `False` the same canonical representation on every backend.