### PR TITLE
Support mod.metafunc() call

### DIFF
--- a/spy/tests/compiler/test_metafunc.py
+++ b/spy/tests/compiler/test_metafunc.py
@@ -38,6 +38,40 @@ class TestMetaFunc(CompilerTest):
         assert mod.test1() == 10
         assert mod.test2() == "hello world"
 
+    def test_call_via_module_attr(self):
+        # Regression test: calling a @blue.metafunc through a module
+        # attribute (`mod.foo(...)`) used to fail with "cannot call blue
+        # function with red arguments", because W_Module.__call_method__
+        # built a direct OpSpec instead of metacalling `foo`.
+        src = """
+        from operator import OpSpec
+
+        @blue.metafunc
+        def foo(m_x):
+            if m_x.static_type == i32:
+                def impl_i32(x: i32) -> i32:
+                    return x * 2
+                return OpSpec(impl_i32)
+            elif m_x.static_type == str:
+                def impl_str(x: str) -> str:
+                    return x + ' world'
+                return OpSpec(impl_str)
+            raise StaticError("unsupported type")
+        """
+        self.write_file("mymod.spy", src)
+
+        mod = self.compile("""
+        import mymod
+
+        def test1() -> i32:
+            return mymod.foo(5)
+
+        def test2() -> str:
+            return mymod.foo('hello')
+        """)
+        assert mod.test1() == 10
+        assert mod.test2() == "hello world"
+
     def test_method(self):
         mod = self.compile("""
         from operator import OpSpec

--- a/spy/vm/module.py
+++ b/spy/vm/module.py
@@ -75,7 +75,14 @@ class W_Module(W_Object):
             return W_OpSpec.NULL
 
         if isinstance(w_func, W_Func):
-            return W_OpSpec(w_func, list(args_wam))
+            wam_func = W_MetaArg.from_w_obj(vm, w_func, color="blue")
+            kind = w_func.w_functype.kind
+            if kind == "plain":
+                return W_Func.op_CALL(vm, wam_func, *args_wam)
+            elif kind == "metafunc":
+                return W_Func.op_METACALL(vm, wam_func, *args_wam)
+            else:
+                return W_OpSpec.NULL
         else:
             raise WIP("trying to call a non-function (we should emit a better error)")
 


### PR DESCRIPTION
SPy fails to call a metafunc like this `mymod.foo(5)`.

Using `W_Func.op_METACALL`  in module.py fixes this issue.