### PR TITLE
Add truth-value support for range

### DIFF
--- a/spy/tests/stdlib/test__range.py
+++ b/spy/tests/stdlib/test__range.py
@@ -190,6 +190,20 @@ class TestRange(CompilerTest):
         assert not mod.eq(0, 10, 2, 0, 10, 3)
         assert mod.ne(0, 10, 2, 0, 10, 3)
 
+    def test_truth(self):
+        mod = self.compile("""
+        from _range import range
+
+        def is_truthy(start: int, stop: int, step: int) -> bool:
+            if range(start, stop, step):
+                return True
+            return False
+        """)
+        assert mod.is_truthy(0, 1, 1) is True
+        assert mod.is_truthy(10, 0, -3) is True
+        assert mod.is_truthy(0, 0, 1) is False
+        assert mod.is_truthy(10, 0, 3) is False
+
     def test_fastiter(self):
         src = """
         from _range import range, range_iterator

--- a/stdlib/_range.spy
+++ b/stdlib/_range.spy
@@ -43,6 +43,16 @@ class range:
             result = result + ", " + str(self.step)
         return result + ")"
 
+    @blue.metafunc
+    def __convert_to__(m_expT, m_gotT, m_self):
+        if m_expT.blueval == bool:
+
+            def to_bool(self: range) -> bool:
+                return len(self) != 0
+
+            return OpSpec(to_bool, [m_self])
+        return OpSpec.NULL
+
     def __len__(self) -> i32:
         if self.step > 0:
             if self.start >= self.stop:


### PR DESCRIPTION
Allow ranges to convert implicitly to `bool`, matching SPy’s condition-conversion model and CPython’s range behavior.

The app-level conversion reuses `range.__len__`: non-empty forward and reverse ranges are true, while empty and direction-mismatched ranges are false.