### PR TITLE
Add value-based repr for NotImplemented

### DIFF
--- a/spy/tests/compiler/test_str.py
+++ b/spy/tests/compiler/test_str.py
@@ -420,13 +420,17 @@ class TestStr(CompilerTest):
         assert mod.none_str() == "None"
         assert mod.none_repr() == "None"
 
-    def test_str_not_implemented(self):
+    def test_str_repr_not_implemented(self):
         src = """
-        def foo() -> str:
+        def not_implemented_str() -> str:
             return str(NotImplemented)
+
+        def not_implemented_repr() -> str:
+            return repr(NotImplemented)
         """
         mod = self.compile(src)
-        assert mod.foo() == "NotImplemented"
+        assert mod.not_implemented_str() == "NotImplemented"
+        assert mod.not_implemented_repr() == "NotImplemented"
 
     def test_escaped_c_literal(self):
         # See https://github.com/spylang/spy/issues/255

--- a/spy/vm/primitive.py
+++ b/spy/vm/primitive.py
@@ -563,12 +563,21 @@ class W_NotImplementedType(W_Object):
         # create additional instances
         raise Exception("You cannot instantiate W_NotImplementedType")
 
-    @builtin_method("__str__", color="blue", kind="metafunc")
     @staticmethod
-    def w_STR(vm: "SPyVM", wam_self: "W_MetaArg") -> "W_OpSpec":
+    def _w_format(vm: "SPyVM") -> "W_OpSpec":
         from spy.vm.opspec import W_OpSpec
 
         return W_OpSpec.const(vm.wrap("NotImplemented"))
+
+    @builtin_method("__str__", color="blue", kind="metafunc")
+    @staticmethod
+    def w_STR(vm: "SPyVM", wam_self: "W_MetaArg") -> "W_OpSpec":
+        return W_NotImplementedType._w_format(vm)
+
+    @builtin_method("__repr__", color="blue", kind="metafunc")
+    @staticmethod
+    def w_REPR(vm: "SPyVM", wam_self: "W_MetaArg") -> "W_OpSpec":
+        return W_NotImplementedType._w_format(vm)
 
 
 B.add("NotImplemented", W_NotImplementedType.__new__(W_NotImplementedType))


### PR DESCRIPTION
`NotImplemented` previously inherited `object`’s identity-based representation in the interpreter, while generated C could not represent the singleton constant used by the generic `repr` path.

Define `NotImplementedType.__repr__` alongside `__str__` and share one constant-producing metafunction helper. Both operations now produce the canonical `NotImplemented` spelling and fold to a string before C generation.