### PR TITLE
Report failed assertion expressions

### DIFF
--- a/spy/analyze/importing.py
+++ b/spy/analyze/importing.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 MODULE = Union[ast.Module, "W_Module", None]
 
 # Cache version: increment this when ast.Module or SymTable structure changes
-SPYC_VERSION = 9
+SPYC_VERSION = 10
 
 
 @dataclass

--- a/spy/ast.py
+++ b/spy/ast.py
@@ -1023,6 +1023,7 @@ class Raise(Stmt):
 class Assert(Stmt):
     test: Expr
     msg: Optional[Expr]
+    source: str
 
 
 @astnode

--- a/spy/backend/c/cwriter.py
+++ b/spy/backend/c/cwriter.py
@@ -261,8 +261,10 @@ class CFuncWriter:
                     f'"{assert_node.loc.filename}", {assert_node.loc.line_start});'
                 )
             else:
+                message = f"assert {assert_node.source}".encode("utf-8")
+                message_literal = C.Literal.from_bytes(message)
                 self.tbc.wl(
-                    f'spy_panic("AssertionError", "assertion failed", '
+                    f'spy_panic("AssertionError", {message_literal}, '
                     f'"{assert_node.loc.filename}", {assert_node.loc.line_start});'
                 )
 

--- a/spy/parser.py
+++ b/spy/parser.py
@@ -732,7 +732,9 @@ class Parser:
     def from_py_stmt_Assert(self, py_node: py_ast.Assert) -> spy.ast.Assert:
         test = self.from_py_expr(py_node.test)
         msg = self.from_py_expr(py_node.msg) if py_node.msg else None
-        return spy.ast.Assert(py_node.loc, test, msg)
+        source = py_ast.get_source_segment(self.src, py_node.test)
+        assert source is not None, "parsed assert expression has no source location"
+        return spy.ast.Assert(py_node.loc, test, msg, source)
 
     def from_py_stmt_Break(self, py_node: py_ast.Break) -> spy.ast.Break:
         return spy.ast.Break(py_node.loc)

--- a/spy/tests/compiler/test_assert.py
+++ b/spy/tests/compiler/test_assert.py
@@ -24,6 +24,32 @@ class TestAssert(CompilerTest):
         with SPyError.raises("W_AssertionError"):
             mod.test()
 
+    def test_assert_reports_original_expression(self):
+        mod = self.compile(
+            """
+            def check_simple(actual: i32, expected: i32) -> None:
+                assert actual == expected
+
+            def check_redshifted(x: i32, expected: i32) -> None:
+                assert x + 2 * 3 == expected
+
+            def check_string(actual: str) -> None:
+                assert actual == "expected"
+            """
+        )
+
+        with SPyError.raises("W_AssertionError") as excinfo:
+            mod.check_simple(41, 42)
+        assert excinfo.value.w_exc.message == "assert actual == expected"
+
+        with SPyError.raises("W_AssertionError") as excinfo:
+            mod.check_redshifted(1, 8)
+        assert excinfo.value.w_exc.message == "assert x + 2 * 3 == expected"
+
+        with SPyError.raises("W_AssertionError") as excinfo:
+            mod.check_string("actual")
+        assert excinfo.value.w_exc.message == 'assert actual == "expected"'
+
     def test_assert_with_message(self):
         mod = self.compile(
             """

--- a/spy/tests/test_parser.py
+++ b/spy/tests/test_parser.py
@@ -1457,6 +1457,51 @@ class TestParser:
         self.assert_dump(body[0], expected0)
         self.assert_dump(body[1], expected1)
 
+    def test_Assert(self):
+        mod = self.parse("""
+        def check(actual: i32, expected: i32) -> None:
+            assert actual == expected
+            assert actual == expected, "custom message"
+        """)
+        plain, custom = mod.get_funcdef("check").body
+        assert isinstance(plain, ast.Assert)
+        assert isinstance(custom, ast.Assert)
+
+        self.assert_dump(
+            plain,
+            """
+            Assert(
+                test=CmpOp(
+                    op='==',
+                    left=Name(id='actual'),
+                    right=Name(id='expected'),
+                ),
+                msg=None,
+                source='actual == expected',
+            )
+            """,
+        )
+        self.assert_dump(
+            custom,
+            """
+            Assert(
+                test=CmpOp(
+                    op='==',
+                    left=Name(id='actual'),
+                    right=Name(id='expected'),
+                ),
+                msg=StrLiteral(value='custom message'),
+                source='actual == expected',
+            )
+            """,
+        )
+        assert plain.test.loc.get_src() == "actual == expected"
+        assert custom.test.loc.get_src() == "actual == expected"
+        assert plain.source == "actual == expected"
+        assert custom.source == "actual == expected"
+        assert custom.msg is not None
+        assert custom.msg.loc.get_src() == '"custom message"'
+
     def test_Raise(self):
         mod = self.parse("""
         def foo() -> None:

--- a/spy/vm/astframe.py
+++ b/spy/vm/astframe.py
@@ -660,7 +660,7 @@ class AbstractFrame:
         assert isinstance(wam_assert.w_val, W_Bool)
 
         if self.vm.is_False(wam_assert.w_val):
-            plain_msg = "assertion failed"
+            plain_msg = "assert " + assert_node.source
 
             if assert_node.msg is not None:
                 wam_msg = self.eval_expr(assert_node.msg)


### PR DESCRIPTION
Use the original assertion expression as the default message when an assertion fails. For example:

```text
AssertionError: assert actual == expected
```

Preserve the source expression through redshift and embed it in compiled output, so interpreted, Doppler, and C execution report the same expression without requiring the `.spy` source file at runtime. Explicit messages such as `assert condition, "message"` remain unchanged.

Add parser characterization for plain assertions and assertions with explicit messages, then extend the cross-backend assertion tests to cover a simple comparison and preservation of the original expression when redshift can transform it.

This differs from CPython's plain `assert`, which raises an `AssertionError` without retaining the failed expression. It establishes source-expression reporting as a basis for pytest-like assertion diagnostics in hypothetical future `spytest`. Later changes could attach values for evaluated expressions and subexpressions while preserving CPython's evaluation semantics. Unlike pytest, SPy can retain the required information in its own compiler pipeline rather than through external AST rewriting hackery.