### PR TITLE
Add CPython based bloom filter when doing str.strip()

### DIFF
--- a/spy/tests/compiler/test_str.py
+++ b/spy/tests/compiler/test_str.py
@@ -462,6 +462,30 @@ class TestStr(CompilerTest):
         assert mod.upper("ABC123") == "ABC123"
         assert mod.upper("") == ""
 
+    def test_strip(self):
+        src = """
+        def strip(s: str) -> str:
+            return s.strip()
+
+        def strip_chars(s: str, chars: str) -> str:
+            return s.strip(chars)
+        """
+        mod = self.compile(src)
+        # no-args
+        assert mod.strip("  hello  ") == "hello"
+        assert mod.strip("hello") == "hello"
+        assert mod.strip("   ") == ""
+        assert mod.strip("") == ""
+        assert mod.strip("\t\n hello \t\n") == "hello"
+        assert mod.strip(" \t\r\n") == ""
+        # with chars
+        assert mod.strip_chars("xxhelloxx", "x") == "hello"
+        assert mod.strip_chars("abchelloabc", "abc") == "hello"
+        assert mod.strip_chars("xyxhelloxyx", "xy") == "hello"
+        assert mod.strip_chars("hello", "") == "hello"
+        assert mod.strip_chars("hello", "xyz") == "hello"
+        assert mod.strip_chars("aaaa", "a") == ""
+
     def test_str_replace(self):
         mod = self.compile("""
         def foo(s: str, old: str, new: str) -> str:

--- a/spy/tests/compiler/test_str.py
+++ b/spy/tests/compiler/test_str.py
@@ -486,6 +486,22 @@ class TestStr(CompilerTest):
         assert mod.strip_chars("hello", "xyz") == "hello"
         assert mod.strip_chars("aaaa", "a") == ""
 
+    def test_strip_chars_bloom(self):
+        src = """
+        def strip_chars(s: str, chars: str) -> str:
+            return s.strip(chars)
+        """
+        mod = self.compile(src)
+        # false positives must be rejected by the linear scan
+        assert mod.strip_chars("!!a!!", "!") == "a"
+        assert mod.strip_chars("a!a", "!") == "a!a"
+        assert mod.strip_chars("!!ab!!", "!") == "ab"
+        # a very long chars set test case
+        big_chars = "".join(chr(i) for i in range(128) if chr(i) not in "hello")
+        assert mod.strip_chars("xxhello" + big_chars, "xx" + big_chars) == "hello"
+        assert mod.strip_chars(big_chars + "hello" + big_chars, big_chars) == "hello"
+        assert mod.strip_chars("hello", big_chars) == "hello"
+
     def test_str_replace(self):
         mod = self.compile("""
         def foo(s: str, old: str, new: str) -> str:

--- a/spy/vm/str.py
+++ b/spy/vm/str.py
@@ -50,6 +50,7 @@ class W_Str(W_Object):
         "__contains__": FQN("_str::methods::__contains__"),
         "split": FQN("_str::methods::split"),
         "isspace": FQN("_str::methods::isspace"),
+        "strip": FQN("_str::methods::strip"),
         "find": FQN("_str::methods::find"),
         "count": FQN("_str::methods::count"),
         "__repr__": FQN("_str::methods::__repr__"),

--- a/stdlib/_str.spy
+++ b/stdlib/_str.spy
@@ -418,6 +418,15 @@ class methods:
         return True
 
     @blue.metafunc
+    def strip(m_self, *args_m):
+        nargs = len(args_m)
+        if nargs == 0:
+            return OpSpec(_strip_whitespace)
+        elif nargs == 1:
+            return OpSpec(_strip_chars)
+        return OpSpec.NULL
+
+    @blue.metafunc
     def find(m_self, *args_m):
         # str.find(sub[, start[, end]]) -> i32
         nargs = len(args_m)
@@ -541,6 +550,62 @@ def _count_2(self: str, sub: str, start: i32) -> i32:
 
 def _count_3(self: str, sub: str, start: i32, end: i32) -> i32:
     return _str_count(self, sub, start, end)
+
+
+def _strip_whitespace(self: str) -> str:
+    ll = StrObject.from_str(self)
+    length = ll.length
+    start = 0
+    end = length
+    while start < end and _ll_isspace(ll.utf8[start]):
+        start = start + 1
+    while end > start and _ll_isspace(ll.utf8[end - 1]):
+        end = end - 1
+    new_len = end - start
+    if new_len == length:
+        return self
+    out = StrObject.alloc(new_len)
+    out.hash = 0
+    if new_len > 0:
+        ptr_copy_slice(out.utf8, 0, new_len, ll.utf8, start, end)
+    return StrObject.to_str(out)
+
+
+def _strip_chars(self: str, chars: str) -> str:
+    ll = StrObject.from_str(self)
+    llchars = StrObject.from_str(chars)
+    length = ll.length
+    chars_len = llchars.length
+    if chars_len == 0:
+        return self
+    start = 0
+    end = length
+    while start < end:
+        found = False
+        for i in range(chars_len):
+            if ll.utf8[start] == llchars.utf8[i]:
+                found = True
+                break
+        if not found:
+            break
+        start = start + 1
+    while end > start:
+        found = False
+        for j in range(chars_len):
+            if ll.utf8[end - 1] == llchars.utf8[j]:
+                found = True
+                break
+        if not found:
+            break
+        end = end - 1
+    new_len = end - start
+    if new_len == length:
+        return self
+    out = StrObject.alloc(new_len)
+    out.hash = 0
+    if new_len > 0:
+        ptr_copy_slice(out.utf8, 0, new_len, ll.utf8, start, end)
+    return StrObject.to_str(out)
 
 
 def _split_sep(self: str, sep: str) -> list[str]:

--- a/stdlib/_str.spy
+++ b/stdlib/_str.spy
@@ -571,6 +571,20 @@ def _strip_whitespace(self: str) -> str:
     return StrObject.to_str(out)
 
 
+def _ll_char_in_chars(
+    mask: u64, llchars: gc_ptr[StrObject], chars_len: i32, ch: u8
+) -> bool:
+    if (mask & (u64(i64(1)) << (u64(i64(ch)) & u64(i64(63))))) == u64(i64(0)):
+        # `ch` is not in `chars`
+        return False
+    # bloom filter can have false positives
+    # confirm with a linear scan
+    for i in range(chars_len):
+        if ch == llchars.utf8[i]:
+            return True
+    return False
+
+
 def _strip_chars(self: str, chars: str) -> str:
     ll = StrObject.from_str(self)
     llchars = StrObject.from_str(chars)
@@ -578,24 +592,18 @@ def _strip_chars(self: str, chars: str) -> str:
     chars_len = llchars.length
     if chars_len == 0:
         return self
+    # bloom filter over `chars`, mirrors CPython's _PyUnicode_XStrip
+    mask: u64 = u64(i64(0))
+    for i in range(chars_len):
+        mask = mask | (u64(i64(1)) << (u64(i64(llchars.utf8[i])) & u64(i64(63))))
     start = 0
     end = length
     while start < end:
-        found = False
-        for i in range(chars_len):
-            if ll.utf8[start] == llchars.utf8[i]:
-                found = True
-                break
-        if not found:
+        if not _ll_char_in_chars(mask, llchars, chars_len, ll.utf8[start]):
             break
         start = start + 1
     while end > start:
-        found = False
-        for j in range(chars_len):
-            if ll.utf8[end - 1] == llchars.utf8[j]:
-                found = True
-                break
-        if not found:
+        if not _ll_char_in_chars(mask, llchars, chars_len, ll.utf8[end - 1]):
             break
         end = end - 1
     new_len = end - start


### PR DESCRIPTION
Follow-up from #670 (See: https://github.com/spylang/spy/pull/670#pullrequestreview-5167456756)

This PR intends to add a CPython like bloom filter in order to outright reject a string when the given character is not present in the original string.

CPython implementations at: 

https://github.com/python/cpython/blob/1f25c333a280561e86cc0af69af307b53ddbaaac/Objects/unicodeobject.c#L12675-L12684

https://github.com/python/cpython/blob/main/Objects/unicodeobject.c#L891