### PR TITLE
Add value-based repr for None

### DIFF
--- a/spy/tests/compiler/test_str.py
+++ b/spy/tests/compiler/test_str.py
@@ -408,13 +408,17 @@ class TestStr(CompilerTest):
         mod = self.compile(src)
         assert mod.foo("hello") == "hello"
 
-    def test_str_none(self):
+    def test_str_repr_none(self):
         src = """
-        def foo() -> str:
+        def none_str() -> str:
             return str(None)
+
+        def none_repr() -> str:
+            return repr(None)
         """
         mod = self.compile(src)
-        assert mod.foo() == "None"
+        assert mod.none_str() == "None"
+        assert mod.none_repr() == "None"
 
     def test_str_not_implemented(self):
         src = """

--- a/spy/vm/primitive.py
+++ b/spy/vm/primitive.py
@@ -40,12 +40,21 @@ class W_NoneType(W_Object):
     def spy_unwrap(self, vm: "SPyVM") -> None:
         return None
 
-    @builtin_method("__str__", color="blue", kind="metafunc")
     @staticmethod
-    def w_STR(vm: "SPyVM", wam_self: "W_MetaArg") -> "W_OpSpec":
+    def _w_format(vm: "SPyVM") -> "W_OpSpec":
         from spy.vm.opspec import W_OpSpec
 
         return W_OpSpec.const(vm.wrap("None"))
+
+    @builtin_method("__str__", color="blue", kind="metafunc")
+    @staticmethod
+    def w_STR(vm: "SPyVM", wam_self: "W_MetaArg") -> "W_OpSpec":
+        return W_NoneType._w_format(vm)
+
+    @builtin_method("__repr__", color="blue", kind="metafunc")
+    @staticmethod
+    def w_REPR(vm: "SPyVM", wam_self: "W_MetaArg") -> "W_OpSpec":
+        return W_NoneType._w_format(vm)
 
 
 B.add("None", W_NoneType.__new__(W_NoneType))


### PR DESCRIPTION
`None` previously inherited `object`’s identity-based representation in the interpreter, while C builds generated a call to a missing generic `repr` symbol.

Define `NoneType.__repr__` alongside `__str__` and share one constant-producing metafunction helper, giving both operations the canonical `None` spelling on every backend.