### PR TITLE
Add value-based repr for complex128

### DIFF
--- a/spy/tests/compiler/test_complex.py
+++ b/spy/tests/compiler/test_complex.py
@@ -19,6 +19,44 @@ class TestComplex(CompilerTest):
         """)
         assert mod.foo() == 12.3j
 
+    def test_repr(self):
+        mod = self.compile("""
+        def complex_repr(x: complex128) -> str:
+            return repr(x)
+
+        def complex_str(x: complex128) -> str:
+            return str(x)
+        """)
+
+        def assert_format(value: complex, expected: str) -> None:
+            assert mod.complex_repr(value) == expected
+            assert mod.complex_str(value) == expected
+
+        assert_format(1.5 + 2.5j, "(1.5+2.5j)")
+        assert_format(1.5 - 2.5j, "(1.5-2.5j)")
+        assert_format(complex(1.0, 2.0), "(1+2j)")
+
+        assert_format(complex(1.0, float("inf")), "(1+infj)")
+        assert_format(complex(1.0, float("-inf")), "(1-infj)")
+        assert_format(complex(float("inf"), 1.0), "(inf+1j)")
+        assert_format(complex(float("-inf"), float("inf")), "(-inf+infj)")
+        assert_format(complex(float("nan"), 1.0), "(nan+1j)")
+        assert_format(complex(1.0, float("nan")), "(1+nanj)")
+        assert_format(complex(float("nan"), float("nan")), "(nan+nanj)")
+
+        assert_format(complex(0.0, float("inf")), "infj")
+        assert_format(complex(0.0, float("-inf")), "-infj")
+        assert_format(complex(0.0, float("nan")), "nanj")
+
+        assert_format(complex(0.0, 1.0), "1j")
+        assert_format(complex(-0.0, 1.0), "(-0+1j)")
+        assert_format(complex(0.0, -1.0), "-1j")
+        assert_format(complex(-0.0, -1.0), "(-0-1j)")
+        assert_format(complex(0.0, 0.0), "0j")
+        assert_format(complex(0.0, -0.0), "-0j")
+        assert_format(complex(-0.0, 0.0), "(-0+0j)")
+        assert_format(complex(-0.0, -0.0), "(-0-0j)")
+
     def test_BinOp(self, complex_type):
         mod = self.compile(f"""
         T = {complex_type}

--- a/spy/vm/primitive.py
+++ b/spy/vm/primitive.py
@@ -443,6 +443,10 @@ class W_F32(W_Object):
 @B.builtin_type("complex128", lazy_definition=True)
 class W_Complex128(W_Object):
     __spy_storage_category__ = "value"
+    __spy_lazy_attributes__ = {
+        "__str__": FQN("_complex::methods::__str__"),
+        "__repr__": FQN("_complex::methods::__repr__"),
+    }
     value: complex
     w_real: Annotated[W_F64, Member("real")]
     w_imag: Annotated[W_F64, Member("imag")]
@@ -487,12 +491,6 @@ class W_Complex128(W_Object):
 
     def spy_key(self, vm: "SPyVM") -> complex:
         return self.value
-
-    @builtin_method("__str__")
-    @staticmethod
-    def w_str(vm: "SPyVM", w_self: "W_Complex128") -> "W_Str":
-        c = vm.unwrap_complex128(w_self)
-        return vm.wrap(str(c))
 
     @builtin_method("conjugate")
     @staticmethod

--- a/stdlib/_complex.spy
+++ b/stdlib/_complex.spy
@@ -1,0 +1,39 @@
+def _strip_integral_suffix(value: str) -> str:
+    if len(value) >= 2 and value[-2:] == ".0":
+        return value[:-2]
+    return value
+
+
+def _format(value: complex128) -> str:
+    real = str(value.real)
+    imag = str(value.imag)
+
+    if real == "0.0":
+        return _strip_integral_suffix(imag) + "j"
+
+    sign = "+"
+    if imag[0] == "-":
+        sign = ""
+    return (
+        "("
+        + _strip_integral_suffix(real)
+        + sign
+        + _strip_integral_suffix(imag)
+        + "j)"
+    )
+
+
+@struct
+class methods:
+    """
+    A fake empty struct used as a container for app-level complex128 methods.
+
+    Each method must have a corresponding entry in
+    W_Complex128.__spy_lazy_attributes__.
+    """
+
+    def __str__(self: complex128) -> str:
+        return _format(self)
+
+    def __repr__(self: complex128) -> str:
+        return _format(self)


### PR DESCRIPTION
Complex values previously inherited `object`’s identity-based representation in the interpreter, while C builds generated a call to a missing generic `repr` symbol.

Implement `complex128.__str__` and `complex128.__repr__` once in app-level SPy, exposed through lazy attributes like the existing `str` and `bytes` methods. The formatter composes canonical `f64` strings according to CPython’s complex formatting rules, so interpreter, Doppler, and C builds share the same behavior.

Adapt CPython’s tests for ordinary values, infinities, NaNs, pure imaginary values, and the full signed-zero matrix.