### PR TITLE
Add repr support for range

### DIFF
--- a/spy/tests/stdlib/test__range.py
+++ b/spy/tests/stdlib/test__range.py
@@ -16,6 +16,27 @@ class TestRange(CompilerTest):
         assert r.start == 0
         assert r.stop == 10
 
+    def test_repr_str(self):
+        mod = self.compile("""
+        from _range import range
+
+        def repr1() -> str:
+            return repr(range(1))
+
+        def repr2() -> str:
+            return repr(range(1, 2))
+
+        def repr3() -> str:
+            return repr(range(1, 2, 3))
+
+        def str3() -> str:
+            return str(range(1, 2, 3))
+        """)
+        assert mod.repr1() == "range(0, 1)"
+        assert mod.repr2() == "range(1, 2)"
+        assert mod.repr3() == "range(1, 2, 3)"
+        assert mod.str3() == "range(1, 2, 3)"
+
     def test_fastiter(self):
         src = """
         from _range import range, range_iterator

--- a/stdlib/_range.spy
+++ b/stdlib/_range.spy
@@ -34,6 +34,12 @@ class range:
         else:
             return OpSpec.NULL
 
+    def __repr__(self) -> str:
+        result = "range(" + str(self.start) + ", " + str(self.stop)
+        if self.step != 1:
+            result = result + ", " + str(self.step)
+        return result + ")"
+
     def __contains__(self, value: int) -> bool:
         if self.step > 0:
             if value < self.start or value >= self.stop:


### PR DESCRIPTION
`range` previously inherited `object`’s identity-based representation, and compiled backends could fail while lowering that generic path.

Implement `range.__repr__` in app-level SPy using CPython’s normalized spelling: always include `start` and `stop`, and include `step` only when it differs from one. `str(range)` inherits the same representation through the existing object fallback.