### PR TITLE
Add slicing support for range

### DIFF
--- a/spy/tests/stdlib/test__range.py
+++ b/spy/tests/stdlib/test__range.py
@@ -87,6 +87,68 @@ class TestRange(CompilerTest):
         with SPyError.raises("W_IndexError"):
             mod.getitem(0, 0, 1, 0)
 
+    def test_getitem_slice(self):
+        mod = self.compile("""
+        from _range import range
+
+        def first_two() -> range:
+            return range(10)[0:2]
+
+        def clipped_stop() -> range:
+            return range(1, 9, 3)[0:20]
+
+        def clipped_len() -> int:
+            return len(range(1, 9, 3)[0:20])
+
+        def empty() -> range:
+            return range(10)[20:30]
+
+        def empty_len() -> int:
+            return len(range(10)[20:30])
+        """)
+        result = mod.first_two()
+        assert (result.start, result.stop, result.step) == (0, 2, 1)
+        result = mod.clipped_stop()
+        assert (result.start, result.stop, result.step) == (1, 10, 3)
+        assert mod.clipped_len() == 3
+        result = mod.empty()
+        assert mod.empty_len() == 0
+
+    def test_getitem_slice_negative_indices_and_step(self):
+        mod = self.compile("""
+        from _range import range
+
+        def without_last() -> range:
+            return range(10)[0:-1]
+
+        def every_other_from_last() -> range:
+            return range(10)[-1:100:2]
+
+        def reverse_middle() -> range:
+            return range(10)[-1:-3:-1]
+
+        def reverse_descending_range() -> range:
+            return range(8, 0, -3)[::-1]
+        """)
+        result = mod.without_last()
+        assert (result.start, result.stop, result.step) == (0, 9, 1)
+        result = mod.every_other_from_last()
+        assert (result.start, result.stop, result.step) == (9, 10, 2)
+        result = mod.reverse_middle()
+        assert (result.start, result.stop, result.step) == (9, 7, -1)
+        result = mod.reverse_descending_range()
+        assert (result.start, result.stop, result.step) == (2, 11, 3)
+
+    def test_getitem_slice_zero_step(self):
+        mod = self.compile("""
+        from _range import range
+
+        def zero_step() -> range:
+            return range(10)[::0]
+        """)
+        with SPyError.raises("W_ValueError", match="slice step cannot be zero"):
+            mod.zero_step()
+
     def test_fastiter(self):
         src = """
         from _range import range, range_iterator

--- a/stdlib/_range.spy
+++ b/stdlib/_range.spy
@@ -1,4 +1,5 @@
 from operator import OpSpec, MetaArg
+from _slice import Slice
 
 
 @struct
@@ -52,13 +53,29 @@ class range:
             return 0
         return (self.start - self.stop - 1) // -self.step + 1
 
-    def __getitem__(self, index: int) -> int:
+    @blue.metafunc
+    def __getitem__(m_self, m_index: MetaArg):
+        if m_index.static_type == i32:
+            return OpSpec(range._getitem_int)
+        elif m_index.static_type == Slice:
+            return OpSpec(range._getitem_slice)
+        return OpSpec.NULL
+
+    def _getitem_int(self, index: int) -> int:
         length = len(self)
         if index < 0:
             index = index + length
         if index < 0 or index >= length:
             raise IndexError
         return self.start + index * self.step
+
+    def _getitem_slice(self, s: Slice) -> range:
+        indices = s.indices(len(self))
+        return range(
+            self.start + indices.start * self.step,
+            self.start + indices.stop * self.step,
+            self.step * indices.step,
+        )
 
     def __contains__(self, value: int) -> bool:
         if self.step > 0:


### PR DESCRIPTION
Dispatch `range.__getitem__` between integer indices and slices, preserving the existing constant-time integer lookup.

Normalize slices through `Slice.indices` and compose the resulting start, stop, and step without iterating the range. Cover clipping, empty slices, negative indices, reverse slices, descending ranges, and zero-step errors.