### PR TITLE
Add length support for range

### DIFF
--- a/spy/tests/stdlib/test__range.py
+++ b/spy/tests/stdlib/test__range.py
@@ -48,6 +48,20 @@ class TestRange(CompilerTest):
         with SPyError.raises("W_ValueError", match=r"range\(\) arg 3 must not be zero"):
             mod.make_range_with_zero_step()
 
+    def test_len(self):
+        mod = self.compile("""
+        from _range import range
+
+        def range_len(start: int, stop: int, step: int) -> int:
+            return len(range(start, stop, step))
+        """)
+        assert mod.range_len(0, 10, 3) == 4
+        assert mod.range_len(10, 0, -3) == 4
+        assert mod.range_len(10, 0, 3) == 0
+        assert mod.range_len(0, 10, -3) == 0
+        assert mod.range_len(5, 5, 1) == 0
+        assert mod.range_len(-10, -1, 2) == 5
+
     def test_fastiter(self):
         src = """
         from _range import range, range_iterator

--- a/stdlib/_range.spy
+++ b/stdlib/_range.spy
@@ -42,6 +42,16 @@ class range:
             result = result + ", " + str(self.step)
         return result + ")"
 
+    def __len__(self) -> i32:
+        if self.step > 0:
+            if self.start >= self.stop:
+                return 0
+            return (self.stop - self.start - 1) // self.step + 1
+
+        if self.start <= self.stop:
+            return 0
+        return (self.start - self.stop - 1) // -self.step + 1
+
     def __contains__(self, value: int) -> bool:
         if self.step > 0:
             if value < self.start or value >= self.stop:


### PR DESCRIPTION
Implement `range.__len__` in app-level SPy using CPython’s arithmetic for positive and negative steps. Empty and direction-mismatched ranges return zero; non-empty ranges use constant-time integer calculation rather than iteration.

Cover forward, reverse, empty, negative-bound, and mismatched-direction cases.