### PR TITLE
Add initial support for string .join() method

### DIFF
--- a/examples/1_high_level/string_manipulation.spy
+++ b/examples/1_high_level/string_manipulation.spy
@@ -1,0 +1,6 @@
+def foo(s: str) -> None:
+    print(" ".join(s.split()))
+
+
+def main() -> None:
+    foo("hello world from spy")

--- a/examples/expected_output/string_manipulation.txt
+++ b/examples/expected_output/string_manipulation.txt
@@ -1,0 +1,1 @@
+hello world from spy

--- a/spy/tests/compiler/test_str.py
+++ b/spy/tests/compiler/test_str.py
@@ -129,6 +129,32 @@ class TestStr(CompilerTest):
         assert mod.split_whitespace("  a    b   c   ") == ["a", "b", "c"]
         assert mod.split_whitespace("\n\ta \t\r b \v ") == ["a", "b"]
 
+    def test_join(self):
+        mod = self.compile("""
+            def join_words(sep: str) -> str:
+                return sep.join(["a", "b", "c"])
+
+            def join_single(sep: str) -> str:
+                return sep.join(["one"])
+
+            def join_empty(sep: str) -> str:
+                return sep.join([])
+
+            def join_empty_items(sep: str) -> str:
+                return sep.join(["", "a", "", "b", ""])
+
+            def split_then_join(s: str) -> str:
+                return " ".join(s.split())
+        """)
+
+        assert mod.join_words(" ") == "a b c"
+        assert mod.join_words("") == "abc"
+        assert mod.join_words("-") == "a-b-c"
+        assert mod.join_single("x") == "one"
+        assert mod.join_empty("-") == ""
+        assert mod.join_empty_items(",") == ",a,,b,"
+        assert mod.split_then_join("hello  world  from spy") == "hello world from spy"
+
     def test_find(self):
         mod = self.compile("""
             def find(s: str, sub: str) -> i32:

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -49,6 +49,7 @@ class W_Str(W_Object):
         "replace": FQN("_str::methods::replace"),
         "__contains__": FQN("_str::methods::__contains__"),
         "split": FQN("_str::methods::split"),
+        "join": FQN("_str::methods::join"),
         "isspace": FQN("_str::methods::isspace"),
         "find": FQN("_str::methods::find"),
         "count": FQN("_str::methods::count"),

--- a/stdlib/_str.spy
+++ b/stdlib/_str.spy
@@ -400,6 +400,31 @@ class methods:
 
         return OpSpec.NULL
 
+    def join(self: str, items: list[str]) -> str:
+        n = len(items)
+        if n == 0:
+            return ""
+        ll_sep = StrObject.from_str(self)
+        sep_len = ll_sep.length
+
+        total_len: i32 = (n - 1) * sep_len
+        for i in range(n):
+            total_len = total_len + len(items[i])
+
+        out = StrObject.alloc(total_len)
+        out.hash = 0
+        pos: i32 = 0
+        for j in range(n):
+            if j > 0 and sep_len > 0:
+                ptr_copy_slice(out.utf8, pos, pos + sep_len, ll_sep.utf8, 0, sep_len)
+                pos = pos + sep_len
+            item = items[j]
+            ll_item = StrObject.from_str(item)
+            item_len = ll_item.length
+            if item_len > 0:
+                ptr_copy_slice(out.utf8, pos, pos + item_len, ll_item.utf8, 0, item_len)
+                pos = pos + item_len
+        return StrObject.to_str(out)
 
     def isspace(self: str) -> bool:
         """


### PR DESCRIPTION
As titled, 

This PR intends to add support for `str.join()` method.

Note: I did not use blue metafunc because the right now `join()` implementation has a fixed signature: `join(self, items: list[str])`. If we want to support something like `join(*items)` I can change it into a blue metafunc as required. 