### PR TITLE
Add conda based non-static bdw-gc support during compiler initialization

### DIFF
--- a/spy/build/config.py
+++ b/spy/build/config.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import subprocess
 import sys
@@ -126,9 +127,19 @@ class CompilerConfig:
                 self.ldflags += ["-L", f"{gc_prefix}/lib", "-lgc"]
             else:
                 self.ldflags += ["-lgc"]
-                # On macOS, Homebrew installs bdw-gc outside the default
-                # compiler search paths
-                if sys.platform == "darwin" and shutil.which("brew"):
+                conda_prefix = os.environ.get("CONDA_PREFIX")
+                if conda_prefix and os.path.exists(
+                    os.path.join(conda_prefix, "include", "gc.h")
+                ):
+                    # bdw-gc installed in a conda environment
+                    self.cflags += ["-I", f"{conda_prefix}/include"]
+                    self.ldflags += ["-L", f"{conda_prefix}/lib"]
+                    # conda-forge libgc has an @rpath install name: without an
+                    # rpath entry the executable won't find it at runtime
+                    self.ldflags += [f"-Wl,-rpath,{conda_prefix}/lib"]
+                elif sys.platform == "darwin" and shutil.which("brew"):
+                    # On macOS, Homebrew installs bdw-gc outside the default
+                    # compiler search paths
                     prefix = subprocess.run(
                         ["brew", "--prefix", "bdw-gc"],
                         capture_output=True,


### PR DESCRIPTION
When trying to install `spy` using `conda` on `macOS`. I ran into problems with `bwd-gc` because the path for `bwd-gc` lives in the `conda` environment so `cc` couldn't find `gc.h` (nor `-lgc` at link time).

Steps I followed (in `spy` root directory): 

```
conda create env -n spylang
conda activate spylang
pip install -e .
make -C spy/libspy
```

Hence I had to use the following fix so that `bwd-gc` could be detected. If it seems useful please do consider adding this fix to `spy`. 