### PR TITLE
Add integer indexing for range

### DIFF
--- a/spy/tests/stdlib/test__range.py
+++ b/spy/tests/stdlib/test__range.py
@@ -62,6 +62,31 @@ class TestRange(CompilerTest):
         assert mod.range_len(5, 5, 1) == 0
         assert mod.range_len(-10, -1, 2) == 5
 
+    def test_getitem(self):
+        mod = self.compile("""
+        from _range import range
+
+        def getitem(start: int, stop: int, step: int, index: int) -> int:
+            return range(start, stop, step)[index]
+        """)
+
+        # Positive indices
+        assert mod.getitem(0, 10, 2, 0) == 0
+        assert mod.getitem(0, 10, 2, 3) == 6
+        assert mod.getitem(10, 0, -2, 2) == 6
+
+        # Negative indices
+        assert mod.getitem(0, 10, 2, -1) == 8
+        assert mod.getitem(10, 0, -2, -2) == 4
+
+        # Out of bounds
+        with SPyError.raises("W_IndexError"):
+            mod.getitem(0, 10, 2, 5)
+        with SPyError.raises("W_IndexError"):
+            mod.getitem(0, 10, 2, -6)
+        with SPyError.raises("W_IndexError"):
+            mod.getitem(0, 0, 1, 0)
+
     def test_fastiter(self):
         src = """
         from _range import range, range_iterator

--- a/stdlib/_range.spy
+++ b/stdlib/_range.spy
@@ -52,6 +52,14 @@ class range:
             return 0
         return (self.start - self.stop - 1) // -self.step + 1
 
+    def __getitem__(self, index: int) -> int:
+        length = len(self)
+        if index < 0:
+            index = index + length
+        if index < 0 or index >= length:
+            raise IndexError
+        return self.start + index * self.step
+
     def __contains__(self, value: int) -> bool:
         if self.step > 0:
             if value < self.start or value >= self.stop:


### PR DESCRIPTION
Implement constant-time `range[index]` lookup in app-level SPy using the range start, step, and computed length.

Normalize negative indices like CPython and raise `IndexError` for positive overflow, overly negative indices, and empty ranges.