### PR TITLE
Fix order ldflags

### DIFF
--- a/spy/build/config.py
+++ b/spy/build/config.py
@@ -65,7 +65,6 @@ class CompilerConfig:
         )
         self.cflags += EXTRA_CFLAGS
 
-        self.ldflags += LDFLAGS
         self.ldflags += get_ldflags(flags_target, config.build_type)
 
         libdir = get_libdir(flags_target, config.build_type, config.kind)
@@ -137,6 +136,9 @@ class CompilerConfig:
                     if prefix:
                         self.cflags += ["-I", f"{prefix}/include"]
                         self.ldflags += ["-L", f"{prefix}/lib"]
+
+        # NOTE: LDFLAGS (-lm) must be the very last thing added
+        self.ldflags += LDFLAGS
 
     @staticmethod
     def _build_bdwgc_static() -> None:

--- a/spy/tests/compiler/test_native.py
+++ b/spy/tests/compiler/test_native.py
@@ -31,3 +31,23 @@ class TestNative(CompilerTest):
         out = exe.run()
         lines = out.splitlines()
         assert lines == ["foo", "bar", "7"]
+
+    def test_f32_mod_link(self):
+        # Regression test for a linker ordering bug: on the native target,
+        # `-lm` used to be placed *before* `-lspy` on the link command line.
+        #
+        # This never showed up on the default "C" backend (wasi/testlib),
+        # because there libspy.a is force-included via --whole-archive and
+        # linked against the wasi-libc sysroot, which doesn't hit the same
+        # as-needed/archive-ordering issue as a native build against the
+        # system libm.
+        src = """
+        def compute(x: f32, y: f32) -> f32:
+            return x % y
+
+        def main() -> None:
+            print(compute(200.0, 64.0))
+        """
+        exe = self.compile(src)
+        out = exe.run()
+        assert out.strip() == "8.0"


### PR DESCRIPTION
Fix a bug (native with `-lm`) by changing ldflags order: `-lm` last.

The PR contains a failing test and a very simple fix. The error produced by `pytest spy/tests/compiler/test_native.py`:

```
E           FAILED: test 
E           cc src/test.o src/_print.o -o test -lm -L /home/pierre/dev/spy/spy/libspy/build/native/debug -lspy
E           /usr/bin/ld: /home/pierre/dev/spy/spy/libspy/build/native/debug/libspy.a(operator.o): in function `spy_operator$f32_floordiv':
E           /home/pierre/dev/spy/spy/libspy/src/operator.c:50: undefined reference to `floorf'
E           /usr/bin/ld: /home/pierre/dev/spy/spy/libspy/build/native/debug/libspy.a(operator.o): in function `spy_unsafe$f32_unchecked_floordiv':
E           /home/pierre/dev/spy/spy/libspy/src/operator.c:60: undefined reference to `floorf'
E           /usr/bin/ld: /home/pierre/dev/spy/spy/libspy/build/native/debug/libspy.a(operator.o): in function `spy_operator$f32_mod':
E           /home/pierre/dev/spy/spy/libspy/src/operator.c:68: undefined reference to `fmodf'
E           /usr/bin/ld: /home/pierre/dev/spy/spy/libspy/build/native/debug/libspy.a(operator.o): in function `spy_unsafe$f32_unchecked_mod':
E           /home/pierre/dev/spy/spy/libspy/src/operator.c:84: undefined reference to `fmodf'
E           /usr/bin/ld: /home/pierre/dev/spy/spy/libspy/build/native/debug/libspy.a(operator.o): in function `spy_operator$f32_pow':
E           /home/pierre/dev/spy/spy/libspy/src/operator.c:135: undefined reference to `truncf'
E           /usr/bin/ld: /home/pierre/dev/spy/spy/libspy/src/operator.c:138: undefined reference to `powf'
E           collect2: error: ld returned 1 exit status
```