### PR TITLE
ptr._debug_get_length

### DIFF
--- a/spy/backend/c/cstructwriter.py
+++ b/spy/backend/c/cstructwriter.py
@@ -214,4 +214,5 @@ class CStructWriter:
         self.tbh_ptrs_def.wb(f"""
         #define {c_reftype}_from_addr {c_ptrtype}_from_addr
         #define {c_reftype}$deref {c_ptrtype}$deref
+        #define {c_reftype}$debug_get_length {c_ptrtype}$debug_get_length
         """)

--- a/spy/libspy/include/spy/unsafe.h
+++ b/spy/libspy/include/spy/unsafe.h
@@ -92,6 +92,11 @@ spy_gc_alloc_pointerless_bdwgc(size_t size) {
     }                                                                                  \
     static inline bool PTR##$to_bool(PTR p) {                                          \
         return p.p;                                                                    \
+    }                                                                                  \
+    static inline ptrdiff_t PTR##$debug_get_length(PTR p) {                            \
+        spy_panic("PanicError", "_debug_get_length called in release mode",            \
+            __FILE__, __LINE__);                                                       \
+        return 0;                                                                      \
     }
 
 #define _SPY_PTR_FUNCTIONS_CHECKED(ALLOC_FUNC, PTR, T)                                 \
@@ -139,6 +144,9 @@ spy_gc_alloc_pointerless_bdwgc(size_t size) {
     }                                                                                  \
     static inline bool PTR##$to_bool(PTR p) {                                          \
         return p.p;                                                                    \
+    }                                                                                  \
+    static inline ptrdiff_t PTR##$debug_get_length(PTR p) {                            \
+        return p.length;                                                               \
     }
 
 /* gc_ptr[u8] is predeclared here, see also cstructwriter.py:emit_PtrType.

--- a/spy/tests/compiler/unsafe/test_ptr.py
+++ b/spy/tests/compiler/unsafe/test_ptr.py
@@ -64,6 +64,23 @@ class TestUnsafePtr(CompilerTest):
         assert mod.bar(1) == 3.4
         assert mod.bar(2) == 5.6
 
+    def test_debug_get_length(self, memkind):
+        k = memkind
+        mod = self.compile(f"""
+        from unsafe import {k}_alloc as k_alloc, {k}_ptr as k_ptr
+
+        def ptr_length(n: i32) -> i32:
+            buf = k_alloc[i32](n)
+            return buf._debug_get_length()
+
+        def null_length() -> i32:
+            return k_ptr[i32].NULL._debug_get_length()
+        """)
+        assert mod.ptr_length(0) == 0
+        assert mod.ptr_length(1) == 1
+        assert mod.ptr_length(42) == 42
+        assert mod.null_length() == 0
+
     def test_gc_ptr_u8(self):
         # gc_ptr[u8] is special-cased and predeclared manually in unsafe.h. Exercise
         # alloc/store/load and bounds-checking to make sure that everything works.
@@ -80,8 +97,13 @@ class TestUnsafePtr(CompilerTest):
         def out_of_bound() -> u8:
             buf = gc_alloc[u8](3)
             return buf[3]
+
+        def get_length() -> i32:
+            buf = gc_alloc[u8](5)
+            return buf._debug_get_length()
         """)
         assert mod.foo() == 6
+        assert mod.get_length() == 5
         with SPyError.raises("W_PanicError", match="ptr_getitem out of bounds"):
             mod.out_of_bound()
 

--- a/spy/vm/modules/unsafe/ptr.py
+++ b/spy/vm/modules/unsafe/ptr.py
@@ -475,6 +475,18 @@ class W_Ptr(W_MemLoc):
         else:
             return W_OpSpec.NULL
 
+    @builtin_method("_debug_get_length", color="blue", kind="metafunc")
+    @staticmethod
+    def w_DEBUG_GET_LENGTH(vm: "SPyVM", wam_self: W_MetaArg) -> W_OpSpec:
+        w_T = W_Ptr._get_memlocT(wam_self)
+        PTR = Annotated[W_Ptr, w_T]
+
+        @vm.register_builtin_func(w_T.fqn, "debug_get_length")
+        def w_debug_get_length(vm: "SPyVM", w_ptr: PTR) -> W_I32:
+            return vm.wrap(w_ptr.length)
+
+        return W_OpSpec(w_debug_get_length, [wam_self])
+
 
 class W_Ref(W_MemLoc):
     """


### PR DESCRIPTION
`ptr._debug_get_length` is mostly a testing utility to get the length of a pointer in DEBUG mode. It panics in RELEASE mode.