### PR TITLE
Reject zero-step ranges

### DIFF
--- a/spy/tests/stdlib/test__range.py
+++ b/spy/tests/stdlib/test__range.py
@@ -1,5 +1,6 @@
 import pytest
 
+from spy.errors import SPyError
 from spy.tests.support import CompilerTest
 
 
@@ -36,6 +37,16 @@ class TestRange(CompilerTest):
         assert mod.repr2() == "range(1, 2)"
         assert mod.repr3() == "range(1, 2, 3)"
         assert mod.str3() == "range(1, 2, 3)"
+
+    def test_zero_step(self):
+        mod = self.compile("""
+        from _range import range
+
+        def make_range_with_zero_step() -> range:
+            return range(1, 2, 0)
+        """)
+        with SPyError.raises("W_ValueError", match=r"range\(\) arg 3 must not be zero"):
+            mod.make_range_with_zero_step()
 
     def test_fastiter(self):
         src = """

--- a/stdlib/_range.spy
+++ b/stdlib/_range.spy
@@ -16,6 +16,8 @@ class range:
             return range.__make__(a, b, 1)
 
         def impl3(a: int, b: int, c: int) -> range:
+            if c == 0:
+                raise ValueError("range() arg 3 must not be zero")
             return range.__make__(a, b, c)
 
         # we cannot do list(args_m), so we need to do it manually somehow :(


### PR DESCRIPTION
SPy previously allowed `range(start, stop, 0)`, creating a range that could not iterate correctly. Match CPython by validating the third constructor argument and raising `ValueError` with the canonical diagnostic when it is zero.